### PR TITLE
Web video

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,8 +28,8 @@ CARGO_FEATURE_CRT_STATIC = "ohyes"
 build-std = ["std", "panic_abort"]
 
 # uncomment for rust analyzer to attempt (and fail) to use wasm32 as default
-[build]
-target = "wasm32-unknown-unknown"
+# [build]
+# target = "wasm32-unknown-unknown"
 
 
 ### for panic_unwind (currently unsupported by walrus)

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,8 +28,8 @@ CARGO_FEATURE_CRT_STATIC = "ohyes"
 build-std = ["std", "panic_abort"]
 
 # uncomment for rust analyzer to attempt (and fail) to use wasm32 as default
-# [build]
-# target = "wasm32-unknown-unknown"
+[build]
+target = "wasm32-unknown-unknown"
 
 
 ### for panic_unwind (currently unsupported by walrus)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "urlencoding",
+ "web-sys",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1146,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1468,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1554,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "glam",
 ]
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1612,12 +1612,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5282a287d435d3b3e4ac7e9c8c490e36457af1ab"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5282a287d435d3b3e4ac7e9c8c490e36457af1ab"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5282a287d435d3b3e4ac7e9c8c490e36457af1ab"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5282a287d435d3b3e4ac7e9c8c490e36457af1ab"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fa87f183b0a9fc06c805308f0d6791406a705611"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#beea7c35480bef5dbe28ebe7261f9ca54bbb95a7"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "urlencoding",
+ "wasm-bindgen",
  "web-sys",
  "wgpu",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hot_reload = ["bevy/file_watcher", "ipfs/hot_reload"]
 livekit = ["comms/livekit", "system_ui/livekit"]
 ffmpeg = ["av/ffmpeg"]
 social = ["dcl_component/social", "social/social"]
-wasm = ["uuid/js", "getrandom/wasm_js", "bevy/webgpu", "bevy/wasm_threaded_asset_loader", "bevy/reduce_image_sizes"]
+wasm = ["uuid/js", "getrandom/wasm_js", "bevy/webgpu", "bevy/wasm_threaded_asset_loader", "bevy/reduce_image_sizes", "av/html"]
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "webgpu_build"
 # - wasm-pack build --target web --out-dir ./deploy/web/pkg --no-default-features --features="wasm" && npx serve deploy/web
 
 [features]
-# default = ["livekit", "ffmpeg", "inspect", "social"]
-default = ["wasm"]
+default = ["livekit", "ffmpeg", "inspect", "social"]
+# default = ["wasm"]
 console = []
 dcl-assert = ["common/dcl-assert"]
 gen-tests = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "webgpu_build"
 # - wasm-pack build --target web --out-dir ./deploy/web/pkg --no-default-features --features="wasm" && npx serve deploy/web
 
 [features]
-default = ["livekit", "ffmpeg", "inspect", "social"]
-# default = ["wasm"]
+# default = ["livekit", "ffmpeg", "inspect", "social"]
+default = ["wasm"]
 console = []
 dcl-assert = ["common/dcl-assert"]
 gen-tests = []

--- a/crates/av/Cargo.toml
+++ b/crates/av/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [features]
 ffmpeg = ["dep:ffmpeg-next"]
+html = ["dep:web-sys"]
 
 [dependencies]
 common = { workspace = true }
@@ -24,6 +25,9 @@ urlencoding = { workspace = true }
 futures-lite = { workspace = true }
 bevy_kira_audio = { workspace = true }
 kira = { workspace = true }
+wgpu = { workspace = true }
 
 ffmpeg-next = { version = "6.0.0", optional = true }
 thiserror = "1.0"
+
+web-sys = { workspace = true, features = ["HtmlMediaElement", "HtmlVideoElement"], optional = true}

--- a/crates/av/Cargo.toml
+++ b/crates/av/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [features]
 ffmpeg = ["dep:ffmpeg-next"]
-html = ["dep:web-sys"]
+html = ["dep:web-sys", "dep:wasm-bindgen"]
 
 [dependencies]
 common = { workspace = true }
@@ -31,3 +31,4 @@ ffmpeg-next = { version = "6.0.0", optional = true }
 thiserror = "1.0"
 
 web-sys = { workspace = true, features = ["HtmlMediaElement", "HtmlVideoElement"], optional = true}
+wasm-bindgen = { workspace = true, optional = true}

--- a/crates/av/src/html_video_player.rs
+++ b/crates/av/src/html_video_player.rs
@@ -27,7 +27,9 @@ use common::{
 };
 use dcl::interface::{ComponentPosition, CrdtType};
 use dcl_component::{
-    proto_components::sdk::components::{PbAudioStream, PbVideoEvent, PbVideoPlayer, VideoState},
+    proto_components::sdk::components::{
+        PbAudioEvent, PbAudioStream, PbVideoEvent, PbVideoPlayer, VideoState,
+    },
     SceneComponentId,
 };
 use ipfs::IpfsResource;
@@ -40,6 +42,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use web_sys::{
     js_sys::{self, Reflect},
     wasm_bindgen::{prelude::Closure, JsValue},
+    HtmlMediaElement,
 };
 use web_sys::{wasm_bindgen::JsCast, HtmlVideoElement};
 
@@ -67,12 +70,11 @@ impl Plugin for VideoPlayerPlugin {
             ComponentPosition::EntityOnly,
         );
 
