### PR TITLE
fix texture address mode on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1146,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1468,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1554,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "glam",
 ]
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1612,12 +1612,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ea37d4c6a52097b4ed9482db9c360d8296f88f66"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
 dependencies = [
  "accesskit",
  "accesskit_winit",


### PR DESCRIPTION
closes #361

large images are auto resized on web down to 1024x1024. as part of that process, the sampler was being lost and replaced with a default sampler.
fix it so the sampler (and other settings) are retained on resize