### PR TITLE
improve material memory and updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1146,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1468,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1554,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "glam",
 ]
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1612,12 +1612,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#0aa91e1a2985965615a093db0692bc9923a14494"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,8 @@ web-time = { workspace = true }
 
 pico-args = "0.5.0"
 chrono = { workspace = true }
-tracing = { version = "0.1", features = ["release_max_level_info"] }
+# tracing = { version = "0.1", features = ["release_max_level_info"] }
+tracing = { version = "0.1" }
 tracing-appender = "0.2.3"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 

--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -94,10 +94,7 @@ fn gen_sdk_components() -> Result<()> {
         "UiCanvasTexture",
     ];
     for component in hash_components {
-        config.type_attribute(
-            component,
-            "#[derive(Hash)]",
-        );
+        config.type_attribute(component, "#[derive(Hash)]");
     }
 
     config.compile_protos(&sources, &["src/proto/"])?;

--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -67,6 +67,7 @@ fn gen_sdk_components() -> Result<()> {
     sources.push("src/proto/decentraland/kernel/comms/v3/archipelago.proto".into());
     sources.push("src/proto/decentraland/social/friendships/friendships.proto".into());
 
+    let mut config = prost_build::Config::new();
     let serde_components = [
         "Vector2",
         "Color3",
@@ -76,11 +77,26 @@ fn gen_sdk_components() -> Result<()> {
         "InputAction",
     ];
 
-    let mut config = prost_build::Config::new();
     for component in serde_components {
         config.type_attribute(
             component,
             "#[derive(serde::Serialize, serde::Deserialize)]\n#[serde(rename_all = \"camelCase\")]",
+        );
+    }
+
+    let hash_components = [
+        "PBMaterial",
+        "GltfMaterial",
+        "TextureUnion",
+        "Texture",
+        "AvatarTexture",
+        "VideoTexture",
+        "UiCanvasTexture",
+    ];
+    for component in hash_components {
+        config.type_attribute(
+            component,
+            "#[derive(Hash)]",
         );
     }
 

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -327,7 +327,9 @@ impl std::hash::Hash for sdk::components::pb_material::Material {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         core::mem::discriminant(self).hash(state);
         match self {
-            sdk::components::pb_material::Material::Unlit(unlit_material) => unlit_material.hash(state),
+            sdk::components::pb_material::Material::Unlit(unlit_material) => {
+                unlit_material.hash(state)
+            }
             sdk::components::pb_material::Material::Pbr(pbr_material) => pbr_material.hash(state),
         }
     }
@@ -340,7 +342,9 @@ impl std::hash::Hash for common::texture_union::Tex {
             common::texture_union::Tex::Texture(texture) => texture.hash(state),
             common::texture_union::Tex::AvatarTexture(avatar_texture) => avatar_texture.hash(state),
             common::texture_union::Tex::VideoTexture(video_texture) => video_texture.hash(state),
-            common::texture_union::Tex::UiTexture(ui_canvas_texture) => ui_canvas_texture.hash(state),
+            common::texture_union::Tex::UiTexture(ui_canvas_texture) => {
+                ui_canvas_texture.hash(state)
+            }
         }
     }
 }
@@ -397,4 +401,3 @@ impl std::hash::Hash for sdk::components::pb_material::PbrMaterial {
         self.direct_intensity.map(FloatOrd).hash(state);
     }
 }
-

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -1,3 +1,5 @@
+use bevy::math::FloatOrd;
+
 use super::{FromDclReader, ToDclWriter};
 
 pub mod sdk {
@@ -320,3 +322,79 @@ impl RoughRoundExt for bevy::math::Vec3 {
         (self * 2f32.powf(-pow2 as f32)).round() * 2f32.powf(pow2 as f32)
     }
 }