-        // TODO: we can't reuse the same html element for audio and video, so will have to do audio separately
-        // app.add_crdt_lww_component::<PbAudioStream, AVPlayer>(
-        //     SceneComponentId::AUDIO_STREAM,
-        //     ComponentPosition::EntityOnly,
-        // );
-        app.add_systems(Update, update_video_players.in_set(SceneSets::PostLoop));
+        app.add_crdt_lww_component::<PbAudioStream, AVPlayer>(
+            SceneComponentId::AUDIO_STREAM,
+            ComponentPosition::EntityOnly,
+        );
+        app.add_systems(Update, update_av_players.in_set(SceneSets::PostLoop));
 
         let (sx, rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -101,11 +103,15 @@ pub struct FrameCopyRequest {
 pub struct AVPlayer {
     // note we reuse PbVideoPlayer for audio as well
     pub source: PbVideoPlayer,
+    pub has_video: bool,
 }
 
 impl From<PbVideoPlayer> for AVPlayer {
     fn from(value: PbVideoPlayer) -> Self {
-        Self { source: value }
+        Self {
+            source: value,
+            has_video: true,
+        }
     }
 }
 
@@ -118,15 +124,17 @@ impl From<PbAudioStream> for AVPlayer {
                 volume: value.volume,
                 ..Default::default()
             },
+            has_video: false,
         }
     }
 }
 
 #[derive(Component)]
