### PR TITLE
Trigger areas

### DIFF
--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -55,6 +55,8 @@ fn gen_sdk_components() -> Result<()> {
         "virtual_camera",
         "main_camera",
         "input_modifier",
+        "trigger_area",
+        "trigger_area_result",
     ];
 
     let mut sources = components

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -87,6 +87,9 @@ impl SceneComponentId {
     pub const CANVAS_INFO: SceneComponentId = SceneComponentId(1054);
     pub const UI_CANVAS: SceneComponentId = SceneComponentId(1203);
 
+    pub const TRIGGER_AREA: SceneComponentId = SceneComponentId(1060);
+    pub const TRIGGER_AREA_RESULT: SceneComponentId = SceneComponentId(1061);
+
     pub const POINTER_EVENTS: SceneComponentId = SceneComponentId(1062);
     pub const POINTER_RESULT: SceneComponentId = SceneComponentId(1063);
 

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/trigger_area.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/trigger_area.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1060;
+
+// The PBTriggerArea component is used to raise collision triggering events (through the TriggerAreaResult component)
+// when entities enter this component's defined area.
+//
+// ADR: https://github.com/decentraland/adr/blob/2b30a5e2b4f359a7c22a68fb827db282f6e5f887/content/ADR-258-trigger-areas.md
+//
+// The area size and rotation is defined by the Entity's Transform.
+message PBTriggerArea {
+  optional TriggerAreaMeshType mesh = 1;         // default: MT_BOX
+  optional uint32 collision_mask = 2; // default: CL_PLAYER
+}
+
+enum TriggerAreaMeshType {
+  TAMT_BOX = 0;
+  TAMT_SPHERE = 1;
+}

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/trigger_area_result.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/trigger_area_result.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/common/vectors.proto";
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1061;
+
+// The PBTriggerAreaResult component is used to transport the trigger collision event data for the PBTriggerArea component.
+// ADR: https://github.com/decentraland/adr/blob/2b30a5e2b4f359a7c22a68fb827db282f6e5f887/content/ADR-258-trigger-areas.md
+message PBTriggerAreaResult {
+  // Trigger data object
+  message Trigger {
+    uint32 entity = 1;                                          // The entity that triggered the Trigger Area
+    uint32 layers = 2;                                          // The collision layermask of the entity that triggered the Trigger Area
+    decentraland.common.Vector3 position = 3;                   // The position of the entity that triggered the trigger
+    decentraland.common.Quaternion rotation = 4;                // The rotation of the entity that triggered the trigger
+    decentraland.common.Vector3 scale = 5;                      // The scale of the entity that triggered the trigger
+  }
+  
+  uint32 triggered_entity = 1;                                  // The entity that was triggered (this is the entity that owns the trigger area)
+  decentraland.common.Vector3 triggered_entity_position = 2;    // The position of the triggered entity at the time of the trigger
+  decentraland.common.Quaternion triggered_entity_rotation = 3; // The rotation of the triggered entity at the time of the trigger
+  TriggerAreaEventType event_type = 4;                          // The state of the trigger event (ENTER, STAY, EXIT)
+  uint32 timestamp = 5;                                         // The timestamp of the trigger event
+  Trigger trigger = 6;
+}
+
+enum TriggerAreaEventType {
+  TAET_ENTER = 0;
+  TAET_STAY = 1;
+  TAET_EXIT = 2;
+}

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -120,6 +120,8 @@ impl DclProtoComponent for sdk::components::PbRealmInfo {}
 impl DclProtoComponent for sdk::components::PbVirtualCamera {}
 impl DclProtoComponent for sdk::components::PbMainCamera {}
 impl DclProtoComponent for sdk::components::PbInputModifier {}
+impl DclProtoComponent for sdk::components::PbTriggerArea {}
+impl DclProtoComponent for sdk::components::PbTriggerAreaResult {}
 
 // VECTOR2 conversions
 impl Copy for common::Vector2 {}
@@ -197,6 +199,17 @@ impl Copy for common::Quaternion {}
 impl From<common::Quaternion> for bevy::math::Quat {
     fn from(q: common::Quaternion) -> Self {
         bevy::math::Quat::from_xyzw(q.x, q.y, -q.z, -q.w)
+    }
+}
+
+impl From<bevy::math::Quat> for common::Quaternion {
+    fn from(q: bevy::math::Quat) -> Self {
+        common::Quaternion {
+            x: q.x,
+            y: q.y,
+            z: -q.z,
+            w: -q.w,
+        }
     }
 }
 

--- a/crates/scene_runner/src/update_scene/raycast_result.rs
+++ b/crates/scene_runner/src/update_scene/raycast_result.rs
@@ -152,6 +152,8 @@ fn run_raycasts(
                     raycast.max_distance,
                     mask,
                     true,
+                    false,
+                    None,
                 )
                 .map(|hit| vec![(scene_ent.root, hit)])
                 .unwrap_or_default(),
@@ -189,6 +191,8 @@ fn run_raycasts(
                         raycast.max_distance,
                         mask,
                         true,
+                        false,
+                        None,
                     ) {
                         if best_result.as_ref().is_none_or(|(_, b)| b.toi > result.toi) {
                             best_result = Some((scene, result));

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -36,7 +36,8 @@ use crate::{
     update_world::{
         lights::LightSource,
         material::{dcl_material_from_standard_material, BaseMaterial},
-        trigger_area::TriggerArea,
+        mesh_collider::{ColliderType, CtCollider},
+        trigger_area::CtTrigger,
     },
     ContainerEntity, ContainingScene, OutOfWorld, SceneEntity, SceneSets,
 };
@@ -845,12 +846,15 @@ fn update_ready_gltfs(
                             h_mesh.clone()
                         };
 
-                        commands.entity(spawned_ent).try_insert(MeshCollider {
-                            shape: MeshColliderShape::Shape(data.shape.clone(), h_collider),
-                            collision_mask: collider_bits,
-                            mesh_name: collider_base_name.map(ToOwned::to_owned),
-                            index: *index,
-                        });
+                        commands
+                            .entity(spawned_ent)
+                            .try_insert(MeshCollider::<CtCollider> {
+                                shape: MeshColliderShape::Shape(data.shape.clone(), h_collider),
+                                collision_mask: collider_bits,
+                                mesh_name: collider_base_name.map(ToOwned::to_owned),
+                                index: *index,
+                                _p: Default::default(),
+                            });
                     }
 
                     if is_trigger && collider_bits != Some(0) {
@@ -866,12 +870,15 @@ fn update_ready_gltfs(
                             h_mesh.clone()
                         };
 
-                        commands.entity(spawned_ent).try_insert(TriggerArea {
-                            shape: MeshColliderShape::Shape(data.shape.clone(), h_collider),
-                            trigger_mask: collider_bits,
-                            mesh_name: collider_base_name.map(ToOwned::to_owned),
-                            index: *index,
-                        });
+                        commands
+                            .entity(spawned_ent)
+                            .try_insert(MeshCollider::<CtTrigger> {
+                                shape: MeshColliderShape::Shape(data.shape.clone(), h_collider),
+                                collision_mask: collider_bits,
+                                mesh_name: collider_base_name.map(ToOwned::to_owned),
+                                index: *index,
+                                _p: Default::default(),
+                            });
                     }
                 }
             }
