### PR TITLE
Web signed fetch headers

### DIFF
--- a/crates/dcl/src/js/fetch.rs
+++ b/crates/dcl/src/js/fetch.rs
@@ -1,0 +1,84 @@
+use std::{cell::RefCell, rc::Rc};
+
+use anyhow::anyhow;
+use bevy::log::{debug, tracing};
+use common::structs::SceneMeta;
+use http::Uri;
+use ipfs::IpfsResource;
+use serde::Serialize;
+use wallet::{Wallet, sign_request};
+
+use crate::{interface::crdt_context::CrdtContext, js::{State, runtime::realm_information}};
+
+#[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedFetchMetaRealm {
+    hostname: String,
+    protocol: String,
+    server_name: String,
+}
+
+#[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedFetchMeta {
+    origin: Option<String>,
+    scene_id: Option<String>,
+    parcel: Option<String>,
+    tld: Option<String>,
+    network: Option<String>,
+    is_guest: Option<bool>,
+    realm: SignedFetchMetaRealm,
+    signer: String,
+}
+
+pub async fn op_signed_fetch_headers(
+    state: Rc<RefCell<impl State>>,
+    uri: String,
+    method: Option<String>,
+) -> Result<Vec<(String, String)>, anyhow::Error> {
+    debug!("op_signed_fetch_headers");
+
+    let is_preview = state.borrow().borrow::<CrdtContext>().preview;
+    let scheme = Uri::try_from(&uri)?;
+    let scheme = scheme.scheme_str();
+    if !is_preview && !([Some("https"), Some("wss")].contains(&scheme)) {
+        anyhow::bail!("URL scheme must be `https` (request `{}`)", uri);
+    }
+
+    let realm_info = realm_information(state.clone()).await?;
+    let wallet = state.borrow().borrow::<Wallet>().clone();
+    let urn = state.borrow().borrow::<CrdtContext>().hash.clone();
+    let ipfs = state.borrow().borrow::<IpfsResource>().clone();
+    let scene_meta = ipfs
+        .entity_definition(&urn)
+        .await
+        .and_then(|(entity, _)| {
+            serde_json::from_str::<SceneMeta>(&entity.metadata.unwrap_or_default()).ok()
+        })
+        .ok_or(anyhow!("failed to parse scene metadata"))?;
+
+    let meta = SignedFetchMeta {
+        origin: Some(realm_info.base_url.clone()),
+        scene_id: Some(urn),
+        parcel: Some(scene_meta.scene.base.clone()),
+        tld: Some("org".to_owned()),
+        network: Some("mainnet".to_owned()),
+        is_guest: Some(wallet.is_guest()),
+        realm: SignedFetchMetaRealm {
+            hostname: realm_info.base_url,
+            protocol: "v3".to_owned(),
+            server_name: realm_info.realm_name,
+        },
+        signer: "decentraland-kernel-scene".to_owned(),
+    };
+
+    debug!("signed fetch meta {:?}", meta);
+
+    sign_request(
+        method.as_deref().unwrap_or("get"),
+        &Uri::try_from(uri)?,
+        &wallet,
+        meta,
+    )
+    .await
+}

--- a/crates/dcl/src/js/fetch.rs
+++ b/crates/dcl/src/js/fetch.rs
@@ -1,14 +1,17 @@
 use std::{cell::RefCell, rc::Rc};
 
 use anyhow::anyhow;
-use bevy::log::{debug, tracing};
+use bevy::log::debug;
 use common::structs::SceneMeta;
 use http::Uri;
 use ipfs::IpfsResource;
 use serde::Serialize;
-use wallet::{Wallet, sign_request};
+use wallet::{sign_request, Wallet};
 
-use crate::{interface::crdt_context::CrdtContext, js::{State, runtime::realm_information}};
+use crate::{
+    interface::crdt_context::CrdtContext,
+    js::{runtime::realm_information, State},
+};
 
 #[derive(Serialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -28,10 +28,10 @@ pub mod adaption_layer_helper;
 pub mod comms;
 pub mod ethereum_controller;
 pub mod events;
+pub mod fetch;
 pub mod player;
 pub mod system_api;
 pub mod testing;
-pub mod fetch;
 
 // marker to indicate shutdown has been triggered
 pub struct ShuttingDown;

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -31,6 +31,7 @@ pub mod events;
 pub mod player;
 pub mod system_api;
 pub mod testing;
+pub mod fetch;
 
 // marker to indicate shutdown has been triggered
 pub struct ShuttingDown;

--- a/crates/dcl_deno/src/js/fetch/mod.rs
+++ b/crates/dcl_deno/src/js/fetch/mod.rs
@@ -3,9 +3,9 @@ use std::{cell::RefCell, rc::Rc};
 mod fetch_response_body_resource;
 
 use bevy::{asset::AsyncReadExt, prelude::debug};
