### PR TITLE
sanitize tween outputs

### DIFF
--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -203,6 +203,17 @@ impl From<common::Quaternion> for bevy::math::Quat {
     }
 }
 
+impl common::Quaternion {
+    pub fn to_bevy_normalized(self) -> bevy::math::Quat {
+        let quat = bevy::math::Quat::from(self).normalize();
+        if quat.is_finite() {
+            quat
+        } else {
+            bevy::math::Quat::IDENTITY
+        }
+    }
+}
+
 impl From<bevy::math::Quat> for common::Quaternion {
     fn from(q: bevy::math::Quat) -> Self {
         common::Quaternion {

--- a/crates/tween/src/lib.rs
+++ b/crates/tween/src/lib.rs
@@ -91,14 +91,23 @@ impl Tween {
                 transform.translation = start + (end - start) * ease_value;
             }
             Some(Mode::Rotate(data)) => {
-                let start: Quat = data.start.unwrap_or_default().into();
-                let end = data.end.unwrap_or_default().into();
+                let start: Quat = data.start.unwrap_or_default().to_bevy_normalized();
+                let end = data.end.unwrap_or_default().to_bevy_normalized();
                 transform.rotation = start.slerp(end, ease_value);
             }
             Some(Mode::Scale(data)) => {
                 let start = data.start.unwrap_or_default().abs_vec_to_vec3();
                 let end = data.end.unwrap_or_default().abs_vec_to_vec3();
                 transform.scale = start + ((end - start) * ease_value);
+                if transform.scale.x == 0.0 {
+                    transform.scale.x = f32::EPSILON;
+                };
+                if transform.scale.y == 0.0 {
+                    transform.scale.y = f32::EPSILON;
+                };
+                if transform.scale.z == 0.0 {
+                    transform.scale.z = f32::EPSILON;
+                };
             }
             Some(Mode::TextureMove(data)) => {
                 let start: Vec2 = (&data.start.unwrap_or_default()).into();


### PR DESCRIPTION
we already sanitize manual transform updates to set scales to non-zero and quats to normalized values. we now apply the same sanitization to tween outputs as well.

closes #445