### PR TITLE
Audio buffer and stickiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,11 +1450,12 @@ dependencies = [
 [[package]]
 name = "bevy_kira_audio"
 version = "0.23.0"
-source = "git+https://github.com/robtfm/bevy_kira_audio?branch=0.16-2#9fd6a63be6ddd3da71d567e6b18d7450aca9d4dd"
+source = "git+https://github.com/robtfm/bevy_kira_audio?branch=0.16-2#a399357a9d8b0a155727086a26ad75970886d52a"
 dependencies = [
  "anyhow",
  "bevy",
  "bevy_math",
+ "cpal",
  "kira",
  "parking_lot",
  "thiserror 2.0.12",

--- a/crates/av/src/audio_source.rs
+++ b/crates/av/src/audio_source.rs
@@ -293,15 +293,12 @@ fn update_source_volume(
                 (volume * volume_adjust, panning)
             };
 
-            emitter.instances.retain_mut(|h_instance| {
+            for h_instance in emitter.instances.iter_mut() {
                 if let Some(instance) = audio_instances.get_mut(h_instance) {
                     instance.set_volume(volume as f64, AudioTween::linear(Duration::ZERO));
                     instance.set_panning(panning as f64, AudioTween::default());
-                    true
-                } else {
-                    false
                 }
-            });
+            };
         } else if maybe_scene.is_some_and(|scene| prev_scenes.contains(&scene.root)) {
             debug!("stop [{:?}]", ent);
             for h_instance in &emitter.instances {

--- a/crates/av/src/audio_source.rs
+++ b/crates/av/src/audio_source.rs
@@ -222,9 +222,7 @@ fn create_audio_sources(
     }
 }
 
-fn remove_dead_audio_assets(
-    mut audio_instances: ResMut<Assets<AudioInstance>>,
-) {
+fn remove_dead_audio_assets(mut audio_instances: ResMut<Assets<AudioInstance>>) {
     let mut dead = HashSet::new();
     for (h, instance) in audio_instances.iter() {
         if instance.state() == bevy_kira_audio::PlaybackState::Stopped {
@@ -319,7 +317,7 @@ fn update_audio_sources(
                     instance.set_volume(volume as f64, AudioTween::linear(Duration::ZERO));
                     instance.set_panning(panning as f64, AudioTween::default());
                 }
-            };
+            }
         } else if maybe_scene.is_some_and(|scene| prev_scenes.contains(&scene.root)) {
             debug!("set zero [{:?}] ({:?})", ent, emitter.instances);
             for h_instance in &emitter.instances {

--- a/crates/av/src/lib.rs
+++ b/crates/av/src/lib.rs
@@ -23,10 +23,17 @@ use bevy::prelude::*;
 #[cfg(feature = "ffmpeg")]
 use video_player::VideoPlayerPlugin;
 
-pub struct AudioPlugin;
+#[derive(Default)]
+pub struct AudioPlugin {
+    pub buffer_size: Option<u32>,
+}
 
 impl Plugin for AudioPlugin {
     fn build(&self, app: &mut App) {
+        app.insert_resource(bevy_kira_audio::AudioSettings {
+            buffer_size: self.buffer_size,
+            ..Default::default()
+        });
         app.add_plugins(bevy_kira_audio::AudioPlugin);
         #[cfg(feature = "ffmpeg")]
         app.add_plugins(VideoPlayerPlugin);

--- a/deploy/web/main.js
+++ b/deploy/web/main.js
@@ -169,7 +169,7 @@ async function run() {
         return "unknown";
       })();
 
-      engine_run(platform, initialRealm, location, systemScene, true, 1e6);
+      engine_run(platform, initialRealm, location, systemScene, true, 1e6, 8);
     };
   } catch (error) {
     console.error(

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -239,17 +239,17 @@ fn main_inner(
     app.add_plugins(AvatarPlugin);
 
     app.add_plugins(AudioPlugin {
-        buffer_size: Some(buffer_size)
+        buffer_size: Some(buffer_size),
     })
-        .add_plugins(RestrictedActionsPlugin)
-        .insert_resource(PrimaryPlayerRes(Entity::PLACEHOLDER))
-        .insert_resource(PrimaryCameraRes(Entity::PLACEHOLDER))
-        .add_systems(Startup, setup.in_set(SetupSets::Init))
-        .insert_resource(AmbientLight {
-            color: Color::srgb(0.85, 0.85, 1.0),
-            brightness: 575.0,
-            ..Default::default()
-        });
+    .add_plugins(RestrictedActionsPlugin)
+    .insert_resource(PrimaryPlayerRes(Entity::PLACEHOLDER))
+    .insert_resource(PrimaryCameraRes(Entity::PLACEHOLDER))
+    .add_systems(Startup, setup.in_set(SetupSets::Init))
+    .insert_resource(AmbientLight {
+        color: Color::srgb(0.85, 0.85, 1.0),
+        brightness: 575.0,
+        ..Default::default()
+    });
 
     app.add_console_command::<ChangeLocationCommand, _>(change_location);
     app.add_console_command::<SceneDistanceCommand, _>(scene_distance);

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -69,6 +69,7 @@ fn main_inner(
     system_scene: &str,
     with_thread_loader: bool,
     rabpf: usize,
+    buffer_size: u32,
 ) {
     // warnings before log init must be stored and replayed later
     let mut app = App::new();
@@ -237,7 +238,9 @@ fn main_inner(
 
     app.add_plugins(AvatarPlugin);
 
-    app.add_plugins(AudioPlugin)
+    app.add_plugins(AudioPlugin {
+        buffer_size: Some(buffer_size)
+    })
         .add_plugins(RestrictedActionsPlugin)
         .insert_resource(PrimaryPlayerRes(Entity::PLACEHOLDER))
         .insert_resource(PrimaryCameraRes(Entity::PLACEHOLDER))
@@ -539,6 +542,7 @@ pub fn engine_run(
     system_scene: &str,
     with_thread_loader: bool,
     rabpf: usize,
+    buffer_size: u32,
 ) {
     main_inner(
         platform,
@@ -547,5 +551,6 @@ pub fn engine_run(
         system_scene,
         with_thread_loader,
         rabpf,
+        buffer_size,
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,7 +453,7 @@ fn main() {
         app.add_plugins(AutomaticTestingPlugin);
     }
 
-    app.add_plugins(AudioPlugin)
+    app.add_plugins(AudioPlugin::default())
         .add_plugins(RestrictedActionsPlugin)
         .insert_resource(PrimaryPlayerRes(Entity::PLACEHOLDER))
         .insert_resource(PrimaryCameraRes(Entity::PLACEHOLDER))


### PR DESCRIPTION
- fix audio failing to stop when dropped after bevy 0.16
- set cpal audio buffer size to 8 for web to avoid underruns / improve quality