-pub struct HtmlVideoEntity {
+pub struct HtmlMediaEntity {
     source: String,
-    video: HtmlVideoElement,
-    image: Handle<Image>,
+    media: HtmlMediaElement,
+    video: Option<HtmlVideoElement>,
+    image: Option<Handle<Image>>,
     size: Option<(u32, u32)>,
     last_state: VideoState,
     last_reported_time: f32,
@@ -137,8 +145,8 @@ pub struct HtmlVideoEntity {
 }
 
 /// safety: engine is single threaded
-unsafe impl Sync for HtmlVideoEntity {}
-unsafe impl Send for HtmlVideoEntity {}
+unsafe impl Sync for HtmlMediaEntity {}
+unsafe impl Send for HtmlMediaEntity {}
 
 // This block imports the global JS function we defined in main.js
 #[wasm_bindgen(js_namespace = window)]
@@ -147,25 +155,10 @@ extern "C" {
     fn set_video_source(elt: &HtmlVideoElement, src: &str);
 }
 
-impl HtmlVideoEntity {
-    pub fn new(url: String, source: String, image: Handle<Image>) -> Self {
-        let frame_time = Arc::new(AtomicU32::default());
+impl HtmlMediaEntity {
+    fn common_init(source: String, media: HtmlMediaElement) -> Self {
+        let mut closures = Vec::default();
         let state = Arc::new(Mutex::new(VideoState::VsLoading));
-        let mut closures = Vec::new();
-        let video = web_sys::window()
-            .unwrap()
-            .document()
-            .and_then(|doc| {
-                let container = doc
-                    .get_element_by_id(VIDEO_CONTAINER_ID)
-                    .expect("video container should exist");
-                let video = doc.create_element("video").unwrap();
-                container.append_child(&video).unwrap();
-                video.dyn_into::<HtmlVideoElement>().ok()
-            })
-            .expect("Couldn't create video element");
-
-        video.set_cross_origin(Some("anonymous"));
 
         fn register_callback<'a>(
             closures: &'a mut Vec<Closure<dyn FnMut()>>,
@@ -184,43 +177,97 @@ impl HtmlVideoEntity {
             closures.last().map(move |c| c.as_ref().unchecked_ref())
         }
 
-        video.set_oncanplay(register_callback(
+        media.set_oncanplay(register_callback(
             &mut closures,
             &state,
             VideoState::VsReady,
         ));
-        video.set_onabort(register_callback(
+        media.set_onabort(register_callback(
             &mut closures,
             &state,
             VideoState::VsError,
         ));
-        video.set_onerror(register_callback(
+        media.set_onerror(register_callback(
             &mut closures,
             &state,
             VideoState::VsError,
         ));
-        video.set_onwaiting(register_callback(
+        media.set_onwaiting(register_callback(
             &mut closures,
             &state,
             VideoState::VsBuffering,
         ));
-        video.set_onplaying(register_callback(
+        media.set_onplaying(register_callback(
             &mut closures,
             &state,
             VideoState::VsPlaying,
         ));
-        video.set_onpause(register_callback(
+        media.set_onpause(register_callback(
             &mut closures,
             &state,
             VideoState::VsPaused,
         ));
-        video.set_onended(register_callback(
+        media.set_onended(register_callback(
             &mut closures,
             &state,
             VideoState::VsPaused,
         ));
 
-        // no wasm_bindgen for this!
+        Self {
+            source,
+            media,
+            video: None,
+            image: None,
+            size: None,
+            last_state: VideoState::VsNone,
+            last_reported_time: -1.0,
+            current_time: -1.0,
+            new_frame_time: Arc::new(AtomicU32::default()),
+            state,
+            _closures: closures,
+        }
+    }
+
+    pub fn new_audio(url: &str, source: String) -> Self {
+        let media = web_sys::window()
+            .unwrap()
+            .document()
+            .and_then(|doc| {
+                let container = doc
+                    .get_element_by_id(VIDEO_CONTAINER_ID)
+                    .expect("video container should exist");
+                let video = doc.create_element("audio").unwrap();
+                container.append_child(&video).unwrap();
+                video.dyn_into::<HtmlMediaElement>().ok()
+            })
+            .expect("Couldn't create video element");
+
+        media.set_src(url);
+
+        Self::common_init(source, media)
+    }
+
+    pub fn new_video(url: &str, source: String, image: Handle<Image>) -> Self {
+        let media = web_sys::window()
+            .unwrap()
+            .document()
+            .and_then(|doc| {
+                let container = doc
+                    .get_element_by_id(VIDEO_CONTAINER_ID)
+                    .expect("video container should exist");
+                let video = doc.create_element("video").unwrap();
+                container.append_child(&video).unwrap();
+                video.dyn_into::<HtmlMediaElement>().ok()
+            })
+            .expect("Couldn't create video element");
+
+        let video = media.clone().dyn_into::<HtmlVideoElement>().unwrap();
+
+        video.set_cross_origin(Some("anonymous"));
+
+        let frame_time = Arc::new(AtomicU32::default());
+
+        // video frame callback - no wasm_bindgen for this!
         let rvc_prop = Reflect::get(&video, &"requestVideoFrameCallback".into()).unwrap();
         if rvc_prop.is_undefined() {
             panic!("no requestVideoFrameCallback");
@@ -257,62 +304,58 @@ impl HtmlVideoEntity {
             .call1(&video, callback.borrow().as_ref().unwrap())
             .unwrap();
 
-        set_video_source(&video, &url);
+        set_video_source(&video, url);
 
-        Self {
-            source,
-            video,
-            image,
-            size: None,
-            new_frame_time: frame_time,
-            last_state: VideoState::VsNone,
-            last_reported_time: -1.0,
-            current_time: -1.0,
-            state,
-            _closures: closures,
-        }
+        let mut slf = Self::common_init(source, media);
+        slf.video = Some(video);
+        slf.image = Some(image);
+        slf
     }
 
     pub fn set_loop(&mut self, looping: bool) {
-        self.video.set_loop(looping)
+        self.media.set_loop(looping)
+    }
+
+    pub fn set_volume(&self, volume: f32) {
+        self.media.set_volume(volume as f64)
     }
 
     pub fn play(&mut self) {
         debug!("called play");
-        let _ = self.video.play();
+        let _ = self.media.play();
     }
 
     pub fn stop(&mut self) {
         debug!("called play");
-        let _ = self.video.pause();
+        let _ = self.media.pause();
     }
 
     pub fn state(&self) -> VideoState {
-        self.state.lock().unwrap().clone()
+        *self.state.lock().unwrap()
     }
 }
 
-impl Drop for HtmlVideoEntity {
+impl Drop for HtmlMediaEntity {
     fn drop(&mut self) {
-        self.video.set_oncanplay(None);
-        self.video.set_onabort(None);
-        self.video.set_onerror(None);
-        self.video.set_onwaiting(None);
-        self.video.set_onplaying(None);
-        self.video.set_onpause(None);
-        self.video.set_onended(None);
-        self.video.remove();
+        self.media.set_oncanplay(None);
+        self.media.set_onabort(None);
+        self.media.set_onerror(None);
+        self.media.set_onwaiting(None);
+        self.media.set_onplaying(None);
+        self.media.set_onpause(None);
+        self.media.set_onended(None);
+        self.media.remove();
     }
 }
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
-pub fn update_video_players(
+pub fn update_av_players(
     mut commands: Commands,
-    mut video_players: Query<(
+    mut av_players: Query<(
         Entity,
         &ContainerEntity,
         Ref<AVPlayer>,
-        Option<&mut HtmlVideoEntity>,
+        Option<&mut HtmlMediaEntity>,
         Option<&VideoTextureOutput>,
         &GlobalTransform,
     )>,
@@ -325,36 +368,13 @@ pub fn update_video_players(
     send_queue: Res<FrameCopyRequestQueue>,
     frame: Res<FrameCount>,
 ) {
-    for (ent, container, player, mut maybe_video, maybe_texture, _) in video_players.iter_mut() {
-        if let Some(video) = maybe_video
-            .as_mut()
-            .filter(|p| p.source == player.source.src)
-        {
+    for (ent, container, player, mut maybe_av, maybe_texture, _) in av_players.iter_mut() {
+        if let Some(av) = maybe_av.as_mut().filter(|p| p.source == player.source.src) {
             if player.is_changed() {
-                video.set_loop(player.source.r#loop.unwrap_or(false));
+                av.set_loop(player.source.r#loop.unwrap_or(false));
+                av.set_volume(player.source.volume.unwrap_or(1.0));
             }
         } else {
-            let image_handle = match maybe_texture {
-                None => {
-                    let mut image = Image::new_fill(
-                        bevy::render::render_resource::Extent3d {
-                            width: 8,
-                            height: 8,
-                            depth_or_array_layers: 1,
-                        },
-                        TextureDimension::D2,
-                        &basic::FUCHSIA.to_u8_array(),
-                        TextureFormat::Rgba8UnormSrgb,
-                        RenderAssetUsages::all(),
-                    );
-                    image.texture_descriptor.usage = TextureUsages::COPY_DST
-                        | TextureUsages::TEXTURE_BINDING
-                        | TextureUsages::RENDER_ATTACHMENT;
-                    images.add(image)
-                }
-                Some(texture) => texture.0.clone(),
-            };
-
             let Ok(context) = scenes.get(container.root) else {
                 continue;
             };
@@ -362,13 +382,47 @@ pub fn update_video_players(
             let source = ipfs
                 .content_url(&player.source.src, &context.hash)
                 .unwrap_or_else(|| player.source.src.clone());
-            let mut video =
-                HtmlVideoEntity::new(player.source.src.clone(), source, image_handle.clone());
 
-            video.set_loop(player.source.r#loop.unwrap_or(false));
-            let video_output = VideoTextureOutput(image_handle);
+            if player.has_video {
+                let image_handle = match maybe_texture {
+                    None => {
+                        let mut image = Image::new_fill(
+                            bevy::render::render_resource::Extent3d {
+                                width: 8,
+                                height: 8,
+                                depth_or_array_layers: 1,
+                            },
+                            TextureDimension::D2,
+                            &basic::FUCHSIA.to_u8_array(),
+                            TextureFormat::Rgba8UnormSrgb,
+                            RenderAssetUsages::all(),
+                        );
+                        image.texture_descriptor.usage = TextureUsages::COPY_DST
+                            | TextureUsages::TEXTURE_BINDING
+                            | TextureUsages::RENDER_ATTACHMENT;
+                        images.add(image)
+                    }
+                    Some(texture) => texture.0.clone(),
+                };
 
-            commands.entity(ent).try_insert((video, video_output));
+                let mut video = HtmlMediaEntity::new_video(
+                    &source,
+                    player.source.src.clone(),
+                    image_handle.clone(),
+                );
+
+                video.set_loop(player.source.r#loop.unwrap_or(false));
+                video.set_volume(player.source.volume.unwrap_or(1.0));
+                let video_output = VideoTextureOutput(image_handle);
+
+                commands.entity(ent).try_insert((video, video_output));
+            } else {
+                let mut audio = HtmlMediaEntity::new_audio(&source, player.source.src.clone());
+                audio.set_loop(player.source.r#loop.unwrap_or(false));
+                audio.set_volume(player.source.volume.unwrap_or(1.0));
+
+                commands.entity(ent).try_insert(audio);
+            }
         }
     }
 
@@ -379,7 +433,7 @@ pub fn update_video_players(
 
     let containing_scenes = containing_scene.get_position(user.translation());
 
-    let mut sorted_players = video_players
+    let mut sorted_players = av_players
         .iter()
         .filter_map(|(ent, container, player, _, _, transform)| {
             if player.source.playing.unwrap_or(true) {
@@ -401,80 +455,100 @@ pub fn update_video_players(
         .map(|(_, _, ent)| *ent)
         .collect::<HashSet<_>>();
 
-    for (ent, container, _, video, _, _) in video_players.iter_mut() {
-        let Some(mut video) = video else { continue };
+    for (ent, container, player, maybe_av, _, _) in av_players.iter_mut() {
+        let Some(mut av) = maybe_av else { continue };
 
         let should_be_playing = should_be_playing.contains(&ent);
 
-        let is_playing = video.state() == VideoState::VsPlaying;
+        let is_playing = av.state() == VideoState::VsPlaying;
         if !is_playing && should_be_playing {
-            video.play()
+            av.play()
         } else if is_playing {
             if !should_be_playing {
-                video.stop();
+                av.stop();
             } else {
-                let new_time = video.new_frame_time.swap(0, Ordering::Relaxed);
-                if new_time != 0 {
-                    // new frame is ready
-                    let new_time = f32::from_bits(new_time);
+                #[allow(clippy::collapsible_else_if)]
+                if let Some(video) = av.video.as_ref() {
+                    let new_time = av.new_frame_time.swap(0, Ordering::Relaxed);
+                    if new_time != 0 {
+                        // new frame is ready
+                        let new_time = f32::from_bits(new_time);
+                        let image_id = av.image.as_ref().unwrap().id();
+                        let video_size = (video.video_width(), video.video_height());
+                        let video = video.clone();
 
-                    // check size
-                    let video_size = (video.video.video_width(), video.video.video_height());
-                    if video.size.is_none_or(|sz| sz != video_size) {
-                        let Some(image) = images.get_mut(video.image.id()) else {
-                            warn!("no image!");
-                            continue;
-                        };
+                        // check size
+                        if av.size.is_none_or(|sz| sz != video_size) {
+                            let Some(image) = images.get_mut(image_id) else {
+                                warn!("no image!");
+                                continue;
+                            };
 
-                        image.resize(Extent3d {
-                            width: video_size.0.max(16),
-                            height: video_size.1.max(16),
-                            depth_or_array_layers: 1,
+                            image.resize(Extent3d {
+                                width: video_size.0.max(16),
+                                height: video_size.1.max(16),
+                                depth_or_array_layers: 1,
+                            });
+                            av.size = Some(video_size)
+                        }
+
+                        // queue copy
+                        let _ = send_queue.0.send(FrameCopyRequest {
+                            video: WgpuWrapper::new(video),
+                            target: image_id,
+                            size: wgpu::Extent3d {
+                                width: video_size.0,
+                                height: video_size.1,
+                                depth_or_array_layers: 1,
+                            },
                         });
-                        video.size = Some(video_size)
+
+                        av.current_time = new_time;
+                    } else {
+                        // we don't report audio timestamps, otherwise would need to grab it here
                     }
-
-                    // queue copy
-                    let _ = send_queue.0.send(FrameCopyRequest {
-                        video: WgpuWrapper::new(video.video.clone()),
-                        target: video.image.id(),
-                        size: wgpu::Extent3d {
-                            width: video_size.0,
-                            height: video_size.1,
-                            depth_or_array_layers: 1,
-                        },
-                    });
-
-                    video.current_time = new_time;
                 }
             }
         }
 
-        const VIDEO_REPORT_FREQUENCY: f32 = 1.0;
-        let new_state = video.state();
-        if new_state != video.last_state
-            || video.current_time > video.last_reported_time + VIDEO_REPORT_FREQUENCY
-            || video.current_time < video.last_reported_time
+        const AV_REPORT_FREQUENCY: f32 = 1.0;
+        let new_state = av.state();
+        if new_state != av.last_state
+            || av.current_time > av.last_reported_time + AV_REPORT_FREQUENCY
+            || av.current_time < av.last_reported_time
         {
             let Ok(mut context) = scenes.get_mut(container.root) else {
                 continue;
             };
             let tick_number = context.tick_number;
-            debug!("set {:?} {:?}", video.state(), video.current_time);
-            context.update_crdt(
-                SceneComponentId::VIDEO_EVENT,
-                CrdtType::GO_ANY,
-                container.container_id,
-                &PbVideoEvent {
-                    timestamp: frame.0,
-                    tick_number,
-                    current_offset: video.current_time,
-                    video_length: video.video.duration() as f32,
-                    state: video.state() as i32,
-                },
-            );
-            video.last_state = new_state;
-            video.last_reported_time = video.current_time;
+            debug!("set {:?} {:?}", av.state(), av.current_time);
+
+            if player.has_video {
+                context.update_crdt(
+                    SceneComponentId::VIDEO_EVENT,
+                    CrdtType::GO_ANY,
+                    container.container_id,
+                    &PbVideoEvent {
+                        timestamp: frame.0,
+                        tick_number,
+                        current_offset: av.current_time,
+                        video_length: av.media.duration() as f32,
+                        state: av.state() as i32,
+                    },
+                );
+            } else {
+                context.update_crdt(
+                    SceneComponentId::AUDIO_EVENT,
+                    CrdtType::GO_ANY,
+                    container.container_id,
+                    &PbAudioEvent {
+                        timestamp: frame.0,
+                        state: av.state() as i32, // a bit hacky - MediaState and VideoState have the same i32 representation
+                    },
+                )
+            }
+            av.last_state = new_state;
+            av.last_reported_time = av.current_time;
         }
     }
 }

--- a/crates/av/src/html_video_player.rs
+++ b/crates/av/src/html_video_player.rs
@@ -1,0 +1,299 @@
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use bevy::{
+    color::palettes::basic,
+    diagnostic::FrameCount,
+    math::FloatOrd,
+    platform::collections::HashMap,
+    prelude::*,
+    render::{
+        render_asset::{RenderAssetUsages, RenderAssets},
+        render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
+        renderer::RenderQueue,
+        texture::GpuImage,
+        Render, RenderApp, RenderSet,
+    },
+};
+use common::{
+    sets::SceneSets,
+    structs::{AppConfig, PrimaryUser},
+};
+use dcl::interface::{ComponentPosition, CrdtType};
+use dcl_component::{
+    proto_components::sdk::components::{PbAudioStream, PbVideoEvent, PbVideoPlayer, VideoState},
+    SceneComponentId,
+};
+use ipfs::IpfsResource;
+use scene_runner::{
+    renderer_context::RendererSceneContext,
+    update_world::{material::VideoTextureOutput, AddCrdtInterfaceExt},
+    ContainerEntity, ContainingScene,
+};
+use web_sys::{
+    js_sys::Reflect,
+    wasm_bindgen::{prelude::Closure, JsValue},
+};
+use web_sys::{wasm_bindgen::JsCast, HtmlVideoElement};
+
+pub struct VideoPlayerPlugin;
+
+impl Plugin for VideoPlayerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_crdt_lww_component::<PbVideoPlayer, AVPlayer>(
+            SceneComponentId::VIDEO_PLAYER,
+            ComponentPosition::EntityOnly,
+        );
+        app.add_crdt_lww_component::<PbAudioStream, AVPlayer>(
+            SceneComponentId::AUDIO_STREAM,
+            ComponentPosition::EntityOnly,
+        );
+        app.add_systems(Update, update_video_players.in_set(SceneSets::PostLoop));
+
+        let (sx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        app.insert_resource(FrameCopyRequestQueue(sx));
+
+        let render_app = app.sub_app_mut(RenderApp);
+        render_app
+            .insert_resource(FrameCopyReceiveQueue(rx))
+            .add_systems(Render, perform_video_copies.in_set(RenderSet::Queue));
+    }
+}
+
+#[derive(Resource)]
+pub struct FrameCopyRequestQueue(tokio::sync::mpsc::UnboundedSender<FrameCopyRequest>);
+
+#[derive(Resource)]
+pub struct FrameCopyReceiveQueue(tokio::sync::mpsc::UnboundedReceiver<FrameCopyRequest>);
+
+pub struct FrameCopyRequest {
+    video: HtmlVideoEntity,
+    target: AssetId<Image>,
+    size: Extent3d,
+}
+
+#[derive(Component, Debug)]
+pub struct AVPlayer {
+    // note we reuse PbVideoPlayer for audio as well
+    pub source: PbVideoPlayer,
+}
+
+impl From<PbVideoPlayer> for AVPlayer {
+    fn from(value: PbVideoPlayer) -> Self {
+        Self { source: value }
+    }
+}
+
+impl From<PbAudioStream> for AVPlayer {
+    fn from(value: PbAudioStream) -> Self {
+        Self {
+            source: PbVideoPlayer {
+                src: value.url,
+                playing: value.playing,
+                volume: value.volume,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[derive(Component, Clone)]
+pub struct HtmlVideoEntity {
+    url: String,
+    source: String,
+    video: HtmlVideoElement,
+    image: Handle<Image>,
+    size: Option<(u32, u32)>,
+    frame_ready: Arc<AtomicBool>,
+}
+
+/// safety: engine is single threaded
+unsafe impl Sync for HtmlVideoEntity {}
+unsafe impl Send for HtmlVideoEntity {}
+
+impl HtmlVideoEntity {
+    pub fn new(url: String, source: String, image: Handle<Image>) -> Self {
+        let frame_ready = Arc::new(AtomicBool::default());
+        let video = web_sys::window()
+            .unwrap()
+            .document()
+            .and_then(|doc| {
+                let video = doc.create_element("video").unwrap();
+                doc.body().unwrap().append_child(&video).unwrap();
+                video.dyn_into::<HtmlVideoElement>().ok()
+            })
+            .expect("Couldn't create video element");
+
+        video.set_cross_origin(Some("anonymous"));
+        video.set_src(&url);
+        video.set_autoplay(true);
+
+        // no wasm_bindgen for this!
+        let rvc_prop = Reflect::get(&video, &"requestVideoFrameCallback".into()).unwrap();
+        if rvc_prop.is_undefined() {
+            panic!("no requestVideoFrameCallback");
+        }
+        let rvc_fn = rvc_prop.dyn_into::<web_sys::js_sys::Function>().unwrap();
+
+        let callback = Rc::new(RefCell::new(None));
+        let callback_clone = callback.clone();
+        let ready_clone = frame_ready.clone();
+        let rvc_clone = rvc_fn.clone();
+
+        *callback.borrow_mut() = Some(
+            Closure::wrap(Box::new({
+                let video = video.clone();
+                move |_now: f64, _metadata: JsValue| {
+                    ready_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                    rvc_clone
+                        .call1(&video, callback_clone.borrow().as_ref().unwrap())
+                        .unwrap();
+                }
+            }) as Box<dyn FnMut(f64, JsValue)>)
+            .into_js_value(),
+        );
+        rvc_fn
+            .call1(&video, callback.borrow().as_ref().unwrap())
+            .unwrap();
+
+        Self {
+            url,
+            source,
+            video,
+            image,
+            size: None,
+            frame_ready,
+        }
+    }
+}
+
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+pub fn update_video_players(
+    mut commands: Commands,
+    mut video_players: Query<(
+        Entity,
+        &ContainerEntity,
+        Ref<AVPlayer>,
+        Option<&mut HtmlVideoEntity>,
+        Option<&VideoTextureOutput>,
+        &GlobalTransform,
+    )>,
+    mut images: ResMut<Assets<Image>>,
+    ipfs: Res<IpfsResource>,
+    scenes: Query<&RendererSceneContext>,
+    config: Res<AppConfig>,
+    containing_scene: ContainingScene,
+    user: Query<&GlobalTransform, With<PrimaryUser>>,
+    mut send_queue: Res<FrameCopyRequestQueue>,
+) {
+
+    for (ent, container, player, mut maybe_html, maybe_texture, _) in video_players.iter_mut() {
+        if maybe_html.as_ref().is_none_or(|html| html.source != player.source.src) {
+            let image_handle = match maybe_texture {
+                None => {
+                    let mut image = Image::new_fill(
+                        bevy::render::render_resource::Extent3d {
+                            width: 8,
+                            height: 8,
+                            depth_or_array_layers: 1,
+                        },
+                        TextureDimension::D2,
+                        &basic::FUCHSIA.to_u8_array(),
+                        TextureFormat::Rgba8UnormSrgb,
+                        RenderAssetUsages::all(),
+                    );
+                    image.texture_descriptor.usage =
+                        TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT;
+                    images.add(image)
+                }
+                Some(texture) => texture.0.clone(),
+            };
+
+            let Ok(context) = scenes.get(container.root) else {
+                continue;
+            };
+
+            let source = ipfs
+                .content_url(&player.source.src, &context.hash)
+                .unwrap_or_else(|| player.source.src.clone());
+            let video_entity = HtmlVideoEntity::new(player.source.src.clone(), source, image_handle.clone());
+            let video_output = VideoTextureOutput(image_handle);
+
+            commands
+                .entity(ent)
+                .try_insert((video_entity, video_output));
+        }
+
+        if let Some(mut html_player) = maybe_html {
+            if html_player.frame_ready.swap(false, Ordering::Relaxed) {
+                // new frame is ready, queue a copy
+
+                // check size
+                let video_size = (
+                    html_player.video.video_width(),
+                    html_player.video.video_height(),
+                );
+                if html_player.size.is_none_or(|sz| sz != video_size) {
+                    let Some(mut image) = images.get_mut(html_player.image.id()) else {
+                        warn!("no image!");
+                        continue;
+                    };
+
+                    image.resize(Extent3d {
+                        width: video_size.0.max(16),
+                        height: video_size.1.max(16),
+                        depth_or_array_layers: 1,
+                    });
+                    html_player.size = Some(video_size)
+                }
+
+                // queue copy
+                let _ = send_queue.0.send(FrameCopyRequest {
+                    video: html_player.clone(),
+                    target: html_player.image.id(),
+                    size: wgpu::Extent3d {
+                        width: video_size.0,
+                        height: video_size.1,
+                        depth_or_array_layers: 1,
+                    },
+                });
+            }
+        }
+    }
+}
+
+fn perform_video_copies(
+    mut requests: ResMut<FrameCopyReceiveQueue>,
+    images: Res<RenderAssets<GpuImage>>,
+    render_queue: Res<RenderQueue>,
+) {
+    while let Ok(request) = requests.0.try_recv() {
+        let Some(gpu_image) = images.get(request.target) else {
+            warn!("missing gpu image");
+            continue;
+        };
+        render_queue.copy_external_image_to_texture(
+            &wgpu::ImageCopyExternalImage {
+                source: wgpu::ExternalImageSource::HTMLVideoElement(request.video.video),
+                origin: wgpu::Origin2d::ZERO,
+                flip_y: false,
+            },
+            wgpu::ImageCopyTextureTagged {
+                texture: &gpu_image.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+                premultiplied_alpha: false, // Video frames are not typically premultiplied.
+                color_space: wgpu::PredefinedColorSpace::Srgb,
+            },
+            request.size,
+        );
+    }
+}

--- a/crates/av/src/html_video_player.rs
+++ b/crates/av/src/html_video_player.rs
@@ -460,8 +460,15 @@ pub fn update_av_players(
 
         let should_be_playing = should_be_playing.contains(&ent);
 
-        let is_playing = av.state() == VideoState::VsPlaying;
-        if !is_playing && should_be_playing {
+        let state = av.state();
+
+        let is_playing = state == VideoState::VsPlaying;
+        let can_play = match state {
+            VideoState::VsReady | VideoState::VsPaused => true,
+            _ => false,
+        };
+
+        if !is_playing && should_be_playing && can_play {
             av.play()
         } else if is_playing {
             if !should_be_playing {

--- a/crates/av/src/lib.rs
+++ b/crates/av/src/lib.rs
@@ -40,7 +40,7 @@ impl Plugin for AudioPlugin {
             ..Default::default()
         });
         app.add_plugins(bevy_kira_audio::AudioPlugin);
-        #[cfg(any(feature = "ffmpeg", feature="html"))]
+        #[cfg(any(feature = "ffmpeg", feature = "html"))]
         app.add_plugins(VideoPlayerPlugin);
 
         app.add_plugins(AudioSourcePlugin);

--- a/crates/av/src/lib.rs
+++ b/crates/av/src/lib.rs
@@ -23,6 +23,11 @@ use bevy::prelude::*;
 #[cfg(feature = "ffmpeg")]
 use video_player::VideoPlayerPlugin;
 
+#[cfg(feature = "html")]
+pub mod html_video_player;
+#[cfg(feature = "html")]
+use html_video_player::VideoPlayerPlugin;
+
 #[derive(Default)]
 pub struct AudioPlugin {
     pub buffer_size: Option<u32>,
@@ -35,7 +40,7 @@ impl Plugin for AudioPlugin {
             ..Default::default()
         });
         app.add_plugins(bevy_kira_audio::AudioPlugin);
-        #[cfg(feature = "ffmpeg")]
+        #[cfg(any(feature = "ffmpeg", feature="html"))]
         app.add_plugins(VideoPlayerPlugin);
 
         app.add_plugins(AudioSourcePlugin);

--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -39,6 +39,7 @@ fn gen_sdk_components() -> Result<()> {
         "video_player",
         "audio_stream",
         "video_event",
+        "audio_event",
         "visibility_component",
         "avatar_modifier_area",
         "nft_shape",

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -69,6 +69,7 @@ impl SceneComponentId {
 
     pub const VIDEO_PLAYER: SceneComponentId = SceneComponentId(1043);
     pub const VIDEO_EVENT: SceneComponentId = SceneComponentId(1044);
+    pub const AUDIO_EVENT: SceneComponentId = SceneComponentId(1105);
 
     pub const GLTF_NODE: SceneComponentId = SceneComponentId(1200);
     pub const GLTF_NODE_STATE: SceneComponentId = SceneComponentId(1201);

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -102,6 +102,7 @@ impl DclProtoComponent for sdk::components::PbAudioSource {}
 impl DclProtoComponent for sdk::components::PbVideoPlayer {}
 impl DclProtoComponent for sdk::components::PbAudioStream {}
 impl DclProtoComponent for sdk::components::PbVideoEvent {}
+impl DclProtoComponent for sdk::components::PbAudioEvent {}
 impl DclProtoComponent for sdk::components::PbVisibilityComponent {}
 impl DclProtoComponent for sdk::components::PbAvatarModifierArea {}
 impl DclProtoComponent for sdk::components::PbNftShape {}

--- a/crates/dcl_wasm/src/inner/local_storage.rs
+++ b/crates/dcl_wasm/src/inner/local_storage.rs
@@ -42,8 +42,7 @@ fn write(state: &WorkerContext) {
         };
 
         let _ = web_fs::create_dir_all("local_storage").await;
-        let Ok(mut file) = web_fs::File::create(format!("local_storage/{scene_urn}")).await
-        else {
+        let Ok(mut file) = web_fs::File::create(format!("local_storage/{scene_urn}")).await else {
             warn!("failed to write storage");
             return;
         };

--- a/crates/dcl_wasm/src/inner/local_storage.rs
+++ b/crates/dcl_wasm/src/inner/local_storage.rs
@@ -16,7 +16,7 @@ struct LocalStorage(HashMap<String, String>);
 pub async fn init(state: &WorkerContext) {
     let scene_urn = state.state.borrow().borrow::<CrdtContext>().hash.clone();
 
-    if let Ok(mut existing) = web_fs::File::open(format!("local_storage/{}", scene_urn)).await {
+    if let Ok(mut existing) = web_fs::File::open(format!("local_storage/{scene_urn}")).await {
         let mut buf = String::default();
         if let Err(e) = existing.read_to_string(&mut buf).await {
             warn!("failed to read storage: {e:?}");
@@ -42,7 +42,7 @@ fn write(state: &WorkerContext) {
         };
 
         let _ = web_fs::create_dir_all("local_storage").await;
-        let Ok(mut file) = web_fs::File::create(format!("local_storage/{}", scene_urn)).await
+        let Ok(mut file) = web_fs::File::create(format!("local_storage/{scene_urn}")).await
         else {
             warn!("failed to write storage");
             return;

--- a/crates/platform/src/wasm.rs
+++ b/crates/platform/src/wasm.rs
@@ -180,11 +180,15 @@ impl<T> AsyncRwLock<T> {
         self.0.write()
     }
 
-    pub fn try_read(&self) -> Result<spin::RwLockReadGuard<'_, T>, ()> {
+    pub fn try_read(&self) -> Result<spin::RwLockReadGuard<'_, T>, NoError> {
         Ok(self.0.read())
     }
 
-    pub fn try_write(&self) -> Result<spin::RwLockWriteGuard<'_, T>, ()> {
+    pub fn try_write(&self) -> Result<spin::RwLockWriteGuard<'_, T>, NoError> {
         Ok(self.0.write())
     }
 }
+
+#[derive(Debug)]
+pub struct NoError;
+

--- a/crates/platform/src/wasm.rs
+++ b/crates/platform/src/wasm.rs
@@ -191,4 +191,3 @@ impl<T> AsyncRwLock<T> {
 
 #[derive(Debug)]
 pub struct NoError;
-

--- a/deploy/web/index.html
+++ b/deploy/web/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bevy Explorer</title>
     <style>
+        video {
+            display: none;
+        }        
         body { 
             font-family: 'Inter', sans-serif; /* Changed to Inter */
             margin: 20px; 

--- a/deploy/web/index.html
+++ b/deploy/web/index.html
@@ -126,6 +126,7 @@
     <canvas id="mygame-canvas" width="1280" height="720"></canvas> 
     
     <script src="https://cdn.jsdelivr.net/npm/livekit-client/dist/livekit-client.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/deploy/web/main.js
+++ b/deploy/web/main.js
@@ -81,6 +81,47 @@ async function run() {
     );
     */
 
+    window.setVideoSource = (video, src) => {
+      async function isHlsStream(url) {
+        try {
+          const response = await fetch(url, {
+            method: 'HEAD',
+            mode: 'cors', 
+          });
+
+          if (!response.ok) {
+            return false;
+          }
+
+          const contentType = response.headers.get('Content-Type');
+
+          if (contentType) {
+            return contentType.includes('application/vnd.apple.mpegurl') ||
+                  contentType.includes('application/x-mpegURL');
+          }
+
+          return false;
+        } catch (error) {
+          return false;
+        }
+      }
+
+      if (video.canPlayType('application/vnd.apple.mpegurl')) {
+        video.src = src;
+      } else if (Hls.isSupported()) {
+        // check if we need hls
+        setTimeout(async () => {
+          if (await isHlsStream(src)) {
+            var hls = new Hls();
+            hls.loadSource(src);
+            hls.attachMedia(video);
+          } else {
+            video.src = src;
+          }
+        }, 0)
+      }
+    }
+
     window.spawn_and_init_sandbox = async () => {
       var timeoutId;
       return new Promise((resolve, _reject) => {

--- a/deploy/web/main.js
+++ b/deploy/web/main.js
@@ -210,7 +210,7 @@ async function run() {
         return "unknown";
       })();
 
-      engine_run(platform, initialRealm, location, systemScene, true, 1e6, 8);
+      engine_run(platform, initialRealm, location, systemScene, true, 1e6, 64);
     };
   } catch (error) {
     console.error(


### PR DESCRIPTION
- support `PbVideoPlayer` on web
- support `PbAudioPlayer` on web
- fix #252 by allowing textures to force override the gpu bytes-per-frame limit, set fontmap texture to force override

implementation:
- use `HtmlVideoElement` and `HtmlAudioElement` to source the data
- copy video textures in gpu queue using webgpu's `copy_external_image_to_texture`
- don't use audio sink, use the embedded audio of the html element directly
- report events using rust-managed callbacks
- use Hls.js to support m3u8 playlists