### PR TITLE
feat: dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+# Base image
+FROM ubuntu:22.04
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUST_VERSION=stable
+ENV TARGET_DIR=/usr/src/app/target
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    clang \
+    pkg-config \
+    libssl-dev \
+    libasound2-dev \
+    libudev-dev \
+    libx11-dev \
+    libgl1-mesa-dev \
+    libxext-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libavfilter-dev \
+    libavdevice-dev \
+    libegl1-mesa \
+    libgl1-mesa-dri \
+    libxcb-xfixes0-dev \
+    mesa-vulkan-drivers \
+    xvfb \
+    git \
+    unzip \
+    ca-certificates \
+    xfce4 xfce4-terminal \
+    x11vnc novnc \
+    supervisor \
+    nvidia-driver-525 \
+    && apt-get clean
+
+# Update CA certificates
+RUN update-ca-certificates
+
+# Install Protobuf
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip && \
+    unzip protoc-21.12-linux-x86_64.zip -d /usr/local && \
+    rm protoc-21.12-linux-x86_64.zip
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain $RUST_VERSION
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Create app directory and set up cache for the target folder
+WORKDIR /usr/src/app
+
+# Copy the Rust project
+COPY . /usr/src/app
+
+# Pre-build dependencies to speed up builds
+RUN cargo fetch
+
+# Build the project in release mode
+RUN cargo build --release
+
+# Copy Supervisor configuration
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Expose necessary ports
+EXPOSE 8080
+
+# Start Supervisor to manage services
+CMD ["/usr/bin/supervisord", "-n"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,4 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 EXPOSE 8080
 
 # Start Supervisor to manage services
-CMD ["/usr/bin/supervisord", "-n"]
+CMD ["/usr/bin/supervisord", "-n", "--loglevel", "debug"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,24 @@
+[supervisord]
+nodaemon=true
+
+[program:Xvfb]
+command=/usr/bin/Xvfb :99 -screen 0 1024x768x24
+autorestart=true
+priority=10
+
+[program:x11vnc]
+command=/usr/bin/x11vnc -forever -nopw -create -display :99
+autorestart=true
+priority=20
+
+[program:novnc]
+command=/usr/share/novnc/utils/launch.sh --vnc localhost:5900 --listen 8080
+autorestart=true
+priority=30
+
+[program:bevy-app]
+command=cargo run --release --bin decentra-bevy
+directory=/usr/src/app
+environment=DISPLAY=:99
+autorestart=true
+priority=40


### PR DESCRIPTION
Requires nvidia docker and an nvidia driver on the host

Guide to install it NVIDIA on the host:
https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html

For testing the NVIDIA Driver for Docker you can run:
```bash
docker run --rm --gpus all nvidia/cuda:11.8.0-base-ubuntu22.04 nvidia-smi
```

Then for building and running the Bevy Explorer:
```bash
docker build -t bevy-explorer .
docker run -it --rm --gpus all -p 8080:8080 bevy-explorer
```

and then you can connect to the X11 Viewer by going to http://localhost:8080/vnc_auto.html