### PR TITLE
apply billboard after avatarattach

### DIFF
--- a/crates/scene_runner/src/update_world/billboard.rs
+++ b/crates/scene_runner/src/update_world/billboard.rs
@@ -6,7 +6,7 @@
 use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
 
-use common::{sets::SceneSets, structs::PrimaryCamera};
+use common::structs::PrimaryCamera;
 use dcl::interface::ComponentPosition;
 use dcl_component::{proto_components::sdk::components::PbBillboard, SceneComponentId};
 
@@ -21,7 +21,10 @@ impl Plugin for BillboardPlugin {
             ComponentPosition::EntityOnly,
         );
 
-        app.add_systems(Update, update_billboards.in_set(SceneSets::PostLoop));
+        app.add_systems(
+            PostUpdate,
+            update_billboards.before(TransformSystem::TransformPropagate),
+        );
     }
 }
 

--- a/crates/scene_runner/src/update_world/transform_and_parent.rs
+++ b/crates/scene_runner/src/update_world/transform_and_parent.rs
@@ -14,7 +14,8 @@ use dcl::{crdt::lww::CrdtLWWState, interface::ComponentPosition};
 
 use crate::{
     initialize_scene::process_scene_lifecycle, primary_entities::PrimaryEntities,
-    DeletedSceneEntities, RendererSceneContext, SceneEntity, SceneLoopSchedule, TargetParent,
+    update_world::billboard::update_billboards, DeletedSceneEntities, RendererSceneContext,
+    SceneEntity, SceneLoopSchedule, TargetParent,
 };
 use common::sets::SceneLoopSets;
 use dcl_component::{
@@ -43,13 +44,15 @@ impl Plugin for TransformAndParentPlugin {
                     .after(anim_last_system!())
                     .after(GltfLinkSet)
                     .before(TransformSystem::TransformPropagate)
-                    .before(process_scene_lifecycle),
+                    .before(process_scene_lifecycle)
+                    .before(update_billboards),
                 parent_position_sync::<SceneProxyStage>
                     .after(anim_last_system!())
                     .after(GltfLinkSet)
                     .after(parent_position_sync::<AvatarAttachStage>)
                     .before(TransformSystem::TransformPropagate)
-                    .before(process_scene_lifecycle),
+                    .before(process_scene_lifecycle)
+                    .before(update_billboards),
             ),
         );
     }


### PR DESCRIPTION
entities with both AvatarAttach and Billboard were unaffected by billboard, as the transform was fully replaced by AvatarAttach position syncing.

change the order so that billboards are applied after AvatarAttach updates