### PR TITLE
fix textshape linear rgba

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,7 +3177,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
  "smallvec",
 ]
 
@@ -4181,6 +4181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "emojis"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c1c1870b766fc398e5f0526498d09c94b6de15be5fd769a28bbc804fb1b05d"
+dependencies = [
+ "phf 0.13.1",
 ]
 
 [[package]]
@@ -8488,7 +8497,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -8497,7 +8515,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -8508,7 +8526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
@@ -8519,6 +8537,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -10148,6 +10175,7 @@ dependencies = [
  "dcl_component",
  "dcl_deno_ipc",
  "dcl_wasm",
+ "emojis",
  "futures-lite 1.13.0",
  "image",
  "input_manager",
@@ -10167,6 +10195,7 @@ dependencies = [
  "system_bridge",
  "tokio",
  "ui_core",
+ "unicode-segmentation",
  "urlencoding",
  "wallet",
  "web-time",

--- a/crates/scene_runner/Cargo.toml
+++ b/crates/scene_runner/Cargo.toml
@@ -53,6 +53,8 @@ web-time = { workspace = true }
 petgraph = "0.6.3"
 spin_sleep = "1.1.1"
 image = "0.25"
+unicode-segmentation = "1"
+emojis = "0.8"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dcl_deno_ipc = { workspace = true }

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -140,7 +140,7 @@ pub fn add_worldui_materials(
         let material = materials.add(TextShapeMaterial {
             base: SceneMaterial {
                 base: StandardMaterial {
-                    base_color: Color::srgb(2.0, 2.0, 2.0),
+                    base_color: Color::WHITE,
                     base_color_texture: Some(target.0.clone()),
                     unlit: true,
                     alpha_mode: wui.blend_mode,


### PR DESCRIPTION
remove accidental Srgb(2.0,2.0,2.0) base color (probably a bad way to do linear/srgba conversion before using proper types)

before
<img width="873" height="541" alt="Screenshot 2026-01-02 at 14 31 41" src="https://github.com/user-attachments/assets/42acd6ef-91e6-4fab-8b2c-c99f90c85858" />


after
<img width="786" height="521" alt="Screenshot 2026-01-02 at 14 35 59" src="https://github.com/user-attachments/assets/9ce0866e-2cfa-4994-af32-29a9bd47531a" />

foundation
<img width="720" height="426" alt="screenshot_2026-01-02_143624_720" src="https://github.com/user-attachments/assets/ebf7d155-108b-4f64-a05f-09799bdc0cf4" />

