### PR TITLE
system scene permissions api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,6 +3382,7 @@ dependencies = [
  "reqwest 0.12.15",
  "serde",
  "serde_json",
+ "strum 0.27.1",
  "system_bridge",
  "tokio",
  "urlencoding",

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -753,7 +753,7 @@ impl PermissionStrings for PermissionType {
 
 #[derive(Clone, Debug)]
 pub enum PermissionLevel {
-    Scene(Entity, String),
+    Scene(String),
     Realm(String),
     Global,
 }

--- a/crates/dcl/Cargo.toml
+++ b/crates/dcl/Cargo.toml
@@ -27,6 +27,7 @@ http = { workspace = true }
 urlencoding = { workspace = true }
 base64 = { workspace = true }
 multihash-codetable = { workspace = true }
+strum = { workspace = true }
 
 num-derive = "0.4.2"
 num = "0.4"

--- a/crates/dcl/src/js/modules/SystemApi.js
+++ b/crates/dcl/src/js/modules/SystemApi.js
@@ -262,3 +262,47 @@ module.exports.sendChat = async function(message, channel) {
 module.exports.quit = function() {
     Deno.core.ops.op_quit();
 }
+
+module.exports.getPermissionRequestStream = async function() {
+  const rid = await Deno.core.ops.op_get_permission_request_stream();
+
+  async function* streamGenerator() {
+    while (true) {
+      const next = await Deno.core.ops.op_read_permission_request_stream(rid);
+      if (next === null) break;
+      yield next;
+    }
+  }
+
+  return streamGenerator();
+}
+
+module.exports.getPermissionUsedStream = async function() {
+  const rid = await Deno.core.ops.op_get_permission_used_stream();
+
+  async function* streamGenerator() {
+    while (true) {
+      const next = await Deno.core.ops.op_read_permission_used_stream(rid);
+      if (next === null) break;
+      yield next;
+    }
+  }
+
+  return streamGenerator();
+}
+
+module.exports.setSinglePermission = function(body) {
+    Deno.core.ops.op_set_single_permission(body.id, body.allow);
+}
+
+module.exports.setPermanentPermission = function(body) {
+    Deno.core.ops.op_set_permanent_permission(body.level, body.value, body.ty, body.allow)
+}
+
+module.exports.getPermanentPermissions = function(body) {
+    return Deno.core.ops.op_get_permanent_permissions(body.level, body.value);
+}
+
+module.exports.getPermissionTypes = function() {
+    return Deno.core.ops.getPermissionTypes();
+}

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use bevy::{ecs::entity::Entity, log::debug};
+use bevy::log::debug;
 use common::{
     inputs::{Action, BindingsData, InputIdentifier, SystemActionEvent},
     profile::SerializedProfile,
@@ -603,10 +603,7 @@ fn get_permanent_level(
 ) -> Result<PermissionLevel, anyhow::Error> {
     Ok(match level {
         "Realm" => PermissionLevel::Realm(value.ok_or(anyhow!("Realm value must be specified"))?),
-        "Scene" => PermissionLevel::Scene(
-            Entity::PLACEHOLDER,
-            value.ok_or(anyhow!("Scene value must be specified"))?,
-        ),
+        "Scene" => PermissionLevel::Scene(value.ok_or(anyhow!("Scene value must be specified"))?),
         "Global" => PermissionLevel::Global,
         _ => anyhow::bail!("invalid level {level}, must be `Realm`, `Scene` or `Global`"),
     })
@@ -650,7 +647,7 @@ pub fn op_get_permanent_permissions(
     let config = state.borrow::<AppConfig>();
 
     let perms = match level {
-        PermissionLevel::Scene(_, hash) => config.scene_permissions.get(&hash),
+        PermissionLevel::Scene(hash) => config.scene_permissions.get(&hash),
         PermissionLevel::Realm(realm) => config.realm_permissions.get(&realm),
         PermissionLevel::Global => Some(&config.default_permissions),
     };

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -1,8 +1,13 @@
-use bevy::log::debug;
+use anyhow::anyhow;
+use bevy::{ecs::entity::Entity, log::debug};
 use common::{
     inputs::{Action, BindingsData, InputIdentifier, SystemActionEvent},
     profile::SerializedProfile,
     rpc::RpcCall,
+    structs::{
+        AppConfig, PermissionLevel, PermissionStrings, PermissionType, PermissionUsed,
+        PermissionValue,
+    },
 };
 use dcl_component::proto_components::{
     common::Vector2,
@@ -12,9 +17,11 @@ use http::Uri;
 use ipfs::IpfsResource;
 use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, rc::Rc};
+use strum::IntoEnumIterator;
 use system_bridge::{
     settings::{SettingInfo, Settings},
-    ChatMessage, HomeScene, LiveSceneInfo, SetAvatarData, SystemApi,
+    ChatMessage, HomeScene, LiveSceneInfo, PermissionRequest, SetAvatarData,
+    SetPermanentPermission, SetSinglePermission, SystemApi,
 };
 use tokio::sync::mpsc::UnboundedReceiver;
 use wallet::{sign_request, Wallet};
@@ -509,4 +516,169 @@ pub fn op_quit(state: Rc<RefCell<impl State>>) {
         .borrow_mut::<SuperUserScene>()
         .send(SystemApi::Quit)
         .unwrap();
+}
+
+pub async fn op_get_permission_request_stream(state: Rc<RefCell<impl State>>) -> u32 {
+    let (sx, rx) = tokio::sync::mpsc::unbounded_channel();
+    state.borrow_mut().put(rx);
+
+    state
+        .borrow_mut()
+        .borrow_mut::<SuperUserScene>()
+        .send(SystemApi::GetPermissionRequestStream(sx))
+        .unwrap();
+
+    1
+}
+
+pub async fn op_read_permission_request_stream(
+    state: Rc<RefCell<impl State>>,
+    _rid: u32,
+) -> Result<Option<PermissionRequest>, anyhow::Error> {
+    let Some(mut receiver) = state
+        .borrow_mut()
+        .try_take::<UnboundedReceiver<PermissionRequest>>()
+    else {
+        return Ok(None);
+    };
+
+    let res = match receiver.recv().await {
+        Some(data) => Ok(Some(data)),
+        None => Ok(None),
+    };
+
+    state.borrow_mut().put(receiver);
+
+    res
+}
+
+pub async fn op_get_permission_used_stream(state: Rc<RefCell<impl State>>) -> u32 {
+    let (sx, rx) = tokio::sync::mpsc::unbounded_channel();
+    state.borrow_mut().put(rx);
+
+    state
+        .borrow_mut()
+        .borrow_mut::<SuperUserScene>()
+        .send(SystemApi::GetPermissionUsedStream(sx))
+        .unwrap();
+
+    1
+}
+
+pub async fn op_read_permission_used_stream(
+    state: Rc<RefCell<impl State>>,
+    _rid: u32,
+) -> Result<Option<PermissionUsed>, anyhow::Error> {
+    let Some(mut receiver) = state
+        .borrow_mut()
+        .try_take::<UnboundedReceiver<PermissionUsed>>()
+    else {
+        return Ok(None);
+    };
+
+    let res = match receiver.recv().await {
+        Some(data) => Ok(Some(data)),
+        None => Ok(None),
+    };
+
+    state.borrow_mut().put(receiver);
+
+    res
+}
+
+pub fn op_set_single_permission(state: Rc<RefCell<impl State>>, id: usize, allow: bool) {
+    state
+        .borrow_mut()
+        .borrow_mut::<SuperUserScene>()
+        .send(SystemApi::SetSinglePermission(SetSinglePermission {
+            id,
+            allow,
+        }))
+        .unwrap();
+}
+
+fn get_permanent_level(
+    level: &str,
+    value: Option<String>,
+) -> Result<PermissionLevel, anyhow::Error> {
+    Ok(match level {
+        "Realm" => PermissionLevel::Realm(value.ok_or(anyhow!("Realm value must be specified"))?),
+        "Scene" => PermissionLevel::Scene(
+            Entity::PLACEHOLDER,
+            value.ok_or(anyhow!("Scene value must be specified"))?,
+        ),
+        "Global" => PermissionLevel::Global,
+        _ => anyhow::bail!("invalid level {level}, must be `Realm`, `Scene` or `Global`"),
+    })
+}
+
+pub fn op_set_permanent_permission(
+    state: Rc<RefCell<impl State>>,
+    level: &str,
+    value: Option<String>,
+    permission_type: PermissionType,
+    allow: Option<PermissionValue>,
+) -> Result<(), anyhow::Error> {
+    let level = get_permanent_level(level, value)?;
+
+    state
+        .borrow_mut()
+        .borrow_mut::<SuperUserScene>()
+        .send(SystemApi::SetPermanentPermission(SetPermanentPermission {
+            ty: permission_type,
+            level,
+            allow,
+        }))
+        .unwrap();
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PermanentPermissionItem {
+    ty: PermissionType,
+    allow: PermissionValue,
+}
+
+pub fn op_get_permanent_permissions(
+    state: Rc<RefCell<impl State>>,
+    level: &str,
+    value: Option<String>,
+) -> Result<Vec<PermanentPermissionItem>, anyhow::Error> {
+    let level = get_permanent_level(level, value)?;
+    let state = state.borrow();
+    let config = state.borrow::<AppConfig>();
+
+    let perms = match level {
+        PermissionLevel::Scene(_, hash) => config.scene_permissions.get(&hash),
+        PermissionLevel::Realm(realm) => config.realm_permissions.get(&realm),
+        PermissionLevel::Global => Some(&config.default_permissions),
+    };
+
+    Ok(perms
+        .map(|h| {
+            h.iter()
+                .map(|(p, v)| PermanentPermissionItem { ty: *p, allow: *v })
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PermissionTypeDetail {
+    ty: PermissionType,
+    name: String,
+    passive: String,
+    active: String,
+}
+
+pub fn op_get_permission_types() -> Vec<PermissionTypeDetail> {
+    PermissionType::iter()
+        .map(|ty| PermissionTypeDetail {
+            ty,
+            name: ty.title().to_owned(),
+            passive: ty.passive().to_owned(),
+            active: ty.active().to_owned(),
+        })
+        .collect()
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
@@ -219,3 +219,77 @@ pub async fn op_get_profile_extras(state: &WorkerContext) -> Result<JsValue, Was
 pub fn op_quit(state: &WorkerContext) {
     dcl::js::system_api::op_quit(state.rc());
 }
+
+#[wasm_bindgen]
+pub async fn op_get_permission_request_stream(state: &WorkerContext) -> u32 {
+    dcl::js::system_api::op_get_permission_request_stream(state.rc()).await
+}
+
+#[wasm_bindgen]
+pub async fn op_read_permission_request_stream(
+    state: &WorkerContext,
+    rid: u32,
+) -> Result<JsValue, WasmError> {
+    serde_result!(dcl::js::system_api::op_read_permission_request_stream(state.rc(), rid).await)
+}
+
+#[wasm_bindgen]
+pub async fn op_get_permission_used_stream(state: &WorkerContext) -> u32 {
+    dcl::js::system_api::op_get_permission_used_stream(state.rc()).await
+}
+
+#[wasm_bindgen]
+pub async fn op_read_permission_used_stream(
+    state: &WorkerContext,
+    rid: u32,
+) -> Result<JsValue, WasmError> {
+    serde_result!(dcl::js::system_api::op_read_permission_used_stream(state.rc(), rid).await)
+}
+
+#[wasm_bindgen]
+pub fn op_set_single_permission(state: &WorkerContext, id: usize, allow: bool) {
+    dcl::js::system_api::op_set_single_permission(state.rc(), id, allow);
+}
+
+#[wasm_bindgen]
+pub fn op_set_permanent_permission(
+    state: &WorkerContext,
+    level: &str,
+    value: Option<String>,
+    permission_type: JsValue,
+    allow: JsValue,
+) -> Result<(), WasmError> {
+    serde_parse!(permission_type);
+    serde_parse!(allow);
+    dcl::js::system_api::op_set_permanent_permission(
+        state.rc(),
+        level,
+        value,
+        permission_type,
+        allow,
+    )
+    .map_err(WasmError::from)
+}
+
+#[wasm_bindgen]
+pub fn op_get_permanent_permissions(
+    state: &WorkerContext,
+    level: &str,
+    value: Option<String>,
+) -> Result<js_sys::Array, WasmError> {
+    dcl::js::system_api::op_get_permanent_permissions(state.rc(), level, value)
+        .map(|r| {
+            r.into_iter()
+                .map(|v| serde_wasm_bindgen::to_value(&v).unwrap())
+                .collect()
+        })
+        .map_err(WasmError::from)
+}
+
+#[wasm_bindgen]
+pub fn op_get_permission_types(_: &WorkerContext) -> js_sys::Array {
+    dcl::js::system_api::op_get_permission_types()
+        .into_iter()
+        .map(|v| serde_wasm_bindgen::to_value(&v).unwrap())
+        .collect()
+}

--- a/crates/scene_runner/src/test/mod.rs
+++ b/crates/scene_runner/src/test/mod.rs
@@ -37,8 +37,7 @@ use common::{
     inputs::InputMap,
     rpc::RpcCall,
     structs::{
-        AppConfig, CursorLocks, GraphicsSettings, PrimaryCamera, PrimaryPlayerRes,
-        SceneGlobalLight, SceneLoadDistance, TimeOfDay, ToolTips,
+        AppConfig, CursorLocks, GraphicsSettings, PermissionUsed, PrimaryCamera, PrimaryPlayerRes, SceneGlobalLight, SceneLoadDistance, TimeOfDay, ToolTips
     },
 };
 use comms::{preview::PreviewMode, CommsPlugin};
@@ -140,6 +139,7 @@ fn init_test_app(entity_json: &str) -> App {
     });
     app.add_event::<RpcCall>();
     app.add_event::<ScrollTargetEvent>();
+    app.add_event::<PermissionUsed>();
     app.insert_resource(SceneLoadDistance {
         load: 1.0,
         unload: 0.0,

--- a/crates/scene_runner/src/test/mod.rs
+++ b/crates/scene_runner/src/test/mod.rs
@@ -37,7 +37,8 @@ use common::{
     inputs::InputMap,
     rpc::RpcCall,
     structs::{
-        AppConfig, CursorLocks, GraphicsSettings, PermissionUsed, PrimaryCamera, PrimaryPlayerRes, SceneGlobalLight, SceneLoadDistance, TimeOfDay, ToolTips
+        AppConfig, CursorLocks, GraphicsSettings, PermissionUsed, PrimaryCamera, PrimaryPlayerRes,
+        SceneGlobalLight, SceneLoadDistance, TimeOfDay, ToolTips,
     },
 };
 use comms::{preview::PreviewMode, CommsPlugin};

--- a/crates/scene_runner/src/update_world/camera_mode_area.rs
+++ b/crates/scene_runner/src/update_world/camera_mode_area.rs
@@ -2,6 +2,7 @@ use bevy::{platform::collections::HashSet, prelude::*};
 
 use crate::{
     permissions::Permission, renderer_context::RendererSceneContext, ContainingScene, SceneEntity,
+    Toaster,
 };
 use common::{
     dynamics::{PLAYER_COLLIDER_HEIGHT, PLAYER_COLLIDER_RADIUS},
@@ -91,6 +92,7 @@ pub fn update_camera_mode_area(
     mut current_areas: Local<Vec<(Entity, PermissionState)>>,
     mut camera: Query<&mut PrimaryCamera>,
     mut perms: Permission<Entity>,
+    mut toaster: Toaster,
 ) {
     let Ok(mut camera) = camera.single_mut() else {
         return;
@@ -269,9 +271,7 @@ pub fn update_camera_mode_area(
     }
 
     if current_areas.is_empty() {
-        perms
-            .toaster
-            .clear_toast(format!("{:?}", PermissionType::ForceCamera).as_str());
+        toaster.clear_toast(format!("{:?}", PermissionType::ForceCamera).as_str());
     }
 
     let succeeded = perms

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -12,7 +12,7 @@ use bevy_console::{ConsoleCommandEntered, PrintConsoleLine};
 use common::{
     inputs::{BindingsData, InputIdentifier, SystemActionEvent},
     rpc::RpcResultSender,
-    structs::AppConfig,
+    structs::{AppConfig, PermissionLevel, PermissionType, PermissionUsed, PermissionValue},
 };
 use dcl_component::proto_components::{
     common::Vector2,
@@ -101,6 +101,31 @@ pub enum SystemApi {
     GetChatStream(tokio::sync::mpsc::UnboundedSender<ChatMessage>),
     SendChat(String, String),
     Quit,
+    GetPermissionRequestStream(tokio::sync::mpsc::UnboundedSender<PermissionRequest>),
+    SetSinglePermission(SetSinglePermission),
+    SetPermanentPermission(SetPermanentPermission),
+    GetPermissionUsedStream(tokio::sync::mpsc::UnboundedSender<PermissionUsed>),
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PermissionRequest {
+    pub ty: PermissionType,
+    pub additional: Option<String>,
+    pub scene: String,
+    pub id: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct SetSinglePermission {
+    pub id: usize,
+    pub allow: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct SetPermanentPermission {
+    pub ty: PermissionType,
+    pub level: PermissionLevel,
+    pub allow: Option<PermissionValue>,
 }
 
 #[derive(Resource)]
@@ -108,6 +133,7 @@ pub struct NativeUi {
     pub login: bool,
     pub emote_wheel: bool,
     pub chat: bool,
+    pub permissions: bool,
 }
 
 #[derive(Resource)]

--- a/crates/system_ui/src/permission_manager.rs
+++ b/crates/system_ui/src/permission_manager.rs
@@ -162,7 +162,7 @@ fn update_permissions(
                     return;
                 };
                 match level {
-                    PermissionLevel::Scene(_, hash) => config
+                    PermissionLevel::Scene(hash) => config
                         .scene_permissions
                         .entry(hash.clone())
                         .or_default()
@@ -252,10 +252,7 @@ fn update_permissions(
 
                                 dialog.level = match combo.selected {
                                     0 => None,
-                                    1 => Some(PermissionLevel::Scene(
-                                        dialog.scene,
-                                        dialog.hash.clone(),
-                                    )),
+                                    1 => Some(PermissionLevel::Scene(dialog.hash.clone())),
                                     2 => {
                                         if is_portable {
                                             Some(PermissionLevel::Global)
@@ -277,7 +274,6 @@ fn update_permissions(
             permit,
             PermissionDialog {
                 level: None,
-                scene: req.scene,
                 hash: hash.to_owned(),
                 realm: req.realm.clone(),
             },
@@ -295,7 +291,6 @@ fn update_permissions(
 #[derive(Component)]
 pub struct PermissionDialog {
     level: Option<PermissionLevel>,
-    scene: Entity,
     hash: String,
     realm: String,
 }
@@ -395,7 +390,7 @@ pub fn handle_scene_permissions(
             }
             SystemApi::SetPermanentPermission(result) => {
                 let store = match &result.level {
-                    PermissionLevel::Scene(_, hash) => {
+                    PermissionLevel::Scene(hash) => {
                         config.scene_permissions.entry(hash.clone()).or_default()
                     }
                     PermissionLevel::Realm(realm) => {

--- a/crates/system_ui/src/permission_manager.rs
+++ b/crates/system_ui/src/permission_manager.rs
@@ -1,32 +1,42 @@
+use std::collections::BTreeMap;
+
 use bevy::prelude::*;
 use bevy_dui::{DuiCommandsExt, DuiProps, DuiRegistry};
 use common::{
     dynamics::PLAYER_COLLIDER_RADIUS,
     rpc::RpcResultSender,
     structs::{
-        ActiveDialog, AppConfig, PermissionTarget, PermissionValue, PrimaryPlayerRes, SettingsTab,
-        ShowSettingsEvent, ZOrder,
+        ActiveDialog, AppConfig, PermissionLevel, PermissionStrings, PermissionTarget,
+        PermissionUsed, PermissionValue, PrimaryPlayerRes, SettingsTab, ShowSettingsEvent, ZOrder,
     },
 };
 use ipfs::CurrentRealm;
 use scene_runner::{
-    permissions::{PermissionLevel, PermissionManager, PermissionRequest, PermissionStrings},
+    initialize_scene::LiveScenes,
+    permissions::{PermissionManager, PermissionRequest},
     renderer_context::RendererSceneContext,
-    ContainingScene,
+    ContainingScene, Toaster,
 };
+use system_bridge::{NativeUi, SystemApi};
 use tokio::sync::oneshot::{channel, error::TryRecvError, Receiver};
 use ui_core::{
     button::DuiButton,
     combo_box::ComboBox,
-    ui_actions::{DataChanged, EventCloneExt, On, UiCaller},
+    ui_actions::{Click, DataChanged, EventCloneExt, On, UiCaller},
 };
 
 pub struct PermissionPlugin;
 
 impl Plugin for PermissionPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<PermissionManager>()
-            .add_systems(PostUpdate, update_permissions);
+        app.init_resource::<PermissionManager>();
+
+        let native_ui = app.world().resource::<NativeUi>();
+        if native_ui.permissions {
+            app.add_systems(PostUpdate, (update_permissions, show_permission_toasts));
+        } else {
+            app.add_systems(PostUpdate, handle_scene_permissions);
+        }
     }
 }
 
@@ -288,4 +298,199 @@ pub struct PermissionDialog {
     scene: Entity,
     hash: String,
     realm: String,
+}
+
+fn show_permission_toasts(
+    mut toaster: Toaster,
+    mut uses: EventReader<PermissionUsed>,
+    live_scenes: Res<LiveScenes>,
+    scenes: Query<&RendererSceneContext>,
+) {
+    for usage in uses.read() {
+        let Some(scene) = live_scenes.scenes.get(&usage.scene).copied() else {
+            error!("no scene for perm request");
+            continue;
+        };
+
+        let Ok(ctx) = scenes.get(scene) else {
+            continue;
+        };
+
+        let portable_name = ctx.is_portable.then_some(ctx.title.as_str());
+        let ty = usage.ty;
+        let message = if usage.was_allowed {
+            usage
+                .ty
+                .on_success(portable_name, usage.additional.as_deref())
+        } else {
+            usage.ty.on_fail(portable_name)
+        };
+
+        toaster.add_clicky_toast(
+            format!("{:?} {:?} {:?}", ty, usage.scene, usage.additional),
+            message,
+            On::<Click>::new(
+                (move |mut target: ResMut<PermissionTarget>| {
+                    target.scene = Some(scene);
+                    target.ty = Some(ty);
+                })
+                .pipe(ShowSettingsEvent(SettingsTab::Permissions).send_value()),
+            ),
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn handle_scene_permissions(
+    mut manager: ResMut<PermissionManager>,
+    mut config: ResMut<AppConfig>,
+    mut system_events: EventReader<SystemApi>,
+    mut requests_streams: Local<
+        Vec<tokio::sync::mpsc::UnboundedSender<system_bridge::PermissionRequest>>,
+    >,
+    mut used_streams: Local<Vec<tokio::sync::mpsc::UnboundedSender<PermissionUsed>>>,
+    // corresponds to the items in the manager deque
+    mut permission_ids: Local<Vec<usize>>,
+    mut inc: Local<usize>,
+    scenes: Query<&RendererSceneContext>,
+    current_realm: Res<CurrentRealm>,
+    mut uses: EventReader<PermissionUsed>,
+) {
+    // gather any resolved permissions in order
+    // (manager.pending index => result)
+    let mut resolved = BTreeMap::default();
+
+    for ev in system_events.read() {
+        // handle events
+        match ev {
+            SystemApi::GetPermissionRequestStream(stream) => {
+                // send any current outstanding requests when a new stream is attached
+                for (handle, req) in permission_ids.iter().zip(manager.pending.iter()) {
+                    let Ok(hash) = scenes.get(req.scene).map(|ctx| &ctx.hash) else {
+                        continue;
+                    };
+
+                    let _ = stream.send(system_bridge::PermissionRequest {
+                        ty: req.ty,
+                        additional: req.additional.clone(),
+                        scene: hash.clone(),
+                        id: *handle,
+                    });
+                }
+
+                requests_streams.push(stream.clone())
+            }
+            SystemApi::GetPermissionUsedStream(stream) => used_streams.push(stream.clone()),
+            SystemApi::SetSinglePermission(result) => {
+                let Some((index, _)) = permission_ids
+                    .iter()
+                    .enumerate()
+                    .find(|(_, id)| **id == result.id)
+                else {
+                    warn!("permission request with id {} not found", result.id);
+                    continue;
+                };
+
+                resolved.insert(index, result.allow);
+            }
+            SystemApi::SetPermanentPermission(result) => {
+                let store = match &result.level {
+                    PermissionLevel::Scene(_, hash) => {
+                        config.scene_permissions.entry(hash.clone()).or_default()
+                    }
+                    PermissionLevel::Realm(realm) => {
+                        config.realm_permissions.entry(realm.clone()).or_default()
+                    }
+                    PermissionLevel::Global => &mut config.default_permissions,
+                };
+
+                if let Some(value) = result.allow {
+                    store.insert(result.ty, value);
+                } else {
+                    store.remove(&result.ty);
+                }
+            }
+            _ => (),
+        }
+    }
+
+    if config.is_changed() {
+        // check for anything that has become determinable
+        for (i, req) in manager.pending.iter().enumerate() {
+            let Ok(hash) = scenes.get(req.scene).map(|ctx| &ctx.hash) else {
+                resolved.insert(i, false);
+                continue;
+            };
+
+            match config.get_permission(req.ty, &req.realm, hash, req.is_portable) {
+                PermissionValue::Allow => resolved.insert(i, true),
+                PermissionValue::Deny => resolved.insert(i, false),
+                PermissionValue::Ask => None,
+            };
+        }
+    }
+
+    // send any new requests
+    for i in permission_ids.len()..manager.pending.len() {
+        let req = manager.pending.get(i).unwrap();
+
+        let Ok(hash) = scenes.get(req.scene).map(|ctx| &ctx.hash) else {
+            resolved.insert(i, false);
+            continue;
+        };
+
+        // make sure it needs to be sent
+        let needs_request = match config.get_permission(req.ty, &req.realm, hash, req.is_portable) {
+            PermissionValue::Allow => {
+                resolved.insert(i, true);
+                false
+            }
+            PermissionValue::Deny => {
+                resolved.insert(i, false);
+                false
+            }
+            PermissionValue::Ask => true,
+        };
+
+        let next_id = *inc;
+        if needs_request {
+            *inc += 1;
+
+            for req_stream in requests_streams.iter() {
+                let _ = req_stream.send(system_bridge::PermissionRequest {
+                    ty: req.ty,
+                    additional: req.additional.clone(),
+                    scene: hash.clone(),
+                    id: next_id,
+                });
+            }
+        }
+
+        permission_ids.push(next_id);
+    }
+
+    // clean up any failed requests
+    for (i, req) in manager.pending.iter().enumerate() {
+        if req.realm != current_realm.about_url && !req.is_portable {
+            resolved.insert(i, false);
+        }
+    }
+
+    // clean up streams
+    requests_streams.retain(|s| !s.is_closed());
+    used_streams.retain(|s| !s.is_closed());
+
+    // send out resolved items
+    for (index, result) in resolved.iter().rev() {
+        permission_ids.remove(*index);
+        let perm = manager.pending.remove(*index).unwrap();
+        perm.sender.send(*result);
+    }
+
+    // send out uses
+    for usage in uses.read() {
+        for used_stream in used_streams.iter() {
+            let _ = used_stream.send(usage.clone());
+        }
+    }
 }

--- a/crates/system_ui/src/permission_manager.rs
+++ b/crates/system_ui/src/permission_manager.rs
@@ -29,7 +29,8 @@ pub struct PermissionPlugin;
 
 impl Plugin for PermissionPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<PermissionManager>();
+        app.init_resource::<PermissionManager>()
+            .add_event::<PermissionUsed>();
 
         let native_ui = app.world().resource::<NativeUi>();
         if native_ui.permissions {

--- a/crates/system_ui/src/permissions.rs
+++ b/crates/system_ui/src/permissions.rs
@@ -2,16 +2,13 @@ use bevy::prelude::*;
 use bevy_dui::{DuiCommandsExt, DuiEntityCommandsExt, DuiProps, DuiRegistry};
 use common::{
     structs::{
-        AppConfig, PermissionTarget, PermissionType, PermissionValue, PrimaryPlayerRes, SettingsTab,
+        AppConfig, PermissionLevel, PermissionStrings, PermissionTarget, PermissionType,
+        PermissionValue, PrimaryPlayerRes, SettingsTab,
     },
     util::{ModifyComponentExt, TryPushChildrenEx},
 };
 use ipfs::CurrentRealm;
-use scene_runner::{
-    permissions::{PermissionLevel, PermissionStrings},
-    renderer_context::RendererSceneContext,
-    ContainingScene,
-};
+use scene_runner::{renderer_context::RendererSceneContext, ContainingScene};
 use ui_core::{
     bound_node::BoundedNode,
     interact_style::set_interaction_style,

--- a/crates/system_ui/src/permissions.rs
+++ b/crates/system_ui/src/permissions.rs
@@ -130,7 +130,7 @@ fn set_permission_settings_content(
                              enabled: bool|
          -> DuiProps {
             let current_value = match &level {
-                PermissionLevel::Scene(_, hash) => config
+                PermissionLevel::Scene(hash) => config
                     .scene_permissions
                     .get(hash)
                     .and_then(|sp| sp.get(&ty))
@@ -184,7 +184,7 @@ fn set_permission_settings_content(
                             };
 
                             let (current_value, dict) = match &level {
-                                PermissionLevel::Scene(_, hash) => {
+                                PermissionLevel::Scene(hash) => {
                                     let dict =
                                         config.0.scene_permissions.entry(hash.clone()).or_default();
                                     (dict.get(&ty).copied(), dict)
@@ -244,19 +244,9 @@ fn set_permission_settings_content(
             let hilight = target.ty == Some(ty);
             let mut props = DuiProps::default().with_prop("permission-name", ty.title().to_owned());
             if let Some(hash) = scene_hash.as_ref() {
-                props = spawn_setting(
-                    props,
-                    ty,
-                    PermissionLevel::Scene(scene_ent.unwrap(), hash.clone()),
-                    true,
-                );
+                props = spawn_setting(props, ty, PermissionLevel::Scene(hash.clone()), true);
             } else {
-                props = spawn_setting(
-                    props,
-                    ty,
-                    PermissionLevel::Scene(Entity::PLACEHOLDER, String::default()),
-                    false,
-                );
+                props = spawn_setting(props, ty, PermissionLevel::Scene(String::default()), false);
             }
             if is_portable {
                 props = spawn_setting(

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -115,6 +115,7 @@ fn main_inner(
             login: false,
             emote_wheel: false,
             chat: false,
+            permissions: false,
         });
         app.insert_resource(SystemScene {
             source: Some(source),
@@ -127,6 +128,7 @@ fn main_inner(
             login: true,
             emote_wheel: true,
             chat: true,
+            permissions: true,
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,7 @@ fn main() {
             login: false,
             emote_wheel: false,
             chat: !args.contains("--no-chat"),
+            permissions: !args.contains("--no-perms"),
         });
         app.insert_resource(SystemScene {
             source: Some(source),
@@ -272,6 +273,7 @@ fn main() {
             login: true,
             emote_wheel: true,
             chat: true,
+            permissions: true,
         });
     }
 


### PR DESCRIPTION
add permission management api for system ui scene:

```js
export type PermissionLevel = 'Realm' | 'Scene' | 'Global';
export type PermissionValue = 'Allow' | 'Deny' | 'Ask';

export type PermissionRequest = {
    ty: string,
    additional: string | undefined,
    scene: string,
    id: number,
}

export type PermissionUsed = {
    ty: string,
    additional: string | undefined,
    scene: string,
    wasAllowed: boolean,
}

export type GetPermanentPermissionsArgs = {
  level: PermissionLevel,
  value?: string,
}

export type PermanentPermissionItem = {
  ty: string,
  allow: PermissionValue,
}

export type SetSinglePermissionArgs = {
  id: number,
  allow: boolean,
}

export type SetPermanentPermissionArgs = {
  level: PermissionLevel,
  value?: string,
  ty: string,
  allow?: PermissionValue,
}

export type PermissionTypeItem = {
  ty: string,
  name: string,
  passive: string,
  active: string,
}

export type BevyApiInterface = {
  [...]
  getPermissionRequestStream: () => Promise<PermissionRequest[]>
  getPermissionUsedStream: () => Promise<PermissionUsed[]>
  setSinglePermission: (arg0: SetSinglePermissionArgs) => void
  getPermanentPermissions: (arg0: GetPermanentPermissionsArgs) => PermanentPermissionItem[]
  setPermanentPermission: (arg0: SetPermanentPermissionArgs) => void
  getPermissionTypes: () => PermissionTypeItem[]
}
```