### PR TITLE
fix audio freeze

### DIFF
--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -305,7 +305,7 @@ pub fn process_transport_updates(
                     },
                 );
 
-                let (audio_sender, audio_receiver) = mpsc::channel(1);
+                let (audio_sender, audio_receiver) = mpsc::channel(10);
 
                 let attach_points = AttachPoints::new(&mut commands);
 
@@ -353,7 +353,7 @@ pub fn process_transport_updates(
             }
             PlayerMessage::AudioStream(audio) => {
                 // pass through
-                let _ = audio_channel.blocking_send(*audio);
+                let _ = audio_channel.try_send(*audio);
             }
             PlayerMessage::PlayerData(Message::Position(pos)) => {
                 let dcl_transform = DclTransformAndParent {

--- a/crates/comms/src/livekit_native.rs
+++ b/crates/comms/src/livekit_native.rs
@@ -293,7 +293,7 @@ fn livekit_handler_inner(
                                                 return;
                                             };
 
-                                            let (frame_sender, frame_receiver) = tokio::sync::mpsc::channel(10);
+                                            let (frame_sender, frame_receiver) = tokio::sync::mpsc::channel(1000);
 
                                             let bridge = LivekitKiraBridge {
                                                 started: false,
@@ -318,6 +318,7 @@ fn livekit_handler_inner(
                                                     Ok(()) => (),
                                                     Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                                                         warn!("livekit audio receiver buffer full, dropping frame");
+                                                        return;
                                                     },
                                                     Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                                                         warn!("livekit audio receiver dropped, exiting task");


### PR DESCRIPTION
fix audio freeze when a single foreign entity sends multiple audio channels within a single frame. should never happen but apparently it can do...

fixes #226 