### PR TITLE
text input bugfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "bevy_simple_text_input"
 version = "0.11.1"
-source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#15d7e3c570cde1c290615af7124c04685ec9ab23"
+source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#3a824afa0c599e27807e2e27427ea7dbdfe662bf"
 dependencies = [
  "bevy",
  "copypwasmta",


### PR DESCRIPTION
fixes #230 

- macos add additional keyboard shortcuts: TextStart, TextEnd, SelectAll, Cut, Copy, Paste, Undo and Redo
- cursor color now reflects text color correctly
- cursor starts at end of input
- single line text fields scroll to end of content correctly
