### PR TITLE
Fix web freeze

### DIFF
--- a/crates/dcl/src/js/runtime.rs
+++ b/crates/dcl/src/js/runtime.rs
@@ -10,7 +10,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     interface::{crdt_context::CrdtContext, CrdtType},
-    js::RendererStore,
+    js::{RendererStore, SceneResponseSender},
     RpcCalls, SceneResponse,
 };
 
@@ -27,8 +27,8 @@ pub async fn op_read_file(
 
     op_state
         .borrow_mut()
-        .borrow_mut::<tokio::sync::mpsc::UnboundedSender<SceneResponse>>()
-        .send(SceneResponse::ImmediateRpcCall(RpcCall::ReadFile {
+        .borrow_mut::<SceneResponseSender>()
+        .try_send(SceneResponse::ImmediateRpcCall(RpcCall::ReadFile {
             scene_hash,
             filename,
             response: sx,

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -240,7 +240,7 @@ pub(crate) fn scene_thread(
         let _ = state
             .borrow_mut()
             .borrow_mut::<SceneResponseSender>()
-            .send(SceneResponse::WaitingForInspector);
+            .try_send(SceneResponse::WaitingForInspector);
 
         runtime
             .inspector()
@@ -265,7 +265,7 @@ pub(crate) fn scene_thread(
             let _ = state
                 .borrow_mut()
                 .take::<SceneResponseSender>()
-                .send(SceneResponse::Error(scene_id, format!("{e:?}")));
+                .try_send(SceneResponse::Error(scene_id, format!("{e:?}")));
             return;
         }
         Ok(script) => script,
@@ -294,7 +294,7 @@ pub(crate) fn scene_thread(
         let _ = state
             .borrow_mut()
             .take::<SceneResponseSender>()
-            .send(SceneResponse::Error(scene_id, format!("{e:?}")));
+            .try_send(SceneResponse::Error(scene_id, format!("{e:?}")));
         return;
     }
 
@@ -349,7 +349,7 @@ pub(crate) fn scene_thread(
                 let _ = state
                     .borrow_mut()
                     .take::<SceneResponseSender>()
-                    .send(SceneResponse::Error(scene_id, format!("{e:?}")));
+                    .try_send(SceneResponse::Error(scene_id, format!("{e:?}")));
                 rt.block_on(async move {
                     drop(runtime);
                 });

--- a/crates/dcl_deno/src/lib.rs
+++ b/crates/dcl_deno/src/lib.rs
@@ -9,13 +9,14 @@ use bevy::{log::error, platform::collections::HashMap};
 use deno_core::v8::IsolateHandle;
 use once_cell::sync::Lazy;
 use system_bridge::SystemApi;
-use tokio::sync::mpsc::{Sender, UnboundedSender};
+use tokio::sync::mpsc::Sender;
 
 use ipfs::SceneJsFile;
 
 use dcl::{
     interface::{CrdtComponentInterfaces, CrdtStore},
-    RendererResponse, SceneId, SceneResponse,
+    js::SceneResponseSender,
+    RendererResponse, SceneId,
 };
 
 use crate::js::scene_thread;
@@ -34,7 +35,7 @@ pub fn spawn_scene(
     scene_hash: String,
     scene_js: SceneJsFile,
     crdt_component_interfaces: CrdtComponentInterfaces,
-    renderer_sender: UnboundedSender<SceneResponse>,
+    renderer_sender: SceneResponseSender,
     global_update_receiver: tokio::sync::broadcast::Receiver<Vec<u8>>,
     id: SceneId,
     storage_root: String,

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -7,8 +7,8 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 use bevy::{log::tracing::span::EnteredSpan, tasks::IoTaskPool};
 use dcl::{
     interface::{CrdtComponentInterfaces, CrdtStore},
-    js::{CommunicatedWithRenderer, ShuttingDown, SuperUserScene},
-    RendererResponse, SceneId, SceneResponse,
+    js::{CommunicatedWithRenderer, SceneResponseSender, ShuttingDown, SuperUserScene},
+    RendererResponse, SceneId,
 };
 use gotham_state::GothamState;
 use ipfs::SceneJsFile;
@@ -25,7 +25,7 @@ pub struct SceneInitializationData {
     pub scene_hash: String,
     pub scene_js: SceneJsFile,
     pub crdt_component_interfaces: CrdtComponentInterfaces,
-    pub renderer_sender: tokio::sync::mpsc::UnboundedSender<SceneResponse>,
+    pub renderer_sender: SceneResponseSender,
     pub global_update_receiver: tokio::sync::broadcast::Receiver<Vec<u8>>,
     pub id: SceneId,
     pub storage_root: String,
@@ -50,7 +50,7 @@ pub fn spawn_scene(
     scene_hash: String,
     scene_js: SceneJsFile,
     crdt_component_interfaces: CrdtComponentInterfaces,
-    renderer_sender: tokio::sync::mpsc::UnboundedSender<SceneResponse>,
+    renderer_sender: SceneResponseSender,
     global_update_receiver: tokio::sync::broadcast::Receiver<Vec<u8>>,
     id: SceneId,
     storage_root: String,

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -447,7 +447,7 @@ pub(crate) fn load_scene_javascript(
             initial_crdt.clean_up(&census.died);
             let updates = initial_crdt.clone().take_updates();
 
-            if let Err(e) = scene_updates.sender.send(SceneResponse::Ok(
+            if let Err(e) = scene_updates.sender.try_send(SceneResponse::Ok(
                 context.scene_id,
                 census,
                 updates,


### PR DESCRIPTION
in wasm a freeze was occurring in scene response channel calling (the apparently non-blocking) `UnboundedReceiver::try_recv`.

replace tokio channel with `std::sync` channel in wasm only.
 