### PR TITLE
Map initial realm

### DIFF
--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -605,18 +605,21 @@ pub fn change_realm(
         let ipfs = ipfs.clone();
         let request = change_realm_requests.read().last().unwrap();
 
-        let new_realm = &request.new_realm;
-        let new_realm = if new_realm.ends_with(".dcl.eth") && !new_realm.starts_with("https://") {
-            format!("https://worlds-content-server.decentraland.org/world/{new_realm}")
-        } else {
-            new_realm.to_owned()
-        };
+        let new_realm = map_realm_name(&request.new_realm);
         let content_server_override = request.content_server_override.to_owned();
         IoTaskPool::get()
             .spawn_compat(async move {
                 ipfs.set_realm(new_realm, content_server_override).await;
             })
             .detach();
+    }
+}
+
+pub fn map_realm_name(request: &str) -> String {
+    if request.ends_with(".dcl.eth") && !request.starts_with("https://") {
+        format!("https://worlds-content-server.decentraland.org/world/{request}")
+    } else {
+        request.to_owned()
     }
 }
 

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -42,7 +42,7 @@ use scene_runner::{
     update_world::mesh_collider::GroundCollider, OutOfWorld, SceneRunnerPlugin,
 };
 
-use ipfs::{CurrentRealm, IpfsIoPlugin};
+use ipfs::{CurrentRealm, IpfsIoPlugin, map_realm_name};
 use system_bridge::SystemBridgePlugin;
 use ui_core::{scrollable::ScrollTargetEvent, UiCorePlugin};
 use wallet::Wallet;
@@ -200,7 +200,7 @@ fn main() {
             })
             .add_before::<bevy::asset::AssetPlugin>(IpfsIoPlugin {
                 preview: false,
-                starting_realm: Some(final_config.server.clone()),
+                starting_realm: Some(map_realm_name(&final_config.server)),
                 content_server_override,
                 assets_root: Default::default(),
                 num_slots: final_config.max_concurrent_remotes,

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -42,7 +42,7 @@ use scene_runner::{
     update_world::mesh_collider::GroundCollider, OutOfWorld, SceneRunnerPlugin,
 };
 
-use ipfs::{CurrentRealm, IpfsIoPlugin, map_realm_name};
+use ipfs::{map_realm_name, CurrentRealm, IpfsIoPlugin};
 use system_bridge::SystemBridgePlugin;
 use ui_core::{scrollable::ScrollTargetEvent, UiCorePlugin};
 use wallet::Wallet;

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -41,7 +41,7 @@ use comms::{
 use console::{ConsolePlugin, DoAddConsoleCommand};
 use futures_lite::io::AsyncReadExt;
 use input_manager::InputManagerPlugin;
-use ipfs::{IpfsAssetServer, IpfsIoPlugin};
+use ipfs::{map_realm_name, IpfsAssetServer, IpfsIoPlugin};
 use nft::{asset_source::NftReaderPlugin, NftShapePlugin};
 use platform::default_camera_components;
 use social::SocialPlugin;
@@ -168,7 +168,7 @@ fn main_inner(
                 })
                 .add_before::<AssetPlugin>(IpfsIoPlugin {
                     preview: is_preview,
-                    starting_realm: Some(final_config.server.clone()),
+                    starting_realm: Some(map_realm_name(&final_config.server)),
                     content_server_override,
                     assets_root: Default::default(),
                     num_slots: final_config.max_concurrent_remotes,
@@ -191,7 +191,7 @@ fn main_inner(
     ));
 
     app.insert_resource(PreviewMode {
-        server: is_preview.then_some(final_config.server.clone()),
+        server: is_preview.then_some(map_realm_name(&final_config.server)),
         is_preview,
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ use comms::{
 };
 use console::{ConsolePlugin, DoAddConsoleCommand};
 use input_manager::InputManagerPlugin;
-use ipfs::{IpfsAssetServer, IpfsIoPlugin};
+use ipfs::{map_realm_name, IpfsAssetServer, IpfsIoPlugin};
 use nft::{asset_source::NftReaderPlugin, NftShapePlugin};
 use social::SocialPlugin;
 use system_bridge::{settings::NewCameraEvent, NativeUi, SystemBridgePlugin};
@@ -362,7 +362,7 @@ fn main() {
                 .build()
                 .add_before::<bevy::asset::AssetPlugin>(IpfsIoPlugin {
                     preview: is_preview,
-                    starting_realm: Some(final_config.server.clone()),
+                    starting_realm: Some(map_realm_name(&final_config.server)),
                     content_server_override,
                     assets_root: Default::default(),
                     num_slots: final_config.max_concurrent_remotes,
@@ -393,7 +393,7 @@ fn main() {
     ));
 
     app.insert_resource(PreviewMode {
-        server: is_preview.then_some(final_config.server.clone()),
+        server: is_preview.then_some(map_realm_name(&final_config.server)),
         is_preview,
     });
 


### PR DESCRIPTION
properly support `name.dcl.eth` as initial realm (currently both work for `/teleport` but only the full url can be used for `--server` or `?initialRealm`).