@@ -1172,7 +1179,7 @@ pub enum GltfLinkState<'a> {
 pub struct HiddenMaterial(MeshMaterial3d<SceneMaterial>);
 
 #[derive(Component)]
-pub struct HiddenCollider(MeshCollider);
+pub struct HiddenCollider<T: ColliderType>(MeshCollider<T>);
 
 #[derive(Component)]
 pub struct HiddenPointLight(PointLight);
@@ -1205,7 +1212,8 @@ fn expose_gltfs(
         Option<&GltfMaterialName>,
         Option<&Mesh3d>,
         Option<&SkinnedMesh>,
-        Option<&MeshCollider>,
+        Option<&MeshCollider<CtCollider>>,
+        Option<&MeshCollider<CtTrigger>>,
         Option<&Name>,
         Option<&PointLight>,
         Option<&SpotLight>,
@@ -1367,6 +1375,7 @@ fn expose_gltfs(
                     maybe_mesh,
                     maybe_skin,
                     maybe_collider,
+                    maybe_trigger,
                     maybe_name,
                     maybe_point,
                     maybe_spot,
@@ -1399,8 +1408,8 @@ fn expose_gltfs(
                     // hide
                     commands
                         .entity(gltf_entity)
-                        .remove::<MeshCollider>()
-                        .insert(HiddenCollider(collider.clone()));
+                        .remove::<MeshCollider<CtCollider>>()
+                        .insert(HiddenCollider::<CtCollider>(collider.clone()));
                     // copy
                     commands.entity(ent).insert(collider.clone());
                     // write to scene
@@ -1419,6 +1428,34 @@ fn expose_gltfs(
                             })),
                         },
                     )
