### PR TITLE
Textshape fixes

### DIFF
--- a/crates/scene_runner/src/update_world/text_shape.rs
+++ b/crates/scene_runner/src/update_world/text_shape.rs
@@ -302,6 +302,8 @@ fn update_text_shapes(
             camera.is_active = false;
         }
 
+        let wrapping = text_shape.0.text_wrapping() && !text_shape.0.font_auto_size();
+
         let text_align = text_shape
             .0
             .text_align
@@ -320,6 +322,12 @@ fn update_text_shapes(
             | TextAlignMode::TamBottomRight => 0.5,
         };
 
+        let valign = if wrapping {
+            -valign
+        } else {
+            valign
+        };
+
         let (halign_wui, halign) = match text_align {
             TextAlignMode::TamTopLeft
             | TextAlignMode::TamMiddleLeft
@@ -332,6 +340,12 @@ fn update_text_shapes(
             | TextAlignMode::TamBottomRight => (-0.5, JustifyText::Right),
         };
 
+        let halign_wui = if wrapping {
+            0.0
+        } else {
+            halign_wui
+        };
+
         // use constant font size to avoid small text being illegible
         let font_size = 30.0;
 
@@ -339,8 +353,6 @@ fn update_text_shapes(
         let pix_per_m = 375.0 / text_shape.0.font_size.unwrap_or(10.0);
 
         let add_y_pix = (text_shape.0.padding_bottom() - text_shape.0.padding_top()) * pix_per_m;
-
-        let wrapping = text_shape.0.text_wrapping() && !text_shape.0.font_auto_size();
 
         let width = if wrapping {
             text_shape.0.width.unwrap_or(1.0) * pix_per_m

--- a/crates/scene_runner/src/update_world/text_shape.rs
+++ b/crates/scene_runner/src/update_world/text_shape.rs
@@ -148,8 +148,6 @@ impl From<PbTextShape> for TextShape {
     }
 }
 
-const PIX_PER_M: f32 = 200.0;
-
 #[derive(Component)]
 pub struct PriorTextShapeUi(Entity, PbTextShape);
 
@@ -334,14 +332,18 @@ fn update_text_shapes(
             | TextAlignMode::TamBottomRight => (-0.5, JustifyText::Right),
         };
 
-        let add_y_pix = (text_shape.0.padding_bottom() - text_shape.0.padding_top()) * PIX_PER_M;
-
+        // use constant font size to avoid small text being illegible
         let font_size = 30.0;
+
+        // use pix per meter based on font size to scale appropriately
+        let pix_per_m = 375.0 / text_shape.0.font_size.unwrap_or(10.0);
+
+        let add_y_pix = (text_shape.0.padding_bottom() - text_shape.0.padding_top()) * pix_per_m;
 
         let wrapping = text_shape.0.text_wrapping() && !text_shape.0.font_auto_size();
 
         let width = if wrapping {
-            text_shape.0.width.unwrap_or(1.0) * PIX_PER_M
+            text_shape.0.width.unwrap_or(1.0) * pix_per_m
         } else {
             4096.0
         };
@@ -390,9 +392,9 @@ fn update_text_shapes(
             .with_children(|c| {
                 if text_shape.0.padding_left.is_some() {
                     c.spawn(Node {
-                        width: Val::Px(text_shape.0.padding_left() * PIX_PER_M),
-                        min_width: Val::Px(text_shape.0.padding_left() * PIX_PER_M),
-                        max_width: Val::Px(text_shape.0.padding_left() * PIX_PER_M),
+                        width: Val::Px(text_shape.0.padding_left() * pix_per_m),
+                        min_width: Val::Px(text_shape.0.padding_left() * pix_per_m),
+                        max_width: Val::Px(text_shape.0.padding_left() * pix_per_m),
                         ..Default::default()
                     });
                 }
@@ -420,9 +422,9 @@ fn update_text_shapes(
 
                 if text_shape.0.padding_right.is_some() {
                     c.spawn(Node {
-                        width: Val::Px(text_shape.0.padding_right() * PIX_PER_M),
-                        min_width: Val::Px(text_shape.0.padding_right() * PIX_PER_M),
-                        max_width: Val::Px(text_shape.0.padding_right() * PIX_PER_M),
+                        width: Val::Px(text_shape.0.padding_right() * pix_per_m),
+                        min_width: Val::Px(text_shape.0.padding_right() * pix_per_m),
+                        max_width: Val::Px(text_shape.0.padding_right() * pix_per_m),
                         ..Default::default()
                     });
                 }
@@ -437,7 +439,7 @@ fn update_text_shapes(
             PriorTextShapeUi(ui_node, text_shape.0.clone()),
             WorldUi {
                 dbg: format!("TextShape `{source}`"),
-                pix_per_m: 375.0 / text_shape.0.font_size.unwrap_or(10.0),
+                pix_per_m,
                 valign,
                 halign: halign_wui,
                 add_y_pix,

--- a/crates/scene_runner/src/update_world/text_shape.rs
+++ b/crates/scene_runner/src/update_world/text_shape.rs
@@ -268,36 +268,43 @@ fn update_text_shapes(
             continue;
         }
 
-        let mut world_ui = views.get(ent).ok().cloned().unwrap_or_else(|| {
-            debug!("make ui for {ent}");
-            let (view, _) = spawn_world_ui_view(&mut commands, images, None);
-            commands.entity(view).insert(DespawnWith(ent));
-            let ui_root = commands
-                .spawn((
-                    Node {
-                        width: Val::Px(4096.0),
-                        min_width: Val::Px(4096.0),
-                        max_width: Val::Px(8192.0),
-                        max_height: Val::Px(8192.0),
-                        flex_direction: FlexDirection::Row,
-                        flex_wrap: FlexWrap::Wrap,
-                        align_items: AlignItems::FlexStart,
-                        align_content: AlignContent::FlexStart,
-                        ..Default::default()
-                    },
-                    UiTargetCamera(view),
-                    DespawnWith(ent),
-                ))
-                .id();
-            let world_ui = TextShapeUi {
-                view,
-                ui_root,
-                ticks: 2,
-            };
-            commands.entity(ent).try_insert(world_ui);
-            world_ui
-        });
-        world_ui.ticks = 2;
+        let world_ui = views
+            .get_mut(ent)
+            .map(|mut world_ui| {
+                // reset ticks on existing camera
+                world_ui.ticks = 2;
+                *world_ui
+            })
+            .ok()
+            .unwrap_or_else(|| {
+                debug!("make ui for {ent}");
+                let (view, _) = spawn_world_ui_view(&mut commands, images, None);
+                commands.entity(view).insert(DespawnWith(ent));
+                let ui_root = commands
+                    .spawn((
+                        Node {
+                            width: Val::Px(4096.0),
+                            min_width: Val::Px(4096.0),
+                            max_width: Val::Px(8192.0),
+                            max_height: Val::Px(8192.0),
+                            flex_direction: FlexDirection::Row,
+                            flex_wrap: FlexWrap::Wrap,
+                            align_items: AlignItems::FlexStart,
+                            align_content: AlignContent::FlexStart,
+                            ..Default::default()
+                        },
+                        UiTargetCamera(view),
+                        DespawnWith(ent),
+                    ))
+                    .id();
+                let world_ui = TextShapeUi {
+                    view,
+                    ui_root,
+                    ticks: 2,
+                };
+                commands.entity(ent).try_insert(world_ui);
+                world_ui
+            });
         if let Ok(mut camera) = cameras.get_mut(world_ui.ui_root) {
             camera.is_active = false;
         }


### PR DESCRIPTION
- fix textshape going blank when updated without changes
- fix textshape world position when using wrapping = true and alignment != centered
- fix textshape padding and offset sizess with non-default font sizes
- use textshape height field as overflow crop when wrapping = true

