### PR TITLE
get/clear focus

### DIFF
--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -271,6 +271,7 @@ impl From<&UserProfile> for AvatarShape {
                 .force_render
                 .clone()
                 .unwrap_or_default(),
+            show_only_wearables: None,
         })
     }
 }

--- a/crates/common/src/rpc.rs
+++ b/crates/common/src/rpc.rs
@@ -220,14 +220,21 @@ pub enum RpcCall {
         urn: String,
         r#loop: bool,
     },
-    SetUiFocus {
+    UiFocus {
         scene: Entity,
-        element_id: Option<String>,
-        response: RpcResultSender<Result<(), String>>,
+        action: RpcUiFocusAction,
+        response: RpcResultSender<Result<Option<String>, String>>,
     },
     CopyToClipboard {
         scene: Entity,
         text: String,
         response: RpcResultSender<Result<(), String>>,
     },
+}
+
+#[derive(Clone, Debug)]
+pub enum RpcUiFocusAction {
+    Focus { element_id: String },
+    Defocus,
+    GetFocus,
 }

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -46,9 +46,14 @@ module.exports.setCommunicationsAdapter = async function (body) {
     return {} 
 }
 module.exports.setUiFocus = async function(body) {
-    return await Deno.core.ops.op_set_ui_focus(body.elementId);
+    return await Deno.core.ops.op_ui_focus(true, body.elementId);
 }
-
+module.exports.clearUiFocus = async function(body) {
+    return await Deno.core.ops.op_ui_focus(true);
+}
+module.exports.getUiFocus = async function() {
+    return await Deno.core.ops.op_ui_focus(false);
+}
 module.exports.copyToClipboard = async function(body) {
     return await Deno.core.ops.op_copy_to_clipboard(body.text);
 }

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -5,6 +5,7 @@ use bevy::{
     transform::components::Transform,
 };
 use common::rpc::{RpcCall, RpcUiFocusAction};
+use serde::Serialize;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
@@ -188,11 +189,16 @@ pub async fn op_open_nft_dialog(
     rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))
 }
 
+#[derive(Serialize)]
+pub struct UiFocusResult {
+    element_id: Option<String>,
+}
+
 pub async fn op_ui_focus(
     op_state: Rc<RefCell<impl State>>,
     apply: bool,
     element_id: Option<String>,
-) -> Result<Option<String>, anyhow::Error> {
+) -> Result<UiFocusResult, anyhow::Error> {
     debug!("op_ui_focus");
     let (sx, rx) = tokio::sync::oneshot::channel::<Result<Option<String>, String>>();
 
@@ -215,7 +221,10 @@ pub async fn op_ui_focus(
         });
     }
 
