### PR TITLE
screen door transparency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1146,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1555,7 +1555,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "glam",
 ]
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1613,12 +1613,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1644,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1778,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1825,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1885,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1947,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/assets/src/assets/shaders/bound_material.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material.wgsl
@@ -8,7 +8,7 @@
     pbr_types,
 }
 #import "embedded://shaders/simplex.wgsl"::simplex_noise_3d
-#import "embedded://shaders/outline.wgsl"::apply_outline
+#import "embedded://shaders/bound_material_effect.wgsl"::{apply_outline, discard_dither}
 
 struct Bounds {
     min: u32,
@@ -37,6 +37,7 @@ const SHOW_OUTSIDE: u32 = 1u;
 //const OUTLINE: u32 = 2u; // replaced by OUTLINE shader def
 const OUTLINE_RED: u32 = 4u;
 const OUTLINE_FORCE: u32 = 8u;
+const DISABLE_DITHER: u32 = 16u;
 
 @group(2) @binding(100)
 var<uniform> bounds: SceneBounds;
@@ -54,6 +55,10 @@ fn fragment(
     // generate a PbrInput struct from the StandardMaterial bindings
     var pbr_input = pbr_input_from_standard_material(in, is_front);
     var out: FragmentOutput;
+
+    if (bounds.flags & (DISABLE_DITHER + OUTLINE_RED)) == 0 {
+        discard_dither(in.position.xy, in.world_position.xyz, globals.user_global);
+    }
 
 #ifdef OUTLINE
 #ifndef MULTISAMPLED

--- a/crates/assets/src/assets/shaders/bound_material_effect.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material_effect.wgsl
@@ -70,12 +70,12 @@ return out;
 
 fn discard_dither(ndc_position: vec2<f32>, world_position: vec3<f32>, depth: f32) {
     let view_to_frag = world_position - view.world_position;
+    
     // player is left of the view forward by 0.25 * clamp(camera distance, 0, 3). we use half of that as our target
-    let target_position = view.world_position 
-        + depth * (view.world_from_view * vec4(0.0, 0.0, -1.0, 0.0)).xyz // view fwd
-        + 0.125 * clamp(depth, 0.0, 3.0) * (view.world_from_view * vec4(-1.0, 0.0, 0.0, 0.0)).xyz; // view left
+    let target_offset = depth * -view.world_from_view[2].xyz // view fwd
+        - 0.125 * clamp(depth, 0.0, 3.0) * view.world_from_view[0].xyz; // view right
 
-    let view_direction = normalize(target_position - view.world_position);
+    let view_direction = normalize(target_offset);
     let projection_length = dot(view_to_frag, view_direction);
 
     if projection_length < depth + 0.35 { // 0.35 = collider radius

--- a/crates/assets/src/assets/shaders/bound_material_effect.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material_effect.wgsl
@@ -1,6 +1,6 @@
 #import bevy_pbr::{
     pbr_types::STANDARD_MATERIAL_FLAGS_EMISSIVE_TEXTURE_BIT,
-    mesh_view_bindings::view,
+    mesh_view_bindings::{view, globals},
     prepass_utils::{prepass_depth, prepass_normal},
     pbr_types,
 }
@@ -66,4 +66,23 @@ fn apply_outline(position: vec4<f32>, color_in: vec4<f32>, hilight: bool, sample
 #endif
 
 return out;
+}
+
+fn discard_dither(ndc_position: vec2<f32>, world_position: vec3<f32>, depth: f32) {
+    let view_to_frag = world_position - view.world_position;
+    // player is left of the view forward by 0.25 * clamp(camera distance, 0, 3). we use half of that as our target
+    let target_position = view.world_position 
+        + depth * (view.world_from_view * vec4(0.0, 0.0, -1.0, 0.0)).xyz // view fwd
+        + 0.125 * clamp(depth, 0.0, 3.0) * (view.world_from_view * vec4(-1.0, 0.0, 0.0, 0.0)).xyz; // view left
+
+    let view_direction = normalize(target_position - view.world_position);
+    let projection_length = dot(view_to_frag, view_direction);
+
+    if projection_length < depth + 0.35 { // 0.35 = collider radius
+        let cone_distance = length(world_position - (view.world_position.xyz + (view_direction * projection_length)));
+        let threshold = fract(52.9829189 * fract(dot(ndc_position * (1.0 * 5.588238), vec2(0.06711056, 0.00583715))));
+        if cone_distance + 0.5 - saturate((depth - projection_length) * 0.5) * 1.0 + saturate(projection_length - depth) * 5.0 < threshold * 2.0 {
+            discard;
+        }
+    }
 }

--- a/crates/assets/src/assets/shaders/bound_material_effect.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material_effect.wgsl
@@ -81,7 +81,7 @@ fn discard_dither(ndc_position: vec2<f32>, world_position: vec3<f32>, depth: f32
     if projection_length < depth + 0.35 { // 0.35 = collider radius
         let cone_distance = length(world_position - (view.world_position.xyz + (view_direction * projection_length)));
         let threshold = fract(52.9829189 * fract(dot(ndc_position * (1.0 * 5.588238), vec2(0.06711056, 0.00583715))));
-        if cone_distance + 0.5 - saturate((depth - projection_length) * 0.5) * 1.0 + saturate(projection_length - depth) * 5.0 < threshold * 2.0 {
+        if max(0.2, cone_distance + 0.5 - saturate((depth - projection_length) * 0.5) * 1.0 + saturate(projection_length - depth) * 5.0) < threshold * 2.0 {
             discard;
         }
     }

--- a/crates/assets/src/assets/shaders/bound_prepass.wgsl
+++ b/crates/assets/src/assets/shaders/bound_prepass.wgsl
@@ -8,6 +8,10 @@
 #import bevy_render::globals::Globals;
 
 #import "embedded://shaders/simplex.wgsl"::simplex_noise_3d
+#import "embedded://shaders/bound_material_effect.wgsl"::discard_dither
+
+const OUTLINE_RED: u32 = 4u;
+const DISABLE_DITHER: u32 = 16u;
 
 @group(0) @binding(1) var<uniform> globals: Globals;
 
@@ -45,6 +49,10 @@ fn fragment(
     @builtin(front_facing) is_front: bool
 ) -> FragmentOutput {
     var out: FragmentOutput;
+
+    if (bounds.flags & (DISABLE_DITHER + OUTLINE_RED)) == 0 {
+        discard_dither(in.position.xy, in.world_position.xyz, globals.user_global);
+    }
 
 #ifdef NORMAL_PREPASS
     out.normal = vec4(in.world_normal * 0.5 + vec3(0.5), 1.0);

--- a/crates/assets/src/assets/shaders/mask_material.wgsl
+++ b/crates/assets/src/assets/shaders/mask_material.wgsl
@@ -5,7 +5,7 @@
     mesh_view_bindings::globals,
 }
 #import "embedded://shaders/simplex.wgsl"::simplex_noise_3d
-#import "embedded://shaders/outline.wgsl"::apply_outline
+#import "embedded://shaders/bound_material_effect.wgsl"::apply_outline
 
 struct Bounds {
     min: u32,

--- a/crates/avatar/src/attach.rs
+++ b/crates/avatar/src/attach.rs
@@ -1,4 +1,7 @@
-use bevy::prelude::*;
+use bevy::{
+    app::{HierarchyPropagatePlugin, Propagate},
+    prelude::*,
+};
 
 use common::{
     sets::SceneSets,
@@ -10,6 +13,7 @@ use dcl_component::{
     proto_components::sdk::components::{AvatarAnchorPointType, PbAvatarAttach},
     SceneComponentId,
 };
+use scene_material::{SceneMaterial, SCENE_MATERIAL_NO_DITHERING};
 use scene_runner::update_world::{
     mesh_collider::DisableCollisions,
     transform_and_parent::{AvatarAttachStage, ParentPositionSync},
@@ -24,9 +28,16 @@ impl Plugin for AttachPlugin {
             SceneComponentId::AVATAR_ATTACHMENT,
             ComponentPosition::Any,
         );
-        app.add_systems(Update, update_attached.in_set(SceneSets::PostLoop));
+        app.add_systems(
+            Update,
+            (update_attached, undither_materials_on_attached_items).in_set(SceneSets::PostLoop),
+        );
+        app.add_plugins(HierarchyPropagatePlugin::<AttachedToPrimaryPlayer>::default());
     }
 }
+
+#[derive(Component, Clone, PartialEq)]
+pub struct AttachedToPrimaryPlayer;
 
 #[derive(Component, Debug)]
 pub struct AvatarAttachment(pub PbAvatarAttach);
@@ -42,40 +53,44 @@ pub fn update_attached(
     attachments: Query<(Entity, &AvatarAttachment), Changed<AvatarAttachment>>,
     mut removed_attachments: RemovedComponents<AvatarAttachment>,
     primary_user: Query<&AttachPoints, With<PrimaryUser>>,
-    all_users: Query<(&AttachPoints, &UserProfile)>,
+    all_users: Query<(&AttachPoints, &UserProfile, Option<&PrimaryUser>)>,
 ) {
     for removed in removed_attachments.read() {
         if let Ok(mut commands) = commands.get_entity(removed) {
-            commands.remove::<(ParentPositionSync<AvatarAttachStage>, DisableCollisions)>();
+            commands.remove::<(
+                ParentPositionSync<AvatarAttachStage>,
+                DisableCollisions,
+                Propagate<AttachedToPrimaryPlayer>,
+            )>();
         }
     }
 
     for (ent, attach) in attachments.iter() {
-        let attach_points = match attach.0.avatar_id.as_ref() {
+        let (is_primary, attach_points) = match attach.0.avatar_id.as_ref() {
             None => {
                 let Ok(data) = primary_user.single() else {
                     warn!("no primary user");
                     continue;
                 };
-                data
+                (true, data)
             }
             Some(id) => {
                 let id = id.to_lowercase();
-                let Some((attach, _)) = all_users
+                let Some((attach, _, maybe_primary)) = all_users
                     .iter()
-                    .find(|(_, profile)| profile.content.eth_address.to_lowercase() == id)
+                    .find(|(_, profile, _)| profile.content.eth_address.to_lowercase() == id)
                 else {
                     warn!("user {:?} not found", id);
                     warn!(
                         "available users: {:?}",
                         all_users
                             .iter()
-                            .map(|(_, profile)| &profile.content)
+                            .map(|(_, profile, _)| &profile.content)
                             .collect::<Vec<_>>()
                     );
                     continue;
                 };
-                attach
+                (maybe_primary.is_some(), attach)
             }
         };
 
@@ -93,10 +108,51 @@ pub fn update_attached(
             }
         };
 
-        commands.entity(ent).try_insert((
+        let mut commands = commands.entity(ent);
+        commands.try_insert((
             ParentPositionSync::<AvatarAttachStage>::new(sync_entity),
             DisableCollisions,
         ));
+        if is_primary {
+            commands.try_insert(Propagate(AttachedToPrimaryPlayer));
+        }
         debug!("syncing {ent:?} to {sync_entity:?}");
+    }
+}
+
+#[derive(Component)]
+pub struct DitheredMaterial<M: Asset>(pub Handle<M>);
+
+#[allow(clippy::type_complexity)]
+fn undither_materials_on_attached_items(
+    mut commands: Commands,
+    mut scene_mats: ResMut<Assets<SceneMaterial>>,
+    new: Query<
+        (Entity, &MeshMaterial3d<SceneMaterial>),
+        (
+            With<AttachedToPrimaryPlayer>,
+            Without<DitheredMaterial<SceneMaterial>>,
+        ),
+    >,
+    old: Query<(Entity, &DitheredMaterial<SceneMaterial>), Without<AttachedToPrimaryPlayer>>,
+) {
+    for (ent, mat) in new.iter() {
+        let Some(mut undithered_material) = scene_mats.get(mat).cloned() else {
+            continue;
+        };
+
+        undithered_material.extension.data.flags |= SCENE_MATERIAL_NO_DITHERING;
+        let undithered_material = scene_mats.add(undithered_material);
+        commands.entity(ent).try_insert((
+            MeshMaterial3d(undithered_material),
+            DitheredMaterial(mat.0.clone()),
+        ));
+    }
+
+    for (ent, dithered) in old.iter() {
+        commands
+            .entity(ent)
+            .try_remove::<DitheredMaterial<SceneMaterial>>()
+            .try_insert(MeshMaterial3d(dithered.0.clone()));
     }
 }

--- a/crates/avatar/src/avatar_texture.rs
+++ b/crates/avatar/src/avatar_texture.rs
@@ -83,6 +83,7 @@ impl PhotoBooth<'_, '_> {
                     scene: None,
                     shape,
                     automatic_delete: false,
+                    disable_dither: true,
                 },
                 Propagate(render_layers.clone()),
                 AvatarDynamicState::default(),

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -302,6 +302,7 @@ pub struct AvatarSelection {
     scene: Option<Entity>,
     shape: AvatarShape,
     automatic_delete: bool,
+    disable_dither: bool,
 }
 
 // choose the avatar shape based on current scene of the player
@@ -363,6 +364,7 @@ fn select_avatar(
                     scene: Some(scene_ent.root),
                     shape: AvatarShape(scene_avatar_shape.0.clone()),
                     automatic_delete: true,
+                    disable_dither: false,
                 });
 
                 debug!("npc avatar {:?}", scene_ent);
@@ -436,6 +438,7 @@ fn select_avatar(
                     scene: update.current_source,
                     shape,
                     automatic_delete: true,
+                    disable_dither: maybe_player.is_none(), // disable for primary avatar only
                 });
             }
         }
@@ -463,6 +466,7 @@ pub struct AvatarDefinition {
     hides: HashSet<WearableCategory>,
     bounds: Vec<BoundRegion>,
     emote: Option<EmoteCommand>,
+    disable_dither: bool,
 }
 
 #[derive(Component)]
@@ -734,6 +738,7 @@ fn update_render_avatar(
                                 .expression_trigger_timestamp
                                 .unwrap_or_default(),
                         }),
+                    disable_dither: selection.disable_dither,
                 },
                 UsedWearables(urns),
             ));
