### PR TITLE
more cpu image reductions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,10 +2229,10 @@ dependencies = [
 [[package]]
 name = "boimp"
 version = "0.1.1"
-source = "git+https://github.com/robtfm/boimp?branch=0.3#fc77ee54d44a074e4990f82800688b3b9809d592"
+source = "git+https://github.com/robtfm/boimp?branch=0.3#236a2c220c3b7b1d794794062bbd5937873c93ec"
 dependencies = [
  "anyhow",
- "async-channel 2.3.1",
+ "async-channel 1.9.0",
  "bevy",
  "bytemuck",
  "crossbeam-channel",

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -580,7 +580,7 @@ fn play_current_emote(
                         data: CollectibleData::<Emote> {
                             hash: hash.to_owned(),
                             urn: active_emote.urn.as_str().to_owned(),
-                            thumbnail: ipfas.asset_server().load("embedded://images/redx.png"),
+                            thumbnail: "embedded://images/redx.png".to_owned(),
                             available_representations: HashSet::from_iter([bodyshape.to_owned()]),
                             name: active_emote.urn.to_string(),
                             description: active_emote.urn.to_string(),

--- a/crates/collectibles/src/emotes.rs
+++ b/crates/collectibles/src/emotes.rs
@@ -217,12 +217,11 @@ fn load_animations(
                                     hash: Default::default(),
                                     urn: urn.as_str().to_string(),
                                     thumbnail: if register_base {
-                                        asset_server.load(format!(
+                                        format!(
                                             "embedded://animations/thumbnails/{network_name}.png"
-                                        ))
-                                        // asset_server.load("embedded://images/redx.png")
+                                        )
                                     } else {
-                                        Handle::default()
+                                        "embedded://images/redx.png".to_owned()
                                     },
                                     available_representations: representations
                                         .keys()
@@ -561,8 +560,13 @@ impl AssetLoader for EmoteLoader {
         debug!("meta: {metadata:#?}");
         let meta = serde_json::from_value::<EmoteMeta>(metadata)?;
 
-        let thumbnail =
-            load_context.load(load_context.path().parent().unwrap().join(&meta.thumbnail));
+        let thumbnail = load_context
+            .path()
+            .parent()
+            .unwrap()
+            .join(&meta.thumbnail)
+            .to_string_lossy()
+            .into_owned();
 
         let mut representations = HashMap::new();
 
@@ -630,8 +634,13 @@ impl AssetLoader for EmoteMetaLoader {
         debug!("meta: {metadata:#?}");
         let meta = serde_json::from_value::<EmoteMeta>(metadata)?;
 
-        let thumbnail =
-            load_context.load(load_context.path().parent().unwrap().join(&meta.thumbnail));
+        let thumbnail = load_context
+            .path()
+            .parent()
+            .unwrap()
+            .join(&meta.thumbnail)
+            .to_string_lossy()
+            .into_owned();
 
         let available_representations = meta
             .emote_extended_data

--- a/crates/collectibles/src/lib.rs
+++ b/crates/collectibles/src/lib.rs
@@ -71,7 +71,7 @@ pub struct Collectible<T: CollectibleType> {
 pub struct CollectibleData<T: CollectibleType> {
     pub hash: String,
     pub urn: String,
-    pub thumbnail: Handle<Image>,
+    pub thumbnail: String,
     pub available_representations: HashSet<String>,
     pub name: String,
     pub description: String,

--- a/crates/collectibles/src/wearables.rs
+++ b/crates/collectibles/src/wearables.rs
@@ -9,6 +9,7 @@ use bevy::{
     asset::AssetLoader,
     diagnostic::FrameCount,
     gltf::{Gltf, GltfLoaderSettings},
+    image::ImageLoaderSettings,
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::render_asset::RenderAssetUsages,
@@ -27,7 +28,7 @@ impl Plugin for WearablePlugin {
             .init_resource::<WearableCollections>();
         app.register_asset_loader(WearableLoader);
         app.register_asset_loader(WearableMetaLoader);
-        app.add_systems(Update, (load_collections, retain_wearables));
+        app.add_systems(Update, (load_collections, retain_wearables, clean_images));
     }
 }
 
@@ -329,8 +330,13 @@ impl AssetLoader for WearableLoader {
         let meta = serde_json::from_value::<WearableMeta>(metadata)?;
 
         let category = meta.data.category;
-        let thumbnail =
-            load_context.load(load_context.path().parent().unwrap().join(&meta.thumbnail));
+        let thumbnail = load_context
+            .path()
+            .parent()
+            .unwrap()
+            .join(&meta.thumbnail)
+            .to_string_lossy()
+            .into_owned();
 
         let mut representations = HashMap::new();
 
@@ -344,12 +350,28 @@ impl AssetLoader for WearableLoader {
                         f.to_lowercase().ends_with(".png")
                             && !f.to_lowercase().ends_with("_mask.png")
                     })
-                    .map(|f| load_context.load(load_context.path().parent().unwrap().join(f)));
+                    .map(|f| {
+                        let path = load_context.path().parent().unwrap().join(f);
+                        load_context
+                            .loader()
+                            .with_settings::<ImageLoaderSettings>(|s| {
+                                s.asset_usage = RenderAssetUsages::RENDER_WORLD
+                            })
+                            .load(path)
+                    });
                 let mask = representation
                     .contents
                     .iter()
                     .find(|f| f.to_lowercase().ends_with("_mask.png"))
-                    .map(|f| load_context.load(load_context.path().parent().unwrap().join(f)));
+                    .map(|f| {
+                        let path = load_context.path().parent().unwrap().join(f);
+                        load_context
+                            .loader()
+                            .with_settings::<ImageLoaderSettings>(|s| {
+                                s.asset_usage = RenderAssetUsages::RENDER_WORLD
+                            })
+                            .load(path)
+                    });
 
                 (None, texture, mask)
             } else {
@@ -514,8 +536,13 @@ impl AssetLoader for WearableMetaLoader {
         let meta = serde_json::from_value::<WearableMeta>(metadata)?;
 
         let category = meta.data.category;
-        let thumbnail =
-            load_context.load(load_context.path().parent().unwrap().join(&meta.thumbnail));
+        let thumbnail = load_context
+            .path()
+            .parent()
+            .unwrap()
+            .join(&meta.thumbnail)
+            .to_string_lossy()
+            .into_owned();
 
         let available_representations = meta
             .data
@@ -537,5 +564,17 @@ impl AssetLoader for WearableMetaLoader {
             available_representations,
             extra_data: WearableExtraData { category },
         })
+    }
+}
+
+fn clean_images(mut ev: EventReader<AssetEvent<Image>>, mut images: ResMut<Assets<Image>>) {
+    for ev in ev.read() {
+        if let AssetEvent::LoadedWithDependencies { id } = ev {
+            let image = images.get(*id).unwrap();
+            if image.asset_usage.intersects(RenderAssetUsages::MAIN_WORLD) {
+                let image = images.get_mut(*id).unwrap();
+                image.asset_usage = RenderAssetUsages::RENDER_WORLD;
+            }
+        }
     }
 }

--- a/crates/imposters/src/floor_imposter.rs
+++ b/crates/imposters/src/floor_imposter.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::AssetLoader,
+    asset::{AssetLoader, RenderAssetUsages},
     pbr::{ExtendedMaterial, MaterialExtension},
     prelude::*,
     render::render_resource::AsBindGroup,
@@ -62,6 +62,7 @@ impl AssetLoader for FloorImposterLoader {
                     multisample: true,
                     alpha_blend: 0.5,
                     immediate_upload: true,
+                    asset_usages: RenderAssetUsages::RENDER_WORLD,
                     ..Default::default()
                 },
                 load_context,

--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use bevy::{
+    asset::RenderAssetUsages,
     diagnostic::FrameCount,
     ecs::system::SystemParam,
     math::FloatOrd,
@@ -947,6 +948,7 @@ impl<'w, 's> ImposterSpecManager<'w, 's> {
                                         alpha_blend: 0.0, // blend
                                         multisample_amount: 0.0,
                                         immediate_upload: true,
+                                        asset_usages: RenderAssetUsages::RENDER_WORLD,
                                     }
                                 },
                             )

--- a/crates/system_ui/src/emote_select.rs
+++ b/crates/system_ui/src/emote_select.rs
@@ -318,7 +318,7 @@ fn show_emote_ui(
         for emote in player_emotes {
             debug!("adding {}", emote.slot);
 
-            let h_thumb = EmoteUrn::new(&emote.urn)
+            let h_thumb: Handle<Image> = EmoteUrn::new(&emote.urn)
                 .ok()
                 .and_then(|emote_urn| match emote_loader.get_data(emote_urn) {
                     Ok(d) => Some(d),
@@ -328,12 +328,12 @@ fn show_emote_ui(
                     }
                     _ => None,
                 })
-                .map(|anim| anim.thumbnail.clone())
+                .map(|anim| asset_server.load(&anim.thumbnail))
                 .unwrap_or_else(|| {
                     debug!("didn't find {}", emote.urn);
                     asset_server.load("embedded://images/redx.png")
                 });
-            props.insert_prop(format!("image_{}", emote.slot), h_thumb.clone())
+            props.insert_prop(format!("image_{}", emote.slot), h_thumb)
         }
 
         if !all_loaded {

--- a/crates/system_ui/src/emotes.rs
+++ b/crates/system_ui/src/emotes.rs
@@ -291,7 +291,7 @@ fn set_emotes_content(
                 let emote_img = emote_settings
                     .current_emotes
                     .get(&slot)
-                    .map(|(_, data)| data.thumbnail.clone())
+                    .map(|(_, data)| ipfas.asset_server().load::<Image>(&data.thumbnail))
                     .unwrap_or_else(|| empty_img.clone());
 
                 let content = commands
@@ -833,7 +833,9 @@ fn update_emote_item(
                                 .available_representations
                                 .contains(settings.body_shape.base().as_str());
 
-                            *state = EmoteItemState::PendingImage(data.thumbnail.clone());
+                            *state = EmoteItemState::PendingImage(
+                                ipfas.asset_server().load(&data.thumbnail),
+                            );
 
                             modified = true;
 
@@ -1074,7 +1076,7 @@ fn update_selected_item(
                 let emote_img = emote_settings
                     .current_emotes
                     .get(&selected_slot)
-                    .map(|(_, data)| data.thumbnail.clone())
+                    .map(|(_, data)| ipfas.asset_server().load::<Image>(&data.thumbnail))
                     .unwrap_or_else(|| empty_img.clone());
 
                 commands

--- a/crates/system_ui/src/wearables.rs
+++ b/crates/system_ui/src/wearables.rs
@@ -301,7 +301,7 @@ fn set_wearables_content(
                 let wearable_img = wearable_settings
                     .current_wearables
                     .get(category)
-                    .map(|(_, data)| data.thumbnail.clone())
+                    .map(|(_, data)| ipfas.asset_server().load::<Image>(&data.thumbnail))
                     .unwrap_or_else(|| empty_img.clone());
 
                 let content = commands
@@ -914,7 +914,9 @@ fn update_wearable_item(
                                     .available_representations
                                     .contains(settings.body_shape.base().as_str());
 
-                            *state = WearableItemState::PendingImage(data.thumbnail.clone());
+                            *state = WearableItemState::PendingImage(
+                                ipfas.asset_server().load(&data.thumbnail),
+                            );
 
                             modified = true;
 
@@ -1163,7 +1165,7 @@ fn update_selected_item(
                 let wearable_img = wearable_settings
                     .current_wearables
                     .get(&category)
-                    .map(|(_, data)| data.thumbnail.clone())
+                    .map(|(_, data)| ipfas.asset_server().load(&data.thumbnail))
                     .unwrap_or_else(|| empty_img.clone());
 
                 commands


### PR DESCRIPTION
- don't load thumbnails on wearable/emote load
- force all images to render-world only
- set imposters to renderworld only