### PR TITLE
gltf immediate upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -926,7 +926,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#064f5231b62b54dabe9e917122553e8eff041e65"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1024,7 +1024,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1098,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#064f5231b62b54dabe9e917122553e8eff041e65"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1164,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#064f5231b62b54dabe9e917122553e8eff041e65"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1249,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1274,7 +1274,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1459,7 +1459,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "glam",
 ]
@@ -1553,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1603,12 +1603,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1815,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1937,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2435fdc552d2e8753bfbf098ca65d4690e9d5350"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#1b645f2810dacd44ccdff26d5243af16d4a4e545"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -23,21 +23,16 @@ use bevy::{
     transform::TransformSystem,
 };
 use common::{
-    anim_last_system,
-    structs::AppConfig,
-    util::{ModifyComponentExt, SceneSpawnerPlus},
+    anim_last_system, dynamics::PLAYER_COLLIDER_RADIUS, structs::{AppConfig, PrimaryPlayerRes}, util::{ModifyComponentExt, SceneSpawnerPlus}
 };
 use rapier3d_f64::prelude::*;
 use serde::Deserialize;
 
 use crate::{
-    initialize_scene::SceneEntityDefinitionHandle,
-    renderer_context::RendererSceneContext,
-    update_world::{
+    ContainerEntity, ContainingScene, SceneEntity, SceneSets, initialize_scene::SceneEntityDefinitionHandle, renderer_context::RendererSceneContext, update_world::{
         lights::LightSource,
-        material::{dcl_material_from_standard_material, BaseMaterial},
-    },
-    ContainerEntity, SceneEntity, SceneSets,
+        material::{BaseMaterial, dcl_material_from_standard_material},
+    }
 };
 use dcl::interface::{ComponentPosition, CrdtType};
 use dcl_component::{
@@ -158,7 +153,11 @@ fn update_gltf(
     mut scene_spawner: ResMut<SceneSpawner>,
     mut contexts: Query<(Entity, &mut RendererSceneContext, Has<SceneResourceLookup>)>,
     mut instances_to_despawn_when_ready: Local<Vec<InstanceId>>,
+    active_scenes: ContainingScene,
+    player: Res<PrimaryPlayerRes>,
 ) {
+    let active_scenes = active_scenes.get_area(player.0, PLAYER_COLLIDER_RADIUS);
+
     // clean up old instances
     instances_to_despawn_when_ready.retain(|instance| {
         if scene_spawner.instance_is_ready(*instance) {
@@ -229,14 +228,16 @@ fn update_gltf(
             continue;
         };
 
+        let immediate_upload = active_scenes.contains(&scene_ent.root) || true;
         let h_gltf = ipfas.load_content_file_with_settings::<Gltf, GltfLoaderSettings>(
             &gltf.0.src,
             &scene_def.id,
-            |s| {
+            move |s| {
                 s.load_cameras = false;
                 s.load_lights = true;
                 s.load_materials = RenderAssetUsages::RENDER_WORLD;
                 s.include_source = true;
+                s.immediate_upload = immediate_upload;
             },
         );
 

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -234,7 +234,7 @@ fn update_gltf(
             continue;
         };
 
-        let immediate_upload = active_scenes.contains(&scene_ent.root) || true;
+        let immediate_upload = active_scenes.contains(&scene_ent.root);
         let h_gltf = ipfas.load_content_file_with_settings::<Gltf, GltfLoaderSettings>(
             &gltf.0.src,
             &scene_def.id,

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -23,16 +23,22 @@ use bevy::{
     transform::TransformSystem,
 };
 use common::{
-    anim_last_system, dynamics::PLAYER_COLLIDER_RADIUS, structs::{AppConfig, PrimaryPlayerRes}, util::{ModifyComponentExt, SceneSpawnerPlus}
+    anim_last_system,
+    dynamics::PLAYER_COLLIDER_RADIUS,
+    structs::{AppConfig, PrimaryPlayerRes},
+    util::{ModifyComponentExt, SceneSpawnerPlus},
 };
 use rapier3d_f64::prelude::*;
 use serde::Deserialize;
 
 use crate::{
-    ContainerEntity, ContainingScene, SceneEntity, SceneSets, initialize_scene::SceneEntityDefinitionHandle, renderer_context::RendererSceneContext, update_world::{
+    initialize_scene::SceneEntityDefinitionHandle,
+    renderer_context::RendererSceneContext,
+    update_world::{
         lights::LightSource,
-        material::{BaseMaterial, dcl_material_from_standard_material},
-    }
+        material::{dcl_material_from_standard_material, BaseMaterial},
+    },
+    ContainerEntity, ContainingScene, SceneEntity, SceneSets,
 };
 use dcl::interface::{ComponentPosition, CrdtType};
 use dcl_component::{


### PR DESCRIPTION
allow gltfs to upload to GPU immediately for active scenes. increases hitches but avoids the scenario where the app thinks the scene is fully loaded and ready to play, but some meshes are not rendering as they are GPU-queued, while still avoiding hitches from non-active scene loading.
