### PR TITLE
Retain renderassets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1031,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1144,7 +1144,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1265,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1316,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1351,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1411,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1528,7 +1528,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "glam",
 ]
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1610,12 +1610,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4784cb867b94636fa741b0e3ee0e83049a9acc73"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/collectibles/src/wearables.rs
+++ b/crates/collectibles/src/wearables.rs
@@ -372,6 +372,7 @@ impl AssetLoader for WearableLoader {
                     .with_settings::<GltfLoaderSettings>(|s| {
                         s.load_cameras = false;
                         s.load_lights = false;
+                        s.load_meshes = RenderAssetUsages::MAIN_WORLD;
                         s.load_materials = RenderAssetUsages::RENDER_WORLD;
                     })
                     .load(path);

--- a/crates/common/src/util.rs
+++ b/crates/common/src/util.rs
@@ -7,7 +7,9 @@ use bevy::{
     ecs::{
         component::{Component, Mutable},
         schedule::IntoScheduleConfigs,
-        system::{Commands, EntityCommand, EntityCommands, Query, ScheduleSystem, SystemParam},
+        system::{
+            Commands, EntityCommand, EntityCommands, Query, ResMut, ScheduleSystem, SystemParam,
+        },
         world::EntityWorldMut,
     },
     math::Vec3,
@@ -531,7 +533,7 @@ impl TaskCompat for IoTaskPool {
 #[allow(clippy::type_complexity)]
 #[derive(SystemParam)]
 pub struct SceneSpawnerPlus<'w, 's> {
-    scene_spawner: Res<'w, SceneSpawner>,
+    scene_spawner: ResMut<'w, SceneSpawner>,
     asset_server: Res<'w, AssetServer>,
     query: Query<
         'w,
@@ -548,6 +550,12 @@ impl std::ops::Deref for SceneSpawnerPlus<'_, '_> {
 
     fn deref(&self) -> &Self::Target {
         &self.scene_spawner
+    }
+}
+
+impl std::ops::DerefMut for SceneSpawnerPlus<'_, '_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.scene_spawner
     }
 }
 

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -197,7 +197,7 @@ pub async fn op_settings(
 ) -> Result<Vec<SettingInfo>, anyhow::Error> {
     debug!("op_settings");
     load_settings(state.clone()).await?;
-    Ok(state.borrow().borrow::<Settings>().get())
+    Ok(state.borrow().borrow::<Settings>().get().await)
 }
 
 pub async fn op_set_setting(
@@ -211,6 +211,7 @@ pub async fn op_set_setting(
         .borrow_mut()
         .borrow_mut::<Settings>()
         .set_value(&name, val)
+        .await
 }
 
 pub async fn op_kernel_fetch_headers(

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -197,7 +197,8 @@ pub async fn op_settings(
 ) -> Result<Vec<SettingInfo>, anyhow::Error> {
     debug!("op_settings");
     load_settings(state.clone()).await?;
-    Ok(state.borrow().borrow::<Settings>().get().await)
+    let settings = state.borrow().borrow::<Settings>().clone();
+    Ok(settings.get().await)
 }
 
 pub async fn op_set_setting(
@@ -207,11 +208,8 @@ pub async fn op_set_setting(
 ) -> Result<(), anyhow::Error> {
     debug!("op_set_setting");
     load_settings(state.clone()).await?;
-    state
-        .borrow_mut()
-        .borrow_mut::<Settings>()
-        .set_value(&name, val)
-        .await
+    let settings = state.borrow().borrow::<Settings>().clone();
+    settings.set_value(&name, val).await
 }
 
 pub async fn op_kernel_fetch_headers(

--- a/crates/scene_runner/src/gltf_resolver.rs
+++ b/crates/scene_runner/src/gltf_resolver.rs
@@ -35,6 +35,7 @@ impl GltfResolver<'_, '_> {
                     |s| {
                         s.load_cameras = false;
                         s.load_lights = false;
+                        s.load_meshes = RenderAssetUsages::all();
                         s.load_materials = RenderAssetUsages::RENDER_WORLD;
                         s.include_source = true;
                     },

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -84,7 +84,6 @@ fn main_inner(
         location: IVec2Arg::from_str(location)
             .map(|l| l.0)
             .unwrap_or(base_config.location),
-        max_concurrent_remotes: 8000,
         graphics: common::structs::GraphicsSettings {
             gpu_bytes_per_frame: rabpf,
             ..base_graphics


### PR DESCRIPTION
- avoid flickering avatar wearables when using gpu transfer throttle, and an existing wearable is used by a newly joining player, by retaining render-world only assets in the cpu-side assets collection 
- remove max downloads override on web
- use async locks for settings to avoid (one source of) invalid waits on web