### PR TITLE
fix service worker

### DIFF
--- a/deploy/web/main.js
+++ b/deploy/web/main.js
@@ -54,6 +54,39 @@ if ("serviceWorker" in navigator) {
         console.log("Page: Service Worker registration failed: ", error);
       });
   });
+
+  // make sure the worker stays around after a hard reload
+  // 1. Check if a service worker is active and controlling the page.
+  if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+    // SUCCESS CASE:
+    // If the recovery flag is present, it means we just successfully
+    // recovered from a hard reload. We can now remove the flag.
+    if (sessionStorage.getItem('sw_reloaded')) {
+      console.log('Service Worker recovery successful. Cleaning up flag.');
+      sessionStorage.removeItem('sw_reloaded');
+    }
+    // Everything is fine, let the app load.
+  } else {
+    // 2. RECOVERY CASE: No service worker is in control.
+    // This could be a first visit or a hard reload.
+    if (navigator.serviceWorker && navigator.serviceWorker.getRegistration) {
+      navigator.serviceWorker.getRegistration().then(registration => {
+        // We only try to recover if a service worker is already registered.
+        if (registration) {
+          // Prevent an infinite reload loop.
+          if (sessionStorage.getItem('sw_reloaded')) {
+            sessionStorage.removeItem('sw_reloaded');
+            console.error('Service Worker failed to take control after reload.');
+          } else {
+            // Set the flag and perform a standard reload.
+            console.log('Page is uncontrolled. Reloading to activate Service Worker...');
+            sessionStorage.setItem('sw_reloaded', 'true');
+            window.location.reload();
+          }
+        }
+      });
+    }
+  }
 }
 
 async function initEngine() {
@@ -227,3 +260,4 @@ Promise.all([initEngine(), initGpuCache()])
     console.log("error", e);
     initButton.textContent = "Load Failed";
   });
+


### PR DESCRIPTION
vibe-coded by gemini

the web service worker is required:
- the web version uses a service worker to cache ipfs requests regardless of the actual content server
- this worker uses a custom header (X-IPFS) to determine when a request is an ipfs/cacheable request. the service worker removes this header before issuing the real request
- if the worker is not running, the request triggers CORS preflight checks for ipfs requests due to the extra header

the service worker is intentionally disabled by chrome on a hard-reload (ctrl+alt+f5 / cmd+shift+r), causing CORS failures.

fix it by checking for presence of the worker and soft-reloading the page if it is not active.