+
+impl std::hash::Hash for sdk::components::pb_material::Material {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        match self {
+            sdk::components::pb_material::Material::Unlit(unlit_material) => unlit_material.hash(state),
+            sdk::components::pb_material::Material::Pbr(pbr_material) => pbr_material.hash(state),
+        }
+    }
+}
+
+impl std::hash::Hash for common::texture_union::Tex {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        match self {
+            common::texture_union::Tex::Texture(texture) => texture.hash(state),
+            common::texture_union::Tex::AvatarTexture(avatar_texture) => avatar_texture.hash(state),
+            common::texture_union::Tex::VideoTexture(video_texture) => video_texture.hash(state),
+            common::texture_union::Tex::UiTexture(ui_canvas_texture) => ui_canvas_texture.hash(state),
+        }
+    }
+}
+impl std::hash::Hash for sdk::components::pb_material::UnlitMaterial {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.texture.hash(state);
+        self.alpha_test.map(FloatOrd).hash(state);
+        self.cast_shadows.hash(state);
+        self.diffuse_color.hash(state);
+        self.alpha_texture.hash(state);
+    }
+}
+
+impl std::hash::Hash for common::Color4 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        FloatOrd(self.r).hash(state);
+        FloatOrd(self.g).hash(state);
+        FloatOrd(self.b).hash(state);
+        FloatOrd(self.a).hash(state);
+    }
+}
+
+impl std::hash::Hash for common::Color3 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        FloatOrd(self.r).hash(state);
+        FloatOrd(self.g).hash(state);
+        FloatOrd(self.b).hash(state);
+    }
+}
+
+impl std::hash::Hash for common::Vector2 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        FloatOrd(self.x).hash(state);
+        FloatOrd(self.y).hash(state);
+    }
+}
+
+impl std::hash::Hash for sdk::components::pb_material::PbrMaterial {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.texture.hash(state);
+        self.alpha_test.map(FloatOrd).hash(state);
+        self.cast_shadows.hash(state);
+        self.alpha_texture.hash(state);
+        self.emissive_texture.hash(state);
+        self.bump_texture.hash(state);
+        self.albedo_color.hash(state);
+        self.emissive_color.hash(state);
+        self.reflectivity_color.hash(state);
+        self.transparency_mode.hash(state);
+        self.metallic.map(FloatOrd).hash(state);
+        self.roughness.map(FloatOrd).hash(state);
+        self.specular_intensity.map(FloatOrd).hash(state);
+        self.emissive_intensity.map(FloatOrd).hash(state);
+        self.direct_intensity.map(FloatOrd).hash(state);
+    }
+}
+

