### PR TITLE
Better depenetration fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,7 +776,7 @@ dependencies = [
  "input_manager",
  "ipfs",
  "platform",
- "rapier3d-f64",
+ "rapier3d",
  "scene_material",
  "scene_runner",
  "serde_json",
@@ -8216,7 +8216,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "parry3d-f64"
+name = "parry3d"
 version = "0.20.1"
 source = "git+https://github.com/robtfm/parry?branch=bugfix-project-local-point#2454ba05183ae9a48e3d6bf086d498b2df2285c1"
 dependencies = [
@@ -9046,10 +9046,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
-name = "rapier3d-f64"
+name = "rapier3d"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a04eab286a82bd2e89e686e4fcfb83ece27ebd72dfcf575404b03d081e7cd51"
+checksum = "a35ec3d01c4f918675411442024a1fbfb7eafdd878a6e82479ff6e461a9092fc"
 dependencies = [
  "approx",
  "arrayvec",
@@ -9062,7 +9062,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "ordered-float 5.0.0",
- "parry3d-f64",
+ "parry3d",
  "profiling",
  "rustc-hash 2.1.1",
  "simba",
@@ -10038,7 +10038,7 @@ dependencies = [
  "petgraph 0.6.5",
  "platform",
  "rand 0.8.5",
- "rapier3d-f64",
+ "rapier3d",
  "scene_material",
  "serde",
  "serde_json",
@@ -12096,7 +12096,7 @@ dependencies = [
  "console",
  "dcl_component",
  "input_manager",
- "rapier3d-f64",
+ "rapier3d",
  "scene_runner",
  "tween",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ bimap = "0.6.3"
 prost = "0.11.8"
 clap = "4.1.10"
 once_cell = "1.16.0"
-rapier3d-f64 = "0.25"
+rapier3d = "0.25"
 urlencoding = "2.1.2"
 async-std = "1.12.0"
 reqwest = { version = "0.12", default-features = false, features = ["native-tls", "json", "blocking"] }
@@ -272,7 +272,7 @@ bevy_platform = { git = "https://github.com/robtfm/bevy", branch = "release-0.16
 # bevy_platform = { path="../bevy/crates/bevy_platform" }
 
 ffmpeg-next = { git = "https://github.com/robtfm/rust-ffmpeg", branch = "audio-linesize-0-6.1" }
-parry3d-f64 = { git = "https://github.com/robtfm/parry", branch = "bugfix-project-local-point" }
+parry3d = { git = "https://github.com/robtfm/parry", branch = "bugfix-project-local-point" }
 # rapier3d-f64 = { git = "https://github.com/robtfm/rapier", branch = "master" }
 deno_core = { git = "https://github.com/robtfm/deno_core", branch = "0_307_hotfix" }
 serde_v8 = { git = "https://github.com/robtfm/deno_core", branch = "0_307_hotfix" }

--- a/crates/avatar/Cargo.toml
+++ b/crates/avatar/Cargo.toml
@@ -29,5 +29,5 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 bevy_console = { workspace = true }
 tokio = { workspace = true }
-rapier3d-f64 = { workspace = true }
+rapier3d = { workspace = true }
 bevy_dui = { workspace = true }

--- a/crates/avatar/src/colliders.rs
+++ b/crates/avatar/src/colliders.rs
@@ -13,7 +13,7 @@ use common::{
 };
 use comms::{global_crdt::ForeignPlayer, profile::UserProfile};
 use input_manager::{InputManager, InputPriority, InputType};
-use rapier3d_f64::{
+use rapier3d::{
     na::Isometry,
     prelude::{ColliderBuilder, SharedShape},
 };
@@ -75,17 +75,17 @@ fn update_avatar_colliders(
         } else {
             // collider didn't exist, make a new one
             let collider = ColliderBuilder::new(SharedShape::capsule_y(
-                (PLAYER_COLLIDER_HEIGHT * 0.5 - PLAYER_COLLIDER_RADIUS) as f64,
-                (PLAYER_COLLIDER_RADIUS - PLAYER_COLLIDER_OVERLAP) as f64,
+                PLAYER_COLLIDER_HEIGHT * 0.5 - PLAYER_COLLIDER_RADIUS,
+                PLAYER_COLLIDER_RADIUS - PLAYER_COLLIDER_OVERLAP,
             ))
             .position(Isometry::from_parts(
-                (transform.translation() + PLAYER_COLLIDER_HEIGHT * 0.5 * Vec3::Y)
-                    .as_dvec3()
-                    .into(),
+                (transform.translation() + PLAYER_COLLIDER_HEIGHT * 0.5 * Vec3::Y).into(),
                 Default::default(),
             ))
             .build();
-            colliders.collider_data.set_collider(&id, collider, ent);
+            colliders
+                .collider_data
+                .set_collider(&id, collider, Some(ent));
             colliders.lookup.insert(id, ent);
         }
     }

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1043,6 +1043,3 @@ pub struct PreviewMode {
     pub server: Option<String>,
     pub is_preview: bool,
 }
-
-#[derive(Resource)]
-pub struct UserClipping(pub bool);

--- a/crates/scene_runner/Cargo.toml
+++ b/crates/scene_runner/Cargo.toml
@@ -37,7 +37,7 @@ bimap = { workspace = true }
 nalgebra = { version = "0.33.2", features = [ "convert-glam029" ] }
 futures-lite = { workspace = true }
 once_cell = { workspace = true }
-rapier3d-f64 = { workspace = true }
+rapier3d = { workspace = true }
 urlencoding = { workspace = true }
 itertools = { workspace = true }
 analytics = { workspace = true }

--- a/crates/scene_runner/src/test/mod.rs
+++ b/crates/scene_runner/src/test/mod.rs
@@ -38,7 +38,7 @@ use common::{
     rpc::RpcCall,
     structs::{
         AppConfig, CursorLocks, GraphicsSettings, PermissionUsed, PreviewMode, PrimaryCamera,
-        PrimaryPlayerRes, SceneGlobalLight, SceneLoadDistance, TimeOfDay, ToolTips, UserClipping,
+        PrimaryPlayerRes, SceneGlobalLight, SceneLoadDistance, TimeOfDay, ToolTips,
     },
 };
 use comms::CommsPlugin;
@@ -133,7 +133,6 @@ fn init_test_app(entity_json: &str) -> App {
     app.init_resource::<CumulativeAxisData>();
     app.init_resource::<ToolTips>();
     app.init_resource::<SceneGlobalLight>();
-    app.insert_resource(UserClipping(true));
     app.insert_resource(TimeOfDay {
         time: 10.0 * 3600.0,
         target_time: None,

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -27,7 +27,7 @@ use common::{
     structs::{AppConfig, PrimaryUser},
     util::{ModifyComponentExt, SceneSpawnerPlus},
 };
-use rapier3d_f64::prelude::*;
+use rapier3d::prelude::*;
 use serde::Deserialize;
 
 use crate::{
@@ -1084,7 +1084,7 @@ pub fn mesh_to_parry_shape(mesh_data: &Mesh) -> SharedShape {
 
     let positions_parry: Vec<_> = positions_ref
         .iter()
-        .map(|pos| Point::from([pos[0] as f64, pos[1] as f64, pos[2] as f64]))
+        .map(|pos| Point::from([pos[0], pos[1], pos[2]]))
         .collect();
 
     let indices: Vec<u32> = match mesh_data.indices() {

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -26,7 +26,6 @@ use crate::{
 use common::{
     dynamics::{PLAYER_COLLIDER_HEIGHT, PLAYER_COLLIDER_OVERLAP, PLAYER_COLLIDER_RADIUS},
     sets::SceneLoopSets,
-    structs::UserClipping,
 };
 use console::DoAddConsoleCommand;
 use dcl::interface::ComponentPosition;
@@ -826,51 +825,84 @@ fn propagate_disabled(
 
 #[allow(clippy::type_complexity)]
 fn update_collider_transforms(
-    changed_colliders: Query<(&ContainerEntity, &HasCollider, &GlobalTransform)>,
+    changed_colliders: Query<
+        (&ContainerEntity, &HasCollider, &GlobalTransform),
+        (
+            Or<(Changed<GlobalTransform>, Changed<HasCollider>)>, // needs updating
+        ),
+    >,
     mut scene_data: Query<&mut SceneColliderData>,
     containing_scene: ContainingScene,
     mut player: Query<(Entity, &mut Transform), With<PrimaryUser>>,
-    clip: Res<UserClipping>,
-    mut last_position: Local<Vec3>,
 ) {
     let mut containing_scenes = HashSet::new();
     let mut player_transform = None;
 
     if let Ok((player, transform)) = player.single_mut() {
-        let last_dir = *last_position - transform.translation;
-        if last_dir.length() > 0.1 {
-            *last_position = transform.translation + last_dir.normalize() * 0.1;
-        }
-
         player_transform = Some(transform);
         containing_scenes.extend(containing_scene.get_area(player, PLAYER_COLLIDER_RADIUS));
     }
 
     let mut player_collider_set = ColliderSet::default();
-    if clip.0 {
-        player_collider_set.insert(
-            ColliderBuilder::new(SharedShape::capsule_y(
-                (PLAYER_COLLIDER_HEIGHT * 0.5 - PLAYER_COLLIDER_RADIUS) as f64,
-                (PLAYER_COLLIDER_RADIUS - PLAYER_COLLIDER_OVERLAP) as f64,
-            ))
-            .position(Isometry::from_parts(
-                player_transform
-                    .as_ref()
-                    .map(|t| t.translation + PLAYER_COLLIDER_HEIGHT * 0.5 * Vec3::Y)
-                    .unwrap_or_default()
-                    .as_dvec3()
-                    .into(),
-                Default::default(),
-            ))
-            .build(),
-        );
-    }
+    player_collider_set.insert(
+        ColliderBuilder::new(SharedShape::capsule_y(
+            (PLAYER_COLLIDER_HEIGHT * 0.5 - PLAYER_COLLIDER_RADIUS) as f64,
+            (PLAYER_COLLIDER_RADIUS - PLAYER_COLLIDER_OVERLAP) as f64,
+        ))
+        .position(Isometry::from_parts(
+            player_transform
+                .as_ref()
+                .map(|t| t.translation + PLAYER_COLLIDER_HEIGHT * 0.5 * Vec3::Y)
+                .unwrap_or_default()
+                .as_dvec3()
+                .into(),
+            Default::default(),
+        ))
+        .build(),
+    );
+
+    // closure to generate vector to (attempt to) fix a penetration with a scene collider
+    // TODO perhaps store last collider position and move this to player dynamics?
+    // not sure ... that would be better for colliders vs other stuff than player
+    // but currently it uses pretty intimate knowledge of scene collider data
+    let depenetration_vector =
+        |scene_data: &mut SceneColliderData, translation: Vec3, toi: &ShapeCastHit| -> Vec3 {
+            // just use the bottom sphere of the player collider
+            let base_of_sphere = translation + PLAYER_COLLIDER_RADIUS * Vec3::Y;
+            let closest_point = match toi.status {
+                ShapeCastStatus::OutOfIterations | ShapeCastStatus::Converged => {
+                    DVec3::from(toi.witness1).as_vec3()
+                }
+                ShapeCastStatus::Failed | ShapeCastStatus::PenetratingOrWithinTargetDist => {
+                    scene_data.force_update();
+                    match scene_data.query_state.as_ref().unwrap().project_point(
+                        &scene_data.dummy_rapier_structs.1,
+                        &scene_data.collider_set,
+                        &base_of_sphere.as_dvec3().into(),
+                        true,
+                        QueryFilter::default().predicate(&|h, _| scene_data.collider_enabled(h)),
+                    ) {
+                        Some((_, point)) => DVec3::from(point.point).as_vec3(),
+                        None => translation,
+                    }
+                }
+            };
+            let fix_dir = base_of_sphere - closest_point;
+            let distance = (PLAYER_COLLIDER_RADIUS - fix_dir.length()).clamp(0.00, 1.0);
+            debug!(
+                "closest point: {}, dir: {fix_dir}, len: {distance}",
+                closest_point
+            );
+            (fix_dir.normalize_or_zero() * distance)
+                // constrain resulting position to above ground
+                .max(Vec3::new(
+                    f32::NEG_INFINITY,
+                    -translation.y,
+                    f32::NEG_INFINITY,
+                ))
+        };
 
     for (container, collider, global_transform) in changed_colliders.iter() {
-        if !containing_scenes.contains(&container.root) {
-            continue;
-        }
-
         let Ok(mut scene_data) = scene_data.get_mut(container.root) else {
             warn!("missing scene root for {container:?}");
             continue;
@@ -886,12 +918,22 @@ fn update_collider_transforms(
             },
         );
 
-        let mut penetrating = false;
         if let Some(original_transform) = maybe_original_transform {
             if let Some(toi) = maybe_toi {
                 match toi.status {
                     ShapeCastStatus::PenetratingOrWithinTargetDist => {
-                        penetrating = true;
+                        // penetrating collider - use closest point to infer fix/depen direction
+                        debug!(
+                            "don't skip pen, player: {:?} [moving {:?}]",
+                            player_transform.as_ref().unwrap().translation,
+                            (&container.root, &collider.0),
+                        );
+                        let fix_vector = depenetration_vector(
+                            &mut scene_data,
+                            player_transform.as_ref().unwrap().translation,
+                            &toi,
+                        );
+                        player_transform.as_mut().unwrap().translation += fix_vector;
                     }
                     _ => {
                         // get contact point at toi
@@ -918,7 +960,7 @@ fn update_collider_transforms(
                             global_transform.transform_point(relative_hit_point) / new_scale;
 
                         // add diff as velocity or as motion?
-                        let mut req_translation = contact_at_end - contact_at_toi;
+                        let req_translation = contact_at_end - contact_at_toi;
                         let dot_w_normal1 = req_translation
                             .normalize_or_zero()
                             .dot(DVec3::from(toi.normal1).as_vec3());
@@ -928,8 +970,8 @@ fn update_collider_transforms(
                         if req_translation.length() > 1.0 {
                             // disregard too large deltas as the collider probably just warped
                             // TODO we could check this before updating based on translation?
-                            warn!("clamp push due to large delta: {}, toi: {}, normal dot1: {}, 2: {}", req_translation, toi.time_of_impact, dot_w_normal1, dot_w_normal2);
-                            req_translation = req_translation.normalize() * 1.0;
+                            warn!("disregarding push due to large delta: {}, toi: {}, normal dot1: {}, 2: {}", req_translation, toi.time_of_impact, dot_w_normal1, dot_w_normal2);
+                            continue;
                         }
                         // add extra 0.01 due to character controller offset / collider size difference
                         debug!(
@@ -968,19 +1010,23 @@ fn update_collider_transforms(
                             )
                             .1;
 
-                        if new_toi.is_some() {
-                            penetrating = true;
+                        if let Some(new_toi) = new_toi {
+                            debug!(
+                                "update toi - can we fix it?: {:?}, player: {}",
+                                new_toi,
+                                player_transform.as_ref().unwrap().translation
+                            );
+                            let fix_vector = depenetration_vector(
+                                &mut scene_data,
+                                player_transform.as_ref().unwrap().translation,
+                                &new_toi,
+                            );
+                            debug!("fix: {fix_vector}");
+                            player_transform.as_mut().unwrap().translation += fix_vector;
                         }
                     }
                 }
             }
-        }
-
-        if penetrating {
-            let translation = player_transform.as_ref().unwrap().translation;
-            let fix = (*last_position - translation + Vec3::Y * 0.1).normalize() * 0.1;
-            player_transform.as_mut().unwrap().translation += fix;
-            *last_position += fix;
         }
     }
 }

--- a/crates/user_input/Cargo.toml
+++ b/crates/user_input/Cargo.toml
@@ -15,5 +15,5 @@ console = { workspace = true }
 
 bevy = { workspace = true }
 bevy_console = { workspace = true }
-rapier3d-f64 = { workspace = true }
+rapier3d = { workspace = true }
 clap = { workspace = true }

--- a/crates/user_input/src/dynamics.rs
+++ b/crates/user_input/src/dynamics.rs
@@ -56,7 +56,7 @@ use common::{
         MAX_CLIMBABLE_INCLINE, MAX_STEP_HEIGHT, PLAYER_COLLIDER_OVERLAP, PLAYER_COLLIDER_RADIUS,
         PLAYER_GROUND_THRESHOLD,
     },
-    structs::{AvatarDynamicState, PlayerModifiers, PrimaryUser, UserClipping},
+    structs::{AvatarDynamicState, PlayerModifiers, PrimaryUser},
 };
 
 use scene_runner::{
@@ -64,6 +64,9 @@ use scene_runner::{
     update_world::mesh_collider::{ColliderId, GroundCollider, SceneColliderData},
     ContainingScene, OutOfWorld,
 };
+
+#[derive(Resource)]
+pub struct UserClipping(pub bool);
 
 const TICK_TIME: f32 = 1.0 / 720.0;
 

--- a/crates/user_input/src/dynamics.rs
+++ b/crates/user_input/src/dynamics.rs
@@ -45,11 +45,11 @@
 
 use bevy::{
     diagnostic::FrameCount,
-    math::{DVec3, Vec3Swizzles},
+    math::{Vec3, Vec3Swizzles},
     prelude::*,
 };
 use bevy_console::ConsoleCommand;
-use rapier3d_f64::control::{CharacterAutostep, CharacterLength, KinematicCharacterController};
+use rapier3d::control::{CharacterAutostep, CharacterLength, KinematicCharacterController};
 
 use common::{
     dynamics::{
@@ -181,15 +181,15 @@ pub fn update_user_position(
 
     // setup physics controller
     let mut controller = KinematicCharacterController {
-        offset: CharacterLength::Absolute(PLAYER_COLLIDER_OVERLAP as f64),
+        offset: CharacterLength::Absolute(PLAYER_COLLIDER_OVERLAP),
         slide: true,
         autostep: Some(CharacterAutostep {
-            max_height: CharacterLength::Absolute(MAX_STEP_HEIGHT as f64),
+            max_height: CharacterLength::Absolute(MAX_STEP_HEIGHT),
             min_width: CharacterLength::Relative(0.75),
             include_dynamic_bodies: true,
         }),
-        max_slope_climb_angle: MAX_CLIMBABLE_INCLINE as f64,
-        min_slope_slide_angle: MAX_CLIMBABLE_INCLINE as f64,
+        max_slope_climb_angle: MAX_CLIMBABLE_INCLINE,
+        min_slope_slide_angle: MAX_CLIMBABLE_INCLINE,
         snap_to_ground: Some(CharacterLength::Absolute(0.1)),
         ..Default::default()
     };
@@ -233,28 +233,27 @@ pub fn update_user_position(
                 }
 
                 // force update new collider
-                let prior_cpos = DVec3::from(
+                let prior_cpos = Vec3::from(
                     collider_data
                         .get_collider(&collider)
                         .unwrap()
                         .position()
                         .translation,
-                )
-                .as_vec3();
+                );
                 collider_data.update_collider_transform(&collider, &new_global_transform, None);
-                let new_cpos = DVec3::from(
+                let new_cpos = Vec3::from(
                     collider_data
                         .get_collider(&collider)
                         .unwrap()
                         .position()
                         .translation,
-                )
-                .as_vec3();
+                );
 
                 // adjust base motion wrt ground collider
                 if clip.0 {
                     let prior = target_motion;
                     target_motion = collider_data.move_character(
+                        dt,
                         ctx.last_update_frame,
                         transform.translation + platform_motion,
                         target_motion,
@@ -288,6 +287,24 @@ pub fn update_user_position(
         }
     }
 
+    // floor
+    target_motion.y = target_motion.y.max(-transform.translation.y);
+
+    // depentrate
+    if clip.0 {
+        for scene in containing_scenes.get_area(user_ent, PLAYER_COLLIDER_RADIUS) {
+            let Ok((context, mut collider_data)) = scene_datas.get_mut(scene) else {
+                continue;
+            };
+
+            if let Some(depen_vector) =
+                collider_data.depentrate_character(context.last_update_frame, transform.translation)
+            {
+                transform.translation += depen_vector;
+            }
+        }
+    }
+
     // check containing scenes
     for scene in containing_scenes.get_area(user_ent, PLAYER_COLLIDER_RADIUS) {
         let Ok((context, mut collider_data)) = scene_datas.get_mut(scene) else {
@@ -304,6 +321,7 @@ pub fn update_user_position(
         // get allowed motion for total motion wrt all but ground collider
         if clip.0 {
             target_motion = collider_data.move_character(
+                dt,
                 context.last_update_frame,
                 transform.translation,
                 target_motion,
@@ -337,10 +355,13 @@ pub fn update_user_position(
             if height < dynamic_state.ground_height {
                 dynamic_state.ground_height = height;
                 if height < PLAYER_GROUND_THRESHOLD {
-                    let entity = collider_data.get_collider_entity(&collider).unwrap();
-                    let gt = calc_global_transform(entity);
-                    ground_collider.0 = Some((scene, collider, gt));
-                    debug!("still on platform (@{height})");
+                    if let Some(entity) = collider_data.get_collider_entity(&collider) {
+                        let gt = calc_global_transform(entity);
+                        ground_collider.0 = Some((scene, collider, gt));
+                        debug!("still on platform (@{height})");
+                    } else {
+                        debug!("left platform (@{height}");
+                    }
                 } else {
                     debug!("left platform (@{height})");
                 }

--- a/crates/user_input/src/lib.rs
+++ b/crates/user_input/src/lib.rs
@@ -15,12 +15,13 @@ use common::{
     anim_last_system,
     sets::SceneSets,
     structs::{
-        CursorLocks, PlayerModifiers, PrimaryCamera, PrimaryUser, UserClipping,
-        PRIMARY_AVATAR_LIGHT_LAYER_INDEX,
+        CursorLocks, PlayerModifiers, PrimaryCamera, PrimaryUser, PRIMARY_AVATAR_LIGHT_LAYER_INDEX,
     },
 };
 use console::DoAddConsoleCommand;
-use dynamics::{jump_cmd, no_clip, speed_cmd, JumpCommand, NoClipCommand, SpeedCommand};
+use dynamics::{
+    jump_cmd, no_clip, speed_cmd, JumpCommand, NoClipCommand, SpeedCommand, UserClipping,
+};
 use scene_runner::{
     update_scene::pointer_lock::update_pointer_lock,
     update_world::{


### PR DESCRIPTION
- revert original moving collider logic
- check for intersections at start of player dynamic phase, if penetrating check nearby points for a valid point
- add 0-height ground colliders / remove manual underground correction to avoid getting stuck under stairs 