### PR TITLE
Entity cycles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 num = "0.4"
 futures-lite = "1.12.0"
+itertools = "0.10.5"
 
 [dev-dependencies]
 petgraph = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ itertools = "0.10.5"
 
 [dev-dependencies]
 petgraph = "0.6.3"
+once_cell = "1.16.0"

--- a/assets/scenes/tests/empty_scene/index.js
+++ b/assets/scenes/tests/empty_scene/index.js
@@ -1,0 +1,2 @@
+exports.onStart = async function() {};
+exports.onUpdate = async function(dt) {};

--- a/src/crdt/lww.rs
+++ b/src/crdt/lww.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::CrdtInterface;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LWWEntry {
     pub timestamp: SceneCrdtTimestamp,
     pub updated: bool,
@@ -22,7 +22,7 @@ pub struct LWWEntry {
     pub data: Vec<u8>,
 }
 
-#[derive(Component)]
+#[derive(Component, Clone)]
 pub struct CrdtLWWState<T> {
     pub last_write: HashMap<SceneEntityId, LWWEntry>,
     _marker: PhantomData<T>,
@@ -159,15 +159,13 @@ pub(crate) fn process_crdt_lww_updates<T: FromDclReader + Component + std::fmt::
         Entity,
         &SceneContext,
         &mut CrdtLWWState<T>,
-        Option<&DeletedSceneEntities>,
+        &DeletedSceneEntities,
     )>,
 ) {
-    for (_root, scene_context, mut updates, maybe_deleted) in scenes.iter_mut() {
-        if let Some(deleted_entities) = maybe_deleted {
-            // remove crdt state for dead entities
-            for deleted in &deleted_entities.0 {
-                updates.last_write.remove(deleted);
-            }
+    for (_root, scene_context, mut updates, deleted_entities) in scenes.iter_mut() {
+        // remove crdt state for dead entities
+        for deleted in &deleted_entities.0 {
+            updates.last_write.remove(deleted);
         }
 
         for (scene_entity, entry) in updates

--- a/src/dcl_component/mod.rs
+++ b/src/dcl_component/mod.rs
@@ -2,10 +2,12 @@ use bevy::prelude::Vec3;
 
 mod reader;
 pub mod transform_and_parent;
+mod writer;
 
 pub use reader::{DclReader, DclReaderError, FromDclReader};
+pub use writer::{DclWriter, ToDclWriter};
 
-#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Clone, Copy, Default)]
 pub struct SceneEntityId {
     pub id: u16,
     pub generation: u16,
@@ -34,6 +36,12 @@ impl FromDclReader for Vec3 {
     }
 }
 
+impl ToDclWriter for Vec3 {
+    fn to_writer(&self, buf: &mut DclWriter) {
+        buf.write_float3(&self.to_array())
+    }
+}
+
 impl FromDclReader for SceneEntityId {
     fn from_reader(buf: &mut DclReader) -> Result<Self, DclReaderError> {
         Ok(Self {
@@ -43,14 +51,33 @@ impl FromDclReader for SceneEntityId {
     }
 }
 
+impl ToDclWriter for SceneEntityId {
+    fn to_writer(&self, buf: &mut DclWriter) {
+        buf.write_u16(self.generation);
+        buf.write_u16(self.id);
+    }
+}
+
 impl FromDclReader for SceneComponentId {
     fn from_reader(buf: &mut DclReader) -> Result<Self, DclReaderError> {
         Ok(Self(buf.read_u32()?))
     }
 }
 
+impl ToDclWriter for SceneComponentId {
+    fn to_writer(&self, buf: &mut DclWriter) {
+        buf.write_u32(self.0)
+    }
+}
+
 impl FromDclReader for SceneCrdtTimestamp {
     fn from_reader(buf: &mut DclReader) -> Result<Self, DclReaderError> {
         Ok(Self(buf.read_u32()?))
+    }
+}
+
+impl ToDclWriter for SceneCrdtTimestamp {
+    fn to_writer(&self, buf: &mut DclWriter) {
+        buf.write_u32(self.0)
     }
 }

--- a/src/dcl_component/writer.rs
+++ b/src/dcl_component/writer.rs
@@ -1,0 +1,54 @@
+pub struct DclWriter {
+    buffer: Vec<u8>,
+}
+
+impl DclWriter {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buffer: Vec::with_capacity(capacity),
+        }
+    }
+
+    fn write_raw(&mut self, data: &[u8]) {
+        self.buffer.extend_from_slice(data)
+    }
+
+    pub fn write_u16(&mut self, value: u16) {
+        self.write_raw(&value.to_be_bytes());
+    }
+
+    pub fn write_u32(&mut self, value: u32) {
+        self.write_raw(&value.to_be_bytes());
+    }
+
+    pub fn write_float(&mut self, value: f32) {
+        self.write_u32(value.to_bits())
+    }
+
+    pub fn write_float3(&mut self, value: &[f32; 3]) {
+        self.write_float(value[0]);
+        self.write_float(value[1]);
+        self.write_float(value[2]);
+    }
+
+    pub fn write_float4(&mut self, value: &[f32; 4]) {
+        self.write_float(value[0]);
+        self.write_float(value[1]);
+        self.write_float(value[2]);
+        self.write_float(value[3]);
+    }
+
+    pub fn write<T: ToDclWriter>(&mut self, value: &T) {
+        value.to_writer(self)
+    }
+}
+
+impl From<DclWriter> for Vec<u8> {
+    fn from(value: DclWriter) -> Self {
+        value.buffer
+    }
+}
+
+pub trait ToDclWriter {
+    fn to_writer(&self, buf: &mut DclWriter);
+}

--- a/src/scene_runner/engine.rs
+++ b/src/scene_runner/engine.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::{debug, error};
 use deno_core::{op, OpDecl, OpState};
 use num::FromPrimitive;
-use num_derive::FromPrimitive;
+use num_derive::{FromPrimitive, ToPrimitive};
 use std::{
     cell::{RefCell, RefMut},
     rc::Rc,
@@ -11,6 +11,7 @@ use std::{
 
 use crate::{
     crdt::{CrdtComponentInterfaces, CrdtInterfacesMap},
+    dcl_assert,
     dcl_component::{DclReader, DclReaderError},
     scene_runner::EngineResponseList,
 };
@@ -19,7 +20,7 @@ use super::SceneContext;
 
 const CRDT_HEADER_SIZE: usize = 8;
 
-#[derive(FromPrimitive, Debug)]
+#[derive(FromPrimitive, ToPrimitive, Debug)]
 pub enum CrdtMessageType {
     PutComponent = 1,
     DeleteComponent = 2,
@@ -49,7 +50,7 @@ fn process_message(
             let content_len = stream.read_u32()? as usize;
 
             debug!("PUT e:{entity:?}, c: {component:?}, timestamp: {timestamp:?}, content len: {content_len}");
-            assert_eq!(content_len, stream.len());
+            dcl_assert!(content_len == stream.len());
 
             // check for a writer
             let Some(writer) = writers.get(&component) else {

--- a/src/scene_runner/test/expected/cyclic_recovery.dot
+++ b/src/scene_runner/test/expected/cyclic_recovery.dot
@@ -1,0 +1,9 @@
+digraph {
+    0 [ label = "\"dcl_0v0\"" ]
+    1 [ label = "\"dcl_3v0\"" ]
+    2 [ label = "\"dcl_2v0\"" ]
+    3 [ label = "\"dcl_1v0\"" ]
+    0 -> 1 [ ]
+    1 -> 2 [ ]
+    2 -> 3 [ ]
+}


### PR DESCRIPTION
handle entity cycles by
 - keeping scene-defined parents separate from renderer transform hierarchy
 - update renderer transform hierarchy from scene-defined parents where possible

plus tests