--- a/crates/scene_runner/src/update_world/material.rs
+++ b/crates/scene_runner/src/update_world/material.rs
@@ -491,10 +491,11 @@ fn update_materials(
         mat.0.hash(hasher);
         let hash = hasher.finish();
 
-        let cached_data = cache
-            .0
-            .get(&hash)
-            .and_then(|(cached_handle, defn)| resolver.ipfas.asset_server().get_id_handle(*cached_handle).map(|h| (h, defn)));
+        let cached_data = cache.0.get(&hash).and_then(|(cached_handle, defn)| {
+            materials
+                .get_strong_handle(*cached_handle)
+                .map(|h| (h, defn))
+        });
 
         let (material, defn) = match cached_data {
             Some(data) => data,

--- a/crates/scene_runner/src/update_world/material.rs
+++ b/crates/scene_runner/src/update_world/material.rs
@@ -1,4 +1,7 @@
-use std::sync::OnceLock;
+use std::{
+    hash::{Hash, Hasher},
+    sync::OnceLock,
+};
 
 use bevy::{
     ecs::system::SystemParam,
@@ -8,6 +11,7 @@ use bevy::{
     },
     math::Affine2,
     pbr::NotShadowCaster,
+    platform::collections::HashMap,
     prelude::*,
     render::primitives::Aabb,
 };
@@ -265,7 +269,12 @@ impl Plugin for MaterialDefinitionPlugin {
 
         app.add_systems(
             Update,
-            (update_materials, update_bias, update_loading_materials)
+            (
+                init_cache,
+                update_materials,
+                update_bias,
+                update_loading_materials,
+            )
                 .chain()
                 .in_set(SceneSets::PostLoop)
                 // we must run after update_mesh as that inserts a default material if none is present
@@ -430,13 +439,25 @@ impl TextureResolver<'_, '_> {
 #[derive(Component)]
 pub struct MeshMaterial3dLoading(Handle<SceneMaterial>);
 
+#[derive(Component, Default)]
+pub struct CachedMaterials(HashMap<u64, (AssetId<SceneMaterial>, MaterialDefinition)>);
+
+fn init_cache(
+    q: Query<Entity, (With<RendererSceneContext>, Without<CachedMaterials>)>,
+    mut commands: Commands,
+) {
+    for ent in q.iter() {
+        commands.entity(ent).try_insert(CachedMaterials::default());
+    }
+}
+
 #[allow(clippy::type_complexity)]
 fn update_materials(
     mut commands: Commands,
     mut new_materials: Query<
         (
             Entity,
-            &PbMaterialComponent,
+            Ref<PbMaterialComponent>,
             &ContainerEntity,
             &SceneEntity,
             Option<&BaseMaterial>,
@@ -454,7 +475,7 @@ fn update_materials(
         Option<Ref<UiTextureOutput>>,
     )>,
     mut resolver: TextureResolver,
-    mut scenes: Query<&mut RendererSceneContext>,
+    mut scenes: Query<(&mut RendererSceneContext, &mut CachedMaterials)>,
     config: Res<AppConfig>,
     mut gltf_resolver: GltfMaterialResolver,
     images: Res<Assets<Image>>,
@@ -462,99 +483,107 @@ fn update_materials(
     gltf_resolver.begin_frame();
 
     for (ent, mat, container, scene_ent, base) in new_materials.iter_mut() {
-        let new_base;
-        let base = if let Some(gltf_def) = mat.0.gltf.as_ref() {
-            if base.is_some_and(|b| b.gltf == gltf_def.gltf_src && b.name == gltf_def.name) {
-                base
-            } else {
-                let Ok(scene_hash) = scenes.get(container.root).map(|scene| &scene.hash) else {
-                    continue;
-                };
-                match gltf_resolver.resolve_material(&gltf_def.gltf_src, scene_hash, &gltf_def.name)
-                {
-                    Err(e) => {
-                        warn!("base not found: {e:?}");
-                        None
+        let Ok((mut scene, mut cache)) = scenes.get_mut(container.root) else {
+            continue;
+        };
+
+        let hasher = &mut std::hash::DefaultHasher::new();
+        mat.0.hash(hasher);
+        let hash = hasher.finish();
+
+        let cached_data = cache
+            .0
+            .get(&hash)
+            .and_then(|(cached_handle, defn)| resolver.ipfas.asset_server().get_id_handle(*cached_handle).map(|h| (h, defn)));
+
+        let (material, defn) = match cached_data {
+            Some(data) => data,
+            None => {
+                let new_base;
+                let base = if let Some(gltf_def) = mat.0.gltf.as_ref() {
+                    if base.is_some_and(|b| b.gltf == gltf_def.gltf_src && b.name == gltf_def.name)
+                    {
+                        base
+                    } else {
+                        match gltf_resolver.resolve_material(
+                            &gltf_def.gltf_src,
+                            &scene.hash,
+                            &gltf_def.name,
+                        ) {
+                            Err(e) => {
+                                warn!("base not found: {e:?}");
+                                None
+                            }
+                            Ok(None) => {
+                                // retry
+                                commands.entity(ent).insert(RetryMaterial(Vec::default()));
+                                continue;
+                            }
+                            Ok(Some(mat)) => {
+                                new_base = BaseMaterial {
+                                    material: mat.clone(),
+                                    gltf: gltf_def.gltf_src.clone(),
+                                    name: gltf_def.name.clone(),
+                                };
+                                commands.entity(ent).insert(new_base.clone());
+                                Some(&new_base)
+                            }
+                        }
                     }
-                    Ok(None) => {
-                        // retry
+                } else {
+                    None
+                };
+
+                let defn = MaterialDefinition::from_base_and_material(base, &mat.0);
+                let textures: Result<Vec<_>, _> = [
+                    &defn.base_color_texture,
+                    &defn.emmissive_texture,
+                    &defn.normal_map,
+                ]
+                .into_iter()
+                .map(
+                    |texture| match texture.as_ref().and_then(|t| t.tex.as_ref()) {
+                        Some(texture) => match resolver.resolve_texture(&scene, texture) {
+                            Ok(resolved) => Ok(Some(resolved)),
+                            Err(TextureResolveError::SourceNotReady) => Err(()),
+                            Err(_) => Ok(None),
+                        },
+                        None => Ok(None),
+                    },
+                )
+                .collect();
+
+                let textures = match textures {
+                    Ok(textures) => textures,
+                    _ => {
                         commands.entity(ent).insert(RetryMaterial(Vec::default()));
                         continue;
                     }
-                    Ok(Some(mat)) => {
-                        new_base = BaseMaterial {
-                            material: mat.clone(),
-                            gltf: gltf_def.gltf_src.clone(),
-                            name: gltf_def.name.clone(),
-                        };
-                        commands.entity(ent).insert(new_base.clone());
-                        Some(&new_base)
+                };
+
+                if let Some(source) = textures
+                    .iter()
+                    .flatten()
+                    .filter_map(|t| t.source_entity)
+                    .next()
+                {
+                    commands.entity(ent).insert(MaterialSource(source));
+                }
+
+                let [mut base_color_texture, emissive_texture, normal_map_texture]: [Option<
+                    ResolvedTexture,
+                >;
+                    3] = textures.try_into().unwrap();
+
+                if let Some(bct) = base_color_texture.as_mut() {
+                    if let Some(cursor) = bct.camera_target.take() {
+                        commands.entity(ent).insert(cursor);
                     }
                 }
-            }
-        } else {
-            None
-        };
 
-        let defn = MaterialDefinition::from_base_and_material(base, &mat.0);
-        let textures: Result<Vec<_>, _> = [
-            &defn.base_color_texture,
-            &defn.emmissive_texture,
-            &defn.normal_map,
-        ]
-        .into_iter()
-        .map(
-            |texture| match texture.as_ref().and_then(|t| t.tex.as_ref()) {
-                Some(texture) => {
-                    let scene = scenes.get(container.root).map_err(|_| ())?;
-                    match resolver.resolve_texture(scene, texture) {
-                        Ok(resolved) => Ok(Some(resolved)),
-                        Err(TextureResolveError::SourceNotReady) => Err(()),
-                        Err(_) => Ok(None),
-                    }
-                }
-                None => Ok(None),
-            },
-        )
-        .collect();
+                let bounds = scene.bounds.clone();
 
-        let textures = match textures {
-            Ok(textures) => textures,
-            _ => {
-                commands.entity(ent).insert(RetryMaterial(Vec::default()));
-                continue;
-            }
-        };
-
-        if let Some(source) = textures
-            .iter()
-            .flatten()
-            .filter_map(|t| t.source_entity)
-            .next()
-        {
-            commands.entity(ent).insert(MaterialSource(source));
-        }
-
-        let [mut base_color_texture, emissive_texture, normal_map_texture]: [Option<
-            ResolvedTexture,
-        >; 3] = textures.try_into().unwrap();
-
-        if let Some(bct) = base_color_texture.as_mut() {
-            if let Some(cursor) = bct.camera_target.take() {
-                commands.entity(ent).insert(cursor);
-            }
-        }
-
-        let bounds = scenes
-            .get(container.root)
-            .map(|c| c.bounds.clone())
-            .unwrap_or_default();
-
-        let mut commands = commands.entity(ent);
-        commands
-            .remove::<RetryMaterial>()
-            .try_insert(MeshMaterial3dLoading(
-                materials.add(SceneMaterial {
+                let material = materials.add(SceneMaterial {
                     base: StandardMaterial {
                         base_color_texture: base_color_texture
                             .map(|t| t.image)
@@ -568,8 +597,18 @@ fn update_materials(
                         ..defn.material.clone()
                     },
                     extension: SceneBound::new(bounds, config.graphics.oob),
-                }),
-            ));
+                });
+
+                cache.0.insert(hash, (material.id(), defn));
+
+                (material, &cache.0.get(&hash).unwrap().1)
+            }
+        };
+
+        let mut commands = commands.entity(ent);
+        commands
+            .remove::<RetryMaterial>()
+            .try_insert(MeshMaterial3dLoading(material));
         if defn.shadow_caster {
             commands.remove::<NotShadowCaster>();
         } else {
@@ -579,10 +618,6 @@ fn update_materials(
         // write material back if required
         if mat.0.material.is_none() {
             if let Some(base) = base.as_ref() {
-                let Ok(mut scene) = scenes.get_mut(container.root) else {
-                    continue;
-                };
-
                 scene.update_crdt(
                     SceneComponentId::MATERIAL,
                     CrdtType::LWW_ANY,

--- a/crates/scene_runner/src/update_world/material.rs
+++ b/crates/scene_runner/src/update_world/material.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use bevy::{
+    asset::RenderAssetUsages,
     ecs::system::SystemParam,
     image::{
         ImageAddressMode, ImageFilterMode, ImageLoaderSettings, ImageSampler,
@@ -364,7 +365,8 @@ impl TextureResolver<'_, '_> {
                                     min_filter: filter_mode,
                                     mipmap_filter: filter_mode,
                                     ..default()
-                                })
+                                });
+                                s.asset_usage = RenderAssetUsages::RENDER_WORLD;
                             },
                         )
                         .unwrap(),


### PR DESCRIPTION
- hash and cache/reuse PBMaterials to limit updates (10fps -> 60pfs on -135,88)
- add render-world-only flag to textures in PBMaterials to save cpu ram
- fix bevy not respecting render-world-only flag on gltf textures referenced by external path 