### PR TITLE
Get meta on room connected

### DIFF
--- a/crates/comms/livekit_web_bindings.js
+++ b/crates/comms/livekit_web_bindings.js
@@ -57,6 +57,15 @@ export async function connect_room(url, token, handler) {
     // check existing streams
     const participants = Array.from(room.remoteParticipants.values());
     for (const participant of participants) {
+        handler({
+            type: 'participantConnected',
+            room_name: room_name,
+            participant: {
+                identity: participant.identity,
+                metadata: participant.metadata || ''
+            }
+        })
+
         const audioPubs = Array.from(participant.trackPublications.values())
             .filter(pub => pub.kind === 'audio');
         for (const publication of audioPubs) {

--- a/crates/comms/src/livekit_native.rs
+++ b/crates/comms/src/livekit_native.rs
@@ -361,6 +361,19 @@ fn livekit_handler_inner(
                                             }).await;
                                         }
                                     }
+                                    let meta = participant.metadata();
+                                    if !meta.is_empty() {
+                                        if let Some(address) = participant.identity().0.as_str().as_h160() {
+                                            if let Err(e) = sender.send(PlayerUpdate {
+                                                transport_id,
+                                                message: PlayerMessage::MetaData(meta),
+                                                address,
+                                            }).await {
+                                                warn!("app pipe broken ({e}), existing loop");
+                                                break 'stream;
+                                            }
+                                        }
+                                    }
                                 } else if participant.identity().as_str().ends_with("-streamer") {
                                     for publication in publications {
                                         publication.set_subscribed(true);


### PR DESCRIPTION
livekit metadata (used for home server for profile fetches) was only initialized for participants who connect after the user joins.
also process metadata for existing participants on joining room.