### PR TITLE
support Auth server and local gatekeeper

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -628,6 +628,7 @@ pub struct SceneMeta {
     pub scene: SceneMetaScene,
     pub runtime_version: Option<String>,
     pub spawn_points: Option<Vec<SpawnPoint>>,
+    pub authoritative_multiplayer: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -124,7 +124,10 @@ impl NetworkMessage {
         }
     }
 
-    pub fn targetted_reliable<D: ToDclWriter>(message: &D, recipient: NetworkMessageRecipient) -> Self {
+    pub fn targetted_reliable<D: ToDclWriter>(
+        message: &D,
+        recipient: NetworkMessageRecipient,
+    ) -> Self {
         Self {
             unreliable: false,
             recipient,

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -92,10 +92,17 @@ pub enum TransportType {
     SceneRoom,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum NetworkMessageRecipient {
+    All,
+    Peer(H160),
+    AuthServer,
+}
+
 pub struct NetworkMessage {
     pub data: Vec<u8>,
     pub unreliable: bool,
-    pub recipient: Option<H160>,
+    pub recipient: NetworkMessageRecipient,
 }
 
 impl NetworkMessage {
@@ -106,7 +113,7 @@ impl NetworkMessage {
         Self {
             data,
             unreliable: true,
-            recipient: None,
+            recipient: NetworkMessageRecipient::All,
         }
     }
 
@@ -117,7 +124,7 @@ impl NetworkMessage {
         }
     }
 
-    pub fn targetted_reliable<D: ToDclWriter>(message: &D, recipient: Option<H160>) -> Self {
+    pub fn targetted_reliable<D: ToDclWriter>(message: &D, recipient: NetworkMessageRecipient) -> Self {
         Self {
             unreliable: false,
             recipient,

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -51,6 +51,8 @@ use self::{
 use self::livekit_room::{LivekitPlugin, StartLivekit};
 
 const GATEKEEPER_URL: &str = "https://comms-gatekeeper.decentraland.org/get-scene-adapter";
+const PREVIEW_GATEKEEPER_URL: &str =
+    "https://comms-gatekeeper-local.decentraland.org/get-scene-adapter";
 
 pub mod chat_marker_things {
     pub const EMOTE: char = '␐';
@@ -208,7 +210,12 @@ fn connect_scene_room(
             *gatekeeper_task = None;
         } else {
             let wallet = wallet.clone();
-            let uri = Uri::try_from(GATEKEEPER_URL).unwrap();
+            let url = if ev.scene_id.starts_with("b64-") {
+                PREVIEW_GATEKEEPER_URL
+            } else {
+                GATEKEEPER_URL
+            };
+            let uri = Uri::try_from(url).unwrap();
             let client = ipfs.ipfs().client();
             *gatekeeper_task = Some(IoTaskPool::get().spawn_compat(async move {
                 let headers = sign_request("POST", &uri, &wallet, &ev).await?;

--- a/crates/comms/src/livekit_native.rs
+++ b/crates/comms/src/livekit_native.rs
@@ -21,11 +21,9 @@ use common::{
 use dcl_component::proto_components::kernel::comms::rfc4;
 
 use crate::{
-    global_crdt::{
+    ChannelControl, NetworkMessage, NetworkMessageRecipient, global_crdt::{
         GlobalCrdtState, LocalAudioFrame, LocalAudioSource, PlayerMessage, PlayerUpdate,
-    },
-    livekit_room::{LivekitConnection, LivekitTransport},
-    ChannelControl, NetworkMessage,
+    }, livekit_room::{LivekitConnection, LivekitTransport}
 };
 
 use livekit::{
@@ -455,10 +453,10 @@ fn livekit_handler_inner(
                         break 'stream;
                     };
 
-                    let destination_identities = if let Some(address) = outgoing.recipient {
-                        vec![ParticipantIdentity(format!("{address:#x}"))]
-                    } else {
-                        default()
+                    let destination_identities = match outgoing.recipient {
+                        NetworkMessageRecipient::All => Vec::default(),
+                        NetworkMessageRecipient::Peer(address) => vec![ParticipantIdentity(format!("{address:#x}"))],
+                        NetworkMessageRecipient::AuthServer => vec![ParticipantIdentity("authoritative-server".to_string())],
                     };
 
                     let packet = livekit::DataPacket { payload: outgoing.data, topic: None, reliable: !outgoing.unreliable, destination_identities };

--- a/crates/comms/src/livekit_native.rs
+++ b/crates/comms/src/livekit_native.rs
@@ -21,9 +21,11 @@ use common::{
 use dcl_component::proto_components::kernel::comms::rfc4;
 
 use crate::{
-    ChannelControl, NetworkMessage, NetworkMessageRecipient, global_crdt::{
+    global_crdt::{
         GlobalCrdtState, LocalAudioFrame, LocalAudioSource, PlayerMessage, PlayerUpdate,
-    }, livekit_room::{LivekitConnection, LivekitTransport}
+    },
+    livekit_room::{LivekitConnection, LivekitTransport},
+    ChannelControl, NetworkMessage, NetworkMessageRecipient,
 };
 
 use livekit::{

--- a/crates/comms/src/livekit_web.rs
+++ b/crates/comms/src/livekit_web.rs
@@ -277,6 +277,12 @@ async fn connect_and_handle_session(
                     break 'stream;
                 };
 
+                let destination_identities = match outgoing.recipient {
+                    NetworkMessageRecipient::All => js_sys::Array::new(),
+                    NetworkMessageRecipient::Peer(address) => js_sys::Array::of1(&JsValue::from_str(&format!("{:#x}", address))),
+                    NetworkMessageRecipient::AuthServer => js_sys::Array::of1(&JsValue::from_str("authoritative-server")),
+                };
+
                 let destinations = if let Some(address) = outgoing.recipient {
                     js_sys::Array::of1(&JsValue::from_str(&format!("{:#x}", address)))
                 } else {

--- a/crates/comms/src/livekit_web.rs
+++ b/crates/comms/src/livekit_web.rs
@@ -12,7 +12,7 @@ use wasm_bindgen_futures::spawn_local;
 use crate::{
     global_crdt::{ChannelControl, GlobalCrdtState, PlayerMessage, PlayerUpdate},
     livekit_room::{LivekitConnection, LivekitTransport},
-    NetworkMessage,
+    NetworkMessage, NetworkMessageRecipient,
 };
 use common::{structs::MicState, util::AsH160};
 use dcl_component::proto_components::kernel::comms::rfc4;

--- a/crates/comms/src/livekit_web.rs
+++ b/crates/comms/src/livekit_web.rs
@@ -283,17 +283,11 @@ async fn connect_and_handle_session(
                     NetworkMessageRecipient::AuthServer => js_sys::Array::of1(&JsValue::from_str("authoritative-server")),
                 };
 
-                let destinations = if let Some(address) = outgoing.recipient {
-                    js_sys::Array::of1(&JsValue::from_str(&format!("{:#x}", address)))
-                } else {
-                    js_sys::Array::new()
-                };
-
                 if let Err(e) = publish_data(
                     &room,
                     &outgoing.data,
                     !outgoing.unreliable,
-                    destinations.into(),
+                    destination_identities.into(),
                 )
                 .await
                 {

--- a/crates/dcl/src/js/modules/CommunicationsController.js
+++ b/crates/dcl/src/js/modules/CommunicationsController.js
@@ -22,7 +22,7 @@ module.exports.sendBinary = async function (body) {
                     await Deno.core.ops.op_comms_send_binary_single(new Uint8Array(buffer), null);
                 }
             }
-        }    
+        }
     }
 
     const data = (await Deno.core.ops.op_comms_recv_binary()).map((item) => new Uint8Array(item));

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -39,9 +39,7 @@ use ipfs::{
 use nft::asset_source::Nft;
 use reqwest::StatusCode;
 use scene_runner::{
-    initialize_scene::{
-        LiveScenes, PortableScenes, PortableSource, SceneLoading, PARCEL_SIZE,
-    },
+    initialize_scene::{LiveScenes, PortableScenes, PortableSource, SceneLoading, PARCEL_SIZE},
     permissions::Permission,
     renderer_context::RendererSceneContext,
     update_world::gltf_container::{GltfDefinition, GltfProcessed},

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -379,6 +379,7 @@ pub(crate) fn load_scene_javascript(
             config.scene_log_to_console,
             if is_sdk7 { "sdk7" } else { "sdk6" },
             false,
+            meta.authoritative_multiplayer.unwrap_or_default(),
         );
 
         scene_updates.scene_ids.insert(scene_id, root);

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -90,6 +90,9 @@ pub struct RendererSceneContext {
 
     // if an inspector is attached
     pub inspected: bool,
+
+    // does the scene use an authoritative multiplayer server
+    pub authoritative_multiplayer: bool,
 }
 
 pub const SCENE_LOG_BUFFER_SIZE: usize = 100;
@@ -111,6 +114,7 @@ impl RendererSceneContext {
         log_to_stdout: bool,
         sdk_version: &'static str,
         inspected: bool,
+        authoritative_multiplayer: bool,
     ) -> Self {
         let mut new_context = Self {
             scene_id,
@@ -142,6 +146,7 @@ impl RendererSceneContext {
             last_action_event: None,
             sdk_version,
             inspected,
+            authoritative_multiplayer,
         };
 
         new_context.live_entities[SceneEntityId::ROOT.id as usize] =


### PR DESCRIPTION
closes #404 

- use `comms-gatekeeper-local` for local scenes
- when scene meta declares `authoritativeServer: true` route all binary messages to auth server