### PR TITLE
allow pointerevents directly on avatars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "serde",
  "serde_json",
  "social",
+ "system_bridge",
  "tokio",
  "ui_core",
  "urn",

--- a/crates/avatar/Cargo.toml
+++ b/crates/avatar/Cargo.toml
@@ -21,6 +21,7 @@ collectibles = { workspace = true }
 scene_material = { workspace = true }
 social = { workspace = true }
 platform = { workspace = true }
+system_bridge = { workspace = true }
 
 bevy = { workspace = true }
 bevy_kira_audio = { workspace = true }

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -144,6 +144,7 @@ pub struct NativeUi {
     pub emote_wheel: bool,
     pub chat: bool,
     pub permissions: bool,
+    pub profile: bool,
 }
 
 #[derive(Resource)]

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -117,6 +117,7 @@ fn main_inner(
             emote_wheel: false,
             chat: false,
             permissions: false,
+            profile: false,
         });
         app.insert_resource(SystemScene {
             source: Some(source),
@@ -130,6 +131,7 @@ fn main_inner(
             emote_wheel: true,
             chat: true,
             permissions: true,
+            profile: true,
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,7 @@ fn main() {
             emote_wheel: false,
             chat: !args.contains("--no-chat"),
             permissions: !args.contains("--no-perms"),
+            profile: !args.contains("--no-profile"),
         });
         app.insert_resource(SystemScene {
             source: Some(source),
@@ -274,6 +275,7 @@ fn main() {
             emote_wheel: true,
             chat: true,
             permissions: true,
+            profile: true,
         });
     }
 


### PR DESCRIPTION
allow PointerEvents directly on avatars.

motivation: the system scene wants to track avatar pointer events so it can show profile for the correct avatar. if it creates a collider that captures pointer actions then no other scene can use a collider on avatars (as it would be blocked). by making it built-in, scenes can share the pointer target and all will receive the events they subscribe to.

- copy pointer events from foreign player proxy entities to root entity, tracking the originating scene
- collate tooltips
- pass avatar events to all scenes that request them