### PR TITLE
More UI fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_internal",
 ]
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -948,7 +948,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "proc-macro2",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "bevy_audio"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1031,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.14.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "bevy_core"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1082,7 +1082,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "quote",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1162,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "proc-macro2",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "encase_derive_impl",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "proc-macro2",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "bevy_hierarchy"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_reflect",
  "glam 0.27.0",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "glam 0.27.0",
 ]
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1460,12 +1460,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_ptr",
  "bevy_reflect_derive",
@@ -1484,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "proc-macro2",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "proc-macro2",
@@ -1555,7 +1555,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1622,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_macro_utils 0.14.1",
  "proc-macro2",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1645,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils_proc_macros"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -1767,7 +1767,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.14.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#9e20f5a2c44aebfd6f3607a82df1576a451d70b1"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.14-dcl-cosmic-noimage#1a879ce59ddfd352a729d6fec9fd4aa85b42e581"
 dependencies = [
  "accesskit_winit",
  "approx",

--- a/crates/common/src/inputs.rs
+++ b/crates/common/src/inputs.rs
@@ -25,6 +25,16 @@ pub enum SystemAction {
     PointerLeft,
     PointerRight,
     ShowProfile,
+    QuickEmote1,
+    QuickEmote2,
+    QuickEmote3,
+    QuickEmote4,
+    QuickEmote5,
+    QuickEmote6,
+    QuickEmote7,
+    QuickEmote8,
+    QuickEmote9,
+    QuickEmote0,
 }
 
 impl From<SystemAction> for Action {
@@ -422,6 +432,46 @@ impl Default for InputMap {
                         AxisIdentifier::GamepadRight,
                         InputDirection::Right,
                     )],
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote0),
+                    vec![InputIdentifier::Key(KeyCode::Digit0)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote1),
+                    vec![InputIdentifier::Key(KeyCode::Digit1)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote2),
+                    vec![InputIdentifier::Key(KeyCode::Digit2)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote3),
+                    vec![InputIdentifier::Key(KeyCode::Digit3)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote4),
+                    vec![InputIdentifier::Key(KeyCode::Digit4)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote5),
+                    vec![InputIdentifier::Key(KeyCode::Digit5)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote6),
+                    vec![InputIdentifier::Key(KeyCode::Digit6)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote7),
+                    vec![InputIdentifier::Key(KeyCode::Digit7)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote8),
+                    vec![InputIdentifier::Key(KeyCode::Digit8)]
+                ),
+                (
+                    Action::System(SystemAction::QuickEmote9),
+                    vec![InputIdentifier::Key(KeyCode::Digit9)]
                 ),
             ]),
         }

--- a/crates/common/src/inputs.rs
+++ b/crates/common/src/inputs.rs
@@ -435,43 +435,43 @@ impl Default for InputMap {
                 ),
                 (
                     Action::System(SystemAction::QuickEmote0),
-                    vec![InputIdentifier::Key(KeyCode::Digit0)]
+                    vec![InputIdentifier::Key(KeyCode::Digit0)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote1),
-                    vec![InputIdentifier::Key(KeyCode::Digit1)]
+                    vec![InputIdentifier::Key(KeyCode::Digit1)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote2),
-                    vec![InputIdentifier::Key(KeyCode::Digit2)]
+                    vec![InputIdentifier::Key(KeyCode::Digit2)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote3),
-                    vec![InputIdentifier::Key(KeyCode::Digit3)]
+                    vec![InputIdentifier::Key(KeyCode::Digit3)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote4),
-                    vec![InputIdentifier::Key(KeyCode::Digit4)]
+                    vec![InputIdentifier::Key(KeyCode::Digit4)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote5),
-                    vec![InputIdentifier::Key(KeyCode::Digit5)]
+                    vec![InputIdentifier::Key(KeyCode::Digit5)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote6),
-                    vec![InputIdentifier::Key(KeyCode::Digit6)]
+                    vec![InputIdentifier::Key(KeyCode::Digit6)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote7),
-                    vec![InputIdentifier::Key(KeyCode::Digit7)]
+                    vec![InputIdentifier::Key(KeyCode::Digit7)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote8),
-                    vec![InputIdentifier::Key(KeyCode::Digit8)]
+                    vec![InputIdentifier::Key(KeyCode::Digit8)],
                 ),
                 (
                     Action::System(SystemAction::QuickEmote9),
-                    vec![InputIdentifier::Key(KeyCode::Digit9)]
+                    vec![InputIdentifier::Key(KeyCode::Digit9)],
                 ),
             ]),
         }

