### PR TITLE
GltfNodeModifiers

### DIFF
--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -334,7 +334,7 @@ fn animate(
 
                 // send to scenes
                 let broadcast_urn = given_urn.unwrap();
-                debug!("broadcasting emote to scenes: {:?}", broadcast_urn);
+                error!("broadcasting emote to scenes: {:?}", broadcast_urn);
 
                 let (scene, scene_id) = match (maybe_foreign, maybe_primary, maybe_container) {
                     (Some(f), ..) => (None, f.scene_id),
@@ -531,7 +531,15 @@ fn play_current_emote(
 
         if let Some(scene_emote) = active_emote.urn.scene_emote() {
             debug!("got {scene_emote:?}");
-            let Some(hash) = scene_emote.split('-').nth(1) else {
+            let mut split = scene_emote.split('-');
+            let maybe_hash = if split.next() == Some("b64") {
+                // stupid to have "-" as a separator and also part of the hash itself for local hashes
+                let parts = split.skip(1).take(2).collect::<Vec<_>>();
+                (parts.len() == 2).then_some(parts.join("-"))
+            } else {
+                split.next().map(ToOwned::to_owned)
+            };
+            let Some(hash) = maybe_hash.as_ref() else {
                 debug!("failed to split scene emote {scene_emote:?}");
                 active_emote.finished = true;
                 continue;

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -334,7 +334,7 @@ fn animate(
 
                 // send to scenes
                 let broadcast_urn = given_urn.unwrap();
-                error!("broadcasting emote to scenes: {:?}", broadcast_urn);
+                debug!("broadcasting emote to scenes: {:?}", broadcast_urn);
 
                 let (scene, scene_id) = match (maybe_foreign, maybe_primary, maybe_container) {
                     (Some(f), ..) => (None, f.scene_id),

--- a/crates/collectibles/src/urn.rs
+++ b/crates/collectibles/src/urn.rs
@@ -81,7 +81,7 @@ impl<T: CollectibleType> CollectibleUrn<T> {
                 value: String::default(),
             });
         }
-        let mut urn = value.to_lowercase();
+        let mut urn = value.to_owned();
         let count = urn.chars().filter(|c| *c == ':').count();
         if count == 0 {
             let Some(base) = T::base_collection() else {
@@ -116,7 +116,17 @@ impl<T: CollectibleType> CollectibleUrn<T> {
         };
 
         let mut iter = parts.into_iter();
-        let urn = iter.by_ref().take(collection_segments + 1).join(":");
+        let urn = iter
+            .by_ref()
+            .take(collection_segments + 1)
+            .map(|segment| {
+                if segment.starts_with("b64-") {
+                    segment.to_owned()
+                } else {
+                    segment.to_ascii_lowercase()
+                }
+            })
+            .join(":");
 
         let token = iter.join(":").to_owned();
         let token = if token.is_empty() { None } else { Some(token) };

--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -57,6 +57,7 @@ fn gen_sdk_components() -> Result<()> {
         "input_modifier",
         "trigger_area",
         "trigger_area_result",
+        "gltf_node_modifiers",
     ];
 
     let mut sources = components

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -69,6 +69,7 @@ impl SceneComponentId {
 
     pub const GLTF_CONTAINER: SceneComponentId = SceneComponentId(1041);
     pub const ANIMATOR: SceneComponentId = SceneComponentId(1042);
+    pub const GLTF_NODE_MODIFIERS: SceneComponentId = SceneComponentId(1099);
 
     pub const VIDEO_PLAYER: SceneComponentId = SceneComponentId(1043);
     pub const VIDEO_EVENT: SceneComponentId = SceneComponentId(1044);

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/gltf_node_modifiers.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/gltf_node_modifiers.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+import "decentraland/sdk/components/material.proto";
+
+option (common.ecs_component_id) = 1099;
+
+// GltfNodeModifiers component is to be used attached to entities that have the GltfContainer component.
+//
+// This allows to override either the Material or the Casting Shadows behaviour of the target GLTF Node.
+// 
+// * If the 'path' of the first modifier in the collection is an empty string: the configuration will
+// affect all of the GLTF Nodes (as a global modifier).
+// * Otherwise, for the modifiers whose 'path' is found in the GLTF hierarchy, the modifier will affect only
+// the target Nodes.
+message PBGltfNodeModifiers {
+  message GltfNodeModifier {
+    string path = 1; // The GLTF hierarchy path of the target Node to be affected
+    optional bool cast_shadows = 2; // The casting shadows enabled override
+    optional PBMaterial material = 3; // The Material that will be overridden on the target Node
+  }
+  repeated GltfNodeModifier modifiers  = 1;
+}

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -122,6 +122,7 @@ impl DclProtoComponent for sdk::components::PbMainCamera {}
 impl DclProtoComponent for sdk::components::PbInputModifier {}
 impl DclProtoComponent for sdk::components::PbTriggerArea {}
 impl DclProtoComponent for sdk::components::PbTriggerAreaResult {}
+impl DclProtoComponent for sdk::components::PbGltfNodeModifiers {}
 
 // VECTOR2 conversions
 impl Copy for common::Vector2 {}

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -412,7 +412,9 @@ async fn run_script(
     if result.is_err() {
         debug!("rerunning event loop");
         for _ in 0..100 {
-            let x = runtime.run_event_loop(PollEventLoopOptions::default()).await;
+            let x = runtime
+                .run_event_loop(PollEventLoopOptions::default())
+                .await;
             if x.is_err() {
                 error!("repeat error: {x:?}");
             } else {

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -404,10 +404,25 @@ async fn run_script(
     };
 
     let f = runtime.resolve(promise);
-    runtime
+    let result = runtime
         .with_event_loop_promise(f, PollEventLoopOptions::default())
         .await
-        .map(|_| ())
+        .map(|_| ());
+
+    if result.is_err() {
+        debug!("rerunning event loop");
+        for _ in 0..100 {
+            let x = runtime.run_event_loop(PollEventLoopOptions::default()).await;
+            if x.is_err() {
+                error!("repeat error: {x:?}");
+            } else {
+                break;
+            }
+        }
+        debug!("done rerunning event loop");
+    }
+
+    result
 }
 
 // synchronously returns a string containing JS code from the file system

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -263,6 +263,19 @@ impl RendererSceneContext {
             .force_update(component_id, crdt_type, id, Some(&mut DclReader::new(&buf)));
     }
 
+    pub fn update_crdt_if_different(
+        &mut self,
+        component_id: SceneComponentId,
+        crdt_type: CrdtType,
+        id: SceneEntityId,
+        data: &impl ToDclWriter,
+    ) {
+        let mut buf = Vec::new();
+        DclWriter::new(&mut buf).write(data);
+        self.crdt_store
+            .update_if_different(component_id, crdt_type, id, Some(&mut DclReader::new(&buf)));
+    }
+
     #[allow(dead_code)]
     pub fn clear_crdt(
         &mut self,

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -272,8 +272,12 @@ impl RendererSceneContext {
     ) {
         let mut buf = Vec::new();
         DclWriter::new(&mut buf).write(data);
-        self.crdt_store
-            .update_if_different(component_id, crdt_type, id, Some(&mut DclReader::new(&buf)));
+        self.crdt_store.update_if_different(
+            component_id,
+            crdt_type,
+            id,
+            Some(&mut DclReader::new(&buf)),
+        );
     }
 
     #[allow(dead_code)]

--- a/crates/scene_runner/src/update_scene/camera_mode.rs
+++ b/crates/scene_runner/src/update_scene/camera_mode.rs
@@ -40,7 +40,7 @@ fn update_camera_mode(mut scenes: Query<&mut RendererSceneContext>, camera: Quer
     let camera_mode = PbCameraMode { mode: mode.into() };
 
     for mut context in scenes.iter_mut() {
-        context.update_crdt(
+        context.update_crdt_if_different(
             SceneComponentId::CAMERA_MODE,
             CrdtType::LWW_ENT,
             SceneEntityId::CAMERA,

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -35,9 +35,7 @@ use crate::{
     renderer_context::RendererSceneContext,
     update_world::{
         lights::LightSource,
-        material::{
-            dcl_material_from_standard_material, BaseMaterial, CheckThis, PbMaterialComponent,
-        },
+        material::{dcl_material_from_standard_material, BaseMaterial, PbMaterialComponent},
         mesh_collider::{ColliderType, CtCollider},
         trigger_area::CtTrigger,
     },
@@ -1225,7 +1223,7 @@ fn debug_modifiers(
                     }
                     commands
                         .entity(*child)
-                        .try_insert((PbMaterialComponent(material.clone()), CheckThis));
+                        .try_insert(PbMaterialComponent(material.clone()));
                 }
             } else {
                 commands
@@ -1237,7 +1235,7 @@ fn debug_modifiers(
             }
         }
 
-        error!("applying (found = {found}): {modifiers:?}");
+        debug!("applying GltfNodeModifiers (found a path match = {found}): {modifiers:?}");
     }
 
     for removed in removed_components.read() {

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -31,12 +31,17 @@ use rapier3d::prelude::*;
 use serde::Deserialize;
 
 use crate::{
-    ContainerEntity, ContainingScene, OutOfWorld, SceneEntity, SceneSets, initialize_scene::SceneEntityDefinitionHandle, renderer_context::RendererSceneContext, update_world::{
+    initialize_scene::SceneEntityDefinitionHandle,
+    renderer_context::RendererSceneContext,
+    update_world::{
         lights::LightSource,
-        material::{BaseMaterial, CheckThis, PbMaterialComponent, dcl_material_from_standard_material},
+        material::{
+            dcl_material_from_standard_material, BaseMaterial, CheckThis, PbMaterialComponent,
+        },
         mesh_collider::{ColliderType, CtCollider},
         trigger_area::CtTrigger,
-    }
+    },
+    ContainerEntity, ContainingScene, OutOfWorld, SceneEntity, SceneSets,
 };
 use dcl::interface::{ComponentPosition, CrdtType};
 use dcl_component::{

--- a/crates/scene_runner/src/update_world/lights.rs
+++ b/crates/scene_runner/src/update_world/lights.rs
@@ -68,6 +68,10 @@ pub struct LightSource {
 
 impl From<PbLightSource> for LightSource {
     fn from(value: PbLightSource) -> Self {
+        if let Some(pb_light_source::Type::Spot(spot)) = &value.r#type {
+                println!("{:?}, {:?}", spot.inner_angle, spot.outer_angle);
+        }
+
         Self {
             enabled: value.active.unwrap_or(true),
             intensity: value.intensity,
@@ -291,8 +295,8 @@ fn update_point_lights(
                     range,
                     radius: 0.0,
                     shadows_enabled: light.shadow.unwrap_or(false),
-                    outer_angle: angles.1.clamp(0.0, 179.0) * TAU / 360.0,
-                    inner_angle: angles.0.clamp(0.0, angles.1.min(179.0)) * TAU / 360.0,
+                    outer_angle: angles.1.clamp(0.0, 179.0) * PI / 360.0,
+                    inner_angle: angles.0.clamp(0.0, angles.1.min(179.0)) * PI / 360.0,
                     ..Default::default()
                 });
 

--- a/crates/scene_runner/src/update_world/lights.rs
+++ b/crates/scene_runner/src/update_world/lights.rs
@@ -69,7 +69,7 @@ pub struct LightSource {
 impl From<PbLightSource> for LightSource {
     fn from(value: PbLightSource) -> Self {
         if let Some(pb_light_source::Type::Spot(spot)) = &value.r#type {
-                println!("{:?}, {:?}", spot.inner_angle, spot.outer_angle);
+            println!("{:?}, {:?}", spot.inner_angle, spot.outer_angle);
         }
 
         Self {

--- a/crates/scene_runner/src/update_world/material.rs
+++ b/crates/scene_runner/src/update_world/material.rs
@@ -453,9 +453,6 @@ fn init_cache(
     }
 }
 
-#[derive(Component)]
-pub struct CheckThis;
-
 #[allow(clippy::type_complexity)]
 fn update_materials(
     mut commands: Commands,
@@ -466,7 +463,6 @@ fn update_materials(
             &ContainerEntity,
             Option<&SceneEntity>,
             Option<&BaseMaterial>,
-            Option<&CheckThis>,
         ),
         Or<(
             Changed<PbMaterialComponent>,
@@ -488,10 +484,7 @@ fn update_materials(
 ) {
     gltf_resolver.begin_frame();
 
-    for (ent, mat, container, maybe_scene_ent, base, check) in new_materials.iter_mut() {
-        if check.is_some() {
-            error!("ok adding material");
-        }
+    for (ent, mat, container, maybe_scene_ent, base) in new_materials.iter_mut() {
         let Ok((mut scene, mut cache)) = scenes.get_mut(container.root) else {
             continue;
         };

--- a/crates/scene_runner/src/update_world/material.rs
+++ b/crates/scene_runner/src/update_world/material.rs
@@ -453,6 +453,9 @@ fn init_cache(
     }
 }
 
+#[derive(Component)]
+pub struct CheckThis;
+
 #[allow(clippy::type_complexity)]
 fn update_materials(
     mut commands: Commands,
@@ -461,8 +464,9 @@ fn update_materials(
             Entity,
             Ref<PbMaterialComponent>,
             &ContainerEntity,
-            &SceneEntity,
+            Option<&SceneEntity>,
             Option<&BaseMaterial>,
+            Option<&CheckThis>,
         ),
         Or<(
             Changed<PbMaterialComponent>,
@@ -484,7 +488,10 @@ fn update_materials(
 ) {
     gltf_resolver.begin_frame();
 
-    for (ent, mat, container, scene_ent, base) in new_materials.iter_mut() {
+    for (ent, mat, container, maybe_scene_ent, base, check) in new_materials.iter_mut() {
+        if check.is_some() {
+            error!("ok adding material");
+        }
         let Ok((mut scene, mut cache)) = scenes.get_mut(container.root) else {
             continue;
         };
@@ -629,19 +636,21 @@ fn update_materials(
 
         // write material back if required
         if mat.0.material.is_none() {
-            if let Some(base) = base.as_ref() {
-                scene.update_crdt(
-                    SceneComponentId::MATERIAL,
-                    CrdtType::LWW_ANY,
-                    scene_ent.id,
-                    &PbMaterial {
-                        material: Some(dcl_material_from_standard_material(
-                            &base.material,
-                            &images,
-                        )),
-                        gltf: mat.0.gltf.clone(),
-                    },
-                );
+            if let Some(scene_ent) = maybe_scene_ent {
+                if let Some(base) = base.as_ref() {
+                    scene.update_crdt(
+                        SceneComponentId::MATERIAL,
+                        CrdtType::LWW_ANY,
+                        scene_ent.id,
+                        &PbMaterial {
+                            material: Some(dcl_material_from_standard_material(
+                                &base.material,
+                                &images,
+                            )),
+                            gltf: mat.0.gltf.clone(),
+                        },
+                    );
+                }
             }
         }
     }

--- a/crates/scene_runner/src/update_world/mesh_renderer/mod.rs
+++ b/crates/scene_runner/src/update_world/mesh_renderer/mod.rs
@@ -217,7 +217,7 @@ pub fn update_mesh(
         commands.entity(ent).remove::<RetryMeshDefinition>();
         let handle = match prim {
             MeshDefinition::Box { uvs } => {
-                if uvs.len() == 0 {
+                if uvs.is_empty() {
                     defaults.boxx.clone()
                 } else {
                     let len = uvs.len();

--- a/crates/scene_runner/src/update_world/mesh_renderer/mod.rs
+++ b/crates/scene_runner/src/update_world/mesh_renderer/mod.rs
@@ -217,9 +217,10 @@ pub fn update_mesh(
         commands.entity(ent).remove::<RetryMeshDefinition>();
         let handle = match prim {
             MeshDefinition::Box { uvs } => {
-                if uvs.len() != 24 {
+                if uvs.len() == 0 {
                     defaults.boxx.clone()
                 } else {
+                    let len = uvs.len();
                     let mut mesh = Mesh::from(bevy::math::primitives::Cuboid::default());
                     let Some(VertexAttributeValues::Float32x2(mesh_uvs)) =
                         mesh.attribute_mut(Mesh::ATTRIBUTE_UV_0)
@@ -252,8 +253,8 @@ pub fn update_mesh(
                         (22, 1),
                         (23, 0),
                     ] {
-                        mesh_uvs[to][0] = uvs[from][0];
-                        mesh_uvs[to][1] = 1.0 - uvs[from][1];
+                        mesh_uvs[to][0] = uvs[from % len][0];
+                        mesh_uvs[to][1] = 1.0 - uvs[from % len][1];
                     }
                     meshes.add(mesh)
                 }
@@ -273,9 +274,10 @@ pub fn update_mesh(
                 }
             }
             MeshDefinition::Plane { uvs } => {
-                if uvs.len() != 8 {
+                if uvs.is_empty() {
                     defaults.plane.clone()
                 } else {
+                    let len = uvs.len();
                     let mut mesh = Cuboid::default()
                         .mesh()
                         .build()
@@ -295,8 +297,8 @@ pub fn update_mesh(
                         (6, 4),
                         (7, 7),
                     ] {
-                        mesh_uvs[to][0] = uvs[from][0];
-                        mesh_uvs[to][1] = 1.0 - uvs[from][1];
+                        mesh_uvs[to][0] = uvs[from % len][0];
+                        mesh_uvs[to][1] = 1.0 - uvs[from % len][1];
                     }
                     meshes.add(mesh)
                 }

--- a/crates/scene_runner/src/update_world/pointer_events.rs
+++ b/crates/scene_runner/src/update_world/pointer_events.rs
@@ -171,6 +171,12 @@ fn hover_text(
                     None
                 })
                 .collect::<Vec<_>>();
+            // make unique
+            texts = texts
+                .into_iter()
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
         }
     }
 


### PR DESCRIPTION
closes #249

add support for `GltfNodeModifiers`
misc additional fixes:
- pump deno event loop after scene error to avoid blocking scenes on native when async tasks throw exceptions
- fix wearable/emote urn case for local server scenes using case-sensitive `b64-` paths
- fix spotlight angle calculations
- support uv subsets for primitive shapes