### PR TITLE
keep existing profile on realm change if fetch fails

### DIFF
--- a/crates/system_ui/src/login.rs
+++ b/crates/system_ui/src/login.rs
@@ -327,14 +327,7 @@ fn update_profile_for_realm(
                 current_profile.is_deployed = true;
             }
             Some(Err(_)) => {
-                current_profile.profile = Some(UserProfile {
-                    version: 0,
-                    content: SerializedProfile {
-                        has_connected_web3: Some(true),
-                        ..Default::default()
-                    },
-                    base_url: ipfas.ipfs().contents_endpoint().unwrap_or_default(),
-                });
+                // keep existing profile
             }
             None => *task = Some(t),
         }


### PR DESCRIPTION
on realm change, we refetch profile for the new realm (as a single address may have different profiles on different realms).
if it fails, we default to a "guest" profile. instead, let's keep the current profile when fetch fails.