### PR TITLE
clean up realm info base url, make realm-permission values consistent

### DIFF
--- a/crates/dcl/src/js/modules/SystemApi.js
+++ b/crates/dcl/src/js/modules/SystemApi.js
@@ -206,11 +206,6 @@ module.exports.setHomeScene = async function(args) {
     await Deno.core.ops.op_set_home_scene(args.realm, args.parcel)
 }
 
-// string
-module.exports.getRealmProvider = async function() {
-    return (await Deno.core.ops.op_get_realm_provider()).realm
-}
-
 // get system actions as a stream
 // type SystemAction = {
 //   action: string,

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -13,7 +13,6 @@ use dcl_component::proto_components::{
     sdk::components::{PbAvatarBase, PbAvatarEquippedData},
 };
 use http::Uri;
-use ipfs::IpfsResource;
 use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, rc::Rc};
 use strum::IntoEnumIterator;
@@ -385,27 +384,6 @@ pub fn op_set_home_scene(state: Rc<RefCell<impl State>>, realm: String, parcel: 
         .borrow_mut::<SuperUserScene>()
         .send(SystemApi::SetHomeScene(HomeScene { realm, parcel }))
         .unwrap();
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RealmProviderString {
-    realm: String,
-}
-
-pub async fn op_get_realm_provider(
-    state: Rc<RefCell<impl State>>,
-) -> Result<RealmProviderString, anyhow::Error> {
-    let url = state
-        .borrow_mut()
-        .borrow_mut::<IpfsResource>()
-        .about_url()
-        .ok_or(anyhow::anyhow!("not connected"))?;
-
-    let url = url.strip_suffix("/about").unwrap_or(&url);
-
-    Ok(RealmProviderString {
-        realm: url.to_owned(),
-    })
 }
 
 pub async fn op_get_system_action_stream(state: Rc<RefCell<impl State>>) -> u32 {

--- a/crates/dcl_deno/src/js/op_wrappers/system_api.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/system_api.rs
@@ -2,7 +2,7 @@ use common::{
     inputs::SystemActionEvent,
     structs::{PermissionType, PermissionUsed, PermissionValue},
 };
-use dcl::js::system_api::{JsBindingsData, PermissionTypeDetail, RealmProviderString};
+use dcl::js::system_api::{JsBindingsData, PermissionTypeDetail};
 use dcl_component::proto_components::{
     common::Vector2,
     sdk::components::{PbAvatarBase, PbAvatarEquippedData},
@@ -39,7 +39,6 @@ pub fn ops(super_user: bool) -> Vec<OpDecl> {
             op_live_scene_info(),
             op_get_home_scene(),
             op_set_home_scene(),
-            op_get_realm_provider(),
             op_get_system_action_stream(),
             op_read_system_action_stream(),
             op_get_chat_stream(),
@@ -208,14 +207,6 @@ pub fn op_set_home_scene(
     #[serde] parcel: Vector2,
 ) {
     dcl::js::system_api::op_set_home_scene(state, realm, parcel);
-}
-
-#[op2(async)]
-#[serde]
-pub async fn op_get_realm_provider(
-    state: Rc<RefCell<OpState>>,
-) -> Result<RealmProviderString, anyhow::Error> {
-    dcl::js::system_api::op_get_realm_provider(state).await
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
@@ -171,11 +171,6 @@ pub fn op_set_home_scene(state: &WorkerContext, realm: String, parcel: JsValue) 
 }
 
 #[wasm_bindgen]
-pub async fn op_get_realm_provider(state: &WorkerContext) -> Result<JsValue, WasmError> {
-    serde_result!(dcl::js::system_api::op_get_realm_provider(state.rc()).await)
-}
-
-#[wasm_bindgen]
 pub async fn op_get_system_action_stream(state: &WorkerContext) -> u32 {
     dcl::js::system_api::op_get_system_action_stream(state.rc()).await
 }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -782,7 +782,14 @@ impl IpfsIo {
 
     pub async fn get_realm_info(&self) -> (String, Option<ServerAbout>) {
         let context = self.context.read().await;
-        (context.base_url.clone(), context.about.clone())
+        (
+            context
+                .about_url
+                .strip_suffix("/about")
+                .unwrap_or(&context.about_url)
+                .to_owned(),
+            context.about.clone(),
+        )
     }
 
     async fn set_realm_inner(

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -724,10 +724,13 @@ fn send_scene_updates(
         .as_ref()
         .and_then(|(scene, addr, _)| (scene.scene_id == context.hash).then_some(addr));
     let base_url = realm
-        .public_url
-        .strip_suffix("/")
-        .unwrap_or(&realm.public_url);
-    let base_url = base_url.strip_suffix("/content").unwrap_or(base_url);
+        .about_url
+        .strip_suffix("/about")
+        .unwrap_or(&realm.about_url);
+    let realm_name = realm.config.realm_name.clone().unwrap_or_default();
+    let base_url = base_url
+        .strip_suffix(&format!("/{realm_name}"))
+        .unwrap_or(base_url);
     let realm_info = PbRealmInfo {
         base_url: base_url.to_owned(),
         realm_name: realm.config.realm_name.clone().unwrap_or_default(),

--- a/crates/scene_runner/src/permissions.rs
+++ b/crates/scene_runner/src/permissions.rs
@@ -112,7 +112,7 @@ impl<T: Send + Sync + 'static> Permission<'_, '_, T> {
             common::structs::PermissionValue::Ask
         } else {
             self.config
-                .get_permission(ty, &self.realm.address, hash, is_portable)
+                .get_permission(ty, &self.realm.about_url, hash, is_portable)
         };
 
         debug!(
@@ -123,7 +123,7 @@ impl<T: Send + Sync + 'static> Permission<'_, '_, T> {
             in_scene,
             allow_out_of_scene,
             self.config
-                .get_permission(ty, &self.realm.address, hash, is_portable)
+                .get_permission(ty, &self.realm.about_url, hash, is_portable)
         );
         match perm {
             common::structs::PermissionValue::Allow => {

--- a/crates/system_ui/src/permission_manager.rs
+++ b/crates/system_ui/src/permission_manager.rs
@@ -395,7 +395,15 @@ pub fn handle_scene_permissions(
                         config.scene_permissions.entry(hash.clone()).or_default()
                     }
                     PermissionLevel::Realm(realm) => {
-                        config.realm_permissions.entry(realm.clone()).or_default()
+                        if current_realm.about_url.starts_with(realm) {
+                            config
+                                .realm_permissions
+                                .entry(current_realm.about_url.clone())
+                                .or_default()
+                        } else {
+                            warn!("permission realm didn't match current realm: {} is not initial segment of {}", realm, current_realm.about_url);
+                            continue;
+                        }
                     }
                     PermissionLevel::Global => &mut config.default_permissions,
                 };

--- a/crates/system_ui/src/permissions.rs
+++ b/crates/system_ui/src/permissions.rs
@@ -99,7 +99,7 @@ fn set_permission_settings_content(
         let realm_address = if is_portable {
             "<portable>".to_owned()
         } else {
-            realm.address.clone()
+            realm.about_url.clone()
         };
 
         commands.entity(ent).despawn_related::<Children>();


### PR DESCRIPTION
- update `GetRealm` response to change baseUrl from content server to realm provider
- remove getRealmProvider system api
- change realm-based permissions to consistently use realm provider (instead of sometimes using content server)