### PR TITLE
ui and collider fixes

### DIFF
--- a/crates/ipfs/Cargo.toml
+++ b/crates/ipfs/Cargo.toml
@@ -20,3 +20,4 @@ tokio = { version = "1.26.0", features = ["sync"] }
 clap = "4.1.10"
 urlencoding = "2.1.2"
 urn = "0.7.0"
+url = "2.4.0"

--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -130,6 +130,7 @@ impl IpfsType {
                 .map(|hash| format!("{base_url}{hash}"))
                 .or_else(|| {
                     // try as a url directly
+                    // TODO: check scene.json for allowed domains (include these in context like baseUrls)
                     url::Url::try_from(file_path.as_str())
                         .is_ok()
                         .then_some(file_path.to_owned())

--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -32,10 +32,9 @@ macro_rules! urlpath {
 
 use std::{
     collections::BTreeMap,
-    ffi::OsStr,
     iter::Peekable,
-    path::{Component, Components, Path, PathBuf},
-    str::FromStr,
+    path::{Path, PathBuf},
+    str::FromStr, ffi::OsStr,
 };
 
 use urn::Urn;
@@ -71,12 +70,12 @@ impl AsRef<Path> for EntityType {
     }
 }
 
-impl<'a> TryFrom<Component<'a>> for EntityType {
+impl TryFrom<&str> for EntityType {
     type Error = anyhow::Error;
 
-    fn try_from(value: Component<'a>) -> Result<Self, Self::Error> {
-        match value.as_os_str().to_str() {
-            Some("type.scene_entity") => Ok(EntityType::Scene),
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "type.scene_entity" => Ok(EntityType::Scene),
             other => anyhow::bail!("invalid pointer type: {:?}", other),
         }
     }
@@ -102,7 +101,7 @@ impl IpfsType {
     pub fn new_content_file(content_hash: String, file_path: String) -> Self {
         Self::ContentFile {
             content_hash,
-            file_path: normalize_path(&file_path.to_lowercase()),
+            file_path: normalize_path(&file_path),
         }
     }
 
@@ -116,7 +115,7 @@ impl IpfsType {
         }
     }
 
-    fn url_target(&self, context: &IpfsContext) -> Result<String, anyhow::Error> {
+    fn url_target(&self, context: &IpfsContext, base_url: &str) -> Result<String, anyhow::Error> {
         match self {
             IpfsType::ContentFile {
                 content_hash: scene_hash,
@@ -127,10 +126,14 @@ impl IpfsType {
                 .get(scene_hash)
                 .ok_or_else(|| anyhow::anyhow!("required collection hash not found: {scene_hash}"))?
                 .hash(file_path)
+                .map(|hash| format!("{base_url}{hash}"))
+                .or_else(|| {
+                    // try as a url directly
+                    url::Url::try_from(file_path.as_str()).is_ok().then_some(file_path.to_owned())
+                })
                 .ok_or_else(|| {
                     anyhow::anyhow!("file not found in content map: {file_path:?} in {scene_hash}")
-                })
-                .map(ToOwned::to_owned),
+                }),
             IpfsType::Pointer {
                 entity_type: pointer_type,
                 address,
@@ -182,7 +185,7 @@ impl From<&IpfsType> for PathBuf {
             } => {
                 // add leading `.` to the file_path's filename when converting to path format
                 let mut file_path = PathBuf::from(file_path);
-                let file_name = format!(".{}", file_path.file_name().unwrap().to_str().unwrap());
+                let file_name = format!(".{}", file_path.file_name().and_then(OsStr::to_str).unwrap_or_default());
                 file_path.pop();
                 file_path.push(file_name);
 
@@ -203,54 +206,51 @@ impl From<&IpfsType> for PathBuf {
     }
 }
 
-impl<'a> TryFrom<Peekable<Components<'a>>> for IpfsType {
+impl<'a, I> TryFrom<Peekable<I>> for IpfsType 
+where 
+    I: Iterator<Item=&'a str> + std::fmt::Debug,
+{
     type Error = anyhow::Error;
 
-    fn try_from(mut components: Peekable<Components>) -> Result<Self, Self::Error> {
+    fn try_from(mut components: Peekable<I>) -> Result<Self, Self::Error> {
         let ty = &components
             .next()
-            .ok_or(anyhow::anyhow!("missing ipfs type"))?
-            .as_os_str()
-            .to_str();
+            .ok_or(anyhow::anyhow!("missing ipfs type"))?;
 
-        match ty {
-            Some("$content_file") => {
+        match *ty {
+            "$content_file" => {
                 let content_hash = components
                     .next()
                     .ok_or(anyhow::anyhow!("content file specifier missing scene hash"))?
-                    .as_os_str()
-                    .to_string_lossy()
-                    .into_owned();
+                    .to_owned();
 
-                let mut file_path = PathBuf::default();
+                let mut file_path = String::default();
                 let mut file_component = components
                     .next()
                     .ok_or(anyhow::anyhow!("content file specifier missing file path"))?;
                 // pass through folders
                 while components.peek().is_some() {
-                    file_path.push(file_component);
+                    file_path.push_str(file_component);
+                    file_path.push_str("/");
                     file_component = components.next().unwrap();
                 }
                 // remove the leading '.' from the last component (the file name)
-                let file_name = file_component.as_os_str().to_str().unwrap();
-                let stripped_file_name = if let Some(stripped) = file_name.strip_prefix('.') {
+                let stripped_file_name = if let Some(stripped) = file_component.strip_prefix('.') {
                     stripped
                 } else {
-                    file_name
+                    file_component
                 };
-                file_path.push(stripped_file_name);
+                file_path.push_str(stripped_file_name);
                 Ok(IpfsType::ContentFile {
                     content_hash,
-                    file_path: normalize_path(file_path.to_str().unwrap()),
+                    file_path: file_path.to_lowercase(),
                 })
             }
-            Some("$pointer") => {
+            "$pointer" => {
                 let address = urlencoding::decode(
                     &components
                         .next()
-                        .ok_or(anyhow::anyhow!("pointer specifier missing address"))?
-                        .as_os_str()
-                        .to_string_lossy(),
+                        .ok_or(anyhow::anyhow!("pointer specifier missing address"))?,
                 )?
                 .into_owned();
                 let pointer_type = components
@@ -262,12 +262,10 @@ impl<'a> TryFrom<Peekable<Components<'a>>> for IpfsType {
                     address,
                 })
             }
-            Some("$entity") => {
+            "$entity" => {
                 let hash_ext: &str = &components
                     .next()
-                    .ok_or(anyhow::anyhow!("entity specifier missing"))?
-                    .as_os_str()
-                    .to_string_lossy();
+                    .ok_or(anyhow::anyhow!("entity specifier missing"))?;
                 let (hash, ext) = hash_ext
                     .split_once('.')
                     .ok_or(anyhow::anyhow!("entity specified malformed (no '.')"))?;
@@ -294,11 +292,10 @@ impl AsRef<Path> for IpfsKey {
     }
 }
 
-impl<'a> TryFrom<Component<'a>> for IpfsKey {
+impl TryFrom<&str> for IpfsKey {
     type Error = anyhow::Error;
 
-    fn try_from(value: Component) -> Result<Self, Self::Error> {
-        let key: &str = &value.as_os_str().to_string_lossy();
+    fn try_from(key: &str) -> Result<Self, Self::Error> {
         match key {
             "&baseUrl" => Ok(Self::BaseUrl),
             other => anyhow::bail!("unrecognised ipfs key `{other}`"),
@@ -359,9 +356,14 @@ impl IpfsPath {
     }
 
     pub fn new_from_path(path: &Path) -> Result<Option<Self>, anyhow::Error> {
-        let mut components = path.components().peekable();
+        let Some(path_str) = path.as_os_str().to_str() else {
+            return Ok(None);
+        };
 
-        if components.peek() != Some(&Component::Normal(OsStr::new("$ipfs"))) {
+        let normalized_path = path_str.replace('\\', "/");
+        let mut components = normalized_path.split('/').peekable();
+
+        if components.peek() != Some(&"$ipfs") {
             // not an ipfs path
             return Ok(None);
         }
@@ -370,14 +372,14 @@ impl IpfsPath {
         let mut key_values = BTreeMap::default();
         while components
             .peek()
-            .map(|c| c.as_os_str().to_string_lossy().starts_with('&'))
+            .map(|c| c.starts_with('&'))
             .unwrap_or_default()
         {
             let key: IpfsKey = components.next().unwrap().try_into()?;
             let value = components
                 .next()
                 .ok_or(anyhow::anyhow!("missing value for {key:?}"))?;
-            key_values.insert(key, value.as_os_str().to_string_lossy().into_owned());
+            key_values.insert(key, value.to_owned());
         }
 
         let ipfs_type = components.try_into()?;
@@ -416,9 +418,7 @@ impl IpfsPath {
             })
             .ok_or_else(|| anyhow::anyhow!("base url not specified in asset path or context"))?;
 
-        let target = self.ipfs_type.url_target(context)?;
-
-        Ok(format!("{base_url}{target}"))
+        self.ipfs_type.url_target(context, &base_url)
     }
 
     pub fn hash(&self, context: &IpfsContext) -> Option<String> {
@@ -453,5 +453,5 @@ impl From<&IpfsPath> for PathBuf {
 
 // must be a better way to do this
 pub fn normalize_path(path: &str) -> String {
-    path.to_lowercase().replace('\\', "/")
+    path.replace('\\', "/")
 }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -660,10 +660,7 @@ impl AssetIo for IpfsIo {
                 None => None,
                 Some(hash) => {
                     debug!("hash: {}", hash);
-                    match ipfs_path.should_cache(hash) {
-                        true => self.default_io.load_path(Path::new(hash)).await.ok(),
-                        false => None,
-                    }
+                    self.default_io.load_path(Path::new(hash)).await.ok()
                 }
             };
 
@@ -707,7 +704,7 @@ impl AssetIo for IpfsIo {
 
                     let response = request.send_async().await;
 
-                    debug!("[{token:?}]: attempt {attempt}: response: {response:?}");
+                    debug!("[{token:?}]: attempt {attempt}: request: {remote}, response: {response:?}");
 
                     let mut response = match response {
                         Err(e) if e.is_timeout() && attempt <= 3 => continue,

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -84,12 +84,10 @@ impl AssetLoader for EntityDefinitionLoader {
                 load_context.set_default_asset(LoadedAsset::new(EntityDefinition::default()));
                 return Ok(());
             };
-            let content = ContentMap(BiMap::from_iter(
-                definition_json
-                    .content
-                    .into_iter()
-                    .map(|ipfs| (normalize_path(&ipfs.file).to_lowercase(), ipfs.hash)),
-            ));
+            let content =
+                ContentMap(BiMap::from_iter(definition_json.content.into_iter().map(
+                    |ipfs| (normalize_path(&ipfs.file).to_lowercase(), ipfs.hash),
+                )));
             let id = definition_json.id.unwrap_or_else(|| {
                 // we must have been loaded as an entity with the format "$ipfs/$entity/{hash}.entity_type" - use the ipfs path to resolve the id
                 load_context
@@ -151,7 +149,9 @@ impl ContentMap {
     }
 
     pub fn hash(&self, file: &str) -> Option<&str> {
-        self.0.get_by_left(file.to_lowercase().as_str()).map(String::as_str)
+        self.0
+            .get_by_left(file.to_lowercase().as_str())
+            .map(String::as_str)
     }
 }
 
@@ -235,7 +235,7 @@ impl IpfsLoaderExt for AssetServer {
 
     fn load_hash<T: Asset>(&self, hash: &str, ty: EntityType) -> Handle<T> {
         let ext = ty.ext();
-        let path = format!("$ipfs//$entity//{hash}.{ext}");
+        let path = format!("$ipfs/$entity/{hash}.{ext}");
         self.load(path)
     }
 

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -88,7 +88,7 @@ impl AssetLoader for EntityDefinitionLoader {
                 definition_json
                     .content
                     .into_iter()
-                    .map(|ipfs| (normalize_path(&ipfs.file), ipfs.hash)),
+                    .map(|ipfs| (normalize_path(&ipfs.file).to_lowercase(), ipfs.hash)),
             ));
             let id = definition_json.id.unwrap_or_else(|| {
                 // we must have been loaded as an entity with the format "$ipfs/$entity/{hash}.entity_type" - use the ipfs path to resolve the id
@@ -151,7 +151,7 @@ impl ContentMap {
     }
 
     pub fn hash(&self, file: &str) -> Option<&str> {
-        self.0.get_by_left(file).map(String::as_str)
+        self.0.get_by_left(file.to_lowercase().as_str()).map(String::as_str)
     }
 }
 
@@ -217,7 +217,7 @@ impl IpfsLoaderExt for AssetServer {
             .context_free_hash()?
             .ok_or(anyhow::anyhow!("urn did not resolve to a hash"))?;
         let ext = ty.ext();
-        let path = format!("$ipfs//$entity//{hash}.{ext}");
+        let path = format!("$ipfs/$entity/{hash}.{ext}");
 
         if let Some(base_url) = ipfs_path.base_url() {
             // update the context
@@ -603,7 +603,7 @@ impl IpfsIo {
                         entity
                             .content
                             .into_iter()
-                            .map(|ipfs| (normalize_path(&ipfs.file), ipfs.hash)),
+                            .map(|ipfs| (normalize_path(&ipfs.file).to_lowercase(), ipfs.hash)),
                     )),
                 });
             }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -704,7 +704,9 @@ impl AssetIo for IpfsIo {
 
                     let response = request.send_async().await;
 
-                    debug!("[{token:?}]: attempt {attempt}: request: {remote}, response: {response:?}");
+                    debug!(
+                        "[{token:?}]: attempt {attempt}: request: {remote}, response: {response:?}"
+                    );
 
                     let mut response = match response {
                         Err(e) if e.is_timeout() && attempt <= 3 => continue,

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -97,6 +97,12 @@ pub struct ContainerEntity {
     pub container_id: SceneEntityId,
 }
 
+// resource into which systems can add debug info
+#[derive(Resource, Default)]
+pub struct DebugInfo {
+    pub info: HashMap<&'static str, String>,
+}
+
 // plugin which creates and runs scripts
 pub struct SceneRunnerPlugin;
 
@@ -109,6 +115,7 @@ pub struct SceneLoopSchedule {
 impl Plugin for SceneRunnerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CrdtExtractors>();
+        app.init_resource::<DebugInfo>();
 
         let (sender, receiver) = sync_channel(1000);
         app.insert_resource(SceneUpdates {
@@ -540,6 +547,8 @@ fn receive_scene_updates(
     }
 }
 
+// entities deleted this loop
+// note this is only valid within the scene loop, as it is overwritten in each lifecycle update (within the loop)
 #[derive(Component, Default)]
 pub struct DeletedSceneEntities(pub HashSet<SceneEntityId>);
 

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -4,7 +4,8 @@ use console::DoAddConsoleCommand;
 
 use crate::{
     update_world::{mesh_collider::SceneColliderData, pointer_events::PointerEvents},
-    ContainingScene, PrimaryUser, RendererSceneContext, SceneEntity, SceneSets, ContainerEntity, DebugInfo,
+    ContainerEntity, ContainingScene, DebugInfo, PrimaryUser, RendererSceneContext, SceneEntity,
+    SceneSets,
 };
 use common::{dynamics::PLAYER_COLLIDER_RADIUS, structs::PrimaryCamera};
 use dcl::interface::CrdtType;
@@ -25,11 +26,16 @@ impl Plugin for PointerResultPlugin {
             .init_resource::<UiPointerTarget>()
             .init_resource::<DebugPointers>();
         app.add_systems(
-            (update_pointer_target, send_hover_events, send_action_events, debug_pointer)
+            (
+                update_pointer_target,
+                send_hover_events,
+                send_action_events,
+                debug_pointer,
+            )
                 .chain()
                 .in_set(SceneSets::Input),
         );
-        app.add_console_command::<DebugPointerCommand,_>(debug_pointer_command);
+        app.add_console_command::<DebugPointerCommand, _>(debug_pointer_command);
     }
 }
 
@@ -156,9 +162,7 @@ fn debug_pointer_command(
     mut debug: ResMut<DebugPointers>,
 ) {
     if let Some(Ok(command)) = input.take() {
-        let new_state = command
-            .show
-            .unwrap_or(!debug.0);
+        let new_state = command.show.unwrap_or(!debug.0);
         debug.0 = new_state;
     }
 }
@@ -175,19 +179,32 @@ fn debug_pointer(
         let info = if let UiPointerTarget::Some(ui_ent) = *ui_target {
             if let Ok(target) = target.get(ui_ent) {
                 if let Ok(scene) = scene.get(target.root) {
-                    format!("ui element {} from scene {}", target.container_id, scene.title)
+                    format!(
+                        "ui element {} from scene {}",
+                        target.container_id, scene.title
+                    )
                 } else {
                     format!("ui element {} unknown scene", target.container_id)
                 }
             } else {
                 format!("ui element (not found - bevy entity {ui_ent:?})")
             }
-        } else if let PointerTarget::Some { container, ref mesh_name } = *pointer_target {
+        } else if let PointerTarget::Some {
+            container,
+            ref mesh_name,
+        } = *pointer_target
+        {
             if let Ok(target) = target.get(container) {
                 if let Ok(scene) = scene.get(target.root) {
-                    format!("world entity {}-{:?} from scene {}", target.container_id, mesh_name, scene.title)
+                    format!(
+                        "world entity {}-{:?} from scene {}",
+                        target.container_id, mesh_name, scene.title
+                    )
                 } else {
-                    format!("world entity {}-{:?} unknown scene", target.container_id, mesh_name)
+                    format!(
+                        "world entity {}-{:?} unknown scene",
+                        target.container_id, mesh_name
+                    )
                 }
             } else {
                 format!("world entity (not found - bevy entity {container:?})")

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -16,11 +16,11 @@ use rapier3d::{
 
 use crate::{
     update_world::mesh_renderer::truncated_cone::TruncatedCone, ContainerEntity, ContainingScene,
-    DeletedSceneEntities, PrimaryUser, RendererSceneContext, SceneSets,
+    DeletedSceneEntities, PrimaryUser, RendererSceneContext, SceneSets, SceneLoopSchedule,
 };
 use common::{
     dynamics::{PLAYER_COLLIDER_HEIGHT, PLAYER_COLLIDER_OVERLAP, PLAYER_COLLIDER_RADIUS},
-    util::TryInsertEx,
+    util::TryInsertEx, sets::SceneLoopSets,
 };
 use console::DoAddConsoleCommand;
 use dcl::interface::ComponentPosition;
@@ -103,6 +103,13 @@ impl Plugin for MeshColliderPlugin {
         // so we use SceneSets::Init for adding colliders to the scene collider data (qbvh).
         app.add_system(update_colliders.in_set(SceneSets::Init));
         app.add_system(update_scene_collider_data.in_set(SceneSets::PostInit));
+
+        // collider deletion has to occur within the scene loop, as the DeletedSceneEntities resource is only
+        // valid within the loop
+        app.world
+            .resource_mut::<SceneLoopSchedule>()
+            .schedule
+            .add_system(remove_deleted_colliders.in_set(SceneLoopSets::UpdateWorld));
 
         // update collider transforms before queries and scenes are run, but after global transforms are updated (at end of prior frame)
         app.add_system(update_collider_transforms.in_set(SceneSets::PostInit));
@@ -517,8 +524,7 @@ fn update_colliders(
         (Entity, &ContainerEntity, &HasCollider),
         Without<MeshCollider>,
     >,
-    // remove colliders for deleted entities
-    mut scene_data: Query<(&mut SceneColliderData, Option<&DeletedSceneEntities>)>,
+    mut scene_data: Query<&mut SceneColliderData>,
 ) {
     // add colliders
     // any entity with a mesh collider that we're not using, or where the mesh collider has changed
@@ -549,7 +555,7 @@ fn update_colliders(
             collider_def.index,
         );
         debug!("{:?} adding collider", collider_id);
-        let Ok((mut scene_data, _)) = scene_data.get_mut(container.root) else {
+        let Ok(mut scene_data) = scene_data.get_mut(container.root) else {
             warn!("missing scene root for {collider_id:?}");
             continue;
         };
@@ -561,7 +567,7 @@ fn update_colliders(
     // remove colliders
     // any entities with a live collider handle that don't have a mesh collider or a mesh definition
     for (ent, container, collider) in colliders_without_source.iter() {
-        let Ok((mut scene_data, _)) = scene_data.get_mut(container.root) else {
+        let Ok(mut scene_data) = scene_data.get_mut(container.root) else {
             warn!("missing scene root for {container:?}");
             continue;
         };
@@ -569,13 +575,14 @@ fn update_colliders(
         scene_data.remove_collider(&collider.0);
         commands.entity(ent).remove::<HasCollider>();
     }
+}
 
-    // remove colliders for deleted entities
-    for (mut scene_data, maybe_deleted_entities) in &mut scene_data {
-        if let Some(deleted_entities) = maybe_deleted_entities {
-            for deleted_entity in &deleted_entities.0 {
-                scene_data.remove_colliders(*deleted_entity);
-            }
+fn remove_deleted_colliders(
+    mut scene_data: Query<(&mut SceneColliderData, &DeletedSceneEntities)>,
+) {
+    for (mut scene_data, deleted_entities) in &mut scene_data {
+        for deleted_entity in &deleted_entities.0 {
+            scene_data.remove_colliders(*deleted_entity);
         }
     }
 }

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -527,7 +527,7 @@ fn update_colliders(
             MeshColliderShape::Box => ColliderBuilder::cuboid(0.5, 0.5, 0.5),
             MeshColliderShape::Cylinder { radius_top, radius_bottom } => {
                 // TODO we could use explicit support points to make queries faster
-                let mesh: Mesh = TruncatedCone{ base_radius: *radius_top, tip_radius: *radius_bottom, ..Default::default() }.into();
+                let mesh: Mesh = TruncatedCone{ base_radius: *radius_bottom, tip_radius: *radius_top, ..Default::default() }.into();
                 let VertexAttributeValues::Float32x3(positions) = mesh.attribute(Mesh::ATTRIBUTE_POSITION).unwrap() else { panic!() };
                 ColliderBuilder::convex_hull(&positions.iter().map(|p| Point::from(*p)).collect::<Vec<_>>()).unwrap()
             }

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -16,11 +16,12 @@ use rapier3d::{
 
 use crate::{
     update_world::mesh_renderer::truncated_cone::TruncatedCone, ContainerEntity, ContainingScene,
-    DeletedSceneEntities, PrimaryUser, RendererSceneContext, SceneSets, SceneLoopSchedule,
+    DeletedSceneEntities, PrimaryUser, RendererSceneContext, SceneLoopSchedule, SceneSets,
 };
 use common::{
     dynamics::{PLAYER_COLLIDER_HEIGHT, PLAYER_COLLIDER_OVERLAP, PLAYER_COLLIDER_RADIUS},
-    util::TryInsertEx, sets::SceneLoopSets,
+    sets::SceneLoopSets,
+    util::TryInsertEx,
 };
 use console::DoAddConsoleCommand;
 use dcl::interface::ComponentPosition;

--- a/crates/scene_runner/src/update_world/scene_ui.rs
+++ b/crates/scene_runner/src/update_world/scene_ui.rs
@@ -636,6 +636,7 @@ fn layout_scene_ui(
                                                     ent_cmds.with_children(|c| {
                                                         c.spawn(NodeBundle {
                                                             style: Style {
+                                                                position_type: PositionType::Absolute,
                                                                 size: Size::all(Val::Percent(100.0)),
                                                                 overflow: Overflow::Hidden,
                                                                 ..Default::default()

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -214,9 +214,12 @@ fn update_scene_load_state(
         set_child(format!("{}", transports));
         set_child(format!("{}", players));
 
-        let debug_info = debug_info.info.iter().fold(String::default(), |msg, (key, info)| {
-            format!("{msg}\n{key}: {info}")
-        });
+        let debug_info = debug_info
+            .info
+            .iter()
+            .fold(String::default(), |msg, (key, info)| {
+                format!("{msg}\n{key}: {info}")
+            });
         set_child(debug_info);
     }
 }


### PR DESCRIPTION
- allow urls for content paths
  - TODO: check scene.json for allowed domains
- support UiBackground texture uvs (only for stretch mode)
- add debug info for pointer events with `/debug_pointer`
- collider fixes 
  - pointer events now only check current scene entities
  - fix upside-down error in cylinder collider construction
  - fix error where deleted colliders still remained if the scene-runner loop ran again after the delete in the same frame
- fix b64s not loading from remote/content/contents by still loading from fs, but only caching via active-entities
