### PR TITLE
Default wearable fix

### DIFF
--- a/crates/avatar/src/avatar_texture.rs
+++ b/crates/avatar/src/avatar_texture.rs
@@ -235,6 +235,7 @@ fn add_booth_camera(
         ..default()
     };
     avatar_texture.resize(size);
+    avatar_texture.data = None;
     let avatar_texture = images.add(avatar_texture);
 
     let mut camera = None;
@@ -288,11 +289,12 @@ fn update_booth_image(
             images
                 .get_mut(h_image.image.id())
                 .unwrap()
-                .resize(Extent3d {
-                    width: (node_size.x as u32).max(16),
-                    height: (node_size.y as u32).max(16),
-                    ..Default::default()
-                });
+                .texture_descriptor
+                .size = Extent3d {
+                width: (node_size.x as u32).max(16),
+                height: (node_size.y as u32).max(16),
+                ..Default::default()
+            };
         }
     }
 }

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -1052,6 +1052,7 @@ fn process_avatar(
                         base: StandardMaterial {
                             base_color,
                             emissive: new_emissive,
+                            depth_bias: -10000.0, // make base model appear under any wearables at the same position, like skinpaint
                             ..mat.clone()
                         },
                         extension: SceneBound::new_outlined(

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -556,7 +556,6 @@ fn update_render_avatar(
                 match wearable_loader.get_representation(&wearable, body_urn.as_str()) {
                     Ok(data) => Some((data.category, (data.clone(), wearable))),
                     Err(CollectibleError::Loading) => {
-                        commands.entity(entity).try_insert(RetryRenderAvatar);
                         debug!("waiting for wearable {wearable:?}");
                         all_loaded = false;
                         None
@@ -583,6 +582,7 @@ fn update_render_avatar(
                 match wearable_loader.get_representation(default.base(), body_urn.as_str()) {
                     Ok(data) => Some((data.clone(), default.base().to_owned())),
                     _ => {
+                        debug!("waiting for {default:?}");
                         all_loaded = false;
                         None
                     }
@@ -591,11 +591,13 @@ fn update_render_avatar(
             .collect();
 
         if !all_loaded {
+            commands.entity(entity).try_insert(RetryRenderAvatar);
             continue;
         }
 
         for (default, default_urn) in defaults {
             if !wearables.contains_key(&default.category) {
+                debug!("adding default {default:?}");
                 wearables.insert(default.category, (default, default_urn));
             }
         }

--- a/crates/avatar/src/mask_material.rs
+++ b/crates/avatar/src/mask_material.rs
@@ -21,6 +21,10 @@ impl Material for MaskMaterial {
     fn alpha_mode(&self) -> AlphaMode {
         AlphaMode::Blend
     }
+
+    fn depth_bias(&self) -> f32 {
+        10000.0
+    }
 }
 
 mod decl {

--- a/crates/collectibles/src/base_wearables.rs
+++ b/crates/collectibles/src/base_wearables.rs
@@ -312,26 +312,26 @@ pub const BASE_URL: &str = "https://peer.decentraland.org/content";
 
 pub fn default_wearables(body_shape: &WearableUrn) -> impl Iterator<Item = WearableInstance> {
     match body_shape.as_str() {
-        "urn:decentraland:off-chain:base-avatars:base_female" => {
+        "urn:decentraland:off-chain:base-avatars:basefemale" => {
             vec![
                 "urn:decentraland:off-chain:base-avatars:f_eyes_00",
                 "urn:decentraland:off-chain:base-avatars:f_eyebrows_00",
                 "urn:decentraland:off-chain:base-avatars:f_mouth_00",
-                "urn:decentraland:off-chain:base-avatars:standard_hair",
-                "urn:decentraland:off-chain:base-avatars:f_simple_yellow_tshirt",
-                "urn:decentraland:off-chain:base-avatars:f_brown_trousers",
-                "urn:decentraland:off-chain:base-avatars:bun_shoes",
+                // "urn:decentraland:off-chain:base-avatars:standard_hair",
+                // "urn:decentraland:off-chain:base-avatars:f_simple_yellow_tshirt",
+                // "urn:decentraland:off-chain:base-avatars:f_brown_trousers",
+                // "urn:decentraland:off-chain:base-avatars:bun_shoes",
             ]
         }
-        "urn:decentraland:off-chain:base-avatars:base_male" => {
+        "urn:decentraland:off-chain:base-avatars:basemale" => {
             vec![
                 "urn:decentraland:off-chain:base-avatars:eyes_00",
                 "urn:decentraland:off-chain:base-avatars:eyebrows_00",
                 "urn:decentraland:off-chain:base-avatars:mouth_00",
-                "urn:decentraland:off-chain:base-avatars:standard_hair",
-                "urn:decentraland:off-chain:base-avatars:simple_blue_tshirt",
-                "urn:decentraland:off-chain:base-avatars:distressed_black_Jeans",
-                "urn:decentraland:off-chain:base-avatars:citycomfortableshoes",
+                // "urn:decentraland:off-chain:base-avatars:standard_hair",
+                // "urn:decentraland:off-chain:base-avatars:simple_blue_tshirt",
+                // "urn:decentraland:off-chain:base-avatars:distressed_black_Jeans",
+                // "urn:decentraland:off-chain:base-avatars:citycomfortableshoes",
             ]
         }
         _ => Vec::default(),

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -236,7 +236,11 @@ pub fn op_continue_running(state: &WorkerContext) -> bool {
 
 #[wasm_bindgen]
 pub fn op_communicated_with_renderer(state: &WorkerContext) -> bool {
-    state.state.borrow_mut().try_take::<CommunicatedWithRenderer>().is_some()
+    state
+        .state
+        .borrow_mut()
+        .try_take::<CommunicatedWithRenderer>()
+        .is_some()
 }
 
 #[wasm_bindgen]

--- a/crates/scene_runner/src/update_world/scene_ui/mod.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/mod.rs
@@ -690,11 +690,11 @@ fn create_ui_roots(
                     ));
                     debug!("create texture root {:?} -> {:?}", ent, root);
 
-                    images.get_mut(&ui_texture).unwrap().resize(Extent3d {
+                    images.get_mut(&ui_texture).unwrap().texture_descriptor.size = Extent3d {
                         width: canvas_info.width,
                         height: canvas_info.height,
                         depth_or_array_layers: 1,
-                    });
+                    };
 
                     commands.entity(ent).try_insert(UiTextureOutput {
                         camera: root,
@@ -720,11 +720,12 @@ fn create_ui_roots(
                     images
                         .get_mut(texture.image.id())
                         .unwrap()
-                        .resize(Extent3d {
-                            width: canvas_info.width,
-                            height: canvas_info.height,
-                            depth_or_array_layers: 1,
-                        });
+                        .texture_descriptor
+                        .size = Extent3d {
+                        width: canvas_info.width,
+                        height: canvas_info.height,
+                        depth_or_array_layers: 1,
+                    };
                     texture.texture_size = UVec2::new(canvas_info.width, canvas_info.height);
                 }
             }

--- a/crates/texture_camera/src/lib.rs
+++ b/crates/texture_camera/src/lib.rs
@@ -2,6 +2,7 @@ use std::f32::consts::FRAC_PI_4;
 
 use bevy::{
     app::{HierarchyPropagatePlugin, Propagate, PropagateStop},
+    diagnostic::FrameCount,
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::{
@@ -217,6 +218,7 @@ fn update_texture_cameras(
     layers: Res<SceneLayerProperties>,
     mut layer_cache: ResMut<TextureLayersCache>,
     scene_distance: Res<SceneLoadDistance>,
+    tick: Res<FrameCount>,
 ) {
     let active_scenes = player
         .single()
@@ -254,7 +256,7 @@ fn update_texture_cameras(
                 Some(existing) => {
                     let prev = images.get_mut(existing.0.id()).unwrap();
                     if prev.texture_descriptor.size != image_size {
-                        prev.resize(image_size);
+                        prev.texture_descriptor.size = image_size;
                     }
                     existing.0.clone()
                 }
@@ -266,7 +268,7 @@ fn update_texture_cameras(
                         TextureFormat::bevy_default(),
                         RenderAssetUsages::all(), // RENDER_WORLD alone doesn't work..?
                     );
-
+                    image.data = None;
                     image.texture_descriptor.usage |= TextureUsages::RENDER_ATTACHMENT;
                     images.add(image)
                 }
@@ -280,7 +282,7 @@ fn update_texture_cameras(
             };
             debug!("create with layers {render_layers:?}");
 
-            let far = texture_cam.0.far_plane.unwrap_or(100_000.0);
+            let far = texture_cam.0.far_plane.unwrap_or(240.0);
             let projection: Projection = match &texture_cam.0.mode {
                 None => {
                     PerspectiveProjection {

--- a/crates/texture_camera/src/lib.rs
+++ b/crates/texture_camera/src/lib.rs
@@ -2,7 +2,6 @@ use std::f32::consts::FRAC_PI_4;
 
 use bevy::{
     app::{HierarchyPropagatePlugin, Propagate, PropagateStop},
-    diagnostic::FrameCount,
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::{
@@ -218,7 +217,6 @@ fn update_texture_cameras(
     layers: Res<SceneLayerProperties>,
     mut layer_cache: ResMut<TextureLayersCache>,
     scene_distance: Res<SceneLoadDistance>,
-    tick: Res<FrameCount>,
 ) {
     let active_scenes = player
         .single()

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -73,6 +73,7 @@ pub fn spawn_world_ui_view(
             TextureFormat::Bgra8UnormSrgb,
             RenderAssetUsages::all(),
         );
+        image.data = None;
         image.texture_descriptor.usage |= TextureUsages::RENDER_ATTACHMENT;
         images.add(image)
     });
@@ -241,11 +242,11 @@ pub fn update_worldui_materials(
                 }
                 let req_size = req_size.min(max_size).max(image.size());
                 debug!("resized to {}", req_size);
-                images.get_mut(id).unwrap().resize(Extent3d {
+                images.get_mut(id).unwrap().texture_descriptor.size = Extent3d {
                     width: req_size.x,
                     height: req_size.y,
                     depth_or_array_layers: 1,
-                });
+                };
             }
 
             Some(id)


### PR DESCRIPTION
- apply default wearables for eyes, mouth, eyebrows (fixes #317)
- add bias to avatar skin and mask elements to avoid flickering
- modify default orthographic texturecamera far plane to avoid mismatch in depth bias interpretation
- avoid uploading gpu-target images on create or resize (minor perf benefit)