### PR TITLE
several small fixes

### DIFF
--- a/crates/av/src/audio_source.rs
+++ b/crates/av/src/audio_source.rs
@@ -106,7 +106,7 @@ fn map_scene_audio_sources(
             ty: AudioType::Scene,
         };
 
-        info!("emitter: {emitter:?}");
+        debug!("emitter: {emitter:?}");
 
         commands.entity(ent).try_insert(emitter);
     }

--- a/crates/common/src/inputs.rs
+++ b/crates/common/src/inputs.rs
@@ -13,6 +13,7 @@ pub enum SystemAction {
     RollLeft,
     RollRight,
     Microphone,
+    Map,
     Chat,
     CameraZoomIn,
     CameraZoomOut,
@@ -377,7 +378,7 @@ impl Default for InputMap {
                 (
                     Action::System(SystemAction::Emote),
                     vec![
-                        InputIdentifier::Key(KeyCode::AltLeft),
+                        InputIdentifier::Key(KeyCode::KeyB),
                         InputIdentifier::Gamepad(GamepadButton::West),
                     ],
                 ),
@@ -402,7 +403,14 @@ impl Default for InputMap {
                 ),
                 (
                     Action::System(SystemAction::Microphone),
-                    vec![InputIdentifier::Key(KeyCode::ControlLeft)],
+                    vec![InputIdentifier::Key(KeyCode::KeyV)],
+                ),
+                (
+                    Action::System(SystemAction::Map),
+                    vec![
+                        InputIdentifier::Key(KeyCode::KeyM),
+                        InputIdentifier::Key(KeyCode::Tab),
+                    ],
                 ),
                 (
                     Action::System(SystemAction::Chat),

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -18,6 +18,7 @@ pub struct Version(pub String);
 
 // main user entity
 #[derive(Component, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct PrimaryUser {
     pub walk_speed: f32,
     pub run_speed: f32,
@@ -27,6 +28,7 @@ pub struct PrimaryUser {
     pub fall_speed: f32,
     pub control_type: AvatarControl,
     pub turn_speed: f32,
+    pub block_all: bool,
     pub block_run: bool,
     pub block_walk: bool,
     pub block_jump: bool,
@@ -44,6 +46,7 @@ impl Default for PrimaryUser {
             fall_speed: -15.0,
             control_type: AvatarControl::Relative,
             turn_speed: PI,
+            block_all: false,
             block_run: false,
             block_walk: false,
             block_jump: false,
@@ -64,6 +67,7 @@ pub struct PlayerModifiers {
     pub fall_speed: Option<f32>,
     pub control_type: Option<AvatarControl>,
     pub turn_speed: Option<f32>,
+    pub block_all: bool,
     pub block_run: bool,
     pub block_walk: bool,
     pub block_jump: bool,
@@ -88,6 +92,7 @@ impl PlayerModifiers {
             fall_speed: self.fall_speed.unwrap_or(user.fall_speed),
             control_type: self.control_type.unwrap_or(user.control_type),
             turn_speed: self.turn_speed.unwrap_or(user.turn_speed),
+            block_all: self.block_all || user.block_all,
             block_run: self.block_run || user.block_run,
             block_walk: self.block_walk || user.block_walk,
             block_jump: self.block_jump || user.block_jump,

--- a/crates/scene_runner/src/update_world/avatar_modifier_area.rs
+++ b/crates/scene_runner/src/update_world/avatar_modifier_area.rs
@@ -193,7 +193,6 @@ fn update_avatar_modifier_area(
                 })
                 .next();
             modifiers.areas.extend(input_modifier.map(|e| {
-                error!("got area");
                 ActiveAvatarArea {
                     entity: e,
                     allow_locomotion: PermissionState::NotRequested,
@@ -247,7 +246,6 @@ fn update_avatar_modifier_area(
             }
 
             if let Some(movement) = maybe_area.and_then(|area| area.0.movement_settings.as_ref()) {
-                error!("check movement");
                 let permit = maybe_foreign.is_some()
                     || match active_area.allow_locomotion {
                         PermissionState::Resolved(true) => true,
@@ -289,7 +287,6 @@ fn update_avatar_modifier_area(
             if let Some(pb_input_modifier::Mode::Standard(modifier)) =
                 maybe_modifier.and_then(|m| m.0.mode.as_ref())
             {
-                error!("check modifier");
                 let permit = maybe_foreign.is_some()
                     || match active_area.allow_locomotion {
                         PermissionState::Resolved(true) => true,
@@ -308,7 +305,6 @@ fn update_avatar_modifier_area(
                     };
 
                 if permit {
-                    error!("modifier ok, blocking: {modifier:?}");
                     modifiers.block_all |= modifier.disable_all();
                     modifiers.block_run |= modifier.disable_all() || modifier.disable_run();
                     modifiers.block_walk |= modifier.disable_all() || modifier.disable_walk();

--- a/crates/scene_runner/src/update_world/avatar_modifier_area.rs
+++ b/crates/scene_runner/src/update_world/avatar_modifier_area.rs
@@ -192,12 +192,12 @@ fn update_avatar_modifier_area(
                         .filter(|player_ent| input_modifiers.get(*player_ent).is_ok())
                 })
                 .next();
-            modifiers.areas.extend(input_modifier.map(|e| {
-                ActiveAvatarArea {
+            modifiers
+                .areas
+                .extend(input_modifier.map(|e| ActiveAvatarArea {
                     entity: e,
                     allow_locomotion: PermissionState::NotRequested,
-                }
-            }));
+                }));
         }
 
         // remove destroyed areas

--- a/crates/scene_runner/src/update_world/avatar_modifier_area.rs
+++ b/crates/scene_runner/src/update_world/avatar_modifier_area.rs
@@ -192,12 +192,13 @@ fn update_avatar_modifier_area(
                         .filter(|player_ent| input_modifiers.get(*player_ent).is_ok())
                 })
                 .next();
-            modifiers
-                .areas
-                .extend(input_modifier.map(|e| ActiveAvatarArea {
+            modifiers.areas.extend(input_modifier.map(|e| {
+                error!("got area");
+                ActiveAvatarArea {
                     entity: e,
                     allow_locomotion: PermissionState::NotRequested,
-                }));
+                }
+            }));
         }
 
         // remove destroyed areas
@@ -246,6 +247,7 @@ fn update_avatar_modifier_area(
             }
 
             if let Some(movement) = maybe_area.and_then(|area| area.0.movement_settings.as_ref()) {
+                error!("check movement");
                 let permit = maybe_foreign.is_some()
                     || match active_area.allow_locomotion {
                         PermissionState::Resolved(true) => true,
@@ -287,6 +289,7 @@ fn update_avatar_modifier_area(
             if let Some(pb_input_modifier::Mode::Standard(modifier)) =
                 maybe_modifier.and_then(|m| m.0.mode.as_ref())
             {
+                error!("check modifier");
                 let permit = maybe_foreign.is_some()
                     || match active_area.allow_locomotion {
                         PermissionState::Resolved(true) => true,
@@ -305,6 +308,8 @@ fn update_avatar_modifier_area(
                     };
 
                 if permit {
+                    error!("modifier ok, blocking: {modifier:?}");
+                    modifiers.block_all |= modifier.disable_all();
                     modifiers.block_run |= modifier.disable_all() || modifier.disable_run();
                     modifiers.block_walk |= modifier.disable_all() || modifier.disable_walk();
                     modifiers.block_jump |= modifier.disable_all() || modifier.disable_jump();

--- a/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
@@ -176,7 +176,10 @@ pub fn set_ui_background(
                     continue;
                 }
                 Some(Err(other)) => {
-                    warn!("failed to load ui image from content map: {:?}: {other:?}", texture);
+                    warn!(
+                        "failed to load ui image from content map: {:?}: {other:?}",
+                        texture
+                    );
                     continue;
                 }
             };
@@ -277,10 +280,8 @@ pub fn set_ui_background(
                         })
                         .try_with_children(|c| {
                             c.spacer();
-                            let mut inner = c.spawn((
-                                node,
-                                ImageNode::new(image.image).with_color(image_color),
-                            ));
+                            let mut inner = c
+                                .spawn((node, ImageNode::new(image.image).with_color(image_color)));
                             if let Some(source) = image.source_entity {
                                 inner.insert(UiMaterialSource(source));
                             }

--- a/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
@@ -165,73 +165,121 @@ pub fn set_ui_background(
                 .tex
                 .as_ref()
                 .map(|tex| resolver.resolve_texture(ctx, tex));
-            if let Some(Err(TextureResolveError::SourceNotReady)) = image.as_ref() {
-                commands.commands().entity(ent).insert(RetryBackground);
-                continue;
-            }
-            let image = image.and_then(|r| r.ok());
 
-            if let Some(image) = image {
-                let image_color = background.color.unwrap_or(Color::WHITE);
-                let image_color = image_color.with_alpha(image_color.alpha() * link.opacity.0);
-                let (border, border_radius) = radii
-                    .get(link.ui_entity)
-                    .ok()
-                    .map(|(node, radius)| (node.border, radius))
-                    .unwrap_or((UiRect::DEFAULT, None));
+            let image = match image {
+                Some(Ok(t)) => t,
+                Some(Err(TextureResolveError::SourceNotReady)) => {
+                    commands.commands().entity(ent).insert(RetryBackground);
+                    continue;
+                }
+                None | Some(Err(TextureResolveError::NoTexture)) => {
+                    continue;
+                }
+                Some(Err(other)) => {
+                    warn!("failed to load ui image from content map: {:?}: {other:?}", texture);
+                    continue;
+                }
+            };
 
-                let unborder = |v: Val| -> Val {
-                    match v {
-                        Val::Auto => Val::Px(0.0),
-                        other => other * -1.0,
-                    }
-                };
+            let image_color = background.color.unwrap_or(Color::WHITE);
+            let image_color = image_color.with_alpha(image_color.alpha() * link.opacity.0);
+            let (border, border_radius) = radii
+                .get(link.ui_entity)
+                .ok()
+                .map(|(node, radius)| (node.border, radius))
+                .unwrap_or((UiRect::DEFAULT, None));
 
-                let node = Node {
-                    position_type: PositionType::Absolute,
-                    top: unborder(border.top),
-                    left: unborder(border.left),
-                    bottom: unborder(border.bottom),
-                    right: unborder(border.right),
-                    border,
-                    overflow: Overflow::clip(),
-                    ..Default::default()
-                };
+            let unborder = |v: Val| -> Val {
+                match v {
+                    Val::Auto => Val::Px(0.0),
+                    other => other * -1.0,
+                }
+            };
 
-                let background_entity = match texture.mode {
-                    BackgroundTextureMode::NineSlices(rect) => commands
-                        .commands()
-                        .spawn((
+            let node = Node {
+                position_type: PositionType::Absolute,
+                top: unborder(border.top),
+                left: unborder(border.left),
+                bottom: unborder(border.bottom),
+                right: unborder(border.right),
+                border,
+                overflow: Overflow::clip(),
+                ..Default::default()
+            };
+
+            let background_entity = match texture.mode {
+                BackgroundTextureMode::NineSlices(rect) => commands
+                    .commands()
+                    .spawn((
+                        node,
+                        Ui9Slice {
+                            image: image.image,
+                            center_region: rect.into(),
+                            tint: Some(image_color),
+                        },
+                        UiBackgroundMarker,
+                    ))
+                    .id(),
+                BackgroundTextureMode::Stretch(ref uvs) => commands
+                    .commands()
+                    .spawn((
+                        Node {
+                            position_type: PositionType::Absolute,
+                            top: Val::Px(0.0),
+                            right: Val::Px(0.0),
+                            left: Val::Px(0.0),
+                            bottom: Val::Px(0.0),
+                            ..Default::default()
+                        },
+                        UiBackgroundMarker,
+                    ))
+                    .try_with_children(|c| {
+                        let mut inner = c.spawn((
                             node,
-                            Ui9Slice {
-                                image: image.image,
-                                center_region: rect.into(),
-                                tint: Some(image_color),
-                            },
-                            UiBackgroundMarker,
-                        ))
-                        .id(),
-                    BackgroundTextureMode::Stretch(ref uvs) => commands
-                        .commands()
-                        .spawn((
-                            Node {
-                                position_type: PositionType::Absolute,
-                                top: Val::Px(0.0),
-                                right: Val::Px(0.0),
-                                left: Val::Px(0.0),
-                                bottom: Val::Px(0.0),
-                                ..Default::default()
-                            },
-                            UiBackgroundMarker,
-                        ))
+                            MaterialNode(stretch_uvs.add(StretchUvMaterial {
+                                image: image.image.clone(),
+                                uvs: *uvs,
+                                color: image_color.to_linear().to_vec4(),
+                            })),
+                        ));
+                        if let Some(source) = image.source_entity {
+                            inner.insert(UiMaterialSource(source));
+                        }
+                        if let Some(radius) = border_radius {
+                            inner.insert(*radius);
+                        }
+                    })
+                    .id(),
+                BackgroundTextureMode::Center => commands
+                    .commands()
+                    .spawn((
+                        Node {
+                            position_type: PositionType::Absolute,
+                            left: Val::Px(0.0),
+                            right: Val::Px(0.0),
+                            top: Val::Px(0.0),
+                            bottom: Val::Px(0.0),
+                            justify_content: JustifyContent::Center,
+                            overflow: Overflow::clip(),
+                            width: Val::Percent(100.0),
+                            ..Default::default()
+                        },
+                        UiBackgroundMarker,
+                    ))
+                    .try_with_children(|c| {
+                        c.spacer();
+                        c.spawn(Node {
+                            flex_direction: FlexDirection::Column,
+                            justify_content: JustifyContent::Center,
+                            overflow: Overflow::clip(),
+                            height: Val::Percent(100.0),
+                            ..Default::default()
+                        })
                         .try_with_children(|c| {
+                            c.spacer();
                             let mut inner = c.spawn((
                                 node,
-                                MaterialNode(stretch_uvs.add(StretchUvMaterial {
-                                    image: image.image.clone(),
-                                    uvs: *uvs,
-                                    color: image_color.to_linear().to_vec4(),
-                                })),
+                                ImageNode::new(image.image).with_color(image_color),
                             ));
                             if let Some(source) = image.source_entity {
                                 inner.insert(UiMaterialSource(source));
@@ -239,56 +287,14 @@ pub fn set_ui_background(
                             if let Some(radius) = border_radius {
                                 inner.insert(*radius);
                             }
-                        })
-                        .id(),
-                    BackgroundTextureMode::Center => commands
-                        .commands()
-                        .spawn((
-                            Node {
-                                position_type: PositionType::Absolute,
-                                left: Val::Px(0.0),
-                                right: Val::Px(0.0),
-                                top: Val::Px(0.0),
-                                bottom: Val::Px(0.0),
-                                justify_content: JustifyContent::Center,
-                                overflow: Overflow::clip(),
-                                width: Val::Percent(100.0),
-                                ..Default::default()
-                            },
-                            UiBackgroundMarker,
-                        ))
-                        .try_with_children(|c| {
                             c.spacer();
-                            c.spawn(Node {
-                                flex_direction: FlexDirection::Column,
-                                justify_content: JustifyContent::Center,
-                                overflow: Overflow::clip(),
-                                height: Val::Percent(100.0),
-                                ..Default::default()
-                            })
-                            .try_with_children(|c| {
-                                c.spacer();
-                                let mut inner = c.spawn((
-                                    node,
-                                    ImageNode::new(image.image).with_color(image_color),
-                                ));
-                                if let Some(source) = image.source_entity {
-                                    inner.insert(UiMaterialSource(source));
-                                }
-                                if let Some(radius) = border_radius {
-                                    inner.insert(*radius);
-                                }
-                                c.spacer();
-                            });
-                            c.spacer();
-                        })
-                        .id(),
-                };
+                        });
+                        c.spacer();
+                    })
+                    .id(),
+            };
 
-                commands.insert_children(0, &[background_entity]);
-            } else {
-                warn!("failed to load ui image from content map: {:?}", texture);
-            }
+            commands.insert_children(0, &[background_entity]);
         } else if let Some(color) = background.color {
             commands.insert(BackgroundColor(color));
         }

--- a/crates/scene_runner/src/update_world/scene_ui/ui_text.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_text.rs
@@ -89,6 +89,7 @@ pub fn set_ui_text(
     links: Query<&UiLink>,
     children: Query<&Children>,
     prev_texts: Query<&UiTextMarker>,
+    mut node_style: Query<&mut Node>,
 ) {
     for ent in removed.read() {
         let Ok(link) = links.get(ent) else {
@@ -235,6 +236,14 @@ pub fn set_ui_text(
             .id();
 
         ent_cmds.insert_children(0, &[text_element]);
+
+        // try and enforce wrapping ? not sure if this is a good idea but
+        // without this we are not wrapping in some cases where foundation client does
+        if ui_text.wrapping && ui_transform.max_size.width == Val::Auto {
+            if let Ok(mut style) = node_style.get_mut(link.ui_entity) {
+                style.max_width = Val::Percent(100.0);
+            }
+        }
     }
 }
 

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -114,7 +114,7 @@ pub fn update_camera(
         );
     }
 
-    let mut mouse_delta = input_manager.get_analog(CAMERA_SET, InputPriority::Scroll) * 10.0;
+    let mut mouse_delta = input_manager.get_analog(CAMERA_SET, InputPriority::Scene) * 10.0;
     if locks.0.contains("camera") {
         mouse_delta += input_manager.get_analog(POINTER_SET, InputPriority::Scroll);
     }


### PR DESCRIPTION
- reduce excessive audio logging
- don't send compressed movement packets (foundation client hides our avatars if we do)
- remove warnings for UiBackground elements with an empty Texture `src` specified
- add Map system action bound to M or tab
- alter default keybindings for microphone (ctrl -> V), emote (alt -> B)
- reduce input priority for camera rotation keys so left and right arrows in chat don't turn the camera
- properly support disableAll in InputModifier
- attempt to fix text wrapping for ui label elements (may have unintended side effects ...)