### PR TITLE
Rust 1.89 lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2025-06-03
           target: wasm32-unknown-unknown
           components: rust-src
           override: true

--- a/crates/avatar/src/mask_material.rs
+++ b/crates/avatar/src/mask_material.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::*,
     reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
+    render::render_resource::{AsBindGroup, ShaderRef},
 };
 use scene_material::BoundRegion;
 
@@ -23,14 +23,20 @@ impl Material for MaskMaterial {
     }
 }
 
-#[derive(ShaderType, Debug, Clone)]
-pub struct MaskData {
-    bounds: [BoundRegion; 8],
-    color: Vec4,
-    distance: f32,
-    num_bounds: u32,
-    _pad: u32,
+mod decl {
+    #![allow(dead_code)]
+    use bevy::{math::Vec4, render::render_resource::ShaderType};
+
+    #[derive(ShaderType, Debug, Clone)]
+    pub struct MaskData {
+        pub(super) bounds: [scene_material::BoundRegion; 8],
+        pub(super) color: Vec4,
+        pub(super) distance: f32,
+        pub(super) num_bounds: u32,
+        pub(super) _pad: u32,
+    }
 }
+use decl::*;
 
 // This is the struct that will be passed to your shader
 #[derive(AsBindGroup, Asset, Debug, Clone, TypePath)]

--- a/crates/common/src/util.rs
+++ b/crates/common/src/util.rs
@@ -188,7 +188,7 @@ pub struct TryChildBuilder<'a> {
 impl TryChildBuilder<'_> {
     /// Spawns an entity with the given bundle and inserts it into the parent entity's [`Children`].
     /// Also adds [`Parent`] component to the created entity.
-    pub fn spawn(&mut self, bundle: impl Bundle) -> EntityCommands {
+    pub fn spawn(&mut self, bundle: impl Bundle) -> EntityCommands<'_> {
         let e = self.commands.spawn(bundle);
         self.push_children.children.push(e.id());
         e
@@ -196,7 +196,7 @@ impl TryChildBuilder<'_> {
 
     /// Spawns an [`Entity`] with no components and inserts it into the parent entity's [`Children`].
     /// Also adds [`Parent`] component to the created entity.
-    pub fn spawn_empty(&mut self) -> EntityCommands {
+    pub fn spawn_empty(&mut self) -> EntityCommands<'_> {
         let e = self.commands.spawn_empty();
         self.push_children.children.push(e.id());
         e

--- a/crates/comms/src/movement_compressed.rs
+++ b/crates/comms/src/movement_compressed.rs
@@ -52,21 +52,29 @@ pub enum VelocityTier {
     Fast = 3,
 }
 
-#[bitfield]
-#[derive(Debug)]
-pub struct Temporal {
-    pub timestamp: B15,
-    pub movement_kind: Kind,
-    pub sliding: bool,
-    pub stunned: bool,
-    pub grounded: bool,
-    pub jump: bool,
-    pub long_jump: bool,
-    pub falling: bool,
-    pub long_falling: bool,
-    pub rotation_y: B6,
-    pub velocity_tier: VelocityTier,
+mod decl {
+    // temporary scope for unused_parens in bitfield macro
+    #![allow(unused_parens)]
+    use modular_bitfield::bitfield;
+    use modular_bitfield::specifiers::*;
+
+    #[bitfield]
+    #[derive(Debug)]
+    pub struct Temporal {
+        pub timestamp: B15,
+        pub movement_kind: super::Kind,
+        pub sliding: bool,
+        pub stunned: bool,
+        pub grounded: bool,
+        pub jump: bool,
+        pub long_jump: bool,
+        pub falling: bool,
+        pub long_falling: bool,
+        pub rotation_y: B6,
+        pub velocity_tier: super::VelocityTier,
+    }
 }
+pub use decl::*;
 
 impl Temporal {
     const TIMESTAMP_BITS: u32 = 15;

--- a/crates/dcl_component/src/reader.rs
+++ b/crates/dcl_component/src/reader.rs
@@ -65,7 +65,7 @@ impl<'a> DclReader<'a> {
         result
     }
 
-    pub fn take_reader(&mut self, len: usize) -> DclReader {
+    pub fn take_reader(&mut self, len: usize) -> DclReader<'_> {
         DclReader::new(self.take_slice(len))
     }
 

--- a/crates/dcl_component/src/writer.rs
+++ b/crates/dcl_component/src/writer.rs
@@ -49,7 +49,7 @@ impl<'a> DclWriter<'a> {
         self.buffer.clear();
     }
 
-    pub fn reader(&self) -> DclReader {
+    pub fn reader(&self) -> DclReader<'_> {
         DclReader::new(self.buffer)
     }
 }

--- a/crates/dcl_deno/src/js/fetch/fetch_response_body_resource.rs
+++ b/crates/dcl_deno/src/js/fetch/fetch_response_body_resource.rs
@@ -12,7 +12,7 @@ pub struct FetchResponseBodyResource {
 }
 
 impl deno_core::Resource for FetchResponseBodyResource {
-    fn name(&self) -> Cow<str> {
+    fn name(&self) -> Cow<'_, str> {
         "fetchResponseBody".into()
     }
 

--- a/crates/imposters/src/bake_scene.rs
+++ b/crates/imposters/src/bake_scene.rs
@@ -459,7 +459,7 @@ fn bake_scene_imposters(
                 ..Default::default()
             });
         } else {
-            if tick.0 % 200 == 0 {
+            if tick.0.is_multiple_of(200) {
                 debug!("waiting for bake ...");
             }
 

--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -859,7 +859,7 @@ fn debug_write_imposters(
     tick: Res<FrameCount>,
     mut debug: ResMut<DebugInfo>,
 ) {
-    if tick.0 % 100 != 0 {
+    if tick.0.is_multiple_of(100) {
         return;
     }
 

--- a/crates/scene_material/src/lib.rs
+++ b/crates/scene_material/src/lib.rs
@@ -1,7 +1,7 @@
 use bevy::{
     pbr::{ExtendedMaterial, MaterialExtension},
     prelude::*,
-    render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
+    render::render_resource::{AsBindGroup, ShaderRef},
 };
 use boimp::bake::{ImposterBakeMaterialExtension, ImposterBakeMaterialPlugin};
 use comms::preview::PreviewMode;
@@ -118,13 +118,29 @@ impl SceneBound {
     }
 }
 
-#[derive(ShaderType, Clone, Copy, Debug, Default)]
-pub struct BoundRegion {
-    pub min: u32, // 2x i16
-    pub max: u32, // 2x i16
-    pub height: f32,
-    pub parcel_count: u32,
+mod decl {
+    // temporary for ShaderType macro, remove in future
+    #![allow(dead_code)]
+
+    use bevy::render::render_resource::ShaderType;
+    #[derive(ShaderType, Clone, Copy, Debug, Default)]
+    pub struct BoundRegion {
+        pub min: u32, // 2x i16
+        pub max: u32, // 2x i16
+        pub height: f32,
+        pub parcel_count: u32,
+    }
+
+    #[derive(ShaderType, Clone)]
+    pub struct SceneBoundData {
+        pub(super) bounds: [BoundRegion; 8],
+        pub distance: f32,
+        pub flags: u32,
+        pub num_bounds: u32,
+        pub(super) _pad: u32,
+    }
 }
+pub use decl::*;
 
 impl BoundRegion {
     pub fn new(min: IVec2, max: IVec2, parcel_count: u32) -> Self {
@@ -218,15 +234,6 @@ mod test {
             }
         }
     }
-}
-
-#[derive(ShaderType, Clone)]
-pub struct SceneBoundData {
-    bounds: [BoundRegion; 8],
-    pub distance: f32,
-    pub flags: u32,
-    pub num_bounds: u32,
-    _pad: u32,
 }
 
 impl MaterialExtension for SceneBound {

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -301,7 +301,7 @@ fn run_scene_loop(world: &mut World) {
     let fps = if config.graphics.vsync {
         // TODO this should use video mode if we add fullscreen video modes
         refresh_rate
-            .map(|rr| (((rr as f64 + 999.0) / 1000.0).ceil()))
+            .map(|rr| ((rr as f64 + 999.0) / 1000.0).ceil())
             .unwrap_or(config.graphics.fps_target as f64)
     } else {
         config.graphics.fps_target as f64

--- a/crates/scene_runner/src/update_world/material.rs
+++ b/crates/scene_runner/src/update_world/material.rs
@@ -524,23 +524,25 @@ fn update_materials(
         }
 
         // write material back if required
-        if mat.0.material.is_none() && base.is_some() {
-            let Ok(mut scene) = scenes.get_mut(container.root) else {
-                continue;
-            };
+        if mat.0.material.is_none() {
+            if let Some(base) = base.as_ref() {
+                let Ok(mut scene) = scenes.get_mut(container.root) else {
+                    continue;
+                };
 
-            scene.update_crdt(
-                SceneComponentId::MATERIAL,
-                CrdtType::LWW_ANY,
-                scene_ent.id,
-                &PbMaterial {
-                    material: Some(dcl_material_from_standard_material(
-                        &base.as_ref().unwrap().material,
-                        &images,
-                    )),
-                    gltf: mat.0.gltf.clone(),
-                },
-            );
+                scene.update_crdt(
+                    SceneComponentId::MATERIAL,
+                    CrdtType::LWW_ANY,
+                    scene_ent.id,
+                    &PbMaterial {
+                        material: Some(dcl_material_from_standard_material(
+                            &base.material,
+                            &images,
+                        )),
+                        gltf: mat.0.gltf.clone(),
+                    },
+                );
+            }
         }
     }
 

--- a/crates/scene_runner/src/update_world/mod.rs
+++ b/crates/scene_runner/src/update_world/mod.rs
@@ -409,7 +409,7 @@ pub fn track_components<C: Component, const ALLOW_UNALLOCATED: bool>(
     mut track: Query<(Entity, &mut ComponentTracker)>,
     frame: Res<FrameCount>,
 ) {
-    if frame.0 % 100 != 0 {
+    if frame.0.is_multiple_of(100) {
         return;
     }
 

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -492,7 +492,7 @@ fn update_tracker(
         return;
     };
 
-    if f.0 % 100 != 0 && !tracker.is_changed() {
+    if !f.0.is_multiple_of(100) && !tracker.is_changed() {
         return;
     }
 
@@ -674,7 +674,7 @@ fn entity_count(
     textshape_mats: Query<(), With<MeshMaterial3d<TextShapeMaterial>>>,
     mats: Res<Assets<SceneMaterial>>,
 ) {
-    if f.0 % 100 == 0 {
+    if f.0.is_multiple_of(100) {
         let entities = q.iter().count();
         let meshes = meshes.iter().count();
         let textures = textures.iter().count();
@@ -710,7 +710,7 @@ fn display_tracked_components(
         return;
     };
 
-    if !track.0 || f.0 % 100 != 0 {
+    if !track.0 || f.0.is_multiple_of(100) {
         return;
     }
 

--- a/crates/ui_core/src/bound_node.rs
+++ b/crates/ui_core/src/bound_node.rs
@@ -2,7 +2,7 @@ use bevy::{
     asset::AssetEvents,
     platform::collections::HashMap,
     prelude::*,
-    render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
+    render::render_resource::{AsBindGroup, ShaderRef},
     transform::TransformSystem,
     ui::FocusPolicy,
     window::{PrimaryWindow, WindowResized},
@@ -83,16 +83,23 @@ impl Plugin for BoundedNodePlugin {
     }
 }
 
-#[derive(ShaderType, Debug, Clone)]
-struct GpuBoundsData {
-    bounds: Vec4,
-    border_color: Vec4,
-    edge_scale: Vec4,
-    corner_size: f32,
-    corner_blend_size: f32,
-    border_size: f32,
-    _pad: u32,
+mod decl {
+    #![allow(dead_code)]
+
+    use bevy::{math::Vec4, render::render_resource::ShaderType};
+
+    #[derive(ShaderType, Debug, Clone)]
+    pub(super) struct GpuBoundsData {
+        pub(super) bounds: Vec4,
+        pub(super) border_color: Vec4,
+        pub(super) edge_scale: Vec4,
+        pub(super) corner_size: f32,
+        pub(super) corner_blend_size: f32,
+        pub(super) border_size: f32,
+        pub(super) _pad: u32,
+    }
 }
+use decl::*;
 
 impl Default for GpuBoundsData {
     fn default() -> Self {

--- a/crates/ui_core/src/nine_slice.rs
+++ b/crates/ui_core/src/nine_slice.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail};
 use bevy::{
     prelude::*,
-    render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
+    render::render_resource::{AsBindGroup, ShaderRef},
     ui::UiSystem,
 };
 use bevy_dui::{DuiContext, DuiProps, DuiRegistry, DuiTemplate, NodeMap};
@@ -125,11 +125,16 @@ fn update_slices(
     }
 }
 
-#[derive(ShaderType, Debug, Clone)]
-struct GpuSliceData {
-    bounds: Vec4,
-    surface: Vec4,
+mod decl {
+    #![allow(dead_code)]
+    use bevy::{math::Vec4, render::render_resource::ShaderType};
+    #[derive(ShaderType, Debug, Clone)]
+    pub(super) struct GpuSliceData {
+        pub(super) bounds: Vec4,
+        pub(super) surface: Vec4,
+    }
 }
+use decl::*;
 
 #[derive(AsBindGroup, Asset, TypePath, Debug, Clone)]
 struct NineSliceMaterial {

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -98,9 +98,9 @@ pub fn update_camera(
         }
 
         allow_cam_move = cine.allow_manual_rotation;
-        yaw_range = cine.yaw_range.map(|r| (-r..r));
-        pitch_range = cine.pitch_range.map(|r| (-r..r));
-        roll_range = cine.roll_range.map(|r| (-r..r));
+        yaw_range = cine.yaw_range.map(|r| -r..r);
+        pitch_range = cine.pitch_range.map(|r| -r..r);
+        roll_range = cine.roll_range.map(|r| -r..r);
         zoom_range = Some(
             cine.zoom_min.unwrap_or(scale.z).clamp(0.3, 100.0)
                 ..cine.zoom_max.unwrap_or(scale.z).clamp(0.3, 100.0),

--- a/crates/visuals/src/nishita_cloud.rs
+++ b/crates/visuals/src/nishita_cloud.rs
@@ -1,3 +1,6 @@
+// temporary for ShaderType macro, remove in future
+#![allow(dead_code)]
+
 use bevy::{
     image::{ImageAddressMode, ImageSampler, ImageSamplerDescriptor},
     prelude::*,

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -7,8 +7,7 @@ use bevy::{
         camera::RenderTarget,
         render_asset::RenderAssetUsages,
         render_resource::{
-            AsBindGroup, Extent3d, ShaderRef, ShaderType, TextureDimension, TextureFormat,
-            TextureUsages,
+            AsBindGroup, Extent3d, ShaderRef, TextureDimension, TextureFormat, TextureUsages,
         },
         renderer::RenderDevice,
         view::NoFrustumCulling,
@@ -244,18 +243,24 @@ pub struct TextQuad {
     pub data: TextQuadData,
 }
 
-#[derive(Clone, ShaderType)]
-pub struct TextQuadData {
-    pub uvs: Vec4,
-    pub valign: f32,
-    pub halign: f32,
-    pub pix_per_m: f32,
-    pub add_y_pix: f32,
-    pub vertex_billboard: u32,
-    _pad0: u32,
-    _pad1: u32,
-    _pad2: u32,
+mod decl {
+    #![allow(dead_code)]
+
+    use bevy::{math::Vec4, render::render_resource::ShaderType};
+    #[derive(Clone, ShaderType)]
+    pub struct TextQuadData {
+        pub uvs: Vec4,
+        pub valign: f32,
+        pub halign: f32,
+        pub pix_per_m: f32,
+        pub add_y_pix: f32,
+        pub vertex_billboard: u32,
+        pub(super) _pad0: u32,
+        pub(super) _pad1: u32,
+        pub(super) _pad2: u32,
+    }
 }
+pub use decl::*;
 
 impl MaterialExtension for TextQuad {
     fn vertex_shader() -> bevy::render::render_resource::ShaderRef {


### PR DESCRIPTION
fix issues with rust 1.89 release

- fix new lints
- work around lints in `ShaderType` and `bitfield` macros with locally scoped warning disables
- freeze web build compiler to nightly-2025-06-03 due to issue in 1.91 / 2025-08-07
