### PR TITLE
never block ui scene on gltfs or user data

### DIFF
--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -652,7 +652,7 @@ fn get_user_data(
         } => Some((user, scene, response)),
         _ => None,
     }) {
-        debug!("process get_user_data");
+        debug!("process get_user_data for {:?}", scene);
         match user {
             None => match profile.profile.as_ref() {
                 Some(profile) => response.send(Ok(profile.content.clone())),


### PR DESCRIPTION
we block scenes in various circumstances:
- when gltfs are initially loading, so that raycasts never fail
- when they request user data and the user is not yet logged in
- when the scene is being baked for imposters

particularly for blocking when the user is not logged in, if this blocks the system scene we cannot ever move forward (since it is responsible for logging us in).

we avoid this by never blocking the system scene, which means it has a slightly tighter contract to adhere to but it's not a big problem.