### PR TITLE
cache shaders and ipfs files on web

### DIFF
--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -1212,7 +1212,7 @@ impl AssetReader for IpfsIo {
 
                 // in wasm we add a custom header to allow the service worker to cache ipfs requests across content servers
                 #[cfg(target_arch = "wasm32")]
-                let request = if ipfs_path.content_path().is_some() {
+                let request = if ipfs_path.content_path().is_some() && ipfs_path.should_cache() {
                     request.header("X-IPFS", "true")
                 } else {
                     request

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -1208,13 +1208,21 @@ impl AssetReader for IpfsIo {
                 let request = self
                     .client
                     .get(&remote)
-                    .timeout(Duration::from_secs(5 + 30 * attempt))
-                    .build()
-                    .map_err(|e| {
-                        AssetReaderError::Io(Arc::new(std::io::Error::other(format!(
-                            "[{token:?}]: {e}"
-                        ))))
-                    })?;
+                    .timeout(Duration::from_secs(5 + 30 * attempt));
+
+                // in wasm we add a custom header to allow the service worker to cache ipfs requests across content servers
+                #[cfg(target_arch = "wasm32")]
+                let request = if ipfs_path.content_path().is_some() {
+                    request.header("X-IPFS", "true")
+                } else {
+                    request
+                };
+
+                let request = request.build().map_err(|e| {
+                    AssetReaderError::Io(Arc::new(std::io::Error::other(format!(
+                        "[{token:?}]: {e}"
+                    ))))
+                })?;
 
                 let response = self.client.execute(request).await;
 

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -1212,7 +1212,11 @@ impl AssetReader for IpfsIo {
 
                 // in wasm we add a custom header to allow the service worker to cache ipfs requests across content servers
                 #[cfg(target_arch = "wasm32")]
-                let request = if ipfs_path.content_path().is_some() && ipfs_path.should_cache() {
+                let request = if ipfs_path.content_path().is_some()
+                    && hash
+                        .as_ref()
+                        .is_some_and(|hash| ipfs_path.should_cache(hash))
+                {
                     request.header("X-IPFS", "true")
                 } else {
                     request

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -726,11 +726,6 @@ fn send_hover_events(
                         }
                     }
                 }
-            } else {
-                warn!(
-                    "failed to query entity for hover event {ev_type:?}: {:?}",
-                    info.container
-                );
             }
 
             action

--- a/deploy/web/gpu_cache.js
+++ b/deploy/web/gpu_cache.js
@@ -27,7 +27,9 @@ function patchWebgpuAdater() {
       return gpuSessionState.device;
     }
 
-    console.log("[GPU Cache] creating device and clearing cache");
+    if (!precaching) {
+        console.log("[GPU Cache] device params are different: creating device and clearing cache");
+    }
     gpuSessionState = {
       shader: new Map(),
       bindgroup: new Map(),
@@ -45,7 +47,6 @@ function patchWebgpuAdater() {
         const hash = simpleHash(jsonArgs);
         const cachedItem = gpuSessionState[itemType].get(hash);
         if (cachedItem !== undefined) {
-          console.log(`[GPU Cache] using cached ${itemType} ${hash}`);
           return cachedItem;
         }
 
@@ -99,12 +100,12 @@ async function createGpuCache() {
   if (cachedDeviceDescriptor === null) {
     return;
   }
+  precaching = true;
   const adapter = await navigator.gpu.requestAdapter();
   const device = await adapter.requestDevice(
     JSON.parse(cachedDeviceDescriptor)
   );
 
-  precaching = true;
   try {
     await createItemType("shader", async (args) => {
       return device.createShaderModule(args);

--- a/deploy/web/gpu_cache.js
+++ b/deploy/web/gpu_cache.js
@@ -1,0 +1,215 @@
+/**
+ * JS Implementation of MurmurHash3 (128-bit)
+ * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
+ * @see http://github.com/garycourt/murmurhash-js
+ * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
+ * @see http://sites.google.com/site/murmurhash/
+ */
+function murmur3_128(key) {
+  let h1 = 0x9747b28c,
+    h2 = 0x9747b28c,
+    h3 = 0x9747b28c,
+    h4 = 0x9747b28c;
+  const len = key.length;
+
+  for (let i = 0; i < len; i++) {
+    let k1 = key.charCodeAt(i);
+    k1 =
+      (k1 & 0xffff) * 0xcc9e2d51 +
+      ((((k1 >>> 16) * 0xcc9e2d51) & 0xffff) << 16);
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 =
+      (k1 & 0xffff) * 0x1b873593 +
+      ((((k1 >>> 16) * 0x1b873593) & 0xffff) << 16);
+
+    h1 ^= k1;
+    h1 = (h1 << 19) | (h1 >>> 13);
+    h1 = h1 * 5 + 0x561ccd1b;
+  }
+
+  h1 ^= len;
+  h2 ^= len;
+  h3 ^= len;
+  h4 ^= len;
+  h1 += h2;
+  h1 += h3;
+  h1 += h4;
+  h2 += h1;
+  h3 += h1;
+  h4 += h1;
+
+  h1 ^= h1 >>> 16;
+  h1 =
+    (h1 & 0xffff) * 0x85ebca6b + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16);
+  h1 ^= h1 >>> 13;
+  h1 =
+    (h1 & 0xffff) * 0xc2b2ae35 + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16);
+  h1 ^= h1 >>> 16;
+
+  // Convert to hex string for the final key
+  return h1.toString(16);
+}
+
+var gpuSessionState = {};
+var requiredItemTypes = new Map();
+
+export async function initGpuCache() {
+  patchWebgpuAdater();
+  await createGpuCache();
+}
+
+function patchWebgpuAdater() {
+  const originalRequestDevice = GPUAdapter.prototype.requestDevice;
+  GPUAdapter.prototype.requestDevice = async function (descriptor) {
+    const jsonDescriptor = JSON.stringify(descriptor || {});
+    if (gpuSessionState.deviceDescriptor === jsonDescriptor) {
+      console.log("[GPU Cache] using precached device");
+      return gpuSessionState.device;
+    }
+
+    console.log("[GPU Cache] creating device and clearing cache");
+    gpuSessionState = {
+      shader: new Map(),
+      bindgroup: new Map(),
+      layout: new Map(),
+      pipeline: new Map(),
+    };
+    gpuSessionState.deviceDescriptor = jsonDescriptor;
+    const device = await originalRequestDevice.apply(this, [descriptor]);
+    gpuSessionState.device = device;
+    localStorage.setItem("deviceDescriptor", jsonDescriptor);
+
+    function wrapDeviceFunction(itemType, originalFunction) {
+      return (...args) => {
+        const jsonArgs = JSON.stringify(args);
+        const hash = murmur3_128(jsonArgs);
+        const cachedItem = gpuSessionState[itemType].get(hash);
+        if (cachedItem !== undefined) {
+          console.log(`[GPU Cache] using cached ${itemType} ${hash}`);
+          return cachedItem;
+        }
+
+        console.log(`[GPU Cache] no cached ${itemType} for ${hash}`);
+        const item = originalFunction.apply(device, args);
+        item.__gpu_item_type = itemType;
+        item.__gpu_hash = hash;
+        gpuSessionState[itemType].set(hash, item);
+
+        if (!requiredItemTypes.has(itemType)) {
+          requiredItemTypes.set(itemType, new Set());
+        }
+        const requiredItems = requiredItemTypes.get(itemType);
+        if (!requiredItems.has(hash)) {
+          requiredItems.add(hash);
+          localStorage.setItem(
+            `required-${itemType}s`,
+            JSON.stringify([...requiredItems])
+          );
+          localStorage.setItem(`${itemType}-${hash}`, JSON.stringify(args));
+        }
+        return item;
+      };
+    }
+
+    device.createShaderModule = wrapDeviceFunction(
+      "shader",
+      device.createShaderModule
+    );
+    device.createBindGroupLayout = wrapDeviceFunction(
+      "bindgroup",
+      device.createBindGroupLayout
+    );
+    device.createPipelineLayout = wrapDeviceFunction(
+      "layout",
+      device.createPipelineLayout
+    );
+    device.createRenderPipeline = wrapDeviceFunction(
+      "pipeline",
+      device.createRenderPipeline
+    );
+
+    return device;
+  };
+}
+
+async function createGpuCache() {
+  const cachedDeviceDescriptor = localStorage.getItem("deviceDescriptor");
+  if (cachedDeviceDescriptor === null) {
+    return;
+  }
+  const adapter = await navigator.gpu.requestAdapter();
+  const device = await adapter.requestDevice(
+    JSON.parse(cachedDeviceDescriptor)
+  );
+
+  await createItemType("shader", async (args) => {
+    return device.createShaderModule(args);
+  });
+  await createItemType("bindgroup", async (args) => {
+    return device.createBindGroupLayout(args);
+  });
+  await createItemType("layout", async (args) => {
+    return device.createPipelineLayout(args);
+  });
+  await createItemType("pipeline", async (args) => {
+    return await device.createRenderPipelineAsync(args);
+  });
+}
+
+async function createItemType(itemType, asyncCreateFunction) {
+  const storedString = localStorage.getItem(`required-${itemType}s`);
+  const storedItems = storedString ? JSON.parse(storedString) : [];
+  const requiredItems = new Set();
+
+  await Promise.all(
+    storedItems.map(async (hash) => {
+      requiredItems.add(hash);
+      const argString = localStorage.getItem(`${itemType}-${hash}`);
+      if (!argString) {
+        return;
+      }
+      const args = JSON.parse(argString);
+      rehydrateItem(args);
+      try {
+        const item = await asyncCreateFunction(args[0]);
+        gpuSessionState[itemType].set(hash, item);
+      } catch (e) {
+        throw e;
+      }
+    })
+  );
+
+  requiredItemTypes.set(itemType, requiredItems);
+}
+
+function rehydrateItem(currentObject) {
+  if (typeof currentObject !== "object" || currentObject === null) {
+    return;
+  }
+
+  if (Array.isArray(currentObject)) {
+    for (let i = 0; i < currentObject.length; i++) {
+      const item = currentObject[i];
+      if (item && item.__gpu_hash) {
+        const type = item.__gpu_item_type;
+        const hash = item.__gpu_hash;
+        currentObject[i] = gpuSessionState[type].get(hash);
+      } else {
+        rehydrateItem(item);
+      }
+    }
+  } else {
+    for (const key in currentObject) {
+      if (Object.prototype.hasOwnProperty.call(currentObject, key)) {
+        const value = currentObject[key];
+        if (value && value.__gpu_hash) {
+          const type = value.__gpu_item_type;
+          const hash = value.__gpu_hash;
+          currentObject[key] = gpuSessionState[type].get(hash);
+        } else {
+          rehydrateItem(value);
+        }
+      }
+    }
+  }
+}

--- a/deploy/web/gpu_cache.js
+++ b/deploy/web/gpu_cache.js
@@ -77,7 +77,7 @@ async function storeRequiredItems() {
 
 async function fetchInstance(type, hash) {
   const db = await openDB();
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const tx = db.transaction(type, "readonly");
     const request = tx.objectStore(type).get(hash);
     request.onsuccess = () => {

--- a/deploy/web/gpu_cache.js
+++ b/deploy/web/gpu_cache.js
@@ -1,53 +1,12 @@
-/**
- * JS Implementation of MurmurHash3 (128-bit)
- * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
- * @see http://github.com/garycourt/murmurhash-js
- * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
- * @see http://sites.google.com/site/murmurhash/
- */
-function murmur3_128(key) {
-  let h1 = 0x9747b28c,
-    h2 = 0x9747b28c,
-    h3 = 0x9747b28c,
-    h4 = 0x9747b28c;
-  const len = key.length;
+function simpleHash(s) {
+  var h = 0x811c9dc5;
 
-  for (let i = 0; i < len; i++) {
-    let k1 = key.charCodeAt(i);
-    k1 =
-      (k1 & 0xffff) * 0xcc9e2d51 +
-      ((((k1 >>> 16) * 0xcc9e2d51) & 0xffff) << 16);
-    k1 = (k1 << 15) | (k1 >>> 17);
-    k1 =
-      (k1 & 0xffff) * 0x1b873593 +
-      ((((k1 >>> 16) * 0x1b873593) & 0xffff) << 16);
-
-    h1 ^= k1;
-    h1 = (h1 << 19) | (h1 >>> 13);
-    h1 = h1 * 5 + 0x561ccd1b;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h += (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24);
   }
 
-  h1 ^= len;
-  h2 ^= len;
-  h3 ^= len;
-  h4 ^= len;
-  h1 += h2;
-  h1 += h3;
-  h1 += h4;
-  h2 += h1;
-  h3 += h1;
-  h4 += h1;
-
-  h1 ^= h1 >>> 16;
-  h1 =
-    (h1 & 0xffff) * 0x85ebca6b + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16);
-  h1 ^= h1 >>> 13;
-  h1 =
-    (h1 & 0xffff) * 0xc2b2ae35 + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16);
-  h1 ^= h1 >>> 16;
-
-  // Convert to hex string for the final key
-  return h1.toString(16);
+  return h >>> 0;
 }
 
 var gpuSessionState = {};
@@ -83,7 +42,7 @@ function patchWebgpuAdater() {
     function wrapDeviceFunction(itemType, originalFunction) {
       return (...args) => {
         const jsonArgs = JSON.stringify(args);
-        const hash = murmur3_128(jsonArgs);
+        const hash = simpleHash(jsonArgs);
         const cachedItem = gpuSessionState[itemType].get(hash);
         if (cachedItem !== undefined) {
           console.log(`[GPU Cache] using cached ${itemType} ${hash}`);

--- a/deploy/web/index.html
+++ b/deploy/web/index.html
@@ -120,7 +120,7 @@
             <input type="text" id="systemScene" name="systemScene" placeholder="">
         </div>
 
-        <button id="initButton">Go</button>
+        <button id="initButton" disabled="true">Loading...</button>
         
         </div>
     <canvas id="mygame-canvas" width="1280" height="720"></canvas> 

--- a/deploy/web/main.js
+++ b/deploy/web/main.js
@@ -1,4 +1,5 @@
 // Import the wasm-bindgen generated JS glue code and Rust functions
+import { initGpuCache } from "./gpu_cache.js";
 import init, { engine_init, engine_run } from "./pkg/webgpu_build.js"; // Ensure this path is correct
 
 const initialRealmInput = document.getElementById("initialRealm");
@@ -41,7 +42,7 @@ function hideSettings() {
 
 var sharedMemory;
 
-async function run() {
+async function initEngine() {
   populateInputsFromQueryParams();
 
   if (initButton) {
@@ -63,41 +64,25 @@ async function run() {
     });
     window.wasm_memory = sharedMemory;
 
-    // TODO: figure out why using blobs fails with livekit feature enabled
-    /*
-    const wasmJs = URL.createObjectURL(
-      await fetch("./pkg/webgpu_build.js")
-        .then((response) => response.text())
-        .then((text) => new Blob([text], { type: "application/javascript" }))
-    );
-
-    const sandboxJs = URL.createObjectURL(
-      await fetch("sandbox_worker.js")
-        .then((response) => response.text())
-        .then((text) => {
-          const replacedText = text.replace("./pkg/webgpu_build.js", wasmJs);
-          return new Blob([replacedText], { type: "application/javascript" });
-        })
-    );
-    */
-
     window.setVideoSource = (video, src) => {
       async function isHlsStream(url) {
         try {
           const response = await fetch(url, {
-            method: 'HEAD',
-            mode: 'cors', 
+            method: "HEAD",
+            mode: "cors",
           });
 
           if (!response.ok) {
             return false;
           }
 
-          const contentType = response.headers.get('Content-Type');
+          const contentType = response.headers.get("Content-Type");
 
           if (contentType) {
-            return contentType.includes('application/vnd.apple.mpegurl') ||
-                  contentType.includes('application/x-mpegURL');
+            return (
+              contentType.includes("application/vnd.apple.mpegurl") ||
+              contentType.includes("application/x-mpegURL")
+            );
           }
 
           return false;
@@ -106,7 +91,7 @@ async function run() {
         }
       }
 
-      if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      if (video.canPlayType("application/vnd.apple.mpegurl")) {
         video.src = src;
       } else if (Hls.isSupported()) {
         // check if we need hls
@@ -118,9 +103,9 @@ async function run() {
           } else {
             video.src = src;
           }
-        }, 0)
+        }, 0);
       }
-    }
+    };
 
     window.spawn_and_init_sandbox = async () => {
       var timeoutId;
@@ -167,7 +152,8 @@ async function run() {
 
     let res = await engine_init();
     console.log(
-      "[Main JS] Main application WebAssembly module custom initialized: ", res
+      "[Main JS] Main application WebAssembly module custom initialized: ",
+      res
     );
 
     // start asset loader thread
@@ -188,30 +174,6 @@ async function run() {
         }
       };
     });
-
-    if (initButton) {
-      initButton.disabled = false;
-      initButton.textContent = "Go";
-    }
-
-    initButton.onclick = () => {
-      const initialRealm = initialRealmInput.value;
-      const location = locationInput.value;
-      const systemScene = systemSceneInput.value;
-      console.log(
-        `[Main JS] "Go" button clicked. Initial Realm: "${initialRealm}", Location: "${location}", System Scene: "${systemScene}"`
-      );
-      hideSettings();
-
-      const platform = (() => {
-        if (navigator.userAgent.includes("Mac")) return "macos";
-        if (navigator.userAgent.includes("Win")) return "windows";
-        if (navigator.userAgent.includes("Linux")) return "linux";
-        return "unknown";
-      })();
-
-      engine_run(platform, initialRealm, location, systemScene, true, 1e6, 64);
-    };
   } catch (error) {
     console.error(
       "[Main JS] Error during Wasm initialization or setup:",
@@ -223,8 +185,29 @@ async function run() {
   }
 }
 
-window.browser_pointer_is_locked = () => {
-  return document.pointerLockElement !== null;
-}
+initButton.onclick = () => {
+  const initialRealm = initialRealmInput.value;
+  const location = locationInput.value;
+  const systemScene = systemSceneInput.value;
+  console.log(
+    `[Main JS] "Go" button clicked. Initial Realm: "${initialRealm}", Location: "${location}", System Scene: "${systemScene}"`
+  );
+  hideSettings();
 
-run().catch(console.error);
+  const platform = (() => {
+    if (navigator.userAgent.includes("Mac")) return "macos";
+    if (navigator.userAgent.includes("Win")) return "windows";
+    if (navigator.userAgent.includes("Linux")) return "linux";
+    return "unknown";
+  })();
+
+  engine_run(platform, initialRealm, location, systemScene, true, 1e6, 64);
+};
+
+Promise.all([initEngine(), initGpuCache()]).then(() => {
+  initButton.disabled = false;
+  initButton.textContent = "Go";
+}).catch((e) => {
+  console.log("error", e)
+  initButton.textContent = "Load Failed";
+});

--- a/deploy/web/main.js
+++ b/deploy/web/main.js
@@ -40,7 +40,21 @@ function hideSettings() {
   if (initButton) initButton.style.display = "none";
 }
 
-var sharedMemory;
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("service_worker.js")
+      .then((registration) => {
+        console.log(
+          "Page: Service Worker registered successfully with scope: ",
+          registration.scope
+        );
+      })
+      .catch((error) => {
+        console.log("Page: Service Worker registration failed: ", error);
+      });
+  });
+}
 
 async function initEngine() {
   populateInputsFromQueryParams();
@@ -204,10 +218,12 @@ initButton.onclick = () => {
   engine_run(platform, initialRealm, location, systemScene, true, 1e6, 64);
 };
 
-Promise.all([initEngine(), initGpuCache()]).then(() => {
-  initButton.disabled = false;
-  initButton.textContent = "Go";
-}).catch((e) => {
-  console.log("error", e)
-  initButton.textContent = "Load Failed";
-});
+Promise.all([initEngine(), initGpuCache()])
+  .then(() => {
+    initButton.disabled = false;
+    initButton.textContent = "Go";
+  })
+  .catch((e) => {
+    console.log("error", e);
+    initButton.textContent = "Load Failed";
+  });

--- a/deploy/web/service_worker.js
+++ b/deploy/web/service_worker.js
@@ -32,7 +32,6 @@ self.addEventListener('activate', (event) => {
     );
 });
 
-
 self.addEventListener('fetch', (event) => {
     const request = event.request;
 

--- a/deploy/web/service_worker.js
+++ b/deploy/web/service_worker.js
@@ -1,0 +1,94 @@
+const CACHE_NAME = 'ipfs-path-cache-v1';
+const CUSTOM_HEADER = 'X-IPFS';
+
+self.addEventListener('install', (event) => {
+    // Force the waiting service worker to become the active service worker.
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    console.log('[IPFS Cache Service Worker]: Active');
+    
+    // An array of cache names that are "allowed" to exist.
+    const cacheWhitelist = [CACHE_NAME];
+
+    event.waitUntil(
+        // Get all the cache keys (names) that exist.
+        caches.keys().then(cacheNames => {
+            return Promise.all(
+                cacheNames.map(cacheName => {
+                    // If a cache name is NOT in our whitelist...
+                    if (cacheWhitelist.indexOf(cacheName) === -1) {
+                        console.log(`SW: Deleting old cache: ${cacheName}`);
+                        // ...delete it.
+                        return caches.delete(cacheName);
+                    }
+                })
+            );
+        }).then(() => {
+            // After cleanup is done, claim the clients.
+            return self.clients.claim();
+        })
+    );
+});
+
+
+self.addEventListener('fetch', (event) => {
+    const request = event.request;
+
+    // Check if the request has our custom header.
+    if (request.headers.has(CUSTOM_HEADER)) {
+        // If it does, use our caching strategy.
+        event.respondWith(cacheFirstStrategy(request));
+    }
+});
+
+async function cacheFirstStrategy(request) {
+    //Generate a cache key from the path only
+    const cacheKey = getCacheKey(request);
+
+    //Open the cache
+    const cache = await caches.open(CACHE_NAME);
+
+    //Try to find a response in the cache
+    const cachedResponse = await cache.match(cacheKey);
+    if (cachedResponse) {
+        return cachedResponse;
+    }
+
+    //If not in cache, fetch from network
+    const networkRequest = stripCustomHeader(request);
+    const networkResponse = await fetch(networkRequest);
+    
+    if (networkResponse.ok) {
+        // Store the new response in the cache
+        const responseToCache = networkResponse.clone();
+        await cache.put(cacheKey, responseToCache);
+    }
+    
+    return networkResponse;
+}
+
+function getCacheKey(request) {
+    const url = new URL(request.url);
+    return url.pathname + url.search;
+}
+
+function stripCustomHeader(request) {
+    const newHeaders = new Headers(request.headers);
+    newHeaders.delete(CUSTOM_HEADER);
+    
+    const newRequest = new Request(request.url, {
+        method: request.method,
+        headers: newHeaders,
+        body: request.body,
+        mode: request.mode,
+        credentials: request.credentials,
+        cache: request.cache,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        integrity: request.integrity
+    });
+
+    return newRequest;
+}

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -84,7 +84,7 @@ fn main_inner(
         location: IVec2Arg::from_str(location)
             .map(|l| l.0)
             .unwrap_or(IVec2::ZERO),
-        max_concurrent_remotes: 8,
+        max_concurrent_remotes: 8000,
         graphics: common::structs::GraphicsSettings {
             gpu_bytes_per_frame: rabpf,
             ..base_graphics


### PR DESCRIPTION
improve startup times (after the first time) by storing details of required shaders, and compiling them at startup in parallel with wasm lib loading. 
also use a service worker to cache IPFS content requests: the browser automatically caches fetches, but doesn't have the context to understand that `peer-eu1.decentraland.org/content/bafkreixyz` is the same as `peer-eu2.decentraland.org/content/bafkreixyz`.

shader caching takes my "fully playable time" from 41 seconds to 27 seconds, and avoids the "only hands and head" issue.
content file caching benefit depends on network speed.

todo: see if we can pre-populate the cache as well, i think this depends on platform and graphics card (and maybe browser version) though. we would need some steam shader-cache style approach where users submit their spec and requirements to a server, which then provides it to other users.

also todo: see if we can get some feedback about gpu uploads so we can only drop the player into the world when the assets are actually ready to render (avoid the "empty world" issue which is still there / worse).


https://github.com/user-attachments/assets/8ef15a38-db01-455d-92c5-16d24c1d3ab9


https://github.com/user-attachments/assets/70f87376-233d-45fe-aad4-915739320d42

