### PR TITLE
prevent zero image resizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "webgpu_build"
 # - copy ./assets to deploy/web/assets
 # - copy ./crates/dcl/src/js/modules to deploy/web/modules
 # - rustup default nightly # (tested with 2025-06-03)
-# - wasm-pack build --target web --out-dir ./deploy/web/pkg --no-default-features --features="wasm" && npx serve deploy/web
+# - wasm-pack build --target web --out-dir ./deploy/web/pkg --no-default-features --features="wasm, livekit" && npx serve deploy/web
 
 [features]
 default = ["livekit", "ffmpeg", "inspect", "social"]

--- a/crates/avatar/src/avatar_texture.rs
+++ b/crates/avatar/src/avatar_texture.rs
@@ -222,7 +222,11 @@ fn add_booth_camera(
     let mut avatar_texture = Image {
         texture_descriptor: TextureDescriptor {
             label: None,
-            size,
+            size: Extent3d {
+                width: size.width.max(16),
+                height: size.height.max(16),
+                ..size
+            },
             dimension: TextureDimension::D2,
             format: TextureFormat::Bgra8UnormSrgb,
             mip_level_count: 1,
@@ -234,7 +238,11 @@ fn add_booth_camera(
         },
         ..default()
     };
-    avatar_texture.resize(size);
+    avatar_texture.resize(Extent3d {
+        width: size.width.max(16),
+        height: size.height.max(16),
+        ..size
+    });
     avatar_texture.data = None;
     let avatar_texture = images.add(avatar_texture);
 

--- a/crates/scene_runner/src/update_world/scene_ui/mod.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/mod.rs
@@ -691,8 +691,8 @@ fn create_ui_roots(
                     debug!("create texture root {:?} -> {:?}", ent, root);
 
                     images.get_mut(&ui_texture).unwrap().texture_descriptor.size = Extent3d {
-                        width: canvas_info.width,
-                        height: canvas_info.height,
+                        width: canvas_info.width.max(16),
+                        height: canvas_info.height.max(16),
                         depth_or_array_layers: 1,
                     };
 
@@ -722,8 +722,8 @@ fn create_ui_roots(
                         .unwrap()
                         .texture_descriptor
                         .size = Extent3d {
-                        width: canvas_info.width,
-                        height: canvas_info.height,
+                        width: canvas_info.width.max(16),
+                        height: canvas_info.height.max(16),
                         depth_or_array_layers: 1,
                     };
                     texture.texture_size = UVec2::new(canvas_info.width, canvas_info.height);


### PR DESCRIPTION
hopefully fix #369

prevent resizing textures to zero for
- avatar attach / profile snapshot
- scene ui canvas info