### PR TITLE
Native video and mic optimization

### DIFF
--- a/crates/av/src/video_player.rs
+++ b/crates/av/src/video_player.rs
@@ -176,7 +176,7 @@ fn play_videos(
     }
 
     impl FrameSource {
-        fn data(&self) -> Cow<[u8]> {
+        fn data(&self) -> Cow<'_, [u8]> {
             match self {
                 FrameSource::Video(video) => Cow::Borrowed(video.data(0)),
                 #[cfg(feature = "livekit")]


### PR DESCRIPTION
- when fps is lower than video framrate, we copy multiple video frames to internal vectors and discard all but the last. remove the copies by using references where possible (using tracy + single threaded, `play_videos` reduced from mean of 3.5ms to mean of 1ms)
- checking the mic source takes ~2ms on my machine. doing this only once every few seconds is good enough and reduces overhead to ~zero