@@ -1109,6 +1114,7 @@ fn process_avatar(
                             def.bounds.clone(),
                             config.graphics.oob,
                             false,
+                            def.disable_dither,
                         ),
                     };
                     let instance_mat = instance_scene_materials
@@ -1174,6 +1180,7 @@ fn process_avatar(
                                     def.bounds.clone(),
                                     config.graphics.oob,
                                     true,
+                                    def.disable_dither,
                                 ),
                             };
                             let material = scene_materials.add(new_mat);
@@ -1366,6 +1373,7 @@ fn process_avatar(
                                 def.bounds.clone(),
                                 config.graphics.oob,
                                 false,
+                                def.disable_dither,
                             ),
                         };
                         let instance_mat = instance_scene_materials

--- a/crates/scene_material/src/lib.rs
+++ b/crates/scene_material/src/lib.rs
@@ -12,6 +12,7 @@ pub const SCENE_MATERIAL_SHOW_OUTSIDE: u32 = 1;
 pub const SCENE_MATERIAL_OUTLINE: u32 = 2;
 pub const SCENE_MATERIAL_OUTLINE_RED: u32 = 4;
 pub const SCENE_MATERIAL_OUTLINE_FORCE: u32 = 8;
+pub const SCENE_MATERIAL_NO_DITHERING: u32 = 16;
 
 pub trait SceneMaterialExt {
     fn unbounded_outlined(mat: StandardMaterial, force: bool) -> Self
@@ -86,12 +87,22 @@ impl SceneBound {
         }
     }
 