+                }
+                if let Some(trigger) = maybe_trigger {
+                    debug!("link trigger");
+                    // hide
+                    commands
+                        .entity(gltf_entity)
+                        .remove::<MeshCollider<CtTrigger>>()
+                        .insert(HiddenCollider::<CtTrigger>(trigger.clone()));
+                    // copy
+                    commands.entity(ent).insert(trigger.clone());
+                    // write to scene
+                    // TODO: extend protocol to allow Gltf type for triggers
+
+                    // scene.update_crdt(
+                    //     SceneComponentId::TRIGGER_AREA,
+                    //     CrdtType::LWW_ANY,
+                    //     scene_ent.id,
+                    //     &PbMeshCollider {
+                    //         collision_mask: Some(trigger.collision_mask),
+                    //         mesh: Some(pb_mesh_collider::Mesh::Gltf(pb_mesh_collider::GltfMesh {
+                    //             gltf_src: src.to_owned(),
+                    //             name: trigger
+                    //                 .mesh_name
+                    //                 .clone()
+                    //                 .unwrap_or_else(|| "???".to_owned()),
+                    //         })),
+                    //     },
+                    // )
                 }
                 if let Some(material) = maybe_material {
                     debug!("link material ({} / {:?})", src, maybe_mat_name);
@@ -1543,7 +1580,8 @@ fn update_gltf_linked_transforms(
         &ContainerEntity,
         &ChildOf,
         Option<&HiddenMaterial>,
-        Option<&HiddenCollider>,
+        Option<&HiddenCollider<CtCollider>>,
+        Option<&HiddenCollider<CtTrigger>>,
         Option<&HiddenPointLight>,
         Option<&HiddenSpotLight>,
     )>,
@@ -1582,6 +1620,7 @@ fn update_gltf_linked_transforms(
         parent,
         maybe_hidden_material,
         maybe_hidden_collider,
+        maybe_hidden_trigger,
         maybe_hidden_point,
         maybe_hidden_spot,
     ) in gltf_nodes.iter()
@@ -1599,7 +1638,13 @@ fn update_gltf_linked_transforms(
             if let Some(hidden) = maybe_hidden_collider {
                 commands
                     .entity(gltf_entity)
-                    .remove::<HiddenCollider>()
+                    .remove::<HiddenCollider<CtCollider>>()
+                    .insert(hidden.0.clone());
+            }
+            if let Some(hidden) = maybe_hidden_trigger {
+                commands
+                    .entity(gltf_entity)
+                    .remove::<HiddenCollider<CtTrigger>>()
                     .insert(hidden.0.clone());
             }
             if let Some(hidden) = maybe_hidden_point {

--- a/crates/scene_runner/src/update_world/mod.rs
+++ b/crates/scene_runner/src/update_world/mod.rs
@@ -18,7 +18,7 @@ use dcl::{
 use dcl_component::{DclReader, FromDclReader, SceneComponentId};
 use scene_material::SceneMaterial;
 
-use crate::ContainerEntity;
+use crate::{update_world::trigger_area::TriggerAreaPlugin, ContainerEntity};
 
 use self::{
     animation::AnimatorPlugin, avatar_modifier_area::AvatarModifierAreaPlugin,
@@ -46,6 +46,7 @@ pub mod raycast;
 pub mod scene_ui;
 pub mod text_shape;
 pub mod transform_and_parent;
+pub mod trigger_area;
 pub mod visibility;
 
 #[derive(Component, Default)]
@@ -156,6 +157,7 @@ impl Plugin for SceneOutputPlugin {
         app.add_plugins(MeshDefinitionPlugin);
         app.add_plugins(MaterialDefinitionPlugin);
         app.add_plugins(MeshColliderPlugin);
+        app.add_plugins(TriggerAreaPlugin);
 
         if !app
             .world()

--- a/crates/scene_runner/src/update_world/trigger_area.rs
+++ b/crates/scene_runner/src/update_world/trigger_area.rs
@@ -1,0 +1,286 @@
+use bevy::{platform::collections::HashMap, prelude::*, render::mesh::VertexAttributeValues};
+use common::sets::SceneSets;
+use dcl::interface::{ComponentPosition, CrdtType};
+use dcl_component::{
+    proto_components::{
+        common::Vector3,
+        sdk::components::{
+            pb_trigger_area_result::Trigger, ColliderLayer, PbTriggerArea, PbTriggerAreaResult,
+            TriggerAreaEventType, TriggerAreaMeshType,
+        },
+    },
+    SceneComponentId,
+};
+use rapier3d::{
+    math::Point,
+    prelude::{ColliderBuilder, SharedShape},
+};
+
+use crate::{
+    gltf_resolver::GltfMeshResolver,
+    renderer_context::RendererSceneContext,
+    update_world::{
+        gltf_container::mesh_to_parry_shape,
+        mesh_collider::{ColliderId, MeshCollider, MeshColliderShape, SceneColliderData},
+        mesh_renderer::truncated_cone::TruncatedCone,
+        AddCrdtInterfaceExt,
+    },
+    ContainerEntity,
+};
+
+#[derive(Component)]
+pub struct TriggerArea {
+    pub shape: MeshColliderShape,
+    pub trigger_mask: u32,
+    pub mesh_name: Option<String>,
+    pub index: u32,
+}
+
+impl Default for TriggerArea {
+    fn default() -> Self {
+        Self {
+            shape: MeshColliderShape::Box,
+            trigger_mask: ColliderLayer::ClPlayer as u32,
+            mesh_name: Default::default(),
+            index: Default::default(),
+        }
+    }
+}
+
+impl From<PbTriggerArea> for TriggerArea {
+    fn from(value: PbTriggerArea) -> Self {
+        let shape = match value.mesh() {
+            TriggerAreaMeshType::TamtBox => MeshColliderShape::Box,
+            TriggerAreaMeshType::TamtSphere => MeshColliderShape::Sphere,
+        };
+
+        Self {
+            shape,
+            trigger_mask: value
+                .collision_mask
+                .unwrap_or(ColliderLayer::ClPlayer as u32),
+            ..Default::default()
+        }
+    }
+}
+
+pub struct TriggerAreaPlugin;
+
+impl Plugin for TriggerAreaPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_crdt_lww_component::<PbTriggerArea, TriggerArea>(
+            SceneComponentId::TRIGGER_AREA,
+            ComponentPosition::EntityOnly,
+        );
+
+        app.add_systems(
+            Update,
+            (update_trigger_shapes, update_triggers)
+                .chain()
+                .in_set(SceneSets::Input),
+        );
+    }
+}
+
+#[derive(Component)]
+pub struct TriggerShape(SharedShape);
+
+fn update_trigger_shapes(
+    mut commands: Commands,
+    changed_triggers: Query<(Entity, &ContainerEntity, &TriggerArea), Changed<TriggerArea>>,
+    scenes: Query<&RendererSceneContext>,
+    mut gltf_mesh_resolver: GltfMeshResolver,
+    meshes: Res<Assets<Mesh>>,
+) {
+    for (entity, container, area) in changed_triggers.iter() {
+        let shape = match &area.shape {
+            MeshColliderShape::Box => ColliderBuilder::cuboid(0.5, 0.5, 0.5),
+            MeshColliderShape::Cylinder {
+                radius_top,
+                radius_bottom,
+            } => {
+                // TODO we could use explicit support points to make queries faster
+                let mesh: Mesh = TruncatedCone {
+                    base_radius: *radius_bottom,
+                    tip_radius: *radius_top,
+                    ..Default::default()
+                }
+                .into();
+                let VertexAttributeValues::Float32x3(positions) =
+                    mesh.attribute(Mesh::ATTRIBUTE_POSITION).unwrap()
+                else {
+                    panic!()
+                };
+                ColliderBuilder::convex_hull(
+                    &positions
+                        .iter()
+                        .map(|p| Point::from([p[0], p[1], p[2]]))
+                        .collect::<Vec<_>>(),
+                )
+                .unwrap()
+            }
+            MeshColliderShape::Plane => ColliderBuilder::cuboid(0.5, 0.5, 0.005),
+            MeshColliderShape::Sphere => ColliderBuilder::ball(0.5),
+            MeshColliderShape::Shape(shape, _) => ColliderBuilder::new(shape.clone()),
+            MeshColliderShape::GltfShape { gltf_src, name } => {
+                let Ok(scene) = scenes.get(container.root) else {
+                    continue;
+                };
+                let Ok(Some(h_mesh)) = gltf_mesh_resolver.resolve_mesh(gltf_src, &scene.hash, name)
+                else {
+                    continue;
+                };
+                let mesh = meshes.get(&h_mesh).unwrap();
+                let shape = mesh_to_parry_shape(mesh);
+                ColliderBuilder::new(shape)
+            }
+        }
+        .build()
+        .shared_shape()
+        .clone();
+
+        commands.entity(entity).try_insert(TriggerShape(shape));
+    }
+}
+
+#[derive(Component)]
+pub struct ActiveTriggers(pub HashMap<ColliderId, u32>);
+
+fn update_triggers(
+    mut commands: Commands,
+    trigger_areas: Query<(
+        Entity,
+        &ContainerEntity,
+        Ref<TriggerArea>,
+        Option<&ActiveTriggers>,
+        &TriggerShape,
+        &GlobalTransform,
+    )>,
+    mut scenes: Query<(&mut RendererSceneContext, &mut SceneColliderData)>,
+    triggers: Query<(&MeshCollider, &GlobalTransform)>,
+) {
+    for (entity, container, trigger, maybe_active, shape, gt) in trigger_areas.iter() {
+        let Ok((mut scene, mut colliders)) = scenes.get_mut(container.root) else {
+            continue;
+        };
+
+        let timestamp = scene.last_update_frame;
+
+        // get intersecting colliders
+        let new_colliders =
+            colliders.intersect_shape(scene.last_update_frame, &shape.0, gt, trigger.trigger_mask);
+        let (_, rotation, translation) = gt.to_scale_rotation_translation();
+
+        let mut results = Vec::default();
+        if let Some(prev_active) = maybe_active.as_ref() {
+            for (prev_collider, prev_frame) in &prev_active.0 {
+                let trigger = colliders
+                    .get_collider_entity(prev_collider)
+                    .and_then(|e| triggers.get(e).ok())
+                    .map(|(collider, gt)| {
+                        let (s, r, t) = gt.to_scale_rotation_translation();
+                        Trigger {
+                            entity: prev_collider.entity.as_proto_u32().unwrap(),
+                            layers: collider.collision_mask,
+                            position: Some(Vector3::world_vec_from_vec3(&t)),
+                            rotation: Some(r.into()),
+                            scale: Some(Vector3::abs_vec_from_vec3(&s)),
+                        }
+                    })
+                    .unwrap_or_else(|| Trigger {
+                        entity: prev_collider.entity.as_proto_u32().unwrap(),
+                        layers: 0,
+                        position: None,
+                        rotation: None,
+                        scale: None,
+                    });
+
+                if new_colliders.contains(prev_collider) {
+                    if prev_frame != &timestamp {
+                        // send only 1 stay per scene tick
+                        results.push((
+                            container.container_id,
+                            PbTriggerAreaResult {
+                                triggered_entity: container.container_id.as_proto_u32().unwrap(),
+                                triggered_entity_position: Some(Vector3::world_vec_from_vec3(
+                                    &translation,
+                                )),
+                                triggered_entity_rotation: Some(rotation.into()),
+                                event_type: TriggerAreaEventType::TaetStay as i32,
+                                timestamp,
+                                trigger: Some(trigger.clone()),
+                            },
+                        ));
+                    }
+                } else {
+                    results.push((
+                        container.container_id,
+                        PbTriggerAreaResult {
+                            triggered_entity: container.container_id.as_proto_u32().unwrap(),
+                            triggered_entity_position: Some(Vector3::world_vec_from_vec3(
+                                &translation,
+                            )),
+                            triggered_entity_rotation: Some(rotation.into()),
+                            event_type: TriggerAreaEventType::TaetExit as i32,
+                            timestamp,
+                            trigger: Some(trigger.clone()),
+                        },
+                    ));
+                }
+            }
+        }
+
+        for new_collider in &new_colliders {
+            if maybe_active
+                .as_ref()
+                .is_none_or(|prev_active| !prev_active.0.contains_key(new_collider))
+            {
+                let trigger = colliders
+                    .get_collider_entity(new_collider)
+                    .and_then(|e| triggers.get(e).ok())
+                    .map(|(collider, gt)| {
+                        let (s, r, t) = gt.to_scale_rotation_translation();
+                        Trigger {
+                            entity: new_collider.entity.as_proto_u32().unwrap(),
+                            layers: collider.collision_mask,
+                            position: Some(Vector3::world_vec_from_vec3(&t)),
+                            rotation: Some(r.into()),
+                            scale: Some(Vector3::abs_vec_from_vec3(&s)),
+                        }
+                    })
+                    .unwrap_or_else(|| Trigger {
+                        entity: new_collider.entity.as_proto_u32().unwrap(),
+                        layers: 0,
+                        position: None,
+                        rotation: None,
+                        scale: None,
+                    });
+
+                results.push((
+                    container.container_id,
+                    PbTriggerAreaResult {
+                        triggered_entity: container.container_id.as_proto_u32().unwrap(),
+                        triggered_entity_position: Some(Vector3::world_vec_from_vec3(&translation)),
+                        triggered_entity_rotation: Some(rotation.into()),
+                        event_type: TriggerAreaEventType::TaetEnter as i32,
+                        timestamp,
+                        trigger: Some(trigger.clone()),
+                    },
+                ));
+            }
+        }
+
+        for (scene_ent, trigger) in results {
+            scene.update_crdt(
+                SceneComponentId::TRIGGER_AREA_RESULT,
+                CrdtType::GO_ENT,
+                scene_ent,
+                &trigger,
+            );
+        }
+
+        commands.entity(entity).try_insert(ActiveTriggers(
+            new_colliders.into_iter().map(|c| (c, timestamp)).collect(),
+        ));
+    }
+}

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -309,6 +309,8 @@ pub fn update_camera_position(
                         1.0,
                         u32::MAX,
                         false,
+                        false,
+                        None,
                     ) {
                         offset_distances[ix] =
                             FloatOrd(offset_distances[ix].0.min(hit.toi).max(0.0));


### PR DESCRIPTION
closes #288

undocumented / non-consistent behaviours:
- pointer: in bevy all triggers under the pointer are hit (even if blocked by a pointer collider). in unity no pointer/triggers are implemented
- trigger area changes: in bevy changing the shape or layers of a trigger maintains previous hits and updates correctly for resulting enter/exit messages. in unity changing the trigger does not work
- first tick: in bevy the trigger area is immediately activated. in unity an extra tick (or more) is required before activation occurs