### PR TITLE
copyToClipboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9101,6 +9101,7 @@ dependencies = [
  "common",
  "comms",
  "console",
+ "copypasta",
  "dcl_component",
  "ethers-core",
  "ipfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ strum_macros = "0.27"
 wasm-bindgen = "0.2.92"
 wasm-bindgen-futures = "0.4.50"
 web-time = "1.1"
+copypasta = "0.10"
 
 [dependencies]
 analytics = { workspace = true }

--- a/crates/common/src/rpc.rs
+++ b/crates/common/src/rpc.rs
@@ -228,4 +228,9 @@ pub enum RpcCall {
         element_id: String,
         response: RpcResultSender<Result<(), String>>,
     },
+    CopyToClipboard {
+        scene: Entity,
+        text: String,
+        response: RpcResultSender<Result<(), String>>,
+    },
 }

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -634,6 +634,7 @@ pub enum PermissionType {
     SpawnPortable,
     KillPortables,
     Web3,
+    CopyToClipboard,
     Fetch,
     Websocket,
     OpenUrl,

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -48,3 +48,7 @@ module.exports.setCommunicationsAdapter = async function (body) {
 module.exports.setUiFocus = async function(body) {
     return await Deno.core.ops.op_set_ui_focus(body.elementId);
 }
+
+module.exports.copyToClipboard = async function(text) {
+    return await Deno.core.ops.op_copy_to_clipboard(text);
+}

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -209,3 +209,26 @@ pub async fn op_set_ui_focus(
 
     rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))
 }
+
+pub async fn op_copy_to_clipboard(
+    state: Rc<RefCell<impl State>>,
+    text: String,
+) -> Result<(), anyhow::Error> {
+    debug!("op_set_ui_focus");
+    let (sx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+
+    {
+        let mut state = state.borrow_mut();
+        let scene = state.borrow::<CrdtContext>().scene_id.0;
+
+        state
+            .borrow_mut::<RpcCalls>()
+            .push(RpcCall::CopyToClipboard {
+                scene,
+                text,
+                response: sx.into(),
+            });
+    }
+
+    rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))
+}

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -12,6 +12,7 @@ pub fn ops() -> Vec<OpDecl> {
         op_scene_emote(),
         op_open_nft_dialog(),
         op_set_ui_focus(),
+        op_copy_to_clipboard(),
     ]
 }
 
@@ -94,4 +95,12 @@ async fn op_set_ui_focus(
     #[string] element_id: String,
 ) -> Result<(), AnyError> {
     dcl::js::restricted_actions::op_set_ui_focus(op_state, element_id).await
+}
+
+#[op2(async)]
+async fn op_copy_to_clipboard(
+    op_state: Rc<RefCell<OpState>>,
+    #[string] text: String,
+) -> Result<(), AnyError> {
+    dcl::js::restricted_actions::op_copy_to_clipboard(op_state, text).await
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -84,3 +84,10 @@ pub async fn op_set_ui_focus(
         .await
         .map_err(WasmError::from)
 }
+
+#[wasm_bindgen]
+pub async fn op_copy_to_clipboard(op_state: &WorkerContext, text: String) -> Result<(), WasmError> {
+    dcl::js::restricted_actions::op_copy_to_clipboard(op_state.rc(), text)
+        .await
+        .map_err(WasmError::from)
+}

--- a/crates/restricted_actions/Cargo.toml
+++ b/crates/restricted_actions/Cargo.toml
@@ -30,3 +30,4 @@ opener = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 async-compat = { workspace = true }
+copypasta = { workspace = true }

--- a/crates/system_ui/Cargo.toml
+++ b/crates/system_ui/Cargo.toml
@@ -50,6 +50,6 @@ build-time = { workspace = true }
 futures-lite = { workspace = true }
 async-compat = { workspace = true }
 web-time = { workspace = true }
+copypasta = { workspace = true }
 
-copypasta = "0.10"
 shlex = "1"

--- a/crates/system_ui/src/permissions.rs
+++ b/crates/system_ui/src/permissions.rs
@@ -331,6 +331,7 @@ fn set_permission_settings_content(
             spawn_row(PermissionType::Fetch, &mut commands),
             spawn_row(PermissionType::Websocket, &mut commands),
             spawn_row(PermissionType::OpenUrl, &mut commands),
+            spawn_row(PermissionType::CopyToClipboard, &mut commands),
         ];
 
         commands


### PR DESCRIPTION
- add `copyToClipboard` to restrictedActions.js
  - active scene only
  - shortly after user interaction only
  - with related permission and notification on use

closes #210

note: doesn't work for web currently