### PR TITLE
main.crdt and misc fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ bevy_console = "0.7.0"
 clap = "4.1.10"
 bevy_atmosphere = "0.6.0"
 petgraph = "0.6.3"
+# requires local version due to once_cell version conflict. probably resolved by updating deno
+# bevy_mod_debugdump = { path = "../bevy_mod_debugdump" }
 
 [dev-dependencies]
 petgraph = "0.6.3"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::io::Result;
 fn main() -> Result<()> {
     let components = [
+        "engine_info",
         "billboard",
         "raycast",
         "raycast_result",

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ fn main() -> Result<()> {
         "mesh_collider",
         "material",
         "gltf_container",
+        "gltf_container_loading_state",
         "animator",
         "pointer_events",
         "pointer_events_result",

--- a/schedule.dot
+++ b/schedule.dot
@@ -1,0 +1,830 @@
+digraph "" {
+	"compound"="true";
+	"splines"="spline";
+	"rankdir"="LR";
+	"bgcolor"="#0d1117";
+	"fontname"="Helvetica";
+	"nodesep"="0.15";
+	edge ["penwidth"="2"];
+	node ["shape"="box", "style"="filled"];
+	subgraph "clusternode_Set(0)" {
+		"style"="rounded,filled";
+		"label"="Update";
+		"tooltip"="Update";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(0)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		subgraph "clusternode_Set(73)" {
+			"style"="rounded,filled";
+			"label"="Commands";
+			"tooltip"="Commands";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(73)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(58)" ["label"="decentra_bevy::ipfs::change_realm_command", "tooltip"="decentra_bevy::ipfs::change_realm_command", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(176)" ["label"="decentra_bevy::scene_runner::update_scene::raycast_result::debug_raycast", "tooltip"="decentra_bevy::scene_runner::update_scene::raycast_result::debug_raycast", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(185)" ["label"="decentra_bevy::scene_runner::update_world::mesh_collider::debug_colliders", "tooltip"="decentra_bevy::scene_runner::update_world::mesh_collider::debug_colliders", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(198)" ["label"="bevy_console::commands::clear::clear_command", "tooltip"="bevy_console::commands::clear::clear_command", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(199)" ["label"="bevy_console::commands::exit::exit_command", "tooltip"="bevy_console::commands::exit::exit_command", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(200)" ["label"="bevy_console::commands::help::help_command", "tooltip"="bevy_console::commands::help::help_command", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(212)" ["label"="decentra_bevy::console::clear_command", "tooltip"="decentra_bevy::console::clear_command", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(213)" ["label"="decentra_bevy::console::help_command", "tooltip"="decentra_bevy::console::help_command", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(214)" ["label"="decentra_bevy::console::exit_command", "tooltip"="decentra_bevy::console::exit_command", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(229)" ["label"="decentra_bevy::change_location", "tooltip"="decentra_bevy::change_location", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(230)" ["label"="decentra_bevy::scene_distance", "tooltip"="decentra_bevy::scene_distance", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(193)" {
+			"style"="rounded,filled";
+			"label"="Init";
+			"tooltip"="Init";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(193)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(166)" ["label"="decentra_bevy::scene_runner::initialize_scene::load_scene_entity", "tooltip"="decentra_bevy::scene_runner::initialize_scene::load_scene_entity", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(167)" ["label"="decentra_bevy::scene_runner::initialize_scene::load_scene_json", "tooltip"="decentra_bevy::scene_runner::initialize_scene::load_scene_json", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(168)" ["label"="decentra_bevy::scene_runner::initialize_scene::load_scene_javascript", "tooltip"="decentra_bevy::scene_runner::initialize_scene::load_scene_javascript", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(169)" ["label"="decentra_bevy::scene_runner::initialize_scene::initialize_scene", "tooltip"="decentra_bevy::scene_runner::initialize_scene::initialize_scene", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(182)" ["label"="decentra_bevy::scene_runner::update_world::mesh_collider::update_colliders", "tooltip"="decentra_bevy::scene_runner::update_world::mesh_collider::update_colliders", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(194)" {
+			"style"="rounded,filled";
+			"label"="PostInit";
+			"tooltip"="PostInit";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(194)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(183)" ["label"="decentra_bevy::scene_runner::update_world::mesh_collider::update_scene_collider_data", "tooltip"="decentra_bevy::scene_runner::update_world::mesh_collider::update_scene_collider_data", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(184)" ["label"="decentra_bevy::scene_runner::update_world::mesh_collider::update_collider_transforms", "tooltip"="decentra_bevy::scene_runner::update_world::mesh_collider::update_collider_transforms", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(192)" ["label"="decentra_bevy::scene_runner::update_world::gltf_container::check_gltfs_ready", "tooltip"="decentra_bevy::scene_runner::update_world::gltf_container::check_gltfs_ready", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(195)" {
+			"style"="rounded,filled";
+			"label"="Input";
+			"tooltip"="Input";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(195)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(175)" ["label"="decentra_bevy::scene_runner::update_scene::raycast_result::run_raycasts", "tooltip"="decentra_bevy::scene_runner::update_scene::raycast_result::run_raycasts", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(177)" ["label"="decentra_bevy::scene_runner::update_scene::pointer_results::update_pointer_target", "tooltip"="decentra_bevy::scene_runner::update_scene::pointer_results::update_pointer_target", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(178)" ["label"="decentra_bevy::scene_runner::update_scene::pointer_results::send_hover_events", "tooltip"="decentra_bevy::scene_runner::update_scene::pointer_results::send_hover_events", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(179)" ["label"="decentra_bevy::scene_runner::update_scene::pointer_results::send_action_events", "tooltip"="decentra_bevy::scene_runner::update_scene::pointer_results::send_action_events", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(195)" ["label"="decentra_bevy::camera_controller::camera_controller", "tooltip"="decentra_bevy::camera_controller::camera_controller", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(196)" {
+			"style"="rounded,filled";
+			"label"="RunLoop";
+			"tooltip"="RunLoop";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(196)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(173)" ["label"="decentra_bevy::scene_runner::update_scene_priority", "tooltip"="decentra_bevy::scene_runner::update_scene_priority", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(174)" ["label"="decentra_bevy::scene_runner::run_scene_loop", "tooltip"="decentra_bevy::scene_runner::run_scene_loop", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(197)" {
+			"style"="rounded,filled";
+			"label"="PostLoop";
+			"tooltip"="PostLoop";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(197)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(180)" ["label"="decentra_bevy::scene_runner::update_world::mesh_renderer::update_mesh", "tooltip"="decentra_bevy::scene_runner::update_world::mesh_renderer::update_mesh", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(181)" ["label"="decentra_bevy::scene_runner::update_world::material::update_materials", "tooltip"="decentra_bevy::scene_runner::update_world::material::update_materials", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(187)" ["label"="decentra_bevy::scene_runner::update_world::gltf_container::update_gltf", "tooltip"="decentra_bevy::scene_runner::update_world::gltf_container::update_gltf", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(188)" ["label"="decentra_bevy::scene_runner::update_world::gltf_container::attach_ready_colliders", "tooltip"="decentra_bevy::scene_runner::update_world::gltf_container::attach_ready_colliders", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(193)" ["label"="decentra_bevy::scene_runner::update_world::animation::update_animations", "tooltip"="decentra_bevy::scene_runner::update_world::animation::update_animations", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+			"node_System(194)" ["label"="decentra_bevy::scene_runner::update_world::billboard::update_billboards", "tooltip"="decentra_bevy::scene_runner::update_world::billboard::update_billboards", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(234)" {
+			"style"="rounded,filled";
+			"label"="ConsoleUI";
+			"tooltip"="ConsoleUI";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(234)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(201)" ["label"="bevy_console::console::console_ui", "tooltip"="bevy_console::console::console_ui", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(236)" {
+			"style"="rounded,filled";
+			"label"="PostCommands";
+			"tooltip"="PostCommands";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(236)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(202)" ["label"="bevy_console::console::receive_console_line", "tooltip"="bevy_console::console::receive_console_line", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		}
+		
+		"node_System(46)" ["label"="bevy_window::system::close_when_requested", "tooltip"="bevy_window::system::close_when_requested", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(67)" ["label"="bevy_scene::scene_spawner::scene_spawner_system", "tooltip"="bevy_scene::scene_spawner::scene_spawner_system", "fillcolor"="#bacfcb", "fontname"="Helvetica", "fontcolor"="#141e1c", "color"="#7da59d", "penwidth"="1"]
+		"node_System(72)" ["label"="bevy_winit::accessibility::handle_window_focus", "tooltip"="bevy_winit::accessibility::handle_window_focus", "fillcolor"="#664f72", "fontname"="Helvetica", "fontcolor"="#e6e0ea", "color"="#9980a6", "penwidth"="1"]
+		"node_System(73)" ["label"="bevy_winit::accessibility::window_closed", "tooltip"="bevy_winit::accessibility::window_closed", "fillcolor"="#664f72", "fontname"="Helvetica", "fontcolor"="#e6e0ea", "color"="#9980a6", "penwidth"="1"]
+		"node_System(74)" ["label"="bevy_winit::accessibility::poll_receivers", "tooltip"="bevy_winit::accessibility::poll_receivers", "fillcolor"="#664f72", "fontname"="Helvetica", "fontcolor"="#e6e0ea", "color"="#9980a6", "penwidth"="1"]
+		"node_System(75)" ["label"="bevy_winit::accessibility::update_accessibility_nodes", "tooltip"="bevy_winit::accessibility::update_accessibility_nodes", "fillcolor"="#664f72", "fontname"="Helvetica", "fontcolor"="#e6e0ea", "color"="#9980a6", "penwidth"="1"]
+		"node_System(114)" ["label"="bevy_ui::accessibility::calc_bounds", "tooltip"="bevy_ui::accessibility::calc_bounds", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		"node_System(115)" ["label"="bevy_ui::accessibility::button_changed", "tooltip"="bevy_ui::accessibility::button_changed", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		"node_System(116)" ["label"="bevy_ui::accessibility::image_changed", "tooltip"="bevy_ui::accessibility::image_changed", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		"node_System(117)" ["label"="bevy_ui::accessibility::label_changed", "tooltip"="bevy_ui::accessibility::label_changed", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		"node_System(162)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+		"node_System(163)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+		"node_System(164)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+		"node_System(165)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+		"node_System(186)" ["label"="decentra_bevy::scene_runner::update_world::mesh_collider::render_debug_colliders", "tooltip"="decentra_bevy::scene_runner::update_world::mesh_collider::render_debug_colliders", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(211)" ["label"="decentra_bevy::console::remove_default_commands", "tooltip"="decentra_bevy::console::remove_default_commands", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(215)" ["label"="decentra_bevy::console::send_pending", "tooltip"="decentra_bevy::console::send_pending", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(219)" ["label"="bevy_atmosphere::pipeline::atmosphere_settings_changed", "tooltip"="bevy_atmosphere::pipeline::atmosphere_settings_changed", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(222)" ["label"="bevy_atmosphere::plugin::atmosphere_cancel_rotation", "tooltip"="bevy_atmosphere::plugin::atmosphere_cancel_rotation", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(223)" ["label"="decentra_bevy::visuals::daylight_cycle", "tooltip"="decentra_bevy::visuals::daylight_cycle", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(224)" ["label"="decentra_bevy::visuals::move_ground", "tooltip"="decentra_bevy::visuals::move_ground", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(225)" ["label"="bevy_diagnostic::frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin::diagnostic_system", "tooltip"="bevy_diagnostic::frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin::diagnostic_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(227)" ["label"="decentra_bevy::update_fps", "tooltip"="decentra_bevy::update_fps", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(228)" ["label"="decentra_bevy::input", "tooltip"="decentra_bevy::input", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(2)" {
+		"style"="rounded,filled";
+		"label"="FirstFlush";
+		"tooltip"="FirstFlush";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(2)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(0)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+	}
+	
+	subgraph "clusternode_Set(3)" {
+		"style"="rounded,filled";
+		"label"="PreUpdateFlush";
+		"tooltip"="PreUpdateFlush";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(3)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(1)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+	}
+	
+	subgraph "clusternode_Set(4)" {
+		"style"="rounded,filled";
+		"label"="UpdateFlush";
+		"tooltip"="UpdateFlush";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(4)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(2)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+	}
+	
+	subgraph "clusternode_Set(5)" {
+		"style"="rounded,filled";
+		"label"="PostUpdateFlush";
+		"tooltip"="PostUpdateFlush";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(5)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(3)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+	}
+	
+	subgraph "clusternode_Set(6)" {
+		"style"="rounded,filled";
+		"label"="LastFlush";
+		"tooltip"="LastFlush";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(6)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(4)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+	}
+	
+	subgraph "clusternode_Set(7)" {
+		"style"="rounded,filled";
+		"label"="First";
+		"tooltip"="First";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(7)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		subgraph "clusternode_Set(16)" {
+			"style"="rounded,filled";
+			"label"="TimeSystem";
+			"tooltip"="TimeSystem";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(16)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(8)" ["label"="bevy_time::time_system", "tooltip"="bevy_time::time_system", "fillcolor"="#c7ddbd", "fontname"="Helvetica", "fontcolor"="#162111", "color"="#8dba79", "penwidth"="1"]
+		}
+		
+		"node_System(5)" ["label"="bevy_ecs::event::Events<bevy_app::app::AppExit>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_app::app::AppExit>::update_system", "fillcolor"="#639d18", "fontname"="Helvetica", "fontcolor"="#e7f8d2", "color"="#98e03a", "penwidth"="1"]
+		"node_System(13)" ["label"="bevy_ecs::event::Events<bevy_hierarchy::events::HierarchyEvent>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_hierarchy::events::HierarchyEvent>::update_system", "fillcolor"="#e4fba3", "fontname"="Helvetica", "fontcolor"="#243002", "color"="#c7f641", "penwidth"="1"]
+		"node_System(14)" ["label"="bevy_ecs::event::Events<bevy_input::keyboard::KeyboardInput>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::keyboard::KeyboardInput>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(16)" ["label"="bevy_ecs::event::Events<bevy_input::mouse::MouseButtonInput>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::mouse::MouseButtonInput>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(17)" ["label"="bevy_ecs::event::Events<bevy_input::mouse::MouseMotion>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::mouse::MouseMotion>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(18)" ["label"="bevy_ecs::event::Events<bevy_input::mouse::MouseWheel>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::mouse::MouseWheel>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(20)" ["label"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadConnectionEvent>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadConnectionEvent>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(21)" ["label"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadButtonChangedEvent>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadButtonChangedEvent>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(22)" ["label"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadAxisChangedEvent>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadAxisChangedEvent>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(23)" ["label"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadEvent>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::gamepad::GamepadEvent>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(28)" ["label"="bevy_ecs::event::Events<bevy_input::touch::TouchInput>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_input::touch::TouchInput>::update_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		"node_System(30)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowResized>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowResized>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(31)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowCreated>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowCreated>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(32)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowClosed>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowClosed>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(33)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowCloseRequested>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowCloseRequested>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(34)" ["label"="bevy_ecs::event::Events<bevy_window::event::RequestRedraw>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::RequestRedraw>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(35)" ["label"="bevy_ecs::event::Events<bevy_window::event::CursorMoved>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::CursorMoved>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(36)" ["label"="bevy_ecs::event::Events<bevy_window::event::CursorEntered>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::CursorEntered>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(37)" ["label"="bevy_ecs::event::Events<bevy_window::event::CursorLeft>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::CursorLeft>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(38)" ["label"="bevy_ecs::event::Events<bevy_window::event::ReceivedCharacter>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::ReceivedCharacter>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(39)" ["label"="bevy_ecs::event::Events<bevy_window::event::Ime>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::Ime>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(40)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowFocused>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowFocused>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(41)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowScaleFactorChanged>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowScaleFactorChanged>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(42)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowBackendScaleFactorChanged>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowBackendScaleFactorChanged>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(43)" ["label"="bevy_ecs::event::Events<bevy_window::event::FileDragAndDrop>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::FileDragAndDrop>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(44)" ["label"="bevy_ecs::event::Events<bevy_window::event::WindowMoved>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_window::event::WindowMoved>::update_system", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(49)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::ipfs::SceneDefinition>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::ipfs::SceneDefinition>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(52)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::ipfs::SceneJsFile>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::ipfs::SceneJsFile>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(55)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::ipfs::SceneMeta>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::ipfs::SceneMeta>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(56)" ["label"="bevy_ecs::event::Events<decentra_bevy::ipfs::ChangeRealmEvent>::update_system", "tooltip"="bevy_ecs::event::Events<decentra_bevy::ipfs::ChangeRealmEvent>::update_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(63)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_scene::dynamic_scene::DynamicScene>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_scene::dynamic_scene::DynamicScene>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(66)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_scene::scene::Scene>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_scene::scene::Scene>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(71)" ["label"="bevy_ecs::event::Events<accesskit::ActionRequest>::update_system", "tooltip"="bevy_ecs::event::Events<accesskit::ActionRequest>::update_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(78)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::render_resource::shader::Shader>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::render_resource::shader::Shader>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(92)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::mesh::mesh::Mesh>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::mesh::mesh::Mesh>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(95)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::mesh::mesh::skinning::SkinnedMeshInverseBindposes>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::mesh::mesh::skinning::SkinnedMeshInverseBindposes>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(98)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::texture::image::Image>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_render::texture::image::Image>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(101)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_sprite::texture_atlas::TextureAtlas>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_sprite::texture_atlas::TextureAtlas>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(104)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_sprite::mesh2d::color_material::ColorMaterial>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_sprite::mesh2d::color_material::ColorMaterial>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(107)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_text::font::Font>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_text::font::Font>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(110)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_text::font_atlas_set::FontAtlasSet>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_text::font_atlas_set::FontAtlasSet>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(124)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_pbr::pbr_material::StandardMaterial>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_pbr::pbr_material::StandardMaterial>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(135)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::Gltf>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::Gltf>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(138)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::GltfNode>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::GltfNode>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(141)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::GltfPrimitive>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::GltfPrimitive>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(144)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::GltfMesh>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_gltf::GltfMesh>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(147)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_audio::audio_source::AudioSource>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_audio::audio_source::AudioSource>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(150)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_audio::sinks::AudioSink>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_audio::sinks::AudioSink>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(153)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_audio::sinks::SpatialAudioSink>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_audio::sinks::SpatialAudioSink>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(158)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_animation::AnimationClip>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_animation::AnimationClip>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(161)" ["label"="bevy_ecs::event::Events<decentra_bevy::scene_runner::LoadSceneEvent>::update_system", "tooltip"="bevy_ecs::event::Events<decentra_bevy::scene_runner::LoadSceneEvent>::update_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(191)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::scene_runner::update_world::gltf_container::GltfCachedShape>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<decentra_bevy::scene_runner::update_world::gltf_container::GltfCachedShape>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(196)" ["label"="bevy_ecs::event::Events<bevy_console::console::ConsoleCommandEntered>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_console::console::ConsoleCommandEntered>::update_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(197)" ["label"="bevy_ecs::event::Events<bevy_console::console::PrintConsoleLine>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_console::console::PrintConsoleLine>::update_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(218)" ["label"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_atmosphere::skybox::SkyBoxMaterial>>::update_system", "tooltip"="bevy_ecs::event::Events<bevy_asset::assets::AssetEvent<bevy_atmosphere::skybox::SkyBoxMaterial>>::update_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(8)" {
+		"style"="rounded,filled";
+		"label"="PreUpdate";
+		"tooltip"="PreUpdate";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(8)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		subgraph "clusternode_Set(25)" {
+			"style"="rounded,filled";
+			"label"="InputSystem";
+			"tooltip"="InputSystem";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(25)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(15)" ["label"="bevy_input::keyboard::keyboard_input_system", "tooltip"="bevy_input::keyboard::keyboard_input_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+			"node_System(19)" ["label"="bevy_input::mouse::mouse_button_input_system", "tooltip"="bevy_input::mouse::mouse_button_input_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+			"node_System(24)" ["label"="bevy_input::gamepad::gamepad_event_system", "tooltip"="bevy_input::gamepad::gamepad_event_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+			"node_System(25)" ["label"="bevy_input::gamepad::gamepad_connection_system", "tooltip"="bevy_input::gamepad::gamepad_connection_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+			"node_System(26)" ["label"="bevy_input::gamepad::gamepad_button_event_system", "tooltip"="bevy_input::gamepad::gamepad_button_event_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+			"node_System(27)" ["label"="bevy_input::gamepad::gamepad_axis_event_system", "tooltip"="bevy_input::gamepad::gamepad_axis_event_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+			"node_System(29)" ["label"="bevy_input::touch::touch_screen_input_system", "tooltip"="bevy_input::touch::touch_screen_input_system", "fillcolor"="#d36aaf", "fontname"="Helvetica", "fontcolor"="#270b1d", "color"="#a5317d", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(134)" {
+			"style"="rounded,filled";
+			"label"="Focus";
+			"tooltip"="Focus";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(134)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(112)" ["label"="bevy_ui::focus::ui_focus_system", "tooltip"="bevy_ui::focus::ui_focus_system", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		}
+		
+		"node_System(59)" ["label"="bevy_asset::asset_server::free_unused_assets_system", "tooltip"="bevy_asset::asset_server::free_unused_assets_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(68)" ["label"="bevy_scene::bundle::scene_spawner", "tooltip"="bevy_scene::bundle::scene_spawner", "fillcolor"="#bacfcb", "fontname"="Helvetica", "fontcolor"="#141e1c", "color"="#7da59d", "penwidth"="1"]
+		"node_System(155)" ["label"="bevy_gilrs::gilrs_system::gilrs_event_system", "tooltip"="bevy_gilrs::gilrs_system::gilrs_event_system", "fillcolor"="#973977", "fontname"="Helvetica", "fontcolor"="#f1d9e9", "color"="#c86da9", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(9)" {
+		"style"="rounded,filled";
+		"label"="StateTransitions";
+		"tooltip"="StateTransitions";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(9)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+	}
+	
+	subgraph "clusternode_Set(10)" {
+		"style"="rounded,filled";
+		"label"="FixedUpdate";
+		"tooltip"="FixedUpdate";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(10)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(9)" ["label"="bevy_time::fixed_timestep::run_fixed_update_schedule", "tooltip"="bevy_time::fixed_timestep::run_fixed_update_schedule", "fillcolor"="#c7ddbd", "fontname"="Helvetica", "fontcolor"="#162111", "color"="#8dba79", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(11)" {
+		"style"="rounded,filled";
+		"label"="PostUpdate";
+		"tooltip"="PostUpdate";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(11)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		subgraph "clusternode_Set(20)" {
+			"style"="rounded,filled";
+			"label"="TransformPropagate";
+			"tooltip"="TransformPropagate";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(20)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			subgraph "clusternode_Set(21)" {
+				"style"="rounded,filled";
+				"label"="PropagateTransformsSet";
+				"tooltip"="PropagateTransformsSet";
+				"fillcolor"="#ffffff44";
+				"color"="#ffffff50";
+				"penwidth"="2";
+				"set_marker_node_Set(21)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+				"node_System(12)" ["label"="bevy_transform::systems::propagate_transforms", "tooltip"="bevy_transform::systems::propagate_transforms", "fillcolor"="#ffe7b9", "fontname"="Helvetica", "fontcolor"="#322100", "color"="#ffc453", "penwidth"="1"]
+			}
+			
+			"node_System(11)" ["label"="bevy_transform::systems::sync_simple_transforms", "tooltip"="bevy_transform::systems::sync_simple_transforms", "fillcolor"="#ffe7b9", "fontname"="Helvetica", "fontcolor"="#322100", "color"="#ffc453", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(95)" {
+			"style"="rounded,filled";
+			"label"="CameraUpdateSystem";
+			"tooltip"="CameraUpdateSystem";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(95)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(80)" ["label"="bevy_render::camera::camera::camera_system<bevy_render::camera::projection::Projection>", "tooltip"="bevy_render::camera::camera::camera_system<bevy_render::camera::projection::Projection>", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+			"node_System(81)" ["label"="bevy_render::camera::camera::camera_system<bevy_render::camera::projection::OrthographicProjection>", "tooltip"="bevy_render::camera::camera::camera_system<bevy_render::camera::projection::OrthographicProjection>", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+			"node_System(82)" ["label"="bevy_render::camera::camera::camera_system<bevy_render::camera::projection::PerspectiveProjection>", "tooltip"="bevy_render::camera::camera::camera_system<bevy_render::camera::projection::PerspectiveProjection>", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(99)" {
+			"style"="rounded,filled";
+			"label"="CalculateBounds";
+			"tooltip"="CalculateBounds";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(99)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(84)" ["label"="bevy_render::view::visibility::calculate_bounds", "tooltip"="bevy_render::view::visibility::calculate_bounds", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(100)" {
+			"style"="rounded,filled";
+			"label"="CalculateBoundsFlush";
+			"tooltip"="CalculateBoundsFlush";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(100)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(83)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+		}
+		
+		subgraph "clusternode_Set(101)" {
+			"style"="rounded,filled";
+			"label"="UpdateOrthographicFrusta";
+			"tooltip"="UpdateOrthographicFrusta";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(101)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(85)" ["label"="bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::OrthographicProjection>", "tooltip"="bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::OrthographicProjection>", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(102)" {
+			"style"="rounded,filled";
+			"label"="UpdatePerspectiveFrusta";
+			"tooltip"="UpdatePerspectiveFrusta";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(102)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(86)" ["label"="bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::PerspectiveProjection>", "tooltip"="bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::PerspectiveProjection>", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(103)" {
+			"style"="rounded,filled";
+			"label"="UpdateProjectionFrusta";
+			"tooltip"="UpdateProjectionFrusta";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(103)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(87)" ["label"="bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::Projection>", "tooltip"="bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::Projection>", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(104)" {
+			"style"="rounded,filled";
+			"label"="CheckVisibility";
+			"tooltip"="CheckVisibility";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(104)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(89)" ["label"="bevy_render::view::visibility::check_visibility", "tooltip"="bevy_render::view::visibility::check_visibility", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(105)" {
+			"style"="rounded,filled";
+			"label"="VisibilityPropagate";
+			"tooltip"="VisibilityPropagate";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(105)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(88)" ["label"="bevy_render::view::visibility::visibility_propagate_system", "tooltip"="bevy_render::view::visibility::visibility_propagate_system", "fillcolor"="#70b9fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#0c88f9", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(135)" {
+			"style"="rounded,filled";
+			"label"="Flex";
+			"tooltip"="Flex";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(135)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(119)" ["label"="bevy_ui::flex::flex_node_system", "tooltip"="bevy_ui::flex::flex_node_system", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(136)" {
+			"style"="rounded,filled";
+			"label"="Stack";
+			"tooltip"="Stack";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(136)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(120)" ["label"="bevy_ui::stack::ui_stack_system", "tooltip"="bevy_ui::stack::ui_stack_system", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(150)" {
+			"style"="rounded,filled";
+			"label"="AddClusters";
+			"tooltip"="AddClusters";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(150)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(125)" ["label"="bevy_pbr::light::add_clusters", "tooltip"="bevy_pbr::light::add_clusters", "fillcolor"="#abd5fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#48a3f8", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(151)" {
+			"style"="rounded,filled";
+			"label"="AddClustersFlush";
+			"tooltip"="AddClustersFlush";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(151)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(126)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers", "fillcolor"="#e70000", "fontname"="Helvetica", "fontcolor"="#ffffff", "color"="#5a0000", "penwidth"="2"]
+		}
+		
+		subgraph "clusternode_Set(152)" {
+			"style"="rounded,filled";
+			"label"="AssignLightsToClusters";
+			"tooltip"="AssignLightsToClusters";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(152)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(127)" ["label"="bevy_pbr::light::assign_lights_to_clusters", "tooltip"="bevy_pbr::light::assign_lights_to_clusters", "fillcolor"="#abd5fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#48a3f8", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(153)" {
+			"style"="rounded,filled";
+			"label"="CheckLightVisibility";
+			"tooltip"="CheckLightVisibility";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(153)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(132)" ["label"="bevy_pbr::light::check_light_mesh_visibility", "tooltip"="bevy_pbr::light::check_light_mesh_visibility", "fillcolor"="#abd5fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#48a3f8", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(154)" {
+			"style"="rounded,filled";
+			"label"="UpdateDirectionalLightCascades";
+			"tooltip"="UpdateDirectionalLightCascades";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(154)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(128)" ["label"="bevy_pbr::light::update_directional_light_cascades", "tooltip"="bevy_pbr::light::update_directional_light_cascades", "fillcolor"="#abd5fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#48a3f8", "penwidth"="1"]
+		}
+		
+		subgraph "clusternode_Set(155)" {
+			"style"="rounded,filled";
+			"label"="UpdateLightFrusta";
+			"tooltip"="UpdateLightFrusta";
+			"fillcolor"="#ffffff44";
+			"color"="#ffffff50";
+			"penwidth"="2";
+			"set_marker_node_Set(155)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+			"node_System(129)" ["label"="bevy_pbr::light::update_directional_light_frusta", "tooltip"="bevy_pbr::light::update_directional_light_frusta", "fillcolor"="#abd5fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#48a3f8", "penwidth"="1"]
+			"node_System(130)" ["label"="bevy_pbr::light::update_point_light_frusta", "tooltip"="bevy_pbr::light::update_point_light_frusta", "fillcolor"="#abd5fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#48a3f8", "penwidth"="1"]
+			"node_System(131)" ["label"="bevy_pbr::light::update_spot_light_frusta", "tooltip"="bevy_pbr::light::update_spot_light_frusta", "fillcolor"="#abd5fc", "fontname"="Helvetica", "fontcolor"="#011a31", "color"="#48a3f8", "penwidth"="1"]
+		}
+		
+		"node_System(45)" ["label"="bevy_window::system::exit_on_all_closed", "tooltip"="bevy_window::system::exit_on_all_closed", "fillcolor"="#bb85d4", "fontname"="Helvetica", "fontcolor"="#1d0d25", "color"="#8e3fb3", "penwidth"="1"]
+		"node_System(57)" ["label"="decentra_bevy::ipfs::change_realm", "tooltip"="decentra_bevy::ipfs::change_realm", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(111)" ["label"="bevy_text::text2d::update_text2d_layout", "tooltip"="bevy_text::text2d::update_text2d_layout", "fillcolor"="#e9bbff", "fontname"="Helvetica", "fontcolor"="#220032", "color"="#c855ff", "penwidth"="1"]
+		"node_System(113)" ["label"="bevy_ui::widget::text::text_system", "tooltip"="bevy_ui::widget::text::text_system", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		"node_System(118)" ["label"="bevy_ui::widget::image::update_image_calculated_size_system", "tooltip"="bevy_ui::widget::image::update_image_calculated_size_system", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		"node_System(121)" ["label"="bevy_ui::update::update_clipping_system", "tooltip"="bevy_ui::update::update_clipping_system", "fillcolor"="#ffb1e5", "fontname"="Helvetica", "fontcolor"="#320021", "color"="#ff4bc2", "penwidth"="1"]
+		"node_System(154)" ["label"="bevy_audio::audio_output::play_queued_audio_system<bevy_audio::audio_source::AudioSource>", "tooltip"="bevy_audio::audio_output::play_queued_audio_system<bevy_audio::audio_source::AudioSource>", "fillcolor"="#98f1d1", "fontname"="Helvetica", "fontcolor"="#062c1e", "color"="#3ee4a8", "penwidth"="1"]
+		"node_System(159)" ["label"="bevy_animation::animation_player", "tooltip"="bevy_animation::animation_player", "fillcolor"="#ffbdb9", "fontname"="Helvetica", "fontcolor"="#320200", "color"="#ff5c53", "penwidth"="1"]
+		"node_System(170)" ["label"="decentra_bevy::scene_runner::initialize_scene::process_realm_change", "tooltip"="decentra_bevy::scene_runner::initialize_scene::process_realm_change", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(171)" ["label"="decentra_bevy::scene_runner::initialize_scene::load_active_entities", "tooltip"="decentra_bevy::scene_runner::initialize_scene::load_active_entities", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(172)" ["label"="decentra_bevy::scene_runner::initialize_scene::process_scene_lifecycle", "tooltip"="decentra_bevy::scene_runner::initialize_scene::process_scene_lifecycle", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(209)" ["label"="bevy_egui::update_egui_textures_system", "tooltip"="bevy_egui::update_egui_textures_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(220)" ["label"="bevy_atmosphere::plugin::atmosphere_insert", "tooltip"="bevy_atmosphere::plugin::atmosphere_insert", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(221)" ["label"="bevy_atmosphere::plugin::atmosphere_remove", "tooltip"="bevy_atmosphere::plugin::atmosphere_remove", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+		"node_System(226)" ["label"="bevy_diagnostic::log_diagnostics_plugin::LogDiagnosticsPlugin::log_diagnostics_system", "tooltip"="bevy_diagnostic::log_diagnostics_plugin::LogDiagnosticsPlugin::log_diagnostics_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(12)" {
+		"style"="rounded,filled";
+		"label"="Last";
+		"tooltip"="Last";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(12)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(6)" ["label"="bevy_core::tick_global_task_pools", "tooltip"="bevy_core::tick_global_task_pools", "fillcolor"="#3e583c", "fontname"="Helvetica", "fontcolor"="#e1eae0", "color"="#689465", "penwidth"="1"]
+		"node_System(7)" ["label"="bevy_core::update_frame_count", "tooltip"="bevy_core::update_frame_count", "fillcolor"="#3e583c", "fontname"="Helvetica", "fontcolor"="#e1eae0", "color"="#689465", "penwidth"="1"]
+		"node_System(10)" ["label"="bevy_hierarchy::valid_parent_check_plugin::check_hierarchy_component_has_valid_parent<bevy_transform::components::global_transform::GlobalTransform>", "tooltip"="bevy_hierarchy::valid_parent_check_plugin::check_hierarchy_component_has_valid_parent<bevy_transform::components::global_transform::GlobalTransform>", "fillcolor"="#e4fba3", "fontname"="Helvetica", "fontcolor"="#243002", "color"="#c7f641", "penwidth"="1"]
+		"node_System(69)" ["label"="bevy_winit::system::changed_window", "tooltip"="bevy_winit::system::changed_window", "fillcolor"="#664f72", "fontname"="Helvetica", "fontcolor"="#e6e0ea", "color"="#9980a6", "penwidth"="1"]
+		"node_System(70)" ["label"="bevy_winit::system::despawn_window", "tooltip"="bevy_winit::system::despawn_window", "fillcolor"="#664f72", "fontname"="Helvetica", "fontcolor"="#e6e0ea", "color"="#9980a6", "penwidth"="1"]
+		"node_System(79)" ["label"="bevy_hierarchy::valid_parent_check_plugin::check_hierarchy_component_has_valid_parent<bevy_render::view::visibility::ComputedVisibility>", "tooltip"="bevy_hierarchy::valid_parent_check_plugin::check_hierarchy_component_has_valid_parent<bevy_render::view::visibility::ComputedVisibility>", "fillcolor"="#e4fba3", "fontname"="Helvetica", "fontcolor"="#243002", "color"="#c7f641", "penwidth"="1"]
+		"node_System(210)" ["label"="bevy_egui::free_egui_textures_system", "tooltip"="bevy_egui::free_egui_textures_system", "fillcolor"="#eff1f3", "fontname"="Helvetica", "fontcolor"="#15191d", "color"="#b4bec7", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(60)" {
+		"style"="rounded,filled";
+		"label"="AssetEvents";
+		"tooltip"="AssetEvents";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(60)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(47)" ["label"="bevy_asset::assets::Assets<decentra_bevy::ipfs::SceneDefinition>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<decentra_bevy::ipfs::SceneDefinition>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(50)" ["label"="bevy_asset::assets::Assets<decentra_bevy::ipfs::SceneJsFile>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<decentra_bevy::ipfs::SceneJsFile>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(53)" ["label"="bevy_asset::assets::Assets<decentra_bevy::ipfs::SceneMeta>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<decentra_bevy::ipfs::SceneMeta>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(61)" ["label"="bevy_asset::assets::Assets<bevy_scene::dynamic_scene::DynamicScene>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_scene::dynamic_scene::DynamicScene>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(64)" ["label"="bevy_asset::assets::Assets<bevy_scene::scene::Scene>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_scene::scene::Scene>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(76)" ["label"="bevy_asset::assets::Assets<bevy_render::render_resource::shader::Shader>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_render::render_resource::shader::Shader>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(90)" ["label"="bevy_asset::assets::Assets<bevy_render::mesh::mesh::Mesh>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_render::mesh::mesh::Mesh>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(93)" ["label"="bevy_asset::assets::Assets<bevy_render::mesh::mesh::skinning::SkinnedMeshInverseBindposes>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_render::mesh::mesh::skinning::SkinnedMeshInverseBindposes>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(96)" ["label"="bevy_asset::assets::Assets<bevy_render::texture::image::Image>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_render::texture::image::Image>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(99)" ["label"="bevy_asset::assets::Assets<bevy_sprite::texture_atlas::TextureAtlas>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_sprite::texture_atlas::TextureAtlas>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(102)" ["label"="bevy_asset::assets::Assets<bevy_sprite::mesh2d::color_material::ColorMaterial>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_sprite::mesh2d::color_material::ColorMaterial>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(105)" ["label"="bevy_asset::assets::Assets<bevy_text::font::Font>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_text::font::Font>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(108)" ["label"="bevy_asset::assets::Assets<bevy_text::font_atlas_set::FontAtlasSet>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_text::font_atlas_set::FontAtlasSet>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(122)" ["label"="bevy_asset::assets::Assets<bevy_pbr::pbr_material::StandardMaterial>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_pbr::pbr_material::StandardMaterial>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(133)" ["label"="bevy_asset::assets::Assets<bevy_gltf::Gltf>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_gltf::Gltf>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(136)" ["label"="bevy_asset::assets::Assets<bevy_gltf::GltfNode>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_gltf::GltfNode>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(139)" ["label"="bevy_asset::assets::Assets<bevy_gltf::GltfPrimitive>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_gltf::GltfPrimitive>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(142)" ["label"="bevy_asset::assets::Assets<bevy_gltf::GltfMesh>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_gltf::GltfMesh>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(145)" ["label"="bevy_asset::assets::Assets<bevy_audio::audio_source::AudioSource>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_audio::audio_source::AudioSource>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(148)" ["label"="bevy_asset::assets::Assets<bevy_audio::sinks::AudioSink>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_audio::sinks::AudioSink>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(151)" ["label"="bevy_asset::assets::Assets<bevy_audio::sinks::SpatialAudioSink>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_audio::sinks::SpatialAudioSink>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(156)" ["label"="bevy_asset::assets::Assets<bevy_animation::AnimationClip>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_animation::AnimationClip>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(189)" ["label"="bevy_asset::assets::Assets<decentra_bevy::scene_runner::update_world::gltf_container::GltfCachedShape>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<decentra_bevy::scene_runner::update_world::gltf_container::GltfCachedShape>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(216)" ["label"="bevy_asset::assets::Assets<bevy_atmosphere::skybox::SkyBoxMaterial>::asset_event_system", "tooltip"="bevy_asset::assets::Assets<bevy_atmosphere::skybox::SkyBoxMaterial>::asset_event_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(62)" {
+		"style"="rounded,filled";
+		"label"="LoadAssets";
+		"tooltip"="LoadAssets";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(62)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+		"node_System(48)" ["label"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::ipfs::SceneDefinition>", "tooltip"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::ipfs::SceneDefinition>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(51)" ["label"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::ipfs::SceneJsFile>", "tooltip"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::ipfs::SceneJsFile>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(54)" ["label"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::ipfs::SceneMeta>", "tooltip"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::ipfs::SceneMeta>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(60)" ["label"="bevy_asset::io::file_asset_io::filesystem_watcher_system", "tooltip"="bevy_asset::io::file_asset_io::filesystem_watcher_system", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(62)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_scene::dynamic_scene::DynamicScene>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_scene::dynamic_scene::DynamicScene>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(65)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_scene::scene::Scene>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_scene::scene::Scene>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(77)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_render::render_resource::shader::Shader>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_render::render_resource::shader::Shader>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(91)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_render::mesh::mesh::Mesh>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_render::mesh::mesh::Mesh>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(94)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_render::mesh::mesh::skinning::SkinnedMeshInverseBindposes>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_render::mesh::mesh::skinning::SkinnedMeshInverseBindposes>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(97)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_render::texture::image::Image>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_render::texture::image::Image>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(100)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_sprite::texture_atlas::TextureAtlas>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_sprite::texture_atlas::TextureAtlas>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(103)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_sprite::mesh2d::color_material::ColorMaterial>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_sprite::mesh2d::color_material::ColorMaterial>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(106)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_text::font::Font>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_text::font::Font>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(109)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_text::font_atlas_set::FontAtlasSet>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_text::font_atlas_set::FontAtlasSet>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(123)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_pbr::pbr_material::StandardMaterial>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_pbr::pbr_material::StandardMaterial>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(134)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::Gltf>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::Gltf>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(137)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::GltfNode>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::GltfNode>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(140)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::GltfPrimitive>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::GltfPrimitive>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(143)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::GltfMesh>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_gltf::GltfMesh>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(146)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_audio::audio_source::AudioSource>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_audio::audio_source::AudioSource>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(149)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_audio::sinks::AudioSink>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_audio::sinks::AudioSink>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(152)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_audio::sinks::SpatialAudioSink>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_audio::sinks::SpatialAudioSink>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(157)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_animation::AnimationClip>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_animation::AnimationClip>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(190)" ["label"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::scene_runner::update_world::gltf_container::GltfCachedShape>", "tooltip"="bevy_asset::loader::update_asset_storage_system<decentra_bevy::scene_runner::update_world::gltf_container::GltfCachedShape>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+		"node_System(217)" ["label"="bevy_asset::loader::update_asset_storage_system<bevy_atmosphere::skybox::SkyBoxMaterial>", "tooltip"="bevy_asset::loader::update_asset_storage_system<bevy_atmosphere::skybox::SkyBoxMaterial>", "fillcolor"="#d1cbc5", "fontname"="Helvetica", "fontcolor"="#1c1916", "color"="#a3978c", "penwidth"="1"]
+	}
+	
+	subgraph "clusternode_Set(191)" {
+		"style"="rounded,filled";
+		"label"="DrawLines";
+		"tooltip"="DrawLines";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(191)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+	}
+	
+	subgraph "clusternode_Set(238)" {
+		"style"="rounded,filled";
+		"label"="InitContexts";
+		"tooltip"="InitContexts";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(238)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+	}
+	
+	subgraph "clusternode_Set(241)" {
+		"style"="rounded,filled";
+		"label"="ProcessInput";
+		"tooltip"="ProcessInput";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(241)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+	}
+	
+	subgraph "clusternode_Set(243)" {
+		"style"="rounded,filled";
+		"label"="BeginFrame";
+		"tooltip"="BeginFrame";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(243)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+	}
+	
+	subgraph "clusternode_Set(245)" {
+		"style"="rounded,filled";
+		"label"="ProcessOutput";
+		"tooltip"="ProcessOutput";
+		"fillcolor"="#ffffff44";
+		"color"="#ffffff50";
+		"penwidth"="2";
+		"set_marker_node_Set(245)" ["style"="invis", "label"="", "height"="0", "shape"="point"]
+	}
+	
+	"node_System(160)" -> "set_marker_node_Set(11)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(11)"]
+	"node_System(160)" -> "set_marker_node_Set(191)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(191)"]
+	"node_System(160)" ["label"="bevy_prototype_debug_lines::update
+In multiple sets, PostUpdate, DrawLines", "tooltip"="bevy_prototype_debug_lines::update"]
+	"node_System(203)" -> "set_marker_node_Set(8)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(8)"]
+	"node_System(203)" -> "set_marker_node_Set(238)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(238)"]
+	"node_System(203)" ["label"="bevy_egui::setup_new_windows_system
+In multiple sets, PreUpdate, InitContexts", "tooltip"="bevy_egui::setup_new_windows_system"]
+	"node_System(204)" -> "set_marker_node_Set(8)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(8)"]
+	"node_System(204)" -> "set_marker_node_Set(238)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(238)"]
+	"node_System(204)" ["label"="bevy_ecs::schedule::executor::apply_system_buffers
+In multiple sets, PreUpdate, InitContexts", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers"]
+	"node_System(205)" -> "set_marker_node_Set(8)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(8)"]
+	"node_System(205)" -> "set_marker_node_Set(238)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(238)"]
+	"node_System(205)" ["label"="bevy_egui::systems::update_window_contexts_system
+In multiple sets, PreUpdate, InitContexts", "tooltip"="bevy_egui::systems::update_window_contexts_system"]
+	"node_System(206)" -> "set_marker_node_Set(8)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(8)"]
+	"node_System(206)" -> "set_marker_node_Set(241)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(241)"]
+	"node_System(206)" ["label"="bevy_egui::systems::process_input_system
+In multiple sets, PreUpdate, ProcessInput", "tooltip"="bevy_egui::systems::process_input_system"]
+	"node_System(207)" -> "set_marker_node_Set(8)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(8)"]
+	"node_System(207)" -> "set_marker_node_Set(243)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(243)"]
+	"node_System(207)" ["label"="bevy_egui::systems::begin_frame_system
+In multiple sets, PreUpdate, BeginFrame", "tooltip"="bevy_egui::systems::begin_frame_system"]
+	"node_System(208)" -> "set_marker_node_Set(11)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(11)"]
+	"node_System(208)" -> "set_marker_node_Set(245)" ["dir"="none", "color"="blue", "lhead"="clusternode_Set(245)"]
+	"node_System(208)" ["label"="bevy_egui::systems::process_output_system
+In multiple sets, PostUpdate, ProcessOutput", "tooltip"="bevy_egui::systems::process_output_system"]
+	"set_marker_node_Set(7)" -> "set_marker_node_Set(2)" ["lhead"="clusternode_Set(2)", "ltail"="clusternode_Set(7)", "tooltip"="First → FirstFlush", "color"="#eede00"]
+	"set_marker_node_Set(2)" -> "set_marker_node_Set(8)" ["lhead"="clusternode_Set(8)", "ltail"="clusternode_Set(2)", "tooltip"="FirstFlush → PreUpdate", "color"="#881877"]
+	"set_marker_node_Set(8)" -> "set_marker_node_Set(3)" ["lhead"="clusternode_Set(3)", "ltail"="clusternode_Set(8)", "tooltip"="PreUpdate → PreUpdateFlush", "color"="#00b0cc"]
+	"set_marker_node_Set(3)" -> "set_marker_node_Set(9)" ["lhead"="clusternode_Set(9)", "ltail"="clusternode_Set(3)", "tooltip"="PreUpdateFlush → StateTransitions", "color"="#aa3a55"]
+	"set_marker_node_Set(9)" -> "set_marker_node_Set(10)" ["lhead"="clusternode_Set(10)", "ltail"="clusternode_Set(9)", "tooltip"="StateTransitions → FixedUpdate", "color"="#44d488"]
+	"set_marker_node_Set(10)" -> "set_marker_node_Set(0)" ["lhead"="clusternode_Set(0)", "ltail"="clusternode_Set(10)", "tooltip"="FixedUpdate → Update", "color"="#0090cc"]
+	"set_marker_node_Set(0)" -> "set_marker_node_Set(4)" ["lhead"="clusternode_Set(4)", "ltail"="clusternode_Set(0)", "tooltip"="Update → UpdateFlush", "color"="#ee9e44"]
+	"set_marker_node_Set(4)" -> "set_marker_node_Set(11)" ["lhead"="clusternode_Set(11)", "ltail"="clusternode_Set(4)", "tooltip"="UpdateFlush → PostUpdate", "color"="#663699"]
+	"set_marker_node_Set(11)" -> "set_marker_node_Set(5)" ["lhead"="clusternode_Set(5)", "ltail"="clusternode_Set(11)", "tooltip"="PostUpdate → PostUpdateFlush", "color"="#3363bb"]
+	"set_marker_node_Set(5)" -> "set_marker_node_Set(12)" ["lhead"="clusternode_Set(12)", "ltail"="clusternode_Set(5)", "tooltip"="PostUpdateFlush → Last", "color"="#22c2bb"]
+	"set_marker_node_Set(12)" -> "set_marker_node_Set(6)" ["lhead"="clusternode_Set(6)", "ltail"="clusternode_Set(12)", "tooltip"="Last → LastFlush", "color"="#99d955"]
+	"node_System(24)" -> "node_System(25)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_input::gamepad::gamepad_event_system\") → bevy_input::gamepad::gamepad_connection_system", "color"="#eede00"]
+	"node_System(24)" -> "node_System(26)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_input::gamepad::gamepad_event_system\") → bevy_input::gamepad::gamepad_button_event_system", "color"="#881877"]
+	"node_System(25)" -> "node_System(26)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_input::gamepad::gamepad_connection_system\") → bevy_input::gamepad::gamepad_button_event_system", "color"="#00b0cc"]
+	"node_System(24)" -> "node_System(27)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_input::gamepad::gamepad_event_system\") → bevy_input::gamepad::gamepad_axis_event_system", "color"="#aa3a55"]
+	"node_System(25)" -> "node_System(27)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_input::gamepad::gamepad_connection_system\") → bevy_input::gamepad::gamepad_axis_event_system", "color"="#44d488"]
+	"set_marker_node_Set(62)" -> "set_marker_node_Set(8)" ["lhead"="clusternode_Set(8)", "ltail"="clusternode_Set(62)", "tooltip"="LoadAssets → PreUpdate", "color"="#0090cc"]
+	"set_marker_node_Set(7)" -> "set_marker_node_Set(62)" ["lhead"="clusternode_Set(62)", "ltail"="clusternode_Set(7)", "tooltip"="First → LoadAssets", "color"="#ee9e44"]
+	"set_marker_node_Set(11)" -> "set_marker_node_Set(60)" ["lhead"="clusternode_Set(60)", "ltail"="clusternode_Set(11)", "tooltip"="PostUpdate → AssetEvents", "color"="#663699"]
+	"set_marker_node_Set(60)" -> "set_marker_node_Set(12)" ["lhead"="clusternode_Set(12)", "ltail"="clusternode_Set(60)", "tooltip"="AssetEvents → Last", "color"="#3363bb"]
+	"node_System(69)" -> "node_System(70)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_winit::system::changed_window\") → bevy_winit::system::despawn_window", "color"="#22c2bb"]
+	"set_marker_node_Set(99)" -> "set_marker_node_Set(100)" ["lhead"="clusternode_Set(100)", "ltail"="clusternode_Set(99)", "tooltip"="CalculateBounds → CalculateBoundsFlush", "color"="#99d955"]
+	"node_System(81)" -> "node_System(85)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_render::camera::camera::camera_system<bevy_render::camera::projection::OrthographicProjection>\") → bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::OrthographicProjection>", "color"="#eede00"]
+	"set_marker_node_Set(20)" -> "node_System(85)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::OrthographicProjection>", "color"="#881877"]
+	"node_System(82)" -> "node_System(86)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_render::camera::camera::camera_system<bevy_render::camera::projection::PerspectiveProjection>\") → bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::PerspectiveProjection>", "color"="#00b0cc"]
+	"set_marker_node_Set(20)" -> "node_System(86)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::PerspectiveProjection>", "color"="#aa3a55"]
+	"node_System(80)" -> "node_System(87)" ["lhead"="", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_render::camera::camera::camera_system<bevy_render::camera::projection::Projection>\") → bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::Projection>", "color"="#44d488"]
+	"set_marker_node_Set(20)" -> "node_System(87)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_render::view::visibility::update_frusta<bevy_render::camera::projection::Projection>", "color"="#0090cc"]
+	"set_marker_node_Set(100)" -> "node_System(89)" ["lhead"="", "ltail"="clusternode_Set(100)", "tooltip"="CalculateBoundsFlush → bevy_render::view::visibility::check_visibility", "color"="#ee9e44"]
+	"set_marker_node_Set(101)" -> "node_System(89)" ["lhead"="", "ltail"="clusternode_Set(101)", "tooltip"="UpdateOrthographicFrusta → bevy_render::view::visibility::check_visibility", "color"="#663699"]
+	"set_marker_node_Set(102)" -> "node_System(89)" ["lhead"="", "ltail"="clusternode_Set(102)", "tooltip"="UpdatePerspectiveFrusta → bevy_render::view::visibility::check_visibility", "color"="#3363bb"]
+	"set_marker_node_Set(103)" -> "node_System(89)" ["lhead"="", "ltail"="clusternode_Set(103)", "tooltip"="UpdateProjectionFrusta → bevy_render::view::visibility::check_visibility", "color"="#22c2bb"]
+	"set_marker_node_Set(105)" -> "node_System(89)" ["lhead"="", "ltail"="clusternode_Set(105)", "tooltip"="VisibilityPropagate → bevy_render::view::visibility::check_visibility", "color"="#99d955"]
+	"set_marker_node_Set(20)" -> "node_System(89)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_render::view::visibility::check_visibility", "color"="#eede00"]
+	"set_marker_node_Set(25)" -> "node_System(112)" ["lhead"="", "ltail"="clusternode_Set(25)", "tooltip"="InputSystem → bevy_ui::focus::ui_focus_system", "color"="#881877"]
+	"node_System(113)" -> "set_marker_node_Set(135)" ["lhead"="clusternode_Set(135)", "ltail"="", "tooltip"="bevy_ui::widget::text::text_system → Flex", "color"="#00b0cc"]
+	"node_System(118)" -> "set_marker_node_Set(135)" ["lhead"="clusternode_Set(135)", "ltail"="", "tooltip"="bevy_ui::widget::image::update_image_calculated_size_system → Flex", "color"="#aa3a55"]
+	"node_System(119)" -> "set_marker_node_Set(20)" ["lhead"="clusternode_Set(20)", "ltail"="", "tooltip"="bevy_ui::flex::flex_node_system → TransformPropagate", "color"="#44d488"]
+	"set_marker_node_Set(20)" -> "node_System(121)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_ui::update::update_clipping_system", "color"="#0090cc"]
+	"set_marker_node_Set(150)" -> "set_marker_node_Set(151)" ["lhead"="clusternode_Set(151)", "ltail"="clusternode_Set(150)", "tooltip"="AddClusters → AddClustersFlush", "color"="#ee9e44"]
+	"set_marker_node_Set(151)" -> "set_marker_node_Set(152)" ["lhead"="clusternode_Set(152)", "ltail"="clusternode_Set(151)", "tooltip"="AddClustersFlush → AssignLightsToClusters", "color"="#663699"]
+	"set_marker_node_Set(20)" -> "node_System(127)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_pbr::light::assign_lights_to_clusters", "color"="#3363bb"]
+	"set_marker_node_Set(104)" -> "node_System(127)" ["lhead"="", "ltail"="clusternode_Set(104)", "tooltip"="CheckVisibility → bevy_pbr::light::assign_lights_to_clusters", "color"="#22c2bb"]
+	"set_marker_node_Set(95)" -> "node_System(127)" ["lhead"="", "ltail"="clusternode_Set(95)", "tooltip"="CameraUpdateSystem → bevy_pbr::light::assign_lights_to_clusters", "color"="#99d955"]
+	"set_marker_node_Set(20)" -> "node_System(128)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_pbr::light::update_directional_light_cascades", "color"="#eede00"]
+	"set_marker_node_Set(95)" -> "node_System(128)" ["lhead"="", "ltail"="clusternode_Set(95)", "tooltip"="CameraUpdateSystem → bevy_pbr::light::update_directional_light_cascades", "color"="#881877"]
+	"set_marker_node_Set(104)" -> "node_System(129)" ["lhead"="", "ltail"="clusternode_Set(104)", "tooltip"="CheckVisibility → bevy_pbr::light::update_directional_light_frusta", "color"="#00b0cc"]
+	"set_marker_node_Set(20)" -> "node_System(129)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_pbr::light::update_directional_light_frusta", "color"="#aa3a55"]
+	"set_marker_node_Set(154)" -> "node_System(129)" ["lhead"="", "ltail"="clusternode_Set(154)", "tooltip"="UpdateDirectionalLightCascades → bevy_pbr::light::update_directional_light_frusta", "color"="#44d488"]
+	"set_marker_node_Set(20)" -> "node_System(130)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_pbr::light::update_point_light_frusta", "color"="#0090cc"]
+	"set_marker_node_Set(152)" -> "node_System(130)" ["lhead"="", "ltail"="clusternode_Set(152)", "tooltip"="AssignLightsToClusters → bevy_pbr::light::update_point_light_frusta", "color"="#ee9e44"]
+	"set_marker_node_Set(20)" -> "node_System(131)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_pbr::light::update_spot_light_frusta", "color"="#663699"]
+	"set_marker_node_Set(152)" -> "node_System(131)" ["lhead"="", "ltail"="clusternode_Set(152)", "tooltip"="AssignLightsToClusters → bevy_pbr::light::update_spot_light_frusta", "color"="#3363bb"]
+	"set_marker_node_Set(100)" -> "node_System(132)" ["lhead"="", "ltail"="clusternode_Set(100)", "tooltip"="CalculateBoundsFlush → bevy_pbr::light::check_light_mesh_visibility", "color"="#22c2bb"]
+	"set_marker_node_Set(20)" -> "node_System(132)" ["lhead"="", "ltail"="clusternode_Set(20)", "tooltip"="TransformPropagate → bevy_pbr::light::check_light_mesh_visibility", "color"="#99d955"]
+	"set_marker_node_Set(155)" -> "node_System(132)" ["lhead"="", "ltail"="clusternode_Set(155)", "tooltip"="UpdateLightFrusta → bevy_pbr::light::check_light_mesh_visibility", "color"="#eede00"]
+	"set_marker_node_Set(104)" -> "node_System(132)" ["lhead"="", "ltail"="clusternode_Set(104)", "tooltip"="CheckVisibility → bevy_pbr::light::check_light_mesh_visibility", "color"="#881877"]
+	"node_System(155)" -> "set_marker_node_Set(25)" ["lhead"="clusternode_Set(25)", "ltail"="", "tooltip"="bevy_gilrs::gilrs_system::gilrs_event_system → InputSystem", "color"="#00b0cc"]
+	"node_System(159)" -> "set_marker_node_Set(20)" ["lhead"="clusternode_Set(20)", "ltail"="", "tooltip"="bevy_animation::animation_player → TransformPropagate", "color"="#aa3a55"]
+	"node_System(67)" -> "set_marker_node_Set(193)" ["lhead"="clusternode_Set(193)", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_scene::scene_spawner::scene_spawner_system\") → Init", "color"="#44d488"]
+	"set_marker_node_Set(193)" -> "set_marker_node_Set(194)" ["lhead"="clusternode_Set(194)", "ltail"="clusternode_Set(193)", "tooltip"="Init → PostInit", "color"="#0090cc"]
+	"set_marker_node_Set(194)" -> "set_marker_node_Set(195)" ["lhead"="clusternode_Set(195)", "ltail"="clusternode_Set(194)", "tooltip"="PostInit → Input", "color"="#ee9e44"]
+	"set_marker_node_Set(195)" -> "set_marker_node_Set(196)" ["lhead"="clusternode_Set(196)", "ltail"="clusternode_Set(195)", "tooltip"="Input → RunLoop", "color"="#663699"]
+	"set_marker_node_Set(196)" -> "set_marker_node_Set(197)" ["lhead"="clusternode_Set(197)", "ltail"="clusternode_Set(196)", "tooltip"="RunLoop → PostLoop", "color"="#3363bb"]
+	"set_marker_node_Set(193)" -> "node_System(162)" ["lhead"="", "ltail"="clusternode_Set(193)", "tooltip"="Init → bevy_ecs::schedule::executor::apply_system_buffers", "color"="#22c2bb"]
+	"node_System(162)" -> "set_marker_node_Set(194)" ["lhead"="clusternode_Set(194)", "ltail"="", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers → PostInit", "color"="#99d955"]
+	"set_marker_node_Set(194)" -> "node_System(163)" ["lhead"="", "ltail"="clusternode_Set(194)", "tooltip"="PostInit → bevy_ecs::schedule::executor::apply_system_buffers", "color"="#eede00"]
+	"node_System(163)" -> "set_marker_node_Set(195)" ["lhead"="clusternode_Set(195)", "ltail"="", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers → Input", "color"="#881877"]
+	"set_marker_node_Set(195)" -> "node_System(164)" ["lhead"="", "ltail"="clusternode_Set(195)", "tooltip"="Input → bevy_ecs::schedule::executor::apply_system_buffers", "color"="#00b0cc"]
+	"node_System(164)" -> "set_marker_node_Set(196)" ["lhead"="clusternode_Set(196)", "ltail"="", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers → RunLoop", "color"="#aa3a55"]
+	"set_marker_node_Set(196)" -> "node_System(165)" ["lhead"="", "ltail"="clusternode_Set(196)", "tooltip"="RunLoop → bevy_ecs::schedule::executor::apply_system_buffers", "color"="#44d488"]
+	"node_System(165)" -> "set_marker_node_Set(197)" ["lhead"="clusternode_Set(197)", "ltail"="", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers → PostLoop", "color"="#0090cc"]
+	"node_System(170)" -> "node_System(171)" ["lhead"="", "ltail"="", "tooltip"="decentra_bevy::scene_runner::initialize_scene::process_realm_change → decentra_bevy::scene_runner::initialize_scene::load_active_entities", "color"="#ee9e44"]
+	"node_System(171)" -> "node_System(172)" ["lhead"="", "ltail"="", "tooltip"="decentra_bevy::scene_runner::initialize_scene::load_active_entities → decentra_bevy::scene_runner::initialize_scene::process_scene_lifecycle", "color"="#663699"]
+	"node_System(173)" -> "node_System(174)" ["lhead"="", "ltail"="", "tooltip"="decentra_bevy::scene_runner::update_scene_priority → decentra_bevy::scene_runner::run_scene_loop", "color"="#3363bb"]
+	"set_marker_node_Set(234)" -> "set_marker_node_Set(73)" ["lhead"="clusternode_Set(73)", "ltail"="clusternode_Set(234)", "tooltip"="ConsoleUI → Commands", "color"="#22c2bb"]
+	"set_marker_node_Set(73)" -> "set_marker_node_Set(236)" ["lhead"="clusternode_Set(236)", "ltail"="clusternode_Set(73)", "tooltip"="Commands → PostCommands", "color"="#99d955"]
+	"node_System(203)" -> "node_System(204)" ["lhead"="", "ltail"="", "tooltip"="bevy_egui::setup_new_windows_system → bevy_ecs::schedule::executor::apply_system_buffers", "color"="#eede00"]
+	"node_System(204)" -> "node_System(205)" ["lhead"="", "ltail"="", "tooltip"="bevy_ecs::schedule::executor::apply_system_buffers → bevy_egui::systems::update_window_contexts_system", "color"="#881877"]
+	"set_marker_node_Set(25)" -> "node_System(206)" ["lhead"="", "ltail"="clusternode_Set(25)", "tooltip"="InputSystem → bevy_egui::systems::process_input_system", "color"="#00b0cc"]
+	"set_marker_node_Set(238)" -> "node_System(206)" ["lhead"="", "ltail"="clusternode_Set(238)", "tooltip"="InitContexts → bevy_egui::systems::process_input_system", "color"="#aa3a55"]
+	"set_marker_node_Set(241)" -> "node_System(207)" ["lhead"="", "ltail"="clusternode_Set(241)", "tooltip"="ProcessInput → bevy_egui::systems::begin_frame_system", "color"="#44d488"]
+	"set_marker_node_Set(245)" -> "node_System(209)" ["lhead"="", "ltail"="clusternode_Set(245)", "tooltip"="ProcessOutput → bevy_egui::update_egui_textures_system", "color"="#0090cc"]
+	"node_System(67)" -> "set_marker_node_Set(234)" ["lhead"="clusternode_Set(234)", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_scene::scene_spawner::scene_spawner_system\") → ConsoleUI", "color"="#ee9e44"]
+	"node_System(67)" -> "set_marker_node_Set(73)" ["lhead"="clusternode_Set(73)", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_scene::scene_spawner::scene_spawner_system\") → Commands", "color"="#663699"]
+	"set_marker_node_Set(236)" -> "set_marker_node_Set(193)" ["lhead"="clusternode_Set(193)", "ltail"="clusternode_Set(236)", "tooltip"="PostCommands → Init", "color"="#3363bb"]
+	"node_System(67)" -> "set_marker_node_Set(236)" ["lhead"="clusternode_Set(236)", "ltail"="", "tooltip"="SystemTypeSet(\"bevy_scene::scene_spawner::scene_spawner_system\") → PostCommands", "color"="#22c2bb"]
+	"set_marker_node_Set(196)" -> "node_System(228)" ["lhead"="", "ltail"="clusternode_Set(196)", "tooltip"="RunLoop → decentra_bevy::input", "color"="#99d955"]
+}

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -1,9 +1,11 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, scene::scene_spawner_system};
 use bevy_console::{
-    Command, ConsoleCommand, ConsoleCommandEntered, ConsoleConfiguration, PrintConsoleLine,
-    ToggleConsoleKey,
+    Command, ConsoleCommand, ConsoleCommandEntered, ConsoleConfiguration, ConsoleSet,
+    PrintConsoleLine, ToggleConsoleKey,
 };
 use clap::Parser;
+
+use crate::scene_runner::SceneSets;
 
 pub trait DoAddConsoleCommand {
     fn add_console_command<T: Command, U>(&mut self, system: impl IntoSystemConfig<U>)
@@ -42,6 +44,16 @@ impl Plugin for ConsolePlugin {
         .add_console_command::<ExitCommand, _>(exit_command)
         .init_resource::<PendingCommands>()
         .add_system(send_pending);
+
+        app.configure_sets(
+            (
+                ConsoleSet::ConsoleUI,
+                ConsoleSet::Commands,
+                ConsoleSet::PostCommands.before(SceneSets::Init),
+            )
+                .in_base_set(CoreSet::Update)
+                .after(scene_spawner_system),
+        );
     }
 }
 

--- a/src/dcl/interface/crdt_context.rs
+++ b/src/dcl/interface/crdt_context.rs
@@ -7,14 +7,14 @@ use crate::{
 
 type LiveTable = Vec<(u16, bool)>;
 
-pub struct SceneSceneContext {
+pub struct CrdtContext {
     pub scene_id: SceneId,
     live_entities: LiveTable,
     nascent: HashSet<SceneEntityId>,
     death_row: HashSet<SceneEntityId>,
 }
 
-impl SceneSceneContext {
+impl CrdtContext {
     pub fn new(scene_id: SceneId) -> Self {
         Self {
             scene_id,

--- a/src/dcl/interface/mod.rs
+++ b/src/dcl/interface/mod.rs
@@ -2,19 +2,35 @@
 // note that take_updates assumes a single lossless reader will be synchronised -
 // it resets internal "updated" markers (for lww) and removes unneeded data (for go)
 
-use bevy::utils::{HashMap, HashSet};
+use bevy::{
+    prelude::{debug, error, warn},
+    utils::{HashMap, HashSet},
+};
+use num::{FromPrimitive, ToPrimitive};
+use num_derive::{FromPrimitive, ToPrimitive};
 
-use crate::dcl_component::{DclReader, SceneComponentId, SceneCrdtTimestamp, SceneEntityId};
+use crate::{
+    dcl_assert,
+    dcl_component::{
+        DclReader, DclReaderError, DclWriter, SceneComponentId, SceneCrdtTimestamp, SceneEntityId,
+        ToDclWriter,
+    },
+};
+
+use self::crdt_context::CrdtContext;
 
 use super::crdt::{growonly::CrdtGOState, lww::CrdtLWWState};
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+pub mod crdt_context;
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum ComponentPosition {
     RootOnly,
     EntityOnly,
+    Any,
 }
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum CrdtType {
     LWW(ComponentPosition),
     GO(ComponentPosition),
@@ -23,7 +39,9 @@ pub enum CrdtType {
 impl CrdtType {
     pub const LWW_ROOT: CrdtType = CrdtType::LWW(ComponentPosition::RootOnly);
     pub const LWW_ENT: CrdtType = CrdtType::LWW(ComponentPosition::EntityOnly);
+    pub const LWW_ANY: CrdtType = CrdtType::LWW(ComponentPosition::Any);
     pub const GO_ENT: CrdtType = CrdtType::GO(ComponentPosition::EntityOnly);
+    pub const GO_ANY: CrdtType = CrdtType::GO(ComponentPosition::Any);
 
     pub fn position(&self) -> ComponentPosition {
         match self {
@@ -33,7 +51,25 @@ impl CrdtType {
     }
 }
 
+#[derive(Default)]
 pub struct CrdtComponentInterfaces(pub HashMap<SceneComponentId, CrdtType>);
+
+const CRDT_HEADER_SIZE: usize = 8;
+
+#[derive(FromPrimitive, ToPrimitive, Debug)]
+pub enum CrdtMessageType {
+    PutComponent = 1,
+    DeleteComponent = 2,
+
+    DeleteEntity = 3,
+    AppendValue = 4,
+}
+
+impl ToDclWriter for CrdtMessageType {
+    fn to_writer(&self, buf: &mut DclWriter) {
+        buf.write_u32(ToPrimitive::to_u32(self).unwrap())
+    }
+}
 
 #[derive(Default, Debug)]
 pub struct CrdtStore {
@@ -115,5 +151,147 @@ impl CrdtStore {
 
         let go = std::mem::take(&mut self.go);
         CrdtStore { lww, go }
+    }
+
+    // handles a single message from the buffer
+    fn process_message(
+        &mut self,
+        writers: &CrdtComponentInterfaces,
+        entity_map: &mut CrdtContext,
+        crdt_type: CrdtMessageType,
+        stream: &mut DclReader,
+        filter_components: bool,
+    ) -> Result<(), DclReaderError> {
+        match crdt_type {
+            CrdtMessageType::PutComponent | CrdtMessageType::AppendValue => {
+                let default_writer = match crdt_type {
+                    CrdtMessageType::PutComponent => &CrdtType::LWW_ANY,
+                    CrdtMessageType::AppendValue => &CrdtType::GO_ANY,
+                    _ => unreachable!(),
+                };
+
+                let entity = stream.read()?;
+                let component = stream.read()?;
+                let timestamp = stream.read()?;
+                let content_len = stream.read_u32()? as usize;
+
+                debug!("PUT e:{entity:?}, c: {component:?}, timestamp: {timestamp:?}, content len: {content_len}");
+                dcl_assert!(content_len == stream.len());
+
+                // check for a writer
+                let writer = match writers.0.get(&component) {
+                    Some(writer) => writer,
+                    None => {
+                        if filter_components {
+                            return Ok(());
+                        }
+
+                        // if we're not filtering this must be a user component
+                        default_writer
+                    }
+                };
+
+                if core::mem::discriminant(writer) != core::mem::discriminant(default_writer) {
+                    warn!("received a {crdt_type:?} message for a {writer:?} component: {component:?}");
+                    return Ok(());
+                }
+
+                match (writer.position(), entity == SceneEntityId::ROOT) {
+                    (ComponentPosition::RootOnly, false)
+                    | (ComponentPosition::EntityOnly, true) => {
+                        warn!("invalid position for component {:?}", component);
+                        return Ok(());
+                    }
+                    _ => (),
+                }
+
+                // create the entity (if not already dead)
+                if !entity_map.init(entity) {
+                    return Ok(());
+                }
+
+                // attempt to write (may fail due to a later write)
+                self.try_update(component, *writer, entity, timestamp, Some(stream));
+            }
+            CrdtMessageType::DeleteComponent => {
+                let entity = stream.read()?;
+                let component = stream.read()?;
+                let timestamp = stream.read()?;
+
+                // check for a writer
+                let writer = match writers.0.get(&component) {
+                    Some(writer) => writer,
+                    None => {
+                        if filter_components {
+                            return Ok(());
+                        }
+
+                        // if we're not filtering this must be a user component
+                        &CrdtType::GO_ANY
+                    }
+                };
+
+                if !matches!(writer, CrdtType::LWW(_)) {
+                    warn!("received a LWW message for a GO component: {component:?}");
+                    return Ok(());
+                }
+
+                match (writer.position(), entity == SceneEntityId::ROOT) {
+                    (ComponentPosition::RootOnly, false)
+                    | (ComponentPosition::EntityOnly, true) => {
+                        warn!("invalid position for component {:?}", component);
+                        return Ok(());
+                    }
+                    _ => (),
+                }
+
+                // check the entity still lives (don't create here, no need)
+                if entity_map.is_dead(entity) {
+                    return Ok(());
+                }
+
+                // attempt to write (may fail due to a later write)
+                self.try_update(component, *writer, entity, timestamp, None);
+            }
+            CrdtMessageType::DeleteEntity => {
+                let entity = stream.read()?;
+                entity_map.kill(entity);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn process_message_stream(
+        &mut self,
+        entity_map: &mut CrdtContext,
+        writers: &CrdtComponentInterfaces,
+        stream: &mut DclReader,
+        filter_components: bool,
+    ) {
+        // collect commands
+        while stream.len() > CRDT_HEADER_SIZE {
+            let pos = stream.pos();
+            let length = stream.read_u32().unwrap() as usize;
+            let crdt_type = stream.read_u32().unwrap();
+
+            debug!("[{pos}] crdt_type: {crdt_type}, length: {length}");
+            let mut message_stream = stream.take_reader(length.saturating_sub(8));
+
+            match FromPrimitive::from_u32(crdt_type) {
+                Some(crdt_type) => {
+                    if let Err(e) = self.process_message(
+                        writers,
+                        entity_map,
+                        crdt_type,
+                        &mut message_stream,
+                        filter_components,
+                    ) {
+                        error!("CRDT Buffer error: {:?}", e);
+                    };
+                }
+                None => error!("CRDT Header error: unhandled crdt message type {crdt_type}"),
+            }
+        }
     }
 }

--- a/src/dcl/interface/mod.rs
+++ b/src/dcl/interface/mod.rs
@@ -71,7 +71,7 @@ impl ToDclWriter for CrdtMessageType {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct CrdtStore {
     pub lww: HashMap<SceneComponentId, CrdtLWWState>,
     pub go: HashMap<SceneComponentId, CrdtGOState>,

--- a/src/dcl/js/engine.rs
+++ b/src/dcl/js/engine.rs
@@ -1,45 +1,20 @@
 // Engine module
 
-use bevy::prelude::{debug, error, info, warn};
+use bevy::prelude::{debug, info};
 use deno_core::{op, OpDecl, OpState};
-use num::{FromPrimitive, ToPrimitive};
-use num_derive::{FromPrimitive, ToPrimitive};
 use std::{cell::RefCell, rc::Rc, sync::mpsc::SyncSender};
 use tokio::sync::mpsc::Receiver;
 
 use crate::{
     dcl::{
         crdt::{growonly::CrdtGOEntry, lww::LWWEntry},
-        interface::ComponentPosition,
-        CrdtComponentInterfaces, CrdtStore, RendererResponse, SceneResponse, SceneElapsedTime,
+        interface::{crdt_context::CrdtContext, CrdtMessageType},
+        CrdtComponentInterfaces, CrdtStore, RendererResponse, SceneElapsedTime, SceneResponse,
     },
-    dcl_assert,
-    dcl_component::{
-        DclReader, DclReaderError, DclWriter, SceneComponentId, SceneCrdtTimestamp, SceneEntityId,
-        ToDclWriter,
-    },
+    dcl_component::{DclReader, DclWriter, SceneComponentId, SceneCrdtTimestamp, SceneEntityId},
 };
 
 use super::ShuttingDown;
-
-use super::context::SceneSceneContext;
-
-const CRDT_HEADER_SIZE: usize = 8;
-
-#[derive(FromPrimitive, ToPrimitive, Debug)]
-pub enum CrdtMessageType {
-    PutComponent = 1,
-    DeleteComponent = 2,
-
-    DeleteEntity = 3,
-    AppendValue = 4,
-}
-
-impl ToDclWriter for CrdtMessageType {
-    fn to_writer(&self, buf: &mut DclWriter) {
-        buf.write_u32(ToPrimitive::to_u32(self).unwrap())
-    }
-}
 
 // list of op declarations
 pub fn ops() -> Vec<OpDecl> {
@@ -49,116 +24,19 @@ pub fn ops() -> Vec<OpDecl> {
     ]
 }
 
-// handles a single message from the buffer
-fn process_message(
-    writers: &CrdtComponentInterfaces,
-    typemap: &mut CrdtStore,
-    entity_map: &mut SceneSceneContext,
-    crdt_type: CrdtMessageType,
-    stream: &mut DclReader,
-) -> Result<(), DclReaderError> {
-    match crdt_type {
-        CrdtMessageType::PutComponent => {
-            let entity = stream.read()?;
-            let component = stream.read()?;
-            let timestamp = stream.read()?;
-            let content_len = stream.read_u32()? as usize;
-
-            debug!("PUT e:{entity:?}, c: {component:?}, timestamp: {timestamp:?}, content len: {content_len}");
-            dcl_assert!(content_len == stream.len());
-
-            // check for a writer
-            let Some(writer) = writers.0.get(&component) else {
-                return Ok(())
-            };
-
-            match (writer.position(), entity == SceneEntityId::ROOT) {
-                (ComponentPosition::RootOnly, false) | (ComponentPosition::EntityOnly, true) => {
-                    warn!("invalid position for component {:?}", component);
-                    return Ok(());
-                }
-                _ => (),
-            }
-
-            // create the entity (if not already dead)
-            if !entity_map.init(entity) {
-                return Ok(());
-            }
-
-            // attempt to write (may fail due to a later write)
-            typemap.try_update(component, *writer, entity, timestamp, Some(stream));
-        }
-        CrdtMessageType::DeleteComponent => {
-            let entity = stream.read()?;
-            let component = stream.read()?;
-            let timestamp = stream.read()?;
-
-            // check for a writer
-            let Some(writer) = writers.0.get(&component) else {
-                return Ok(())
-            };
-
-            match (writer.position(), entity == SceneEntityId::ROOT) {
-                (ComponentPosition::RootOnly, false) | (ComponentPosition::EntityOnly, true) => {
-                    warn!("invalid position for component {:?}", component);
-                    return Ok(());
-                }
-                _ => (),
-            }
-
-            // check the entity still lives (don't create here, no need)
-            if entity_map.is_dead(entity) {
-                return Ok(());
-            }
-
-            // attempt to write (may fail due to a later write)
-            typemap.try_update(component, *writer, entity, timestamp, None);
-        }
-        CrdtMessageType::DeleteEntity => {
-            let entity = stream.read()?;
-            entity_map.kill(entity);
-        }
-        CrdtMessageType::AppendValue => unimplemented!(),
-    }
-
-    Ok(())
-}
-
 // receive and process a buffer of crdt messages
 #[op(v8)]
 fn op_crdt_send_to_renderer(op_state: Rc<RefCell<OpState>>, messages: &[u8]) {
     let mut op_state = op_state.borrow_mut();
     let elapsed_time = op_state.borrow::<SceneElapsedTime>().0;
-    let mut entity_map = op_state.take::<SceneSceneContext>();
+    let mut entity_map = op_state.take::<CrdtContext>();
     let mut typemap = op_state.take::<CrdtStore>();
     let writers = op_state.take::<CrdtComponentInterfaces>();
     let mut stream = DclReader::new(messages);
     debug!("BATCH len: {}", stream.len());
 
     // collect commands
-    while stream.len() > CRDT_HEADER_SIZE {
-        let pos = stream.pos();
-        let length = stream.read_u32().unwrap() as usize;
-        let crdt_type = stream.read_u32().unwrap();
-
-        debug!("[{pos}] crdt_type: {crdt_type}, length: {length}");
-        let mut message_stream = stream.take_reader(length.saturating_sub(8));
-
-        match FromPrimitive::from_u32(crdt_type) {
-            Some(crdt_type) => {
-                if let Err(e) = process_message(
-                    &writers,
-                    &mut typemap,
-                    &mut entity_map,
-                    crdt_type,
-                    &mut message_stream,
-                ) {
-                    error!("CRDT Buffer error: {:?}", e);
-                };
-            }
-            None => error!("CRDT Header error: unhandled crdt message type {crdt_type}"),
-        }
-    }
+    typemap.process_message_stream(&mut entity_map, &writers, &mut stream, true);
 
     let census = entity_map.take_census();
     typemap.clean_up(&census.died);
@@ -166,7 +44,12 @@ fn op_crdt_send_to_renderer(op_state: Rc<RefCell<OpState>>, messages: &[u8]) {
 
     let sender = op_state.borrow_mut::<SyncSender<SceneResponse>>();
     sender
-        .send(SceneResponse::Ok(entity_map.scene_id, census, updates, SceneElapsedTime(elapsed_time)))
+        .send(SceneResponse::Ok(
+            entity_map.scene_id,
+            census,
+            updates,
+            SceneElapsedTime(elapsed_time),
+        ))
         .expect("failed to send to renderer");
 
     op_state.put(writers);

--- a/src/dcl/js/engine.rs
+++ b/src/dcl/js/engine.rs
@@ -11,7 +11,7 @@ use crate::{
     dcl::{
         crdt::{growonly::CrdtGOEntry, lww::LWWEntry},
         interface::ComponentPosition,
-        CrdtComponentInterfaces, CrdtStore, RendererResponse, SceneResponse,
+        CrdtComponentInterfaces, CrdtStore, RendererResponse, SceneResponse, SceneElapsedTime,
     },
     dcl_assert,
     dcl_component::{
@@ -128,6 +128,7 @@ fn process_message(
 #[op(v8)]
 fn op_crdt_send_to_renderer(op_state: Rc<RefCell<OpState>>, messages: &[u8]) {
     let mut op_state = op_state.borrow_mut();
+    let elapsed_time = op_state.borrow::<SceneElapsedTime>().0;
     let mut entity_map = op_state.take::<SceneSceneContext>();
     let mut typemap = op_state.take::<CrdtStore>();
     let writers = op_state.take::<CrdtComponentInterfaces>();
@@ -165,7 +166,7 @@ fn op_crdt_send_to_renderer(op_state: Rc<RefCell<OpState>>, messages: &[u8]) {
 
     let sender = op_state.borrow_mut::<SyncSender<SceneResponse>>();
     sender
-        .send(SceneResponse::Ok(entity_map.scene_id, census, updates))
+        .send(SceneResponse::Ok(entity_map.scene_id, census, updates, SceneElapsedTime(elapsed_time)))
         .expect("failed to send to renderer");
 
     op_state.put(writers);

--- a/src/dcl/js/init.js
+++ b/src/dcl/js/init.js
@@ -46,3 +46,6 @@ const console = {
     log: function(text) { Deno.core.print("LOG  :" + text + "\n") },
     error: function(text) { Deno.core.print("ERROR: " + text + "\n") },
 }
+
+// timeout handler
+globalThis.setImmediate = (fn) => Promise.resolve().then(fn)

--- a/src/dcl/js/mod.rs
+++ b/src/dcl/js/mod.rs
@@ -7,15 +7,13 @@ use deno_core::{
 };
 use tokio::sync::mpsc::Receiver;
 
-use self::context::SceneSceneContext;
 use crate::ipfs::SceneJsFile;
 
 use super::{
-    interface::{CrdtComponentInterfaces, CrdtStore},
-    RendererResponse, SceneId, SceneResponse, VM_HANDLES, SceneElapsedTime,
+    interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
+    RendererResponse, SceneElapsedTime, SceneId, SceneResponse, VM_HANDLES,
 };
 
-pub mod context;
 pub mod engine;
 
 // marker to indicate shutdown has been triggered
@@ -70,7 +68,7 @@ pub(crate) fn scene_thread(
     thread_sx: SyncSender<SceneResponse>,
     thread_rx: Receiver<RendererResponse>,
 ) {
-    let scene_context = SceneSceneContext::new(scene_id);
+    let scene_context = CrdtContext::new(scene_id);
     let mut runtime = create_runtime();
 
     // store handle
@@ -136,7 +134,9 @@ pub(crate) fn scene_thread(
             - elapsed;
         elapsed += dt;
 
-        state.borrow_mut().put(SceneElapsedTime(elapsed.as_secs_f32()));
+        state
+            .borrow_mut()
+            .put(SceneElapsedTime(elapsed.as_secs_f32()));
 
         // run the onUpdate function
         let result = run_script(&mut runtime, &script, "onUpdate", (), |scope| {

--- a/src/dcl/js/mod.rs
+++ b/src/dcl/js/mod.rs
@@ -12,7 +12,7 @@ use crate::ipfs::SceneJsFile;
 
 use super::{
     interface::{CrdtComponentInterfaces, CrdtStore},
-    RendererResponse, SceneId, SceneResponse, VM_HANDLES,
+    RendererResponse, SceneId, SceneResponse, VM_HANDLES, SceneElapsedTime,
 };
 
 pub mod context;
@@ -135,6 +135,8 @@ pub(crate) fn scene_thread(
             .unwrap_or(elapsed)
             - elapsed;
         elapsed += dt;
+
+        state.borrow_mut().put(SceneElapsedTime(elapsed.as_secs_f32()));
 
         // run the onUpdate function
         let result = run_script(&mut runtime, &script, "onUpdate", (), |scope| {

--- a/src/dcl/mod.rs
+++ b/src/dcl/mod.rs
@@ -53,11 +53,7 @@ static SCENE_ID: Lazy<AtomicU32> = Lazy::new(Default::default);
 pub(crate) static VM_HANDLES: Lazy<Mutex<HashMap<SceneId, IsolateHandle>>> =
     Lazy::new(Default::default);
 
-pub fn spawn_scene(
-    scene_js: SceneJsFile,
-    crdt_component_interfaces: CrdtComponentInterfaces,
-    renderer_sender: SyncSender<SceneResponse>,
-) -> (SceneId, Sender<RendererResponse>) {
+pub fn get_next_scene_id() -> SceneId {
     let mut id = SceneId(SCENE_ID.fetch_add(1, Ordering::Relaxed));
 
     if id.0 == 0 {
@@ -67,6 +63,15 @@ pub fn spawn_scene(
         id = SceneId(SCENE_ID.fetch_add(1, Ordering::Relaxed));
     }
 
+    id
+}
+
+pub fn spawn_scene(
+    scene_js: SceneJsFile,
+    crdt_component_interfaces: CrdtComponentInterfaces,
+    renderer_sender: SyncSender<SceneResponse>,
+    id: SceneId,
+) -> Sender<RendererResponse> {
     let (main_sx, thread_rx) = tokio::sync::mpsc::channel::<RendererResponse>(1);
 
     std::thread::Builder::new()
@@ -82,5 +87,5 @@ pub fn spawn_scene(
         })
         .unwrap();
 
-    (id, main_sx)
+    main_sx
 }

--- a/src/dcl/mod.rs
+++ b/src/dcl/mod.rs
@@ -30,6 +30,8 @@ pub struct SceneCensus {
     pub died: HashSet<SceneEntityId>,
 }
 
+pub struct SceneElapsedTime(pub f32);
+
 // data from renderer to scene
 #[derive(Debug)]
 pub enum RendererResponse {
@@ -40,7 +42,7 @@ pub enum RendererResponse {
                                      // data from scene to renderer
 pub enum SceneResponse {
     Error(SceneId, String),
-    Ok(SceneId, SceneCensus, CrdtStore),
+    Ok(SceneId, SceneCensus, CrdtStore, SceneElapsedTime),
 }
 
 static SCENE_ID: Lazy<AtomicU32> = Lazy::new(Default::default);

--- a/src/dcl_component/mod.rs
+++ b/src/dcl_component/mod.rs
@@ -33,7 +33,10 @@ impl SceneEntityId {
     }
 
     pub fn from_proto_u32(id: u32) -> Self {
-        SceneEntityId { id: id as u16, generation: (id >> 16) as u16 }
+        SceneEntityId {
+            id: id as u16,
+            generation: (id >> 16) as u16,
+        }
     }
 }
 

--- a/src/dcl_component/mod.rs
+++ b/src/dcl_component/mod.rs
@@ -43,6 +43,7 @@ impl SceneComponentId {
     pub const MESH_COLLIDER: SceneComponentId = SceneComponentId(1019);
     pub const GLTF_CONTAINER: SceneComponentId = SceneComponentId(1041);
     pub const ANIMATOR: SceneComponentId = SceneComponentId(1042);
+    pub const ENGINE_INFO: SceneComponentId = SceneComponentId(1048);
     pub const POINTER_EVENTS: SceneComponentId = SceneComponentId(1062);
     pub const POINTER_RESULT: SceneComponentId = SceneComponentId(1063);
     pub const RAYCAST: SceneComponentId = SceneComponentId(1067);

--- a/src/dcl_component/mod.rs
+++ b/src/dcl_component/mod.rs
@@ -51,6 +51,7 @@ impl SceneComponentId {
     pub const GLTF_CONTAINER: SceneComponentId = SceneComponentId(1041);
     pub const ANIMATOR: SceneComponentId = SceneComponentId(1042);
     pub const ENGINE_INFO: SceneComponentId = SceneComponentId(1048);
+    pub const GLTF_CONTAINER_LOADING_STATE: SceneComponentId = SceneComponentId(1049);
     pub const POINTER_EVENTS: SceneComponentId = SceneComponentId(1062);
     pub const POINTER_RESULT: SceneComponentId = SceneComponentId(1063);
     pub const RAYCAST: SceneComponentId = SceneComponentId(1067);

--- a/src/dcl_component/mod.rs
+++ b/src/dcl_component/mod.rs
@@ -29,7 +29,11 @@ impl SceneEntityId {
     pub const CAMERA: SceneEntityId = Self::reserved(2);
 
     pub fn as_proto_u32(&self) -> Option<u32> {
-        Some((self.id as u32) << 16 | self.generation as u32)
+        Some(self.id as u32 | (self.generation as u32) << 16)
+    }
+
+    pub fn from_proto_u32(id: u32) -> Self {
+        SceneEntityId { id: id as u16, generation: (id >> 16) as u16 }
     }
 }
 

--- a/src/dcl_component/proto/decentraland/bff/authentication_service.proto
+++ b/src/dcl_component/proto/decentraland/bff/authentication_service.proto
@@ -1,5 +1,12 @@
 syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
 package decentraland.bff;
+
+enum DisconnectionReason {
+  DR_KICKED = 0;
+}
 
 message GetChallengeRequest {
   string address = 1;
@@ -21,7 +28,12 @@ message WelcomePeerInformation {
   repeated string available_modules = 2;
 }
 
+message DisconnectionMessage {
+  DisconnectionReason reason = 1;
+}
+
 service BffAuthenticationService {
   rpc GetChallenge(GetChallengeRequest) returns (GetChallengeResponse) {}
   rpc Authenticate(SignedChallenge) returns (WelcomePeerInformation) {}
+  rpc GetDisconnectionMessage(google.protobuf.Empty) returns (DisconnectionMessage) {}
 }

--- a/src/dcl_component/proto/decentraland/common/border_rect.proto
+++ b/src/dcl_component/proto/decentraland/common/border_rect.proto
@@ -6,5 +6,13 @@ message BorderRect {
   float top = 1;
   float left = 2;
   float right = 3;
-  float bottom = 4; 
+  float bottom = 4;
+}
+
+// Defines a rect with x, y, width and height
+message Rect {
+  float x = 1;
+  float y = 2;
+  float width = 3;
+  float height = 4;
 }

--- a/src/dcl_component/proto/decentraland/kernel/apis/environment_api.proto
+++ b/src/dcl_component/proto/decentraland/kernel/apis/environment_api.proto
@@ -59,7 +59,7 @@ message GetExplorerConfigurationRequest {}
 message GetDecentralandTimeRequest {}
 
 service EnvironmentApiService {
-  // @deprecated, only available for SDK6 compatibility
+  // @deprecated, only available for SDK6 compatibility. Use runtime_api instead
   rpc GetBootstrapData(GetBootstrapDataRequest) returns (BootstrapDataResponse) {}
   // @deprecated, only available for SDK6 compatibility. Needs migration
   rpc IsPreviewMode(IsPreviewModeRequest) returns (PreviewModeResponse) {}

--- a/src/dcl_component/proto/decentraland/kernel/apis/restricted_actions.proto
+++ b/src/dcl_component/proto/decentraland/kernel/apis/restricted_actions.proto
@@ -1,22 +1,18 @@
 syntax = "proto3";
 package decentraland.kernel.apis;
 
-message Vector3 {
-    float x = 1;
-    float y = 2;
-    float z = 3;
-}
+import "decentraland/common/vectors.proto";
 
 message MovePlayerToResponse { }
 
 message MovePlayerToRequest {
-  Vector3 new_relative_position = 1;
-  optional Vector3 camera_target = 2;
+  decentraland.common.Vector3 new_relative_position = 1;
+  optional decentraland.common.Vector3 camera_target = 2;
 }
 
 message TeleportToRequest {
-  Vector3 world_position = 1;
-  optional Vector3 camera_target = 2;
+  decentraland.common.Vector3 world_position = 1;
+  optional decentraland.common.Vector3 camera_target = 2;
 }
 
 message TriggerEmoteResponse { }

--- a/src/dcl_component/proto/decentraland/kernel/apis/runtime.proto
+++ b/src/dcl_component/proto/decentraland/kernel/apis/runtime.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package decentraland.kernel.apis;
 
+import "decentraland/common/content_mapping.proto";
+
 // This API will contain all the information related to the world runtime.
 // Things related to the user, players or the scene itself has they own api, and
 // won't live here. (UserIdentity, Players, ParcelIdentity)
@@ -24,10 +26,40 @@ message GetWorldTimeResponse {
 message GetRealmRequest {}
 message GetWorldTimeRequest {}
 
+message ReadFileRequest {
+  // name of the deployed file
+  string file_name = 1;
+}
+message ReadFileResponse {
+  // contents of the file
+  bytes content = 1;
+  // deployed hash/CID
+  string hash = 2;
+}
+
+message CurrentSceneEntityRequest {}
+message CurrentSceneEntityResponse {
+  // this is either the entityId or the full URN of the scene that is running
+  string urn = 1;
+  // contents of the deployed entities
+  repeated decentraland.common.ContentMapping content = 2;
+  // JSON serialization of the entity.metadata field
+  string metadata_json = 3;
+  // baseUrl used to resolve all content files
+  string base_url = 4;
+}
+
 service RuntimeService {
   // Provides information about the current realm
   rpc GetRealm(GetRealmRequest) returns (GetRealmResponse) {}
   // Provides information about the Decentraland Time, which is coordinated
   // across players.
   rpc GetWorldTime(GetWorldTimeRequest) returns (GetWorldTimeResponse) {}
+  // Returns the file content of a deployed asset. If the file doesn't
+  // exist or cannot be retrieved, the RPC call throws an error.
+  // This method is called to load any assets deployed among the scene,
+  // runtime may cache this response much more than the provided "fetch" function.
+  rpc ReadFile(ReadFileRequest) returns (ReadFileResponse) {}
+  // Returns information about the current scene. This is the replacement of GetBootstrapData
+  rpc GetSceneInformation(CurrentSceneEntityRequest) returns (CurrentSceneEntityResponse) {}
 }

--- a/src/dcl_component/proto/decentraland/kernel/apis/testing.proto
+++ b/src/dcl_component/proto/decentraland/kernel/apis/testing.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+package decentraland.kernel.apis;
+
+service TestingService {
+  // sends a test result to the test runner
+  rpc LogTestResult(TestResult) returns (TestResultResponse) {}
+  // send a list of all planned tests to the test runner
+  rpc Plan(TestPlan) returns (TestPlanResponse) {}
+  // sets the camera position and rotation in the engine
+  rpc SetCameraTransform (SetCameraTransformTestCommand) returns (SetCameraTransformTestCommandResponse) {}
+}
+
+
+message TestResult {
+    string name = 1;
+    bool ok = 2;
+    optional string error = 3;
+    optional string stack = 4;
+
+    // how many ADR-148 ticks were spent running this test
+    uint32 total_frames = 5;
+
+    // total time in seconds spent running this test
+    float total_time = 6;
+}
+message TestResultResponse {}
+
+message TestPlan {
+  message TestPlanEntry {
+    string name = 1;
+  }
+
+  repeated TestPlanEntry tests = 1;
+}
+message TestPlanResponse {}
+
+message SetCameraTransformTestCommand {
+  Vector3 position = 1;
+  Quaternion rotation = 2;
+
+  message Vector3 {
+    float x = 1;
+    float y = 2;
+    float z = 3;
+  }
+
+  message Quaternion {
+    float x = 1;
+    float y = 2;
+    float z = 3;
+    float w = 4;
+  }
+}
+message SetCameraTransformTestCommandResponse {}
+

--- a/src/dcl_component/proto/decentraland/kernel/comms/v3/archipelago.proto
+++ b/src/dcl_component/proto/decentraland/kernel/comms/v3/archipelago.proto
@@ -1,23 +1,24 @@
 syntax = "proto3";
 
+import "decentraland/common/vectors.proto";
+
 package decentraland.kernel.comms.v3;
 
-enum TransportType {
-  TT_LIVEKIT = 0;
-  TT_WS = 1;
+// Server->Client messsages
+message ChallengeResponseMessage {
+  string challenge_to_sign = 1;
+  bool already_connected = 2;
 }
 
-message Position3DMessage {
-  double x = 1;
-  double y = 2;
-  double z = 3;
+message WelcomeMessage {
+  string peer_id = 1;
 }
 
 message IslandChangedMessage {
   string island_id = 1;
   string conn_str = 2;
   optional string from_island_id = 3;
-  map<string, Position3DMessage> peers = 4;
+  map<string, decentraland.common.Position> peers = 4;
 }
 
 message LeftIslandMessage {
@@ -30,44 +31,56 @@ message JoinIslandMessage {
   string peer_id = 2;
 }
 
+enum KickedReason {
+  KR_NEW_SESSION = 0;
+}
+
+message KickedMessage {
+  KickedReason reason = 1;
+}
+
+message ServerPacket {
+  oneof message {
+    ChallengeResponseMessage challenge_response = 1;
+    WelcomeMessage welcome = 2;
+    IslandChangedMessage island_changed = 3;
+    LeftIslandMessage  left_island = 4;
+    JoinIslandMessage join_island = 5;
+    KickedMessage kicked = 6;
+  }
+}
+
+// Client->Server messsages
+message ChallengeRequestMessage {
+  string address = 1;
+}
+
+message SignedChallengeMessage {
+  string auth_chain_json = 1;
+}
+
+message Heartbeat {
+  decentraland.common.Position position = 1;
+  optional string desired_room = 2;
+}
+
+message ClientPacket {
+  oneof message {
+    ChallengeRequestMessage challenge_request = 1;
+    SignedChallengeMessage signed_challenge = 2;
+    Heartbeat heartbeat = 3;
+  }
+}
+
+// Others
 message IslandData {
   string id = 1;
   repeated string peers = 2;
   uint32 max_peers = 3;
-  Position3DMessage center = 4;
+  decentraland.common.Position center = 4;
   double radius = 5;
 }
 
 message IslandStatusMessage {
   repeated IslandData data = 1;
-}
-
-message TransportInit {
-  TransportType type = 1;
-  uint32 max_island_size = 2;
-}
-
-message TransportHeartbeat {
-  uint32 available_seats = 1;
-  uint32 users_count = 2;
-}
-
-message TransportAuthorizationRequest {
-  string request_id = 1;
-  string room_id = 2;
-  repeated string user_ids = 3;
-}
-
-message TransportAuthorizationResponse {
-  string request_id = 1;
-  map<string, string> conn_strs = 2;
-}
-
-message TransportMessage {
-  oneof message {
-    TransportInit init = 1;
-    TransportHeartbeat heartbeat = 2;
-    TransportAuthorizationRequest auth_request = 3;
-    TransportAuthorizationResponse auth_response = 4;
-  }
 }

--- a/src/dcl_component/proto/decentraland/realm/about.proto
+++ b/src/dcl_component/proto/decentraland/realm/about.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+package decentraland.realm;
+
+message AboutResponse {
+  bool healthy = 1;
+  AboutConfiguration configurations = 2;
+  ContentInfo content = 3;
+  CommsInfo comms = 4;
+  LambdasInfo lambdas = 5;
+  optional BffInfo bff = 6;
+  bool accepting_users = 7;
+
+  message MinimapConfiguration {
+    bool enabled = 1;
+    optional string data_image = 2;
+    optional string estate_image = 3;
+  }
+
+  message SkyboxConfiguration {
+    // only one value at a time
+    optional float fixed_hour = 1;
+  }
+
+  message AboutConfiguration {
+    optional string realm_name = 1;
+    uint32 network_id = 2;
+    repeated string global_scenes_urn = 3;
+    repeated string scenes_urn = 4;
+    optional MinimapConfiguration minimap = 5;
+    optional SkyboxConfiguration skybox = 6;
+
+    // A content server to be used to load the parcels around the user. Uses the POST /entities/active endpoint
+    // to continously fetch the parcels around the users. if null, then the default content server will be used
+    // if == "" then the city_loader will be disabled and the scenes_urn will be used to load the world
+    optional string city_loader_content_server = 7;
+  }
+
+  message ContentInfo {
+    // common properties
+    bool healthy = 1;
+    optional string version = 2;
+    optional string commit_hash = 3;
+    string public_url = 4;
+  }
+  message LambdasInfo {
+    // common properties
+    bool healthy = 1;
+    optional string version = 2;
+    optional string commit_hash = 3;
+    string public_url = 4;
+  }
+  message CommsInfo {
+    // common properties
+    bool healthy = 1;
+    optional string version = 2;
+    optional string commit_hash = 3;
+    optional string public_url = 4;
+    // specific properties
+    string protocol = 50;
+    optional int32 users_count = 51;
+    optional string fixed_adapter = 52;
+  }
+  message BffInfo {
+    // common properties
+    bool healthy = 1;
+    optional string version = 2;
+    optional string commit_hash = 3;
+    string public_url = 4;
+    // specific properties
+    optional int32 user_count = 51;
+    optional string protocol_version = 52;
+  }
+}

--- a/src/dcl_component/proto/decentraland/sdk/components/billboard.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/billboard.proto
@@ -4,6 +4,7 @@ package decentraland.sdk.components;
 
 import "decentraland/sdk/components/common/id.proto";
 
+// https://adr.decentraland.org/adr/ADR-198
 option (common.ecs_component_id) = 1090;
 
 // The Billboard component makes an Entity automatically reorient its rotation to face the camera. 
@@ -17,6 +18,7 @@ message PBBillboard {
 }
 
 // BillboardMode indicates one or more axis for automatic rotation, in OR-able bit flag form.
+// Only the values below and the (BM_X | BM_Y) combination are valid.
 enum BillboardMode {
   BM_NONE = 0;
   BM_X = 1;

--- a/src/dcl_component/proto/decentraland/sdk/components/common/loading_state.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/common/loading_state.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package decentraland.sdk.components.common;
+
+enum LoadingState {
+  UNKNOWN = 0;
+  LOADING = 1;
+  NOT_FOUND = 2;
+  FINISHED_WITH_ERROR = 3;
+  FINISHED = 4;
+}

--- a/src/dcl_component/proto/decentraland/sdk/components/engine_info.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/engine_info.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1048;
+
+// EngineInfo provides information about the graphics engine running the scene.
+// The values of this component are written at the "physics" stage of the ADR-148. Meaning
+// the tick_number and frame_number of the same frame could be used as correlation numbers
+// for timestamps in other components.
+message PBEngineInfo {
+  uint32 frame_number = 1; // frame counter of the engine
+  float total_runtime = 2; // total runtime of this scene in seconds
+  uint32 tick_number  = 3; // tick counter of the scene as per ADR-148
+}

--- a/src/dcl_component/proto/decentraland/sdk/components/gltf_container.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/gltf_container.proto
@@ -10,4 +10,10 @@ option (common.ecs_component_id) = 1041;
 // achieved using MeshRenderer, MeshCollider and other standard components.
 message PBGltfContainer {
   string src = 1; // the GLTF file path as listed in the scene's manifest.
+
+  reserved 2;
+  reserved 3;
+
+  optional uint32 visible_meshes_collision_mask = 4; // default: 0
+  optional uint32 invisible_meshes_collision_mask = 5; // default: CL_POINTER | CL_PHYSICS
 }

--- a/src/dcl_component/proto/decentraland/sdk/components/gltf_container_loading_state.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/gltf_container_loading_state.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1049;
+
+import "decentraland/sdk/components/common/loading_state.proto";
+
+// GltfContainerLoadingState is set by the engine and provides information about
+// the current state of the GltfContainer of an entity.
+message PBGltfContainerLoadingState {
+  common.LoadingState current_state = 1;
+}

--- a/src/dcl_component/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/mesh_collider.proto
@@ -20,8 +20,8 @@ message PBMeshCollider {
 
   // CylinderMesh is a truncated cone shape that contains the Entity.
   message CylinderMesh {
-    optional float radius_top = 1;    // (default 1.0)
-    optional float radius_bottom = 2; // (default 1.0)
+    optional float radius_top = 1;    // (default 0.5)
+    optional float radius_bottom = 2; // (default 0.5)
   }
 
   // PlaneMesh is a 2D rectangle described by the Entity's Transform.
@@ -30,7 +30,7 @@ message PBMeshCollider {
   // SphereMesh is a sphere shape that contains the Entity.
   message SphereMesh {}
 
-  optional int32 collision_mask = 1; // enabled ColliderLayers (default CL_POINTER | CL_PHYSICS)
+  optional uint32 collision_mask = 1; // enabled ColliderLayers (default CL_POINTER | CL_PHYSICS)
 
   oneof mesh {
     BoxMesh box = 2;
@@ -45,7 +45,7 @@ enum ColliderLayer {
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
-  CL_VISIBLE_MESHES = 4; // all visible meshes, use with extreme care since the performance penalty is high
+  CL_RESERVED1 = 4;
   CL_RESERVED2 = 8;
   CL_RESERVED3 = 16;
   CL_RESERVED4 = 32;

--- a/src/dcl_component/proto/decentraland/sdk/components/mesh_renderer.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/mesh_renderer.proto
@@ -21,8 +21,8 @@ message PBMeshRenderer {
 
     // CylinderMesh renders a truncated cone shape.
     message CylinderMesh {
-        optional float radius_top = 1;    // (default 1.0)
-        optional float radius_bottom = 2; // (default 1.0)
+        optional float radius_top = 1;    // (default 0.5)
+        optional float radius_bottom = 2; // (default 0.5)
     }
 
     // PlaneMesh renders a 2D rectangular shape.

--- a/src/dcl_component/proto/decentraland/sdk/components/pointer_events_result.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/pointer_events_result.proto
@@ -13,6 +13,7 @@ message PBPointerEventsResult {
   common.InputAction button = 1; // identifier of the input
   common.RaycastHit hit = 2;
   common.PointerEventType state = 4;
-  uint32 timestamp = 5;          // could be a Lamport timestamp
+  uint32 timestamp = 5;          // monotonic counter
   optional float analog = 6;     // if the input is analog then we store it here
+  uint32 tick_number = 7;        // number of tick in which the event was produced, equals to EngineInfo.tick_number
 }

--- a/src/dcl_component/proto/decentraland/sdk/components/raycast.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/raycast.proto
@@ -43,7 +43,7 @@ message PBRaycast {
   // otherwise it will be performed only once, defaults to false
   optional bool continuous = 8;
 
-  // Collision mask, by default all bits are 1 (0xFFFF_FFFF)
+  // Collision mask, by default CL_POINTER | CL_PHYSICS
   optional uint32 collision_mask = 9;
 }
 

--- a/src/dcl_component/proto/decentraland/sdk/components/raycast_result.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/raycast_result.proto
@@ -17,4 +17,5 @@ message PBRaycastResult {
   decentraland.common.Vector3 global_origin = 2; // the starting point of the ray in global coordinates
   decentraland.common.Vector3 direction = 3;     // the direction vector of the ray in global coordinates
   repeated decentraland.sdk.components.common.RaycastHit hits = 4; // zero or more hits
+  uint32 tick_number = 5;                        // number of tick in which the event was produced, equals to EngineInfo.tick_number
 }

--- a/src/dcl_component/proto/decentraland/sdk/components/ui_background.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/ui_background.proto
@@ -22,12 +22,12 @@ enum BackgroundTextureMode {
   // https://docs.unity3d.com/Manual/9SliceSprites.html
   // https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-slice
   NINE_SLICES = 0;
-  
+
   // CENTER enables the texture to be rendered centered in relation to the
   // element. If the element is smaller than the texture then the background
   // should use the element as stencil to cut off the out-of-bounds area
   CENTER = 1;
-  
+
   // STRETCH enables the texture to cover all the area of the container,
   // adopting its aspect ratio.
   STRETCH = 2;

--- a/src/dcl_component/proto/decentraland/sdk/components/ui_canvas_information.proto
+++ b/src/dcl_component/proto/decentraland/sdk/components/ui_canvas_information.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/common/border_rect.proto";
+
+import "decentraland/sdk/components/common/id.proto";
+option (common.ecs_component_id) = 1054;
+
+// This component is created by the renderer and used by the scenes to know the resolution of the UI canvas
+message PBUiCanvasInformation {
+  // informs the scene about the resolution used for the UI rendering
+  float device_pixel_ratio = 1;
+  // informs about the width of the canvas, in virtual pixels. this value does not change when the pixel ratio changes.
+  int32 width = 2;
+  // informs about the height of the canvas, in virtual pixels. this value does not change when the pixel ratio changes.
+  int32 height = 3;
+  // informs the sdk about the interactable area. some implementations may change
+  // this area depending on the HUD that is being shown. this value may change at
+  // any time by the Renderer to create reactive UIs. as an example, an explorer with the
+  // chat UI hidden and with no minimap could have a rect that covers the whole screen.
+  // on the contrary, if the chat UI is shown, the rect would be smaller.
+  decentraland.common.BorderRect interactable_area = 4;
+}

--- a/src/dcl_component/proto/decentraland/social/friendships/friendships.proto
+++ b/src/dcl_component/proto/decentraland/social/friendships/friendships.proto
@@ -1,16 +1,20 @@
+// ***
+// FOR INTERNAL USE ONLY, IN BETA VERSION OF THE PROTOCOL.
+// SUBJECT TO CHANGE.
+// ***
+
 syntax = "proto3";
 package decentraland.social.friendships;
 
-import "google/protobuf/empty.proto";
-
-// Validation and anti-spam errors
-enum FriendshipErrorCode {
-  TOO_MANY_REQUESTS_SENT = 0;
-  NOT_ENOUGH_TIME_PASSED = 1;
-  BLOCKED_USER = 2;
-  NON_EXISTING_USER = 3;
-  INVALID_REQUEST = 4;
-  UNKNOWN = 5;
+enum ServiceErrors {
+  // proto3 requires that first value in enum have numeric value of 0
+  UNKNOWN = 0;
+  BAD_REQUEST = 400;
+  UNAUTHORIZED = 401;
+  FORBIDDEN = 403;
+  NOT_FOUND = 404;
+  TOO_MANY_REQUESTS = 429;
+  INTERNAL_SERVER_ERROR = 500;
 }
 
 // This message is a response that is sent from the server to the client
@@ -75,25 +79,29 @@ message CancelResponse { User user = 1; }
 
 message CancelPayload { User user = 1; }
 
-message UpdateFriendshipPayload { FriendshipEventPayload event = 1; }
-
-message UpdateFriendshipResponse {
-  oneof response {
-    FriendshipErrorCode error = 1;
-    FriendshipEventResponse event = 2;
-  }
+message UpdateFriendshipPayload {
+  FriendshipEventPayload event = 1;
+  // For internal use only, subject to change.
+  optional Payload auth_token = 2;
 }
+
+message UpdateFriendshipResponse { FriendshipEventResponse event = 1; }
 
 message SubscribeFriendshipEventsUpdatesResponse {
   repeated FriendshipEventResponse events = 1;
 }
 
+message Payload {
+  // For internal use only, subject to change.
+  optional string synapse_token = 1;
+}
+
 service FriendshipsService {
   // Get the list of friends for the authenticated user
-  rpc GetFriends(google.protobuf.Empty) returns (stream Users) {}
+  rpc GetFriends(Payload) returns (stream Users) {}
 
   // Get the list of request events for the authenticated user
-  rpc GetRequestEvents(google.protobuf.Empty) returns (RequestEvents) {}
+  rpc GetRequestEvents(Payload) returns (RequestEvents) {}
 
   // Update friendship status: REQUEST, ACCEPT, REJECT, CANCEL, DELETE
   rpc UpdateFriendshipEvent(UpdateFriendshipPayload)
@@ -101,6 +109,6 @@ service FriendshipsService {
 
   // Subscribe to updates of friendship status: REQUEST, ACCEPT, REJECT, CANCEL,
   // DELETE
-  rpc SubscribeFriendshipEventsUpdates(google.protobuf.Empty)
+  rpc SubscribeFriendshipEventsUpdates(Payload)
       returns (stream SubscribeFriendshipEventsUpdatesResponse) {}
 }

--- a/src/dcl_component/proto_components.rs
+++ b/src/dcl_component/proto_components.rs
@@ -46,6 +46,7 @@ impl DclProtoComponent for sdk::components::PbAnimator {}
 impl DclProtoComponent for sdk::components::PbPointerEvents {}
 impl DclProtoComponent for sdk::components::PbPointerEventsResult {}
 impl DclProtoComponent for sdk::components::PbEngineInfo {}
+impl DclProtoComponent for sdk::components::PbGltfContainerLoadingState {}
 
 // VECTOR3 conversions
 impl Copy for common::Vector3 {}

--- a/src/dcl_component/proto_components.rs
+++ b/src/dcl_component/proto_components.rs
@@ -45,6 +45,7 @@ impl DclProtoComponent for sdk::components::PbGltfContainer {}
 impl DclProtoComponent for sdk::components::PbAnimator {}
 impl DclProtoComponent for sdk::components::PbPointerEvents {}
 impl DclProtoComponent for sdk::components::PbPointerEventsResult {}
+impl DclProtoComponent for sdk::components::PbEngineInfo {}
 
 // VECTOR3 conversions
 impl Copy for common::Vector3 {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,7 @@ fn input(
     keys: Res<Input<KeyCode>>,
     mut load: EventWriter<ChangeRealmEvent>,
     frame: Res<FrameCount>,
-    loading_scenes: Query<(), With<SceneLoading>>,
+    loading_scenes: Query<&SceneLoading>,
     running_scenes: Query<&RendererSceneContext>,
 ) {
     let realm = if keys.pressed(KeyCode::Up) {
@@ -333,7 +333,13 @@ fn input(
     }
 
     if frame.0 % 1000 == 0 {
-        info!("{} loading", loading_scenes.iter().count());
+        info!(
+            "{} loading ({:?})",
+            loading_scenes.iter().count(),
+            loading_scenes.iter().fold(String::new(), |msg, loadng| {
+                format!("{msg}, {loadng:?}")
+            })
+        );
 
         let running = running_scenes
             .iter()
@@ -348,7 +354,15 @@ fn input(
             .filter(|context| context.broken)
             .count();
         info!("{} running", running);
-        info!("{} blocked", blocked);
+        info!(
+            "{} blocked ({:?})",
+            blocked,
+            running_scenes
+                .iter()
+                .filter(|context| !context.broken && !context.blocked.is_empty())
+                .map(|context| &context.blocked)
+                .collect::<Vec<_>>()
+        );
         info!("{} broken", broken);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,11 @@ fn setup(mut commands: Commands, config: Res<AppConfig>, asset_server: Res<Asset
     // add a camera
     commands.spawn((
         Camera3dBundle {
+            camera: Camera {
+                // TODO enable when we can use gizmos instead of debuglines in bevy 0.11
+                // hdr: true,
+                ..Default::default()
+            },
             transform: Transform::from_translation(Vec3::new(16.0 * 77.5, 2.0, 16.0 * 7.5))
                 .looking_at(Vec3::new(1.0, 8.0, -1.0), Vec3::Y),
             tonemapping: Tonemapping::TonyMcMapface,

--- a/src/scene_runner/initialize_scene.rs
+++ b/src/scene_runner/initialize_scene.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use bevy::{
     math::Vec3Swizzles,
     prelude::*,
-    scene::scene_spawner_system,
     tasks::{IoTaskPool, Task},
     utils::{HashMap, HashSet},
 };
@@ -42,7 +41,6 @@ impl Plugin for SceneLifecyclePlugin {
                 load_scene_javascript,
                 initialize_scene,
             )
-                .after(scene_spawner_system) // these can despawn scenes, make sure that the scene spawner system doesn't try to write to deleted entities
                 .in_set(SceneSets::Init),
         );
 

--- a/src/scene_runner/mod.rs
+++ b/src/scene_runner/mod.rs
@@ -213,7 +213,7 @@ fn run_scene_loop(world: &mut World) {
     #[cfg(debug_assertions)]
     let millis = 100;
     #[cfg(not(debug_assertions))]
-    let millis = 100;
+    let millis = 16;
     let end_time = last_end_time + Duration::from_millis(millis);
     world.resource_mut::<SceneUpdates>().loop_end_time = end_time;
 

--- a/src/scene_runner/mod.rs
+++ b/src/scene_runner/mod.rs
@@ -396,7 +396,7 @@ fn receive_scene_updates(
                         None
                     }
                 }
-                SceneResponse::Ok(scene_id, census, mut crdt) => {
+                SceneResponse::Ok(scene_id, census, mut crdt, runtime) => {
                     let root = updates.scene_ids.get(&scene_id).unwrap();
                     debug!(
                         "scene {:?}/{:?} received updates! [+{}, -{}]",
@@ -406,6 +406,8 @@ fn receive_scene_updates(
                         census.died.len()
                     );
                     if let Ok(mut context) = scenes.get_mut(*root) {
+                        context.tick_number += 1;
+                        context.total_runtime += runtime.0;
                         context.last_update_frame = frame.0;
                         context.in_flight = false;
                         context.nascent = census.born;

--- a/src/scene_runner/mod.rs
+++ b/src/scene_runner/mod.rs
@@ -406,7 +406,7 @@ fn receive_scene_updates(
                         census.died.len()
                     );
                     if let Ok(mut context) = scenes.get_mut(*root) {
-                        context.tick_number += 1;
+                        context.tick_number = context.tick_number.wrapping_add(1);
                         context.total_runtime += runtime.0;
                         context.last_update_frame = frame.0;
                         context.in_flight = false;

--- a/src/scene_runner/mod.rs
+++ b/src/scene_runner/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use self::{
-    initialize_scene::SceneLifecyclePlugin,
+    initialize_scene::{SceneLifecyclePlugin, SceneLoading},
     renderer_context::RendererSceneContext,
     update_scene::SceneInputPlugin,
     update_world::{CrdtExtractors, SceneOutputPlugin},
@@ -213,7 +213,7 @@ fn run_scene_loop(world: &mut World) {
     #[cfg(debug_assertions)]
     let millis = 100;
     #[cfg(not(debug_assertions))]
-    let millis = 16;
+    let millis = 100;
     let end_time = last_end_time + Duration::from_millis(millis);
     world.resource_mut::<SceneUpdates>().loop_end_time = end_time;
 
@@ -246,7 +246,7 @@ fn run_scene_loop(world: &mut World) {
 }
 
 fn update_scene_priority(
-    mut scenes: Query<(Entity, &GlobalTransform, &mut RendererSceneContext)>,
+    mut scenes: Query<(Entity, &GlobalTransform, &mut RendererSceneContext), Without<SceneLoading>>,
     camera: Query<&GlobalTransform, With<PrimaryCamera>>,
     mut updates: ResMut<SceneUpdates>,
     time: Res<Time>,

--- a/src/scene_runner/renderer_context.rs
+++ b/src/scene_runner/renderer_context.rs
@@ -52,6 +52,11 @@ pub struct RendererSceneContext {
 
     // readiness to update, if anything blocks the scene should not run
     pub blocked: HashSet<&'static str>,
+
+    // total scene run time in seconds
+    pub total_runtime: f32,
+    // scene tick number
+    pub tick_number: u32,
 }
 
 impl RendererSceneContext {
@@ -71,6 +76,8 @@ impl RendererSceneContext {
             priority,
             crdt_store: Default::default(),
             blocked: Default::default(),
+            total_runtime: 0.0,
+            tick_number: 0,
         };
 
         new_context.live_entities[SceneEntityId::ROOT.id as usize] =

--- a/src/scene_runner/renderer_context.rs
+++ b/src/scene_runner/renderer_context.rs
@@ -77,7 +77,7 @@ impl RendererSceneContext {
             crdt_store: Default::default(),
             blocked: Default::default(),
             total_runtime: 0.0,
-            tick_number: 0,
+            tick_number: u32::MAX,
         };
 
         new_context.live_entities[SceneEntityId::ROOT.id as usize] =

--- a/src/scene_runner/renderer_context.rs
+++ b/src/scene_runner/renderer_context.rs
@@ -49,6 +49,9 @@ pub struct RendererSceneContext {
     pub broken: bool,
 
     pub crdt_store: CrdtStore,
+
+    // readiness to update, if anything blocks the scene should not run
+    pub blocked: HashSet<&'static str>,
 }
 
 impl RendererSceneContext {
@@ -67,6 +70,7 @@ impl RendererSceneContext {
             broken: false,
             priority,
             crdt_store: Default::default(),
+            blocked: Default::default(),
         };
 
         new_context.live_entities[SceneEntityId::ROOT.id as usize] =

--- a/src/scene_runner/test/mod.rs
+++ b/src/scene_runner/test/mod.rs
@@ -46,7 +46,7 @@ impl console::DoAddConsoleCommand for App {
     }
 }
 
-use super::{PrimaryCamera, initialize_scene::SceneLoading};
+use super::{initialize_scene::SceneLoading, PrimaryCamera};
 
 pub struct TestPlugins;
 
@@ -124,7 +124,9 @@ fn init_test_app(entity_json: &str) -> App {
     });
 
     // run app once to get the scene initialized
-    let mut q = app.world.query_filtered::<&RendererSceneContext, Without<SceneLoading>>();
+    let mut q = app
+        .world
+        .query_filtered::<&RendererSceneContext, Without<SceneLoading>>();
     while q.get_single(&mut app.world).is_err() {
         app.update();
         // if let Ok(loading) = app.world.query::<&SceneLoading>().get_single(&mut app.world) {

--- a/src/scene_runner/test/mod.rs
+++ b/src/scene_runner/test/mod.rs
@@ -46,7 +46,7 @@ impl console::DoAddConsoleCommand for App {
     }
 }
 
-use super::PrimaryCamera;
+use super::{PrimaryCamera, initialize_scene::SceneLoading};
 
 pub struct TestPlugins;
 
@@ -124,9 +124,15 @@ fn init_test_app(entity_json: &str) -> App {
     });
 
     // run app once to get the scene initialized
-    let mut q = app.world.query::<&RendererSceneContext>();
+    let mut q = app.world.query_filtered::<&RendererSceneContext, Without<SceneLoading>>();
     while q.get_single(&mut app.world).is_err() {
         app.update();
+        // if let Ok(loading) = app.world.query::<&SceneLoading>().get_single(&mut app.world) {
+        //     warn!("load state: {loading:?}");
+        // }
+        // if let Ok(context) = app.world.query::<&RendererSceneContext>().get_single(&mut app.world) {
+        //     warn!("context tick: {:?} (blocked: {:?})", context.tick_number, context.blocked);
+        // }
     }
 
     app

--- a/src/scene_runner/update_scene/engine_info.rs
+++ b/src/scene_runner/update_scene/engine_info.rs
@@ -1,0 +1,32 @@
+use bevy::{prelude::*, core::FrameCount};
+
+use crate::{scene_runner::{renderer_context::RendererSceneContext, SceneSets}, dcl_component::{SceneComponentId, SceneEntityId, proto_components::sdk::components::PbEngineInfo}, dcl::interface::CrdtType};
+
+pub struct EngineInfoPlugin;
+
+impl Plugin for EngineInfoPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_system(update_engine_info.in_set(SceneSets::Input));
+    }
+}
+
+fn update_engine_info(
+    mut scenes: Query<&mut RendererSceneContext>,
+    frame: Res<FrameCount>,
+) {
+    for mut context in scenes.iter_mut() {
+        let total_runtime = context.total_runtime;
+        let tick_number = context.tick_number;
+
+        context.update_crdt(
+            SceneComponentId::ENGINE_INFO,
+            CrdtType::LWW_ROOT, 
+            SceneEntityId::ROOT,
+            &PbEngineInfo{
+                frame_number: frame.0,
+                total_runtime,
+                tick_number,
+            }
+        );
+    }
+}

--- a/src/scene_runner/update_scene/engine_info.rs
+++ b/src/scene_runner/update_scene/engine_info.rs
@@ -1,6 +1,12 @@
-use bevy::{prelude::*, core::FrameCount};
+use bevy::{core::FrameCount, prelude::*};
 
-use crate::{scene_runner::{renderer_context::RendererSceneContext, SceneSets}, dcl_component::{SceneComponentId, SceneEntityId, proto_components::sdk::components::PbEngineInfo}, dcl::interface::CrdtType};
+use crate::{
+    dcl::interface::CrdtType,
+    dcl_component::{
+        proto_components::sdk::components::PbEngineInfo, SceneComponentId, SceneEntityId,
+    },
+    scene_runner::{renderer_context::RendererSceneContext, SceneSets},
+};
 
 pub struct EngineInfoPlugin;
 
@@ -10,23 +16,20 @@ impl Plugin for EngineInfoPlugin {
     }
 }
 
-fn update_engine_info(
-    mut scenes: Query<&mut RendererSceneContext>,
-    frame: Res<FrameCount>,
-) {
+fn update_engine_info(mut scenes: Query<&mut RendererSceneContext>, frame: Res<FrameCount>) {
     for mut context in scenes.iter_mut() {
         let total_runtime = context.total_runtime;
         let tick_number = context.tick_number;
 
         context.update_crdt(
             SceneComponentId::ENGINE_INFO,
-            CrdtType::LWW_ROOT, 
+            CrdtType::LWW_ROOT,
             SceneEntityId::ROOT,
-            &PbEngineInfo{
+            &PbEngineInfo {
                 frame_number: frame.0,
                 total_runtime,
                 tick_number,
-            }
+            },
         );
     }
 }

--- a/src/scene_runner/update_scene/mod.rs
+++ b/src/scene_runner/update_scene/mod.rs
@@ -1,10 +1,13 @@
 use bevy::prelude::Plugin;
 
-use self::{pointer_results::PointerResultPlugin, raycast_result::RaycastResultPlugin, engine_info::EngineInfoPlugin};
+use self::{
+    engine_info::EngineInfoPlugin, pointer_results::PointerResultPlugin,
+    raycast_result::RaycastResultPlugin,
+};
 
+pub mod engine_info;
 pub mod pointer_results;
 pub mod raycast_result;
-pub mod engine_info;
 
 pub struct SceneInputPlugin;
 

--- a/src/scene_runner/update_scene/mod.rs
+++ b/src/scene_runner/update_scene/mod.rs
@@ -1,14 +1,16 @@
 use bevy::prelude::Plugin;
 
-use self::{pointer_results::PointerResultPlugin, raycast_result::RaycastResultPlugin};
+use self::{pointer_results::PointerResultPlugin, raycast_result::RaycastResultPlugin, engine_info::EngineInfoPlugin};
 
 pub mod pointer_results;
 pub mod raycast_result;
+pub mod engine_info;
 
 pub struct SceneInputPlugin;
 
 impl Plugin for SceneInputPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
+        app.add_plugin(EngineInfoPlugin);
         app.add_plugin(RaycastResultPlugin);
         app.add_plugin(PointerResultPlugin);
     }

--- a/src/scene_runner/update_scene/pointer_results.rs
+++ b/src/scene_runner/update_scene/pointer_results.rs
@@ -152,7 +152,7 @@ fn update_pointer_target(
     };
     let cursor_position = if window.cursor.grab_mode == bevy::window::CursorGrabMode::Locked {
         // if pointer locked, just middle
-        Vec2::splat(0.5)
+        Vec2::new(window.width(), window.height()) / 2.0
     } else {
         let Some(cursor_position) = window.cursor_position() else {
             // outside window

--- a/src/scene_runner/update_scene/pointer_results.rs
+++ b/src/scene_runner/update_scene/pointer_results.rs
@@ -22,7 +22,9 @@ impl Plugin for PointerResultPlugin {
         app.init_resource::<InputMap>();
         app.init_resource::<PointerTarget>();
         app.add_systems(
-            (update_pointer_target, send_hover_events, send_action_events).chain().in_set(SceneSets::Input),
+            (update_pointer_target, send_hover_events, send_action_events)
+                .chain()
+                .in_set(SceneSets::Input),
         );
     }
 }

--- a/src/scene_runner/update_scene/pointer_results.rs
+++ b/src/scene_runner/update_scene/pointer_results.rs
@@ -274,6 +274,7 @@ fn send_hover_events(
                                     state: ev_type as i32,
                                     timestamp: frame.0,
                                     analog: None,
+                                    tick_number: 0, // TODO
                                 },
                             );
                         }
@@ -380,6 +381,7 @@ fn send_action_events(
                                     state: ev_type as i32,
                                     timestamp: frame.0,
                                     analog: None,
+                                    tick_number: 0, // TODO
                                 },
                             );
                         }
@@ -428,6 +430,7 @@ fn send_action_events(
                     state: PointerEventType::PetDown as i32,
                     timestamp: frame.0,
                     analog: None,
+                    tick_number: 0, // TODO
                 },
             );
         }
@@ -451,6 +454,7 @@ fn send_action_events(
                     state: PointerEventType::PetUp as i32,
                     timestamp: frame.0,
                     analog: None,
+                    tick_number: 0, // TODO
                 },
             );
         }

--- a/src/scene_runner/update_scene/pointer_results.rs
+++ b/src/scene_runner/update_scene/pointer_results.rs
@@ -22,7 +22,7 @@ impl Plugin for PointerResultPlugin {
         app.init_resource::<InputMap>();
         app.init_resource::<PointerTarget>();
         app.add_systems(
-            (update_pointer_target, send_hover_events, send_action_events).in_set(SceneSets::Input),
+            (update_pointer_target, send_hover_events, send_action_events).chain().in_set(SceneSets::Input),
         );
     }
 }

--- a/src/scene_runner/update_scene/pointer_results.rs
+++ b/src/scene_runner/update_scene/pointer_results.rs
@@ -256,6 +256,7 @@ fn send_hover_events(
                             .and_then(|info| info.max_distance)
                             .unwrap_or(10.0);
                         if distance <= max_distance {
+                            let tick_number = context.tick_number;
                             context.update_crdt(
                                 SceneComponentId::POINTER_RESULT,
                                 CrdtType::GO_ENT,
@@ -274,7 +275,7 @@ fn send_hover_events(
                                     state: ev_type as i32,
                                     timestamp: frame.0,
                                     analog: None,
-                                    tick_number: 0, // TODO
+                                    tick_number,
                                 },
                             );
                         }
@@ -363,6 +364,7 @@ fn send_action_events(
                             .and_then(|info| info.max_distance)
                             .unwrap_or(10.0);
                         if distance <= max_distance {
+                            let tick_number = context.tick_number;
                             context.update_crdt(
                                 SceneComponentId::POINTER_RESULT,
                                 CrdtType::GO_ENT,
@@ -381,7 +383,7 @@ fn send_action_events(
                                     state: ev_type as i32,
                                     timestamp: frame.0,
                                     analog: None,
-                                    tick_number: 0, // TODO
+                                    tick_number,
                                 },
                             );
                         }
@@ -411,6 +413,7 @@ fn send_action_events(
 
     // send events to scene roots
     for (mut context, _) in scenes.iter_mut() {
+        let tick_number = context.tick_number;
         for down in input_mgr.iter_just_down() {
             context.update_crdt(
                 SceneComponentId::POINTER_RESULT,
@@ -430,7 +433,7 @@ fn send_action_events(
                     state: PointerEventType::PetDown as i32,
                     timestamp: frame.0,
                     analog: None,
-                    tick_number: 0, // TODO
+                    tick_number,
                 },
             );
         }
@@ -454,7 +457,7 @@ fn send_action_events(
                     state: PointerEventType::PetUp as i32,
                     timestamp: frame.0,
                     analog: None,
-                    tick_number: 0, // TODO
+                    tick_number,
                 },
             );
         }

--- a/src/scene_runner/update_scene/raycast_result.rs
+++ b/src/scene_runner/update_scene/raycast_result.rs
@@ -179,6 +179,7 @@ fn run_raycasts(
                 global_origin: Some(Vector3::world_vec_from_vec3(&scene_origin)),
                 direction: Some(Vector3::world_vec_from_vec3(&direction)),
                 hits: results.into_iter().map(make_hit).collect(),
+                tick_number: 0, // TODO
             };
 
             context.update_crdt(

--- a/src/scene_runner/update_scene/raycast_result.rs
+++ b/src/scene_runner/update_scene/raycast_result.rs
@@ -179,7 +179,7 @@ fn run_raycasts(
                 global_origin: Some(Vector3::world_vec_from_vec3(&scene_origin)),
                 direction: Some(Vector3::world_vec_from_vec3(&direction)),
                 hits: results.into_iter().map(make_hit).collect(),
-                tick_number: 0, // TODO
+                tick_number: context.tick_number,
             };
 
             context.update_crdt(

--- a/src/scene_runner/update_scene/raycast_result.rs
+++ b/src/scene_runner/update_scene/raycast_result.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     scene_runner::{
         update_world::{
+            gltf_container::GLTF_LOADING,
             mesh_collider::{RaycastResult, SceneColliderData},
             raycast::Raycast,
         },
@@ -77,6 +78,12 @@ fn run_raycasts(
         if let Ok((mut context, mut scene_data, scene_transform)) =
             scene_datas.get_mut(scene_ent.root)
         {
+            // check if we can run
+            if context.blocked.contains(GLTF_LOADING) {
+                debug!("raycast skipped, waiting for gltfs");
+                continue;
+            }
+
             // check if we need to run
             let continuous = raycast.raycast.continuous.unwrap_or(false);
             if !continuous && raycast.last_run > 0 {
@@ -86,6 +93,7 @@ fn run_raycasts(
                 continue;
             }
             raycast.last_run = context.last_update_frame;
+            debug!("running raycast");
 
             // execute the raycast
             let raycast = &raycast.raycast;

--- a/src/scene_runner/update_scene/raycast_result.rs
+++ b/src/scene_runner/update_scene/raycast_result.rs
@@ -120,7 +120,7 @@ fn run_raycasts(
                         .map(|gt| gt.translation())
                         .unwrap_or(origin);
                     target_position - origin
-                },
+                }
                 None => {
                     warn!("no direction on raycast");
                     continue;

--- a/src/scene_runner/update_world/gltf_container.rs
+++ b/src/scene_runner/update_world/gltf_container.rs
@@ -464,7 +464,6 @@ fn check_gltfs_ready(
             debug!("{root:?} blocked on gltfs");
             context.blocked.insert(GLTF_LOADING);
         } else {
-            debug!("{root:?} not blocked on gltfs");
             context.blocked.remove(GLTF_LOADING);
         }
     }

--- a/src/scene_runner/update_world/gltf_container.rs
+++ b/src/scene_runner/update_world/gltf_container.rs
@@ -55,7 +55,11 @@ impl Plugin for GltfDefinitionPlugin {
         );
 
         app.add_system(update_gltf.in_set(SceneSets::PostLoop));
-        app.add_system(attach_ready_colliders.after(update_gltf).in_set(SceneSets::PostLoop));
+        app.add_system(
+            attach_ready_colliders
+                .after(update_gltf)
+                .in_set(SceneSets::PostLoop),
+        );
         app.add_asset::<GltfCachedShape>();
         app.init_resource::<MeshToShape>();
         app.add_system(check_gltfs_ready.in_set(SceneSets::PostInit));

--- a/src/scene_runner/update_world/gltf_container.rs
+++ b/src/scene_runner/update_world/gltf_container.rs
@@ -55,7 +55,7 @@ impl Plugin for GltfDefinitionPlugin {
         );
 
         app.add_system(update_gltf.in_set(SceneSets::PostLoop));
-        app.add_system(attach_ready_colliders.in_set(SceneSets::PostLoop));
+        app.add_system(attach_ready_colliders.after(update_gltf).in_set(SceneSets::PostLoop));
         app.add_asset::<GltfCachedShape>();
         app.init_resource::<MeshToShape>();
         app.add_system(check_gltfs_ready.in_set(SceneSets::PostInit));

--- a/src/scene_runner/update_world/gltf_container.rs
+++ b/src/scene_runner/update_world/gltf_container.rs
@@ -460,7 +460,7 @@ fn check_gltfs_ready(
     }
 
     for (root, mut context) in scenes.iter_mut() {
-        if unready_scenes.contains(&root) {
+        if unready_scenes.contains(&root) && context.tick_number == 0 {
             debug!("{root:?} blocked on gltfs");
             context.blocked.insert(GLTF_LOADING);
         } else {

--- a/src/scene_runner/update_world/mesh_collider.rs
+++ b/src/scene_runner/update_world/mesh_collider.rs
@@ -75,7 +75,7 @@ impl From<PbMeshCollider> for MeshCollider {
             // TODO update to u32
             collision_mask: value
                 .collision_mask
-                .unwrap_or(ColliderLayer::ClPointer as i32 | ColliderLayer::ClPhysics as i32)
+                .unwrap_or(ColliderLayer::ClPointer as u32 | ColliderLayer::ClPhysics as u32)
                 as u32,
             ..Default::default()
         }

--- a/src/scene_runner/update_world/mesh_collider.rs
+++ b/src/scene_runner/update_world/mesh_collider.rs
@@ -75,8 +75,7 @@ impl From<PbMeshCollider> for MeshCollider {
             // TODO update to u32
             collision_mask: value
                 .collision_mask
-                .unwrap_or(ColliderLayer::ClPointer as u32 | ColliderLayer::ClPhysics as u32)
-                as u32,
+                .unwrap_or(ColliderLayer::ClPointer as u32 | ColliderLayer::ClPhysics as u32),
             ..Default::default()
         }
     }

--- a/src/scene_runner/update_world/mesh_collider.rs
+++ b/src/scene_runner/update_world/mesh_collider.rs
@@ -89,8 +89,14 @@ impl Plugin for MeshColliderPlugin {
             ComponentPosition::EntityOnly,
         );
 
+        // collider components are created in SceneSets::Loop (by PbMeshCollider messages) and
+        // in SceneSets::PostLoop (by gltf processing).
+        // they are positioned in SceneSets::PostInit and
+        // they are used in SceneSets::Input (for raycasts).
+        // we want to avoid using CoreSet::PostUpdate as that's where we create/destroy scenes,
+        // so we use SceneSets::Init for adding colliders to the scene collider data (qbvh).
+        app.add_system(update_colliders.in_set(SceneSets::Init));
         app.add_system(update_scene_collider_data.in_set(SceneSets::PostInit));
-        app.add_system(update_colliders.in_set(SceneSets::PostLoop));
 
         // update collider transforms before queries and scenes are run, but after global transforms are updated (at end of prior frame)
         app.add_system(update_collider_transforms.in_set(SceneSets::PostInit));
@@ -338,6 +344,7 @@ impl SceneColliderData {
 
         self.scaled_collider.remove_by_left(id);
         self.collider_state.remove(id);
+        self.query_state_valid_at = None;
     }
 
     // TODO use map of maps to make this faster?

--- a/src/scene_runner/update_world/mesh_renderer/truncated_cone.rs
+++ b/src/scene_runner/update_world/mesh_renderer/truncated_cone.rs
@@ -35,9 +35,9 @@ impl Default for TruncatedCone {
 
 impl From<TruncatedCone> for Mesh {
     fn from(c: TruncatedCone) -> Self {
-        debug_assert!(c.base_radius > 0.0);
-        debug_assert!(c.tip_radius > 0.0);
-        debug_assert!(c.height > 0.0);
+        debug_assert!(c.base_radius >= 0.0);
+        debug_assert!(c.tip_radius >= 0.0);
+        debug_assert!(c.height >= 0.0);
         debug_assert!(c.resolution > 2);
         debug_assert!(c.segments > 0);
 


### PR DESCRIPTION
- EngineInfo component
- GltfContainerLoadingState component
- main.crdt handling 
    - immediately pipe to renderer
    - send to scene as initial state
    - block until gltfs and raycasts are done
    - move crdt message parsing into interface lib
    - TODO: add a mechanism to delay js load/run, so we can have distant static scenes without js overhead
- gltf fixes
    - handle container mask bits
    - process colliders on mesh node children of _collider nodes 
- raycast fixes
    - block until gltfs/colliders loaded on tick 0
    - add target entity mode
    - fix mouselocked raycast origin
- console commands
    - teleport x y (move player)
    - scene_distance x (set how far away from player the engine should load scenes)
- fix js setLocalTimeout
- general schedule cleanup