-    rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))
+    rx.await
+        .map_err(|e| anyhow!(e))?
+        .map(|element_id| UiFocusResult { element_id })
+        .map_err(|e| anyhow!(e))
 }
 
 pub async fn op_copy_to_clipboard(

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -128,7 +128,7 @@ impl SceneComponentId {
     pub const TEXTURE_CAMERA: SceneComponentId = SceneComponentId(1207);
     pub const CAMERA_LAYERS: SceneComponentId = SceneComponentId(1208);
     pub const PRIMARY_POINTER_INFO: SceneComponentId = SceneComponentId(1209);
-    pub const CAMERA_LAYER: SceneComponentId = SceneComponentId(1210);
+    pub const CAMERA_LAYER: SceneComponentId = SceneComponentId(1211);
 
     pub const REALM_INFO: SceneComponentId = SceneComponentId(1106);
 }

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_shape.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_shape.proto
@@ -38,7 +38,7 @@ message PBAvatarShape {
   //     Shoes   : "urn:decentraland:off-chain:base-avatars:bun_shoes"]
   repeated string wearables = 10; 
   repeated string emotes = 11; // available emotes (default empty)
-  repeated string show_only_wearables = 12; // hides the skin + hair + facial features
+  optional bool show_only_wearables = 12; // hides the skin + hair + facial features
   repeated string force_render = 13; // slots that will render even if hidden
 }
 

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_shape.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_shape.proto
@@ -38,6 +38,7 @@ message PBAvatarShape {
   //     Shoes   : "urn:decentraland:off-chain:base-avatars:bun_shoes"]
   repeated string wearables = 10; 
   repeated string emotes = 11; // available emotes (default empty)
-  repeated string force_render = 12; // slots that will render even if hidden
+  repeated string show_only_wearables = 12; // hides the skin + hair + facial features
+  repeated string force_render = 13; // slots that will render even if hidden
 }
 

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/camera_layer.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/camera_layer.proto
@@ -5,7 +5,7 @@ package decentraland.sdk.components;
 import "decentraland/sdk/components/common/id.proto";
 import "decentraland/common/colors.proto";
 
-option (common.ecs_component_id) = 1210;
+option (common.ecs_component_id) = 1211;
 
 message PBCameraLayer {
     // layer to which these settings apply. must be > 0

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/mesh_collider.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/mesh_collider.proto
@@ -52,7 +52,7 @@ enum ColliderLayer {
   CL_NONE = 0;           // no collisions
   CL_POINTER = 1;        // collisions with the player's pointer ray (e.g. mouse cursor hovering)
   CL_PHYSICS = 2;        // collision affecting your player's physics i.e. walls, floor, moving platfroms
-  CL_RESERVED1 = 4;
+  CL_PLAYER = 4;
   CL_RESERVED2 = 8;
   CL_RESERVED3 = 16;
   CL_RESERVED4 = 32;

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -1,3 +1,4 @@
+use dcl::js::restricted_actions::UiFocusResult;
 use deno_core::{anyhow, error::AnyError, op2, OpDecl, OpState};
 use std::{cell::RefCell, rc::Rc};
 
@@ -90,12 +91,12 @@ async fn op_open_nft_dialog(
 }
 
 #[op2(async)]
-#[string]
+#[serde]
 async fn op_ui_focus(
     op_state: Rc<RefCell<OpState>>,
     apply: bool,
     #[string] element_id: Option<String>,
-) -> Result<Option<String>, AnyError> {
+) -> Result<UiFocusResult, AnyError> {
     dcl::js::restricted_actions::op_ui_focus(op_state, apply, element_id).await
 }
 

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -11,7 +11,7 @@ pub fn ops() -> Vec<OpDecl> {
         op_emote(),
         op_scene_emote(),
         op_open_nft_dialog(),
-        op_set_ui_focus(),
+        op_ui_focus(),
         op_copy_to_clipboard(),
     ]
 }
@@ -90,11 +90,13 @@ async fn op_open_nft_dialog(
 }
 
 #[op2(async)]
-async fn op_set_ui_focus(
+#[string]
+async fn op_ui_focus(
     op_state: Rc<RefCell<OpState>>,
-    #[string] element_id: String,
-) -> Result<(), AnyError> {
-    dcl::js::restricted_actions::op_set_ui_focus(op_state, element_id).await
+    apply: bool,
+    #[string] element_id: Option<String>,
+) -> Result<Option<String>, AnyError> {
+    dcl::js::restricted_actions::op_ui_focus(op_state, apply, element_id).await
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -1,4 +1,4 @@
-use crate::{WasmError, WorkerContext};
+use crate::{serde_result, WasmError, WorkerContext};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -76,13 +76,12 @@ pub async fn op_open_nft_dialog(op_state: &WorkerContext, urn: String) -> Result
 }
 
 #[wasm_bindgen]
-pub async fn op_set_ui_focus(
+pub async fn op_ui_focus(
     op_state: &WorkerContext,
-    element_id: String,
-) -> Result<(), WasmError> {
-    dcl::js::restricted_actions::op_set_ui_focus(op_state.rc(), element_id)
-        .await
-        .map_err(WasmError::from)
+    apply: bool,
+    element_id: Option<String>,
+) -> Result<JsValue, WasmError> {
+    serde_result!(dcl::js::restricted_actions::op_ui_focus(op_state.rc(), apply, element_id).await)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
closes #219 (via rpc calls instead of component)

- add ClearUiFocus and GetUiFocus
- make all ui rpc calls return UiFocusResult containing element_id

requires https://github.com/decentraland/protocol/pull/321 and associated sdk pr once i get that building on macos.