-use common::{rpc::RpcCall, structs::SceneMeta};
+use common::rpc::RpcCall;
 use deno_core::{
-    anyhow::{self, anyhow},
+    anyhow,
     error::{type_error, AnyError},
     futures::{FutureExt, TryStreamExt},
     op2, AsyncRefCell, BufView, ByteString, CancelHandle, JsBuffer, OpDecl, OpState, Resource,
@@ -16,18 +16,15 @@ use deno_net::NetPermissions;
 use deno_web::TimersPermission;
 use http::{
     header::{ACCEPT_ENCODING, CONTENT_LENGTH, HOST, RANGE},
-    HeaderName, HeaderValue, Method, Uri,
+    HeaderName, HeaderValue, Method,
 };
 use ipfs::IpfsResource;
 use serde::{Deserialize, Serialize};
 
 use fetch_response_body_resource::FetchResponseBodyResource;
 use tokio::sync::oneshot::channel;
-use wallet::{sign_request, Wallet};
 
 use dcl::{interface::crdt_context::CrdtContext, RpcCalls};
-
-use dcl::js::runtime::realm_information;
 
 // we have to provide fetch perm structs even though we don't use them
 pub struct FP;
@@ -350,27 +347,6 @@ pub fn op_fetch_custom_client(
     Ok(state.resource_table.add(ClientResource(builder.build()?)))
 }
 
-#[derive(Serialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SignedFetchMetaRealm {
-    hostname: String,
-    protocol: String,
-    server_name: String,
-}
-
-#[derive(Serialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SignedFetchMeta {
-    origin: Option<String>,
-    scene_id: Option<String>,
-    parcel: Option<String>,
-    tld: Option<String>,
-    network: Option<String>,
-    is_guest: Option<bool>,
-    realm: SignedFetchMetaRealm,
-    signer: String,
-}
-
 #[op2(async)]
 #[serde]
 pub async fn op_signed_fetch_headers(
@@ -378,51 +354,7 @@ pub async fn op_signed_fetch_headers(
     #[string] uri: String,
     #[string] method: Option<String>,
 ) -> Result<Vec<(String, String)>, AnyError> {
-    debug!("op_signed_fetch_headers");
-
-    let is_preview = state.borrow().borrow::<CrdtContext>().preview;
-    let scheme = Uri::try_from(&uri)?;
-    let scheme = scheme.scheme_str();
-    if !is_preview && !([Some("https"), Some("wss")].contains(&scheme)) {
-        anyhow::bail!("URL scheme must be `https` (request `{}`)", uri);
-    }
-
-    let realm_info = realm_information(state.clone()).await?;
-    let wallet = state.borrow().borrow::<Wallet>().clone();
-    let urn = state.borrow().borrow::<CrdtContext>().hash.clone();
-    let ipfs = state.borrow().borrow::<IpfsResource>().clone();
-    let scene_meta = ipfs
-        .entity_definition(&urn)
-        .await
-        .and_then(|(entity, _)| {
-            serde_json::from_str::<SceneMeta>(&entity.metadata.unwrap_or_default()).ok()
-        })
-        .ok_or(anyhow!("failed to parse scene metadata"))?;
-
-    let meta = SignedFetchMeta {
-        origin: Some(realm_info.base_url.clone()),
-        scene_id: Some(urn),
-        parcel: Some(scene_meta.scene.base.clone()),
-        tld: Some("org".to_owned()),
-        network: Some("mainnet".to_owned()),
-        is_guest: Some(wallet.is_guest()),
-        realm: SignedFetchMetaRealm {
-            hostname: realm_info.base_url,
-            protocol: "v3".to_owned(),
-            server_name: realm_info.realm_name,
-        },
-        signer: "decentraland-kernel-scene".to_owned(),
-    };
-
-    debug!("signed fetch meta {:?}", meta);
-
-    sign_request(
-        method.as_deref().unwrap_or("get"),
-        &Uri::try_from(uri)?,
-        &wallet,
-        meta,
-    )
-    .await
+    dcl::js::fetch::op_signed_fetch_headers(state, uri, method).await
 }
 
 use core::future::Future;

--- a/crates/dcl_wasm/src/inner/op_wrappers/fetch.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/fetch.rs
@@ -1,0 +1,11 @@
+use crate::{serde_result, WasmError, WorkerContext};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub async fn op_signed_fetch_headers(
+    state: &WorkerContext,
+    uri: String,
+    method: Option<String>,
+) -> Result<JsValue, WasmError> {
+    serde_result!(dcl::js::fetch::op_signed_fetch_headers(state.rc(), uri, method).await)
+}

--- a/crates/dcl_wasm/src/inner/op_wrappers/mod.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/mod.rs
@@ -3,6 +3,7 @@ pub mod comms;
 pub mod engine;
 pub mod ethereum_controller;
 pub mod events;
+pub mod fetch;
 pub mod player;
 pub mod portables;
 pub mod restricted_actions;

--- a/deploy/web/sandbox_worker.js
+++ b/deploy/web/sandbox_worker.js
@@ -255,24 +255,24 @@ self.onmessage = async (event) => {
         
     // add listener to clean up on unhandled rejections
     self.addEventListener("unhandledrejection", (event) => {
-      // Prevent the default browser action (logging to console)
+      // Prevent the default browser action
       event.preventDefault();
 
       console.error(
-        "[Sandbox worker] FATAL: Unhandled Promise Rejection in Worker:",
+        "[Sandbox worker] Unhandled Promise Rejection in Worker:",
         event.reason
       );
 
-      try {
-        wasm_init.__wbindgen_thread_destroy();
-      } catch (cleanupError) {
-        console.error(
-          "[Sandbox worker] Error during WASM cleanup:",
-          cleanupError
-        );
-      }
+      // try {
+      //   wasm_init.__wbindgen_thread_destroy();
+      // } catch (cleanupError) {
+      //   console.error(
+      //     "[Sandbox worker] Error during WASM cleanup:",
+      //     cleanupError
+      //   );
+      // }
 
-      self.close();
+      // self.close();
     });
 
     var wasmContext;


### PR DESCRIPTION
fix no coins on 1/95:
- add wasm `op_fetch_signed_headers` api
- allow unhandled promise rejections without terminating scene