--- a/crates/common/src/inputs.rs
+++ b/crates/common/src/inputs.rs
@@ -212,7 +212,7 @@ pub enum Action {
     System(SystemAction),
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BindingsData {
     pub bindings: HashMap<Action, Vec<InputIdentifier>>,

--- a/crates/common/src/inputs.rs
+++ b/crates/common/src/inputs.rs
@@ -324,7 +324,10 @@ impl Default for InputMap {
                 ),
                 (
                     Action::System(SystemAction::Emote),
-                    vec![InputIdentifier::Key(KeyCode::AltLeft)],
+                    vec![
+                        InputIdentifier::Key(KeyCode::AltLeft),
+                        InputIdentifier::Gamepad(GamepadButtonType::West),
+                    ],
                 ),
                 (
                     Action::System(SystemAction::Cancel),

--- a/crates/common/src/rpc.rs
+++ b/crates/common/src/rpc.rs
@@ -12,8 +12,14 @@ pub trait DynRpcResult: std::any::Any + std::fmt::Debug + Send + Sync + 'static 
     fn as_any(&mut self) -> &mut dyn Any;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RpcResultSender<T>(Arc<RwLock<Option<tokio::sync::oneshot::Sender<T>>>>);
+
+impl<T> std::fmt::Debug for RpcResultSender<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RpcResultSender").finish()
+    }
+}
 
 impl<T: 'static> Default for RpcResultSender<T> {
     fn default() -> Self {

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -288,6 +288,7 @@ pub struct GraphicsSettings {
     // pub fullscreen_res: FullscreenResSetting,
     pub fog: FogSetting,
     pub bloom: BloomSetting,
+    pub dof: DofSetting,
     pub ssao: SsaoSetting,
     pub oob: f32,
     pub ambient_brightness: i32,
@@ -308,6 +309,7 @@ impl Default for GraphicsSettings {
             // fullscreen_res: FullscreenResSetting(UVec2::new(1280,720)),
             fog: FogSetting::Atmospheric,
             bloom: BloomSetting::Low,
+            dof: DofSetting::High,
             ssao: SsaoSetting::Off,
             oob: 2.0,
             ambient_brightness: 50,
@@ -391,6 +393,20 @@ pub enum BloomSetting {
     Off,
     Low,
     High,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DofSetting {
+    Off,
+    Low,
+    High,
+}
+
+#[derive(Component)]
+// (sensor height, extra focal distance)
+pub struct DofConfig {
+    pub default_sensor_height: f32,
+    pub extra_focal_distance: f32,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -300,7 +300,7 @@ impl Default for GraphicsSettings {
         Self {
             vsync: false,
             log_fps: true,
-            msaa: AaSetting::Msaa4x,
+            msaa: AaSetting::FxaaHigh,
             fps_target: 60,
             shadow_distance: 200.0,
             shadow_settings: ShadowSetting::High,

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -292,6 +292,7 @@ pub struct GraphicsSettings {
     pub ssao: SsaoSetting,
     pub oob: f32,
     pub ambient_brightness: i32,
+    pub gpu_bytes_per_frame: usize,
 }
 
 impl Default for GraphicsSettings {
@@ -311,6 +312,7 @@ impl Default for GraphicsSettings {
             ssao: SsaoSetting::Off,
             oob: 2.0,
             ambient_brightness: 50,
+            gpu_bytes_per_frame: 0,
         }
     }
 }

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -206,9 +206,9 @@ pub struct AppConfig {
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            server: "https://sdk-team-cdn.decentraland.org/ipfs/goerli-plaza-main-latest"
+            server: "https://realm-provider-ea.decentraland.org/main"
                 .to_owned(),
-            location: IVec2::new(78, -7),
+            location: IVec2::new(0, 0),
             previous_login: None,
             graphics: Default::default(),
             audio: Default::default(),

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -206,8 +206,7 @@ pub struct AppConfig {
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            server: "https://realm-provider-ea.decentraland.org/main"
-                .to_owned(),
+            server: "https://realm-provider-ea.decentraland.org/main".to_owned(),
             location: IVec2::new(0, 0),
             previous_login: None,
             graphics: Default::default(),

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -8,7 +8,7 @@ use bevy::{
 use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender},
-    structs::{AttachPoints, AudioDecoderError},
+    structs::{AttachPoints, AudioDecoderError}, util::TryPushChildrenEx,
 };
 use ethers_core::types::Address;
 use kira::sound::streaming::StreamingSoundData;
@@ -310,7 +310,7 @@ pub fn process_transport_updates(
                         ForeignAudioSource(audio_receiver),
                         propagate::Propagate(RenderLayers::default()),
                     ))
-                    .push_children(&attach_points.entities())
+                    .try_push_children(&attach_points.entities())
                     .insert(attach_points)
                     .id();
 

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -8,7 +8,8 @@ use bevy::{
 use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender},
-    structs::{AttachPoints, AudioDecoderError}, util::TryPushChildrenEx,
+    structs::{AttachPoints, AudioDecoderError},
+    util::TryPushChildrenEx,
 };
 use ethers_core::types::Address;
 use kira::sound::streaming::StreamingSoundData;

--- a/crates/comms/src/profile.rs
+++ b/crates/comms/src/profile.rs
@@ -21,7 +21,11 @@ use super::{
     NetworkMessage, Transport,
 };
 use common::{
-    profile::{AvatarSnapshots, LambdaProfiles, SerializedProfile}, rpc::RpcEventSender, sets::SceneSets, structs::PrimaryUser, util::{FireEventEx, TaskCompat, TaskExt}
+    profile::{AvatarSnapshots, LambdaProfiles, SerializedProfile},
+    rpc::RpcEventSender,
+    sets::SceneSets,
+    structs::PrimaryUser,
+    util::{FireEventEx, TaskCompat, TaskExt},
 };
 use common::{rpc::RpcCall, util::AsH160};
 use dcl_component::{
@@ -36,16 +40,12 @@ impl Plugin for UserProfilePlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            (
-                request_missing_profiles,
-                process_profile_events,
-            )
-                .before(process_transport_updates), // .in_set(TODO)
+            (request_missing_profiles, process_profile_events).before(process_transport_updates), // .in_set(TODO)
         );
 
         app.add_systems(
             Update,
-            setup_primary_profile.in_set(SceneSets::RestrictedActions) // in restricted actions so we get profile updates from login before a scene tick runs
+            setup_primary_profile.in_set(SceneSets::RestrictedActions), // in restricted actions so we get profile updates from login before a scene tick runs
         );
 
         app.insert_resource(CurrentUserProfile::default());

--- a/crates/comms/src/profile.rs
+++ b/crates/comms/src/profile.rs
@@ -21,10 +21,7 @@ use super::{
     NetworkMessage, Transport,
 };
 use common::{
-    profile::{AvatarSnapshots, LambdaProfiles, SerializedProfile},
-    rpc::RpcEventSender,
-    structs::PrimaryUser,
-    util::{FireEventEx, TaskCompat, TaskExt},
+    profile::{AvatarSnapshots, LambdaProfiles, SerializedProfile}, rpc::RpcEventSender, sets::SceneSets, structs::PrimaryUser, util::{FireEventEx, TaskCompat, TaskExt}
 };
 use common::{rpc::RpcCall, util::AsH160};
 use dcl_component::{
@@ -42,9 +39,13 @@ impl Plugin for UserProfilePlugin {
             (
                 request_missing_profiles,
                 process_profile_events,
-                setup_primary_profile,
             )
                 .before(process_transport_updates), // .in_set(TODO)
+        );
+
+        app.add_systems(
+            Update,
+            setup_primary_profile.in_set(SceneSets::RestrictedActions) // in restricted actions so we get profile updates from login before a scene tick runs
         );
 
         app.insert_resource(CurrentUserProfile::default());

--- a/crates/imposters/src/imposter_spec.rs
+++ b/crates/imposters/src/imposter_spec.rs
@@ -169,6 +169,7 @@ pub async fn load_imposter_remote(
     let bytes = response.bytes().await?;
     let mut zip = ZipArchive::new(Cursor::new(bytes))?;
     let root = file_root(ipfs.cache_path(), id, level);
+    async_fs::create_dir_all(&root).await?;
     zip.extract(root)?;
     Ok(())
 }

--- a/crates/input_manager/src/lib.rs
+++ b/crates/input_manager/src/lib.rs
@@ -173,7 +173,7 @@ impl InputManager<'_> {
             || self.key_input.get_just_released().len() != 0
             || self.gamepad_input.get_just_pressed().len() != 0
             || self.gamepad_input.get_just_released().len() != 0
-            || self.axis_data.current.len() != 0
+            || !self.axis_data.current.is_empty()
     }
 
     fn inputs(&self, action: Action) -> impl Iterator<Item = &InputIdentifier> {

--- a/crates/input_manager/src/lib.rs
+++ b/crates/input_manager/src/lib.rs
@@ -171,6 +171,9 @@ impl InputManager<'_> {
             || self.mouse_input.get_just_released().len() != 0
             || self.key_input.get_just_pressed().len() != 0
             || self.key_input.get_just_released().len() != 0
+            || self.gamepad_input.get_just_pressed().len() != 0
+            || self.gamepad_input.get_just_released().len() != 0
+            || self.axis_data.current.len() != 0
     }
 
     fn inputs(&self, action: Action) -> impl Iterator<Item = &InputIdentifier> {

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -584,7 +584,12 @@ pub fn change_realm(
         let ipfs = ipfs.clone();
         let request = change_realm_requests.read().last().unwrap();
 
-        let new_realm = request.new_realm.to_owned();
+        let new_realm = &request.new_realm;
+        let new_realm = if new_realm.ends_with(".dcl.eth") && !new_realm.starts_with("https://") {
+            format!("https://worlds-content-server.decentraland.org/world/{new_realm}")
+        } else {
+            new_realm.to_owned()
+        };
         let content_server_override = request.content_server_override.to_owned();
         IoTaskPool::get()
             .spawn_compat(async move {

--- a/crates/nft/src/lib.rs
+++ b/crates/nft/src/lib.rs
@@ -114,6 +114,7 @@ fn update_nft_shapes(
                         "nft://{}.nft",
                         urlencoding::encode(&nft_shape.0.urn)
                     ))),
+                    scene_ent.clone(),
                 ));
             })
             .id();
@@ -221,6 +222,7 @@ fn load_nft(
     config: Res<AppConfig>,
 ) {
     for (ent, scene_ent, nft) in q.iter() {
+        println!("checking: {ent:?}");
         let Some(nft) = nfts.get(nft.0.id()) else {
             if let LoadState::Failed(_) = asset_server.load_state(nft.0.id()) {
                 debug!("nft failed");
@@ -238,8 +240,11 @@ fn load_nft(
 
         // get bounds
         let Ok(bounds) = scenes.get(scene_ent.root).map(|ctx| ctx.bounds.clone()) else {
+            println!("fail bounds");
             continue;
         };
+
+        println!("got all: {ipfs_path:?} , {bounds:?}");
 
         commands
             .entity(ent)

--- a/crates/nft/src/lib.rs
+++ b/crates/nft/src/lib.rs
@@ -222,7 +222,6 @@ fn load_nft(
     config: Res<AppConfig>,
 ) {
     for (ent, scene_ent, nft) in q.iter() {
-        println!("checking: {ent:?}");
         let Some(nft) = nfts.get(nft.0.id()) else {
             if let LoadState::Failed(_) = asset_server.load_state(nft.0.id()) {
                 debug!("nft failed");
@@ -240,11 +239,8 @@ fn load_nft(
 
         // get bounds
         let Ok(bounds) = scenes.get(scene_ent.root).map(|ctx| ctx.bounds.clone()) else {
-            println!("fail bounds");
             continue;
         };
-
-        println!("got all: {ipfs_path:?} , {bounds:?}");
 
         commands
             .entity(ent)

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -819,6 +819,7 @@ pub fn process_realm_change(
     current_realm: Res<CurrentRealm>,
     mut live_scenes: ResMut<LiveScenes>,
     mut segment_config: Option<ResMut<SegmentConfig>>,
+    scenes: Query<&RendererSceneContext>,
 ) {
     if current_realm.is_changed() {
         info!(
@@ -860,10 +861,11 @@ pub fn process_realm_change(
         //     PointerResult::Exists{ hash, .. } => realm_scene_ids.contains_key(hash),
         // });
         if !realm_scene_ids.is_empty() {
-            // purge pointers and scenes that are not in the realm list
-            live_scenes
-                .scenes
-                .retain(|hash, _| realm_scene_ids.contains_key(hash));
+            // purge pointers and scenes that are not in the realm list (and not portable)
+            live_scenes.scenes.retain(|hash, entity| {
+                realm_scene_ids.contains_key(hash)
+                    || scenes.get(*entity).is_ok_and(|ctx| ctx.is_portable)
+            });
         }
 
         if let Some(ref mut segment_config) = segment_config {

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 use bevy::{
     app::{Plugin, Update},
     ecs::{event::EventReader, system::Local},
+    log::debug,
     prelude::{Event, EventWriter, ResMut, Resource},
 };
 use bevy_console::{clap::builder::StyledStr, ConsoleCommandEntered, PrintConsoleLine};
@@ -40,7 +41,7 @@ impl Plugin for SystemBridgePlugin {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SetAvatarData {
     pub base: Option<PbAvatarBase>,
     pub equip: Option<PbAvatarEquippedData>,
@@ -60,7 +61,7 @@ pub struct LiveSceneInfo {
     pub sdk_version: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct HomeScene {
     pub realm: String,
     pub parcel: Vector2,
@@ -73,7 +74,7 @@ pub struct ChatMessage {
     pub channel: String,
 }
 
-#[derive(Event, Clone)]
+#[derive(Event, Clone, Debug)]
 pub enum SystemApi {
     ConsoleCommand(String, Vec<String>, RpcResultSender<Result<String, String>>),
     CheckForUpdate(RpcResultSender<Option<(String, String)>>),
@@ -122,8 +123,10 @@ pub fn post_events(
 ) {
     while let Ok(ev) = bridge.receiver.try_recv() {
         if let SystemApi::ConsoleCommand(cmd, args, sender) = ev {
+            debug!("system bridge (cc): {cmd} {args:?}");
             pending.push_back((cmd, args, sender));
         } else {
+            debug!("system bridge: {ev:?}");
             writer.send(ev);
         }
     }

--- a/crates/system_bridge/src/settings/dof_setting.rs
+++ b/crates/system_bridge/src/settings/dof_setting.rs
@@ -1,0 +1,100 @@
+use super::SettingCategory;
+use bevy::{
+    core_pipeline::dof::{DepthOfFieldMode, DepthOfFieldSettings},
+    ecs::system::{lifetimeless::SRes, SystemParamItem},
+    prelude::*,
+};
+use common::structs::{AppConfig, DofConfig, DofSetting, PrimaryCameraRes};
+
+use super::{AppSetting, EnumAppSetting};
+
+impl EnumAppSetting for DofSetting {
+    fn variants() -> Vec<Self> {
+        vec![Self::Off, Self::Low, Self::High]
+    }
+
+    fn name(&self) -> String {
+        match self {
+            DofSetting::Off => "Off",
+            DofSetting::Low => "Low",
+            DofSetting::High => "High",
+        }
+        .to_owned()
+    }
+}
+
+impl AppSetting for DofSetting {
+    type Param = SRes<PrimaryCameraRes>;
+
+    fn title() -> String {
+        "Depth of Field".to_owned()
+    }
+
+    fn category() -> SettingCategory {
+        SettingCategory::Graphics
+    }
+
+    fn description(&self) -> String {
+        format!("Bloom is a post-processing effect used to reproduce an imaging artifact of real-world cameras. The effect produces fringes (or feathers) of light extending from the borders of bright areas in an image, contributing to the illusion of an extremely bright light overwhelming the camera capturing the scene.\n\n{}", 
+        match self {
+            DofSetting::Off => "Off: No depth of field.",
+            DofSetting::Low => "Low: A bit of depth of field is applied.",
+            DofSetting::High => "High: Lots of depth of field is applied.",
+        })
+    }
+
+    fn save(&self, config: &mut AppConfig) {
+        config.graphics.dof = *self;
+    }
+
+    fn load(config: &AppConfig) -> Self {
+        config.graphics.dof
+    }
+
+    fn apply(&self, cam_res: SystemParamItem<Self::Param>, commands: Commands) {
+        self.apply_to_camera(&cam_res, commands, cam_res.0);
+    }
+
+    fn apply_to_camera(
+        &self,
+        _: &SystemParamItem<Self::Param>,
+        mut commands: Commands,
+        camera_entity: Entity,
+    ) {
+        let Some(mut cmds) = commands.get_entity(camera_entity) else {
+            return;
+        };
+
+        match self {
+            DofSetting::Off => cmds.remove::<(DepthOfFieldSettings, DofConfig)>(),
+            DofSetting::Low => cmds.try_insert((
+                DepthOfFieldSettings {
+                    mode: DepthOfFieldMode::Gaussian,
+                    focal_distance: 0.0, // updated based on cam + extra
+                    aperture_f_stops: 0.15,
+                    max_depth: 300.0,
+                    max_circle_of_confusion_diameter: 20.0,
+                    ..Default::default()
+                },
+                DofConfig {
+                    default_sensor_height: 0.06,
+                    extra_focal_distance: 50.0,
+                },
+            )),
+            DofSetting::High => cmds.try_insert((
+                DepthOfFieldSettings {
+                    mode: DepthOfFieldMode::Gaussian,
+                    focal_distance: 0.0, // updated based on cam + extra
+                    aperture_f_stops: 0.05,
+                    max_depth: 300.0,
+                    max_circle_of_confusion_diameter: 20.0,
+                    ..Default::default()
+                },
+                DofConfig {
+                    default_sensor_height: 0.06,
+                    extra_focal_distance: 50.0,
+                },
+            )),
+        };
+    }
+}

--- a/crates/system_bridge/src/settings/mod.rs
+++ b/crates/system_bridge/src/settings/mod.rs
@@ -17,7 +17,8 @@ use cache_size::CacheSizeSetting;
 use common::{
     sets::SceneSets,
     structs::{
-        AaSetting, AppConfig, BloomSetting, FogSetting, ShadowSetting, SsaoSetting, WindowSetting,
+        AaSetting, AppConfig, BloomSetting, DofSetting, FogSetting, ShadowSetting, SsaoSetting,
+        WindowSetting,
     },
     util::config_file,
 };
@@ -47,6 +48,7 @@ pub mod ambient_brightness_setting;
 pub mod bloom_settings;
 pub mod cache_size;
 pub mod constrain_ui;
+pub mod dof_setting;
 pub mod fog_settings;
 pub mod frame_rate;
 pub mod load_distance;
@@ -131,6 +133,7 @@ impl Plugin for SettingBridgePlugin {
 
         add_enum_setting::<FogSetting>(app, &mut settings, &mut schedule);
         add_enum_setting::<BloomSetting>(app, &mut settings, &mut schedule);
+        add_enum_setting::<DofSetting>(app, &mut settings, &mut schedule);
         add_enum_setting::<SsaoSetting>(app, &mut settings, &mut schedule);
         add_enum_setting::<OobSetting>(app, &mut settings, &mut schedule);
         add_enum_setting::<AaSetting>(app, &mut settings, &mut schedule);

--- a/crates/system_ui/src/app_settings/mod.rs
+++ b/crates/system_ui/src/app_settings/mod.rs
@@ -1,9 +1,9 @@
 use bevy::{ecs::system::StaticSystemParam, prelude::*, ui::RelativeCursorPosition};
 use bevy_dui::{DuiCommandsExt, DuiEntities, DuiEntityCommandsExt, DuiProps, DuiRegistry};
-use common::structs::{
-    AaSetting, AppConfig, BloomSetting, FogSetting, SettingsTab, ShadowSetting, SsaoSetting,
-    WindowSetting,
-};
+use common::{structs::{
+    AaSetting, AppConfig, BloomSetting, DofSetting, FogSetting, SettingsTab, ShadowSetting,
+    SsaoSetting, WindowSetting,
+}, util::TryPushChildrenEx};
 use system_bridge::settings::{cache_size::CacheSizeSetting, EnumAppSetting, IntAppSetting};
 use ui_core::ui_actions::{Click, ClickRepeat, HoverEnter, On, UiCaller};
 
@@ -105,6 +105,7 @@ fn set_app_settings_content(
             spawn_int_setting_template::<ShadowCasterCountSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<FogSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<BloomSetting>(&mut commands, &dui, &config),
+            spawn_enum_setting_template::<DofSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<SsaoSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<OobSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<ConstrainUiSetting>(&mut commands, &dui, &config),
@@ -155,7 +156,7 @@ fn set_app_settings_content(
 
         commands
             .entity(components.named("settings"))
-            .push_children(&children);
+            .try_push_children(&children);
 
         commands
             .entity(components.named("settings-description"))

--- a/crates/system_ui/src/app_settings/mod.rs
+++ b/crates/system_ui/src/app_settings/mod.rs
@@ -1,9 +1,12 @@
 use bevy::{ecs::system::StaticSystemParam, prelude::*, ui::RelativeCursorPosition};
 use bevy_dui::{DuiCommandsExt, DuiEntities, DuiEntityCommandsExt, DuiProps, DuiRegistry};
-use common::{structs::{
-    AaSetting, AppConfig, BloomSetting, DofSetting, FogSetting, SettingsTab, ShadowSetting,
-    SsaoSetting, WindowSetting,
-}, util::TryPushChildrenEx};
+use common::{
+    structs::{
+        AaSetting, AppConfig, BloomSetting, DofSetting, FogSetting, SettingsTab, ShadowSetting,
+        SsaoSetting, WindowSetting,
+    },
+    util::TryPushChildrenEx,
+};
 use system_bridge::settings::{cache_size::CacheSizeSetting, EnumAppSetting, IntAppSetting};
 use ui_core::ui_actions::{Click, ClickRepeat, HoverEnter, On, UiCaller};
 

--- a/crates/system_ui/src/chat/conversation_manager.rs
+++ b/crates/system_ui/src/chat/conversation_manager.rs
@@ -175,7 +175,7 @@ impl ConversationManager<'_, '_> {
                 .insert_children(0, &[bubble]);
             added.1 = Some((address, color, (bubble, content)));
         } else {
-            self.commands.entity(container).push_children(&[bubble]);
+            self.commands.entity(container).try_push_children(&[bubble]);
             added.2 = Some((address, color, (bubble, content)));
         }
 

--- a/crates/system_ui/src/chat/mod.rs
+++ b/crates/system_ui/src/chat/mod.rs
@@ -638,17 +638,12 @@ fn pipe_chats_to_scene(
 ) {
     senders.extend(requests.read().filter_map(|ev| {
         if let SystemApi::GetChatStream(sender) = ev {
-            println!("got sender");
             Some(sender.clone())
         } else {
             None
         }
     }));
     senders.retain(|s| !s.is_closed());
-
-    if senders.is_empty() {
-        println!("no senders");
-    }
 
     for chat_event in chat_events.read().filter(|ce| {
         ce.sender != Entity::PLACEHOLDER && !ce.message.starts_with(chat_marker_things::EMOTE)

--- a/crates/system_ui/src/chat/mod.rs
+++ b/crates/system_ui/src/chat/mod.rs
@@ -133,7 +133,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, ui_root: Res<Sy
         ))
         .id();
 
-    commands.entity(ui_root.0).push_children(&[button]);
+    commands.entity(ui_root.0).try_push_children(&[button]);
 }
 
 fn keyboard_popup(

--- a/crates/system_ui/src/emote_select.rs
+++ b/crates/system_ui/src/emote_select.rs
@@ -14,7 +14,7 @@ use common::{
     inputs::SystemAction,
     sets::SetupSets,
     structs::{ActiveDialog, PrimaryUser, SystemAudio},
-    util::{FireEventEx, ModifyComponentExt},
+    util::{FireEventEx, ModifyComponentExt, TryPushChildrenEx},
 };
 use comms::profile::CurrentUserProfile;
 use input_manager::{InputManager, InputPriority};
@@ -89,7 +89,7 @@ fn setup(
         DuiComponentFromClone::<DuiLayout>::new("layout"),
     );
 
-    commands.entity(ui_root.0).push_children(&[button]);
+    commands.entity(ui_root.0).try_push_children(&[button]);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/system_ui/src/login.rs
+++ b/crates/system_ui/src/login.rs
@@ -11,6 +11,7 @@ use bevy_dui::{DuiCommandsExt, DuiEntityCommandsExt, DuiProps, DuiRegistry};
 use common::{
     profile::SerializedProfile,
     rpc::RpcResultSender,
+    sets::SceneSets,
     structs::{ActiveDialog, AppConfig, ChainLink, DialogPermit, PreviousLogin, SystemAudio},
     util::{config_file, FireEventEx, TaskCompat, TaskExt},
 };
@@ -40,7 +41,7 @@ impl Plugin for LoginPlugin {
             Update,
             (
                 (login, update_profile_for_realm).run_if(in_state(ui_core::State::Ready)),
-                process_login_bridge,
+                process_login_bridge.in_set(SceneSets::PostLoop), // use post loop here so that the PlayerIdentityData can be picked up in RestrictedActions
             ),
         );
     }

--- a/crates/system_ui/src/map.rs
+++ b/crates/system_ui/src/map.rs
@@ -157,7 +157,7 @@ fn set_map_content(
                     let cursor_rel_position = cursor_rel_position * Vec2::new(1.0, -1.0);
                     let cursor_parcel = map.center + cursor_rel_position / data.pixels_per_parcel;
 
-                    let adj = 1.1f32.powf(-wheel.wheel);
+                    let adj = 1.01f32.powf(-wheel.wheel);
                     map.parcels_per_vmin = (map.parcels_per_vmin * adj).clamp(10.0, 500.0);
                     let pixels_per_parcel =
                         (window.width().min(window.height()) / map.parcels_per_vmin).round();

--- a/crates/system_ui/src/mic.rs
+++ b/crates/system_ui/src/mic.rs
@@ -4,7 +4,7 @@ use common::{
     inputs::SystemAction,
     sets::SetupSets,
     structs::{SystemAudio, ToolTips, TooltipSource},
-    util::FireEventEx,
+    util::{FireEventEx, TryPushChildrenEx},
 };
 use comms::{Transport, TransportType};
 use input_manager::{InputManager, InputPriority};
@@ -87,7 +87,7 @@ fn setup(mut commands: Commands, images: Res<MicImages>, ui_root: Res<SystemUiRo
         ))
         .id();
 
-    commands.entity(ui_root.0).push_children(&[mic_button]);
+    commands.entity(ui_root.0).try_push_children(&[mic_button]);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/system_ui/src/permissions.rs
+++ b/crates/system_ui/src/permissions.rs
@@ -4,7 +4,7 @@ use common::{
     structs::{
         AppConfig, PermissionTarget, PermissionType, PermissionValue, PrimaryPlayerRes, SettingsTab,
     },
-    util::{FireEventEx, ModifyComponentExt},
+    util::{FireEventEx, ModifyComponentExt, TryPushChildrenEx},
 };
 use ipfs::CurrentRealm;
 use scene_runner::{
@@ -335,7 +335,7 @@ fn set_permission_settings_content(
 
         commands
             .entity(components.named("permissions-box"))
-            .push_children(&children);
+            .try_push_children(&children);
 
         commands
             .entity(components.named("permission-description"))

--- a/crates/system_ui/src/profile.rs
+++ b/crates/system_ui/src/profile.rs
@@ -14,7 +14,7 @@ use common::{
         ActiveDialog, AppConfig, PermissionTarget, SettingsTab, ShowSettingsEvent, SystemAudio,
         PROFILE_UI_RENDERLAYER,
     },
-    util::FireEventEx,
+    util::{FireEventEx, TryPushChildrenEx},
 };
 use comms::profile::{CurrentUserProfile, ProfileDeployedEvent};
 use ipfs::{ChangeRealmEvent, CurrentRealm};
@@ -82,7 +82,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, ui_root: Res<Sy
         ))
         .id();
 
-    commands.entity(ui_root.0).push_children(&[button]);
+    commands.entity(ui_root.0).try_push_children(&[button]);
 }
 
 pub struct InfoDialog;

--- a/crates/system_ui/src/profile_detail.rs
+++ b/crates/system_ui/src/profile_detail.rs
@@ -1,6 +1,6 @@
 use bevy::{color::palettes::css, prelude::*};
 use bevy_dui::{DuiCommandsExt, DuiEntityCommandsExt, DuiProps, DuiRegistry};
-use common::{profile::SerializedProfile, structs::SettingsTab};
+use common::{profile::SerializedProfile, structs::SettingsTab, util::TryPushChildrenEx};
 use comms::profile::CurrentUserProfile;
 use ui_core::{
     button::{DuiButton, TabSelection},
@@ -183,6 +183,6 @@ fn set_profile_detail_content(
 
         commands
             .entity(components.named("items"))
-            .push_children(&cat_items.iter().map(|de| de.root).collect::<Vec<_>>());
+            .try_push_children(&cat_items.iter().map(|de| de.root).collect::<Vec<_>>());
     }
 }

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -669,7 +669,7 @@ fn update_map_visibilty(
         };
         *init = true;
         // todo this is really bad
-        if realm.address == "https://realm-provider.decentraland.org/main" {
+        if realm.about_url.ends_with("decentraland.org/main/about") {
             style.display = Display::Flex;
         } else {
             style.display = Display::None;

--- a/crates/texture_camera/src/lib.rs
+++ b/crates/texture_camera/src/lib.rs
@@ -22,7 +22,7 @@ use common::{
     dynamics::PLAYER_COLLIDER_RADIUS,
     sets::SceneSets,
     structs::{AppConfig, Cubemap, PrimaryUser, GROUND_RENDERLAYER, PRIMARY_AVATAR_LIGHT_LAYER},
-    util::{camera_to_render_layers, AudioReceiver},
+    util::{camera_to_render_layers, AudioReceiver, TryPushChildrenEx},
 };
 use comms::global_crdt::ForeignPlayer;
 use dcl_component::{
@@ -411,7 +411,7 @@ fn update_texture_cameras(
 
             commands
                 .entity(ent)
-                .push_children(&[camera_id])
+                .try_push_children(&[camera_id])
                 .insert((TextureCamEntity(camera_id), VideoTextureOutput(image)));
 
             new_cam_events.send(NewCameraEvent(camera_id));

--- a/crates/ui_core/src/scrollable.rs
+++ b/crates/ui_core/src/scrollable.rs
@@ -853,7 +853,7 @@ impl DuiTemplate for ScrollableTemplate {
                     },
                     ..Default::default()
                 })
-                .push_children(&[content]);
+                .try_push_children(&[content]);
             });
 
         commands.try_insert((Interaction::default(), scrollable, ScrollContent(content)));

--- a/crates/ui_core/src/text_entry.rs
+++ b/crates/ui_core/src/text_entry.rs
@@ -188,7 +188,7 @@ fn propagate_focus(
 
 fn pipe_events(
     mut submit: EventReader<TextInputSubmitEvent>,
-    changed: Query<(Entity, &TextInputValue), Changed<TextInputValue>>,
+    changed: Query<(Entity, Ref<TextInputValue>), Changed<TextInputValue>>,
     parents: Query<&Parent>,
     settings: Query<&TextEntry>,
     mut commands: Commands,
@@ -215,6 +215,10 @@ fn pipe_events(
     }
 
     for (entity, value) in changed.iter() {
+        if value.is_added() {
+            debug!("{:?} skip updated (added)", entity);
+            continue;
+        }
         debug!("{:?} update", entity);
         if let Some(mut commands) = parents
             .get(entity)

--- a/crates/ui_core/src/text_entry.rs
+++ b/crates/ui_core/src/text_entry.rs
@@ -14,7 +14,7 @@ use bevy_simple_text_input::{
     TextInputSelectionStyle, TextInputSettings, TextInputSubmitEvent, TextInputSystem,
     TextInputTextStyle, TextInputValue,
 };
-use common::sets::SceneSets;
+use common::{sets::SceneSets, util::TryPushChildrenEx};
 use input_manager::{InputManager, InputPriority, InputType};
 
 use super::focus::Focus;
@@ -96,7 +96,7 @@ fn update_text_entry_components(
                 let id = commands.spawn_empty().id();
                 commands
                     .entity(entity)
-                    .push_children(&[id])
+                    .try_push_children(&[id])
                     .insert(TextEntryEntity(id));
                 let mut cmds = commands.entity(id);
                 cmds.insert((

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -411,12 +411,13 @@ fn update_dof(
 
     // let base_distance = 10.0;
     let constant_distance = mydof.extra_focal_distance;
-    let current_distance =
-        ((cam.translation - (player.translation + Vec3::Y * 1.81)).length() + constant_distance).min(100.0);
+    let current_distance = ((cam.translation - (player.translation + Vec3::Y * 1.81)).length()
+        + constant_distance)
+        .min(100.0);
 
     dof.sensor_height = mydof.default_sensor_height;
-        // * ((current_distance * (current_distance + constant_distance))
-        //     / (base_distance * (base_distance + constant_distance)))
-        //     .sqrt();
+    // * ((current_distance * (current_distance + constant_distance))
+    //     / (base_distance * (base_distance + constant_distance)))
+    //     .sqrt();
     dof.focal_distance = current_distance;
 }

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -35,8 +35,15 @@ impl Plugin for VisualsPlugin {
             .add_plugins(WireframePlugin)
             .add_systems(Update, apply_global_light)
             .add_systems(Update, move_ground)
-            .add_systems(Startup, setup.in_set(SetupSets::Main))
-            .insert_resource(RenderAssetBytesPerFrame::new(1 << 27)); // ~100mb/frame @ 60fps
+            .add_systems(Startup, setup.in_set(SetupSets::Main));
+
+        let config = app.world().resource::<AppConfig>();
+
+        if config.graphics.gpu_bytes_per_frame > 0 {
+            app.insert_resource(RenderAssetBytesPerFrame::new(
+                config.graphics.gpu_bytes_per_frame,
+            ));
+        }
 
         app.add_console_command::<ShadowConsoleCommand, _>(shadow_console_command);
         app.add_console_command::<FogConsoleCommand, _>(fog_console_command);

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -23,6 +23,7 @@ use common::{
     },
     util::{config_file, UtilsPlugin},
 };
+use input_manager::{CumulativeAxisData, InputPriorities};
 use nft::asset_source::Nft;
 use restricted_actions::RestrictedActionsPlugin;
 use scene_material::SceneBoundPlugin;
@@ -194,6 +195,8 @@ fn main() {
         .add_event::<SystemAudio>()
         .init_resource::<PermissionManager>()
         .init_resource::<InputMap>()
+        .init_resource::<InputPriorities>()
+        .init_resource::<CumulativeAxisData>()
         .init_resource::<ToolTips>()
         .init_resource::<SceneGlobalLight>()
         .add_event::<RpcCall>()

--- a/src/bin/social.rs
+++ b/src/bin/social.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_simple_text_input::{
     TextInputBundle, TextInputPlaceholder, TextInputPlugin, TextInputSettings, TextInputSubmitEvent,
 };
-use common::util::AsH160;
+use common::util::{AsH160, TryPushChildrenEx};
 use dcl_component::proto_components::social::friendship_event_response;
 use social::{
     client::{DirectChatMessage, SocialClientHandler},
@@ -152,7 +152,7 @@ fn update(
                 ..Default::default()
             })
             .id();
-        c2.entity(output).push_children(&[text]);
+        c2.entity(output).try_push_children(&[text]);
     };
 
     for ev in input.read() {
@@ -164,7 +164,7 @@ fn update(
                 ..Default::default()
             })
             .id();
-        commands.entity(output).push_children(&[text]);
+        commands.entity(output).try_push_children(&[text]);
 
         if ev.value.starts_with('/') {
             let mut words = ev.value[1..].trim().split(' ');

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ use common::{
         PreviewCommand, PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser,
         SceneImposterBake, SceneLoadDistance, SystemScene, Version, GROUND_RENDERLAYER,
     },
-    util::{config_file, project_directories, TaskCompat, TaskExt, UtilsPlugin},
+    util::{config_file, project_directories, TaskCompat, TaskExt, TryPushChildrenEx, UtilsPlugin},
 };
 use restricted_actions::{lookup_portable, RestrictedActionsPlugin};
 use scene_material::SceneBoundPlugin;
@@ -492,7 +492,7 @@ fn setup(
             GroundCollider::default(),
             propagate::Propagate(RenderLayers::default()),
         ))
-        .push_children(&attach_points.entities())
+        .try_push_children(&attach_points.entities())
         .insert(attach_points)
         .id();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,10 @@ fn main() {
                 .value_from_str::<_, usize>("--fps")
                 .ok()
                 .unwrap_or(base_config.graphics.fps_target),
+            gpu_bytes_per_frame: args
+                .value_from_str::<_, usize>("--gpu_bytes_per_frame")
+                .ok()
+                .unwrap_or(base_config.graphics.gpu_bytes_per_frame),
             ..base_config.graphics
         },
         scene_threads: args


### PR DESCRIPTION
features
- depth of field
- quick emote actions
- auto-redirect xxx.dcl.eth realms

misc
- make gpu bytes per frame configurable
- default aa to fxaa
- update impost binary
- change default starting realm to realm-provider-ea

bugfixes
- stop initial onUpdate event for ui input entities
- fix getPlayer() returning null immediately after login
- act on modifications to existing ui inputs
- fix imposters don't create missing folders (broken by zip crate upgrade)
- fix ui input cursor color
- fix occasional crash with push_children on despawned entity
- fix scene actions generated from gamepad buttons not being reported to scene root
- purge imposters on new realm connect, instead of on change realm command
- keep portable scenes (inc system ui scene) alive over realm changes
- fix nfts not displaying
- fix minimap display realm check