-    pub fn new_outlined(bounds: Vec<BoundRegion>, distance: f32, force_outline: bool) -> Self {
+    pub fn new_outlined(
+        bounds: Vec<BoundRegion>,
+        distance: f32,
+        force_outline: bool,
+        disable_dither: bool,
+    ) -> Self {
         Self {
             data: SceneBoundData {
                 flags: SCENE_MATERIAL_OUTLINE
                     + if force_outline {
                         SCENE_MATERIAL_OUTLINE_FORCE
+                    } else {
+                        0
+                    }
+                    + if disable_dither {
+                        SCENE_MATERIAL_NO_DITHERING
                     } else {
                         0
                     },

--- a/crates/user_input/src/lib.rs
+++ b/crates/user_input/src/lib.rs
@@ -6,7 +6,7 @@ use bevy::{
     app::Propagate,
     ecs::query::Has,
     prelude::*,
-    render::{camera::CameraUpdateSystem, view::RenderLayers},
+    render::{camera::CameraUpdateSystem, globals::UserGlobal, view::RenderLayers},
     transform::TransformSystem,
 };
 
@@ -45,6 +45,7 @@ pub struct UserInputPlugin;
 
 impl Plugin for UserInputPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<UserGlobal>();
         app.add_systems(
             Update,
             (update_user_velocity, update_camera)


### PR DESCRIPTION
- add screen door transparency for meshes blocking the view from camera to player
- stop pushing camera position in front of any blockers
- don't apply screen-door for items attached to the primary player

questionable: 
- other players avatars do not count as blocking / activate transparency, but other players avatars ARE set to transparent when transparency is activated
- things cannot be interacted with when cursor is blocked by a partly/fully-transparent wall 

closes #475 