### PR TITLE
Stop leaking `broadcast::Receiver`

### DIFF
--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -52,7 +52,7 @@ pub struct GlobalCrdtPlugin;
 impl Plugin for GlobalCrdtPlugin {
     fn build(&self, app: &mut App) {
         let (ext_sender, ext_receiver) = mpsc::channel(1000);
-        let (int_sender, ) = broadcast::channel(1000);
+        let (int_sender, _) = broadcast::channel(1000);
         app.insert_resource(GlobalCrdtState {
             ext_receiver,
             ext_sender,


### PR DESCRIPTION
A `tokio::sync::broadcast::Sender` does not get closed because its `Receiver`s are dropped, so no need to leak it