### PR TITLE
Screen door improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1400,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1470,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "glam",
 ]
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1614,12 +1614,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1645,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#45e3680d7e1c8fcb196d2271b30b6320376922cf"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1400,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1470,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "glam",
 ]
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1614,12 +1614,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1645,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1855,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#71f7aa155b3ffb2b5122dafcee168f59bc6ecac5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#cd0ca3c0da36ea3bc93fa37e36781aacab00a89c"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/assets/src/assets/shaders/bound_material.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material.wgsl
@@ -55,7 +55,7 @@ fn fragment(
 ) -> FragmentOutput {
     var cap_brightness: f32 = 0.0;
     if (bounds.flags & (DISABLE_DITHER + OUTLINE_RED)) == 0 {
-        cap_brightness = discard_dither(in.position.xy, in.world_position.xyz, globals.user_global, (bounds.flags & CONE_ONLY_DITHER) == 0);
+        cap_brightness = discard_dither(in.position.xy, in.world_position.xyz, view.user_value, (bounds.flags & CONE_ONLY_DITHER) == 0);
     }
 
     // generate a PbrInput struct from the StandardMaterial bindings
@@ -186,7 +186,7 @@ fn fragment(
     out.color = main_pass_post_lighting_processing(pbr_input, out.color);
 
     let cap_factor = max(max(out.color.r, out.color.g), max(out.color.b, 1.0));
-    out.color = mix(out.color, vec4<f32>(out.color.rgb * cap_factor, out.color.a), saturate(cap_brightness * 2.0));
+    out.color = mix(out.color, vec4<f32>(out.color.rgb / cap_factor, out.color.a), saturate(cap_brightness * 2.0));
 
     return out;
 }

--- a/crates/assets/src/assets/shaders/bound_material_effect.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material_effect.wgsl
@@ -92,11 +92,19 @@ fn discard_dither(ndc_position: vec2<f32>, world_position: vec3<f32>, depth: f32
 
             let full_transparent_factor = saturate((projection_length - full_transparent_start_distance) / (full_transparent_end_distance - full_transparent_start_distance));
 
-            use_distance = mix(
-                min(cone_distance, full_transparent_factor), 
-                min(cone_distance, 2.0),
-                full_transparent_factor,
-            );
+            if cone_distance < 1.0 {
+                use_distance = mix(
+                    min(cone_distance, full_transparent_factor * 0.75), 
+                    cone_distance,
+                    full_transparent_factor,
+                );
+            } else {
+                use_distance = mix(
+                    full_transparent_factor * 0.75,
+                    min(pow(cone_distance, 0.5), 2.0),
+                    full_transparent_factor,
+                );
+            }
         }
 
         if  max(

--- a/crates/assets/src/assets/shaders/bound_prepass.wgsl
+++ b/crates/assets/src/assets/shaders/bound_prepass.wgsl
@@ -2,6 +2,7 @@
     prepass_bindings,
     prepass_io::{Vertex, VertexOutput, FragmentOutput},
     mesh_view_bindings::{view, previous_view_proj},
+    pbr_types::STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT,
     pbr_fragment::pbr_input_from_standard_material,
     pbr_prepass_functions::prepass_alpha_discard,
 }
@@ -12,6 +13,7 @@
 
 const OUTLINE_RED: u32 = 4u;
 const DISABLE_DITHER: u32 = 16u;
+const CONE_ONLY_DITHER: u32 = 32u;
 
 @group(0) @binding(1) var<uniform> globals: Globals;
 
@@ -51,7 +53,7 @@ fn fragment(
     var out: FragmentOutput;
 
     if (bounds.flags & (DISABLE_DITHER + OUTLINE_RED)) == 0 {
-        discard_dither(in.position.xy, in.world_position.xyz, globals.user_global);
+        discard_dither(in.position.xy, in.world_position.xyz, globals.user_global, (bounds.flags & CONE_ONLY_DITHER) == 0);
     }
 
 #ifdef NORMAL_PREPASS

--- a/crates/avatar/src/attach.rs
+++ b/crates/avatar/src/attach.rs
@@ -13,7 +13,7 @@ use dcl_component::{
     proto_components::sdk::components::{AvatarAnchorPointType, PbAvatarAttach},
     SceneComponentId,
 };
-use scene_material::{SCENE_MATERIAL_CONE_ONLY_DITHER, SCENE_MATERIAL_NO_DITHERING, SceneMaterial};
+use scene_material::{SceneMaterial, SCENE_MATERIAL_CONE_ONLY_DITHER, SCENE_MATERIAL_NO_DITHERING};
 use scene_runner::update_world::{
     mesh_collider::DisableCollisions,
     transform_and_parent::{AvatarAttachStage, ParentPositionSync},
@@ -37,7 +37,7 @@ impl Plugin for AttachPlugin {
 }
 
 #[derive(Component, Clone, PartialEq)]
-pub struct AttachedToPlayer{
+pub struct AttachedToPlayer {
     pub is_primary: bool,
 }
 
@@ -114,7 +114,7 @@ pub fn update_attached(
         commands.try_insert((
             ParentPositionSync::<AvatarAttachStage>::new(sync_entity),
             DisableCollisions,
-            AttachedToPlayer{ is_primary },
+            AttachedToPlayer { is_primary },
         ));
         debug!("syncing {ent:?} to {sync_entity:?}");
     }

--- a/crates/avatar/src/attach.rs
+++ b/crates/avatar/src/attach.rs
@@ -13,7 +13,7 @@ use dcl_component::{
     proto_components::sdk::components::{AvatarAnchorPointType, PbAvatarAttach},
     SceneComponentId,
 };
-use scene_material::{SceneMaterial, SCENE_MATERIAL_NO_DITHERING};
+use scene_material::{SCENE_MATERIAL_CONE_ONLY_DITHER, SCENE_MATERIAL_NO_DITHERING, SceneMaterial};
 use scene_runner::update_world::{
     mesh_collider::DisableCollisions,
     transform_and_parent::{AvatarAttachStage, ParentPositionSync},
@@ -32,12 +32,14 @@ impl Plugin for AttachPlugin {
             Update,
             (update_attached, undither_materials_on_attached_items).in_set(SceneSets::PostLoop),
         );
-        app.add_plugins(HierarchyPropagatePlugin::<AttachedToPrimaryPlayer>::default());
+        app.add_plugins(HierarchyPropagatePlugin::<AttachedToPlayer>::default());
     }
 }
 
 #[derive(Component, Clone, PartialEq)]
-pub struct AttachedToPrimaryPlayer;
+pub struct AttachedToPlayer{
+    pub is_primary: bool,
+}
 
 #[derive(Component, Debug)]
 pub struct AvatarAttachment(pub PbAvatarAttach);
@@ -60,7 +62,7 @@ pub fn update_attached(
             commands.remove::<(
                 ParentPositionSync<AvatarAttachStage>,
                 DisableCollisions,
-                Propagate<AttachedToPrimaryPlayer>,
+                Propagate<AttachedToPlayer>,
             )>();
         }
     }
@@ -112,10 +114,8 @@ pub fn update_attached(
         commands.try_insert((
             ParentPositionSync::<AvatarAttachStage>::new(sync_entity),
             DisableCollisions,
+            AttachedToPlayer{ is_primary },
         ));
-        if is_primary {
-            commands.try_insert(Propagate(AttachedToPrimaryPlayer));
-        }
         debug!("syncing {ent:?} to {sync_entity:?}");
     }
 }
@@ -128,20 +128,21 @@ fn undither_materials_on_attached_items(
     mut commands: Commands,
     mut scene_mats: ResMut<Assets<SceneMaterial>>,
     new: Query<
-        (Entity, &MeshMaterial3d<SceneMaterial>),
-        (
-            With<AttachedToPrimaryPlayer>,
-            Without<DitheredMaterial<SceneMaterial>>,
-        ),
+        (Entity, &MeshMaterial3d<SceneMaterial>, &AttachedToPlayer),
+        Without<DitheredMaterial<SceneMaterial>>,
     >,
-    old: Query<(Entity, &DitheredMaterial<SceneMaterial>), Without<AttachedToPrimaryPlayer>>,
+    old: Query<(Entity, &DitheredMaterial<SceneMaterial>), Without<AttachedToPlayer>>,
 ) {
-    for (ent, mat) in new.iter() {
+    for (ent, mat, attached) in new.iter() {
         let Some(mut undithered_material) = scene_mats.get(mat).cloned() else {
             continue;
         };
 
-        undithered_material.extension.data.flags |= SCENE_MATERIAL_NO_DITHERING;
+        if attached.is_primary {
+            undithered_material.extension.data.flags |= SCENE_MATERIAL_NO_DITHERING;
+        } else {
+            undithered_material.extension.data.flags |= SCENE_MATERIAL_CONE_ONLY_DITHER;
+        }
         let undithered_material = scene_mats.add(undithered_material);
         commands.entity(ent).try_insert((
             MeshMaterial3d(undithered_material),

--- a/crates/scene_material/src/lib.rs
+++ b/crates/scene_material/src/lib.rs
@@ -13,6 +13,7 @@ pub const SCENE_MATERIAL_OUTLINE: u32 = 2;
 pub const SCENE_MATERIAL_OUTLINE_RED: u32 = 4;
 pub const SCENE_MATERIAL_OUTLINE_FORCE: u32 = 8;
 pub const SCENE_MATERIAL_NO_DITHERING: u32 = 16;
+pub const SCENE_MATERIAL_CONE_ONLY_DITHER: u32 = 32;
 
 pub trait SceneMaterialExt {
     fn unbounded_outlined(mat: StandardMaterial, force: bool) -> Self
@@ -105,7 +106,8 @@ impl SceneBound {
                         SCENE_MATERIAL_NO_DITHERING
                     } else {
                         0
-                    },
+                    }
+                    + SCENE_MATERIAL_CONE_ONLY_DITHER,
                 ..Self::new(bounds, distance).data
             },
         }

--- a/crates/scene_material/src/lib.rs
+++ b/crates/scene_material/src/lib.rs
@@ -254,6 +254,13 @@ impl MaterialExtension for SceneBound {
         ShaderRef::Path("embedded://shaders/bound_material.wgsl".into())
     }
 
+    fn alpha_mode(base_mode: AlphaMode) -> Option<AlphaMode> {
+        Some(match base_mode {
+            AlphaMode::Opaque => AlphaMode::Mask(0.0),
+            other => other,
+        })
+    }
+
     fn prepass_fragment_shader() -> ShaderRef {
         ShaderRef::Path("embedded://shaders/bound_prepass.wgsl".into())
     }

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -285,59 +285,59 @@ pub fn update_camera_position(
         }
 
         let base_distance = distance;
-        if distance > 0.0 {
-            // cast to check visibility
-            let scenes_head = containing_scene.get_position(player_head);
-            let scenes_cam =
-                containing_scene.get_position(player_head + target_direction * distance);
+        // if distance > 0.0 {
+        //     // cast to check visibility
+        //     let scenes_head = containing_scene.get_position(player_head);
+        //     let scenes_cam =
+        //         containing_scene.get_position(player_head + target_direction * distance);
 
-            const OFFSET_SIZE: f32 = 0.15;
-            let offsets = [
-                Vec3::ZERO,
-                Vec3::new(-OFFSET_SIZE, 0.0, 0.0),
-                Vec3::new(OFFSET_SIZE, 0.0, 0.0),
-                Vec3::new(0.0, -OFFSET_SIZE, 0.0),
-                Vec3::new(0.0, OFFSET_SIZE, 0.0),
-            ];
-            let mut offset_distances = [FloatOrd(1.0); 5];
-            for scene in (scenes_head).union(&scenes_cam) {
-                let Ok((context, mut colliders)) = scene_colliders.get_mut(*scene) else {
-                    continue;
-                };
+        //     const OFFSET_SIZE: f32 = 0.15;
+        //     let offsets = [
+        //         Vec3::ZERO,
+        //         Vec3::new(-OFFSET_SIZE, 0.0, 0.0),
+        //         Vec3::new(OFFSET_SIZE, 0.0, 0.0),
+        //         Vec3::new(0.0, -OFFSET_SIZE, 0.0),
+        //         Vec3::new(0.0, OFFSET_SIZE, 0.0),
+        //     ];
+        //     let mut offset_distances = [FloatOrd(1.0); 5];
+        //     for scene in (scenes_head).union(&scenes_cam) {
+        //         let Ok((context, mut colliders)) = scene_colliders.get_mut(*scene) else {
+        //             continue;
+        //         };
 
-                for ix in 0..5 {
-                    let origin = player_head + target_transform.rotation.mul_vec3(offsets[ix]);
-                    if let Some(hit) = colliders.cast_ray_nearest(
-                        context.last_update_frame,
-                        origin,
-                        target_translation - origin,
-                        1.0,
-                        u32::MAX,
-                        false,
-                        false,
-                        None,
-                    ) {
-                        offset_distances[ix] =
-                            FloatOrd(offset_distances[ix].0.min(hit.toi).max(0.0));
-                    }
-                }
-            }
-            debug!(
-                "{distance} vs {:?}",
-                offset_distances.iter().map(|d| d.0).collect::<Vec<_>>()
-            );
-            distance *= offset_distances.iter().min().unwrap().0;
-        }
+        //         for ix in 0..5 {
+        //             let origin = player_head + target_transform.rotation.mul_vec3(offsets[ix]);
+        //             if let Some(hit) = colliders.cast_ray_nearest(
+        //                 context.last_update_frame,
+        //                 origin,
+        //                 target_translation - origin,
+        //                 1.0,
+        //                 u32::MAX,
+        //                 false,
+        //                 false,
+        //                 None,
+        //             ) {
+        //                 offset_distances[ix] =
+        //                     FloatOrd(offset_distances[ix].0.min(hit.toi).max(0.0));
+        //             }
+        //         }
+        //     }
+        //     debug!(
+        //         "{distance} vs {:?}",
+        //         offset_distances.iter().map(|d| d.0).collect::<Vec<_>>()
+        //     );
+        //     distance *= offset_distances.iter().min().unwrap().0;
+        // }
 
         target_transform.translation = player_head
             + head_offset * base_distance.clamp(0.0, 3.0)
             + target_direction * base_distance;
 
-        if base_distance == distance {
-            user_global.0 = 0.0;
-        } else {
+        // if base_distance == distance {
+        //     user_global.0 = 0.0;
+        // } else {
             user_global.0 = base_distance;
-        }
+        // }
     }
 
     let changed = (prev_override.is_some() != options.scene_override.is_some())

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -1,9 +1,8 @@
 use std::f32::consts::{FRAC_PI_4, PI};
 
 use bevy::{
-    math::FloatOrd,
     prelude::*,
-    render::globals::UserGlobal,
+    render::view::ViewUserValue,
     window::{CursorGrabMode, PrimaryWindow},
 };
 
@@ -14,10 +13,7 @@ use common::{
 };
 use dcl_component::proto_components::sdk::components::common::camera_transition::TransitionMode;
 use input_manager::{InputManager, InputPriority};
-use scene_runner::{
-    renderer_context::RendererSceneContext, update_world::mesh_collider::SceneColliderData,
-    ContainingScene, OutOfWorld,
-};
+use scene_runner::OutOfWorld;
 use tween::SystemTween;
 
 use crate::TRANSITION_TIME;
@@ -177,12 +173,9 @@ pub fn update_camera_position(
         (&Transform, &AvatarDynamicState, Has<OutOfWorld>),
         (With<PrimaryUser>, Without<PrimaryCamera>),
     >,
-    containing_scene: ContainingScene,
-    mut scene_colliders: Query<(&RendererSceneContext, &mut SceneColliderData)>,
     mut prev_override: Local<Option<CameraOverride>>,
     mut prev_oow: Local<bool>,
     gt_helper: TransformHelper,
-    mut user_global: ResMut<UserGlobal>,
 ) {
     let (
         Ok((player_transform, dynamic_state, is_oow)),
@@ -250,7 +243,7 @@ pub fn update_camera_position(
             target_transition = transition.clone();
         }
 
-        user_global.0 = 0.0;
+        commands.entity(camera_ent).insert(ViewUserValue(0.0));
     } else {
         let target_fov = (dynamic_state.velocity.length() / 4.0).clamp(1.25, 1.25) * FRAC_PI_4;
         if let Projection::Perspective(PerspectiveProjection { ref mut fov, .. }) = &mut *projection
@@ -275,69 +268,17 @@ pub fn update_camera_position(
             + Vec3::Y * -0.08;
 
         let target_direction = target_transform.rotation.mul_vec3(Vec3::Z);
-        let mut target_translation =
+        let target_translation =
             player_head + head_offset * distance.clamp(0.0, 3.0) + target_direction * distance;
 
-        if target_translation.y < 0.1 {
-            distance -= (target_translation.y - 0.1) / target_direction.y;
-            target_translation =
-                player_head + head_offset * distance.clamp(0.0, 3.0) + target_direction * distance;
+        if target_translation.y < distance * 0.25 {
+            distance = player_head.y / (0.25 - target_direction.y);
         }
 
-        let base_distance = distance;
-        // if distance > 0.0 {
-        //     // cast to check visibility
-        //     let scenes_head = containing_scene.get_position(player_head);
-        //     let scenes_cam =
-        //         containing_scene.get_position(player_head + target_direction * distance);
+        target_transform.translation =
+            player_head + head_offset * distance.clamp(0.0, 3.0) + target_direction * distance;
 
-        //     const OFFSET_SIZE: f32 = 0.15;
-        //     let offsets = [
-        //         Vec3::ZERO,
-        //         Vec3::new(-OFFSET_SIZE, 0.0, 0.0),
-        //         Vec3::new(OFFSET_SIZE, 0.0, 0.0),
-        //         Vec3::new(0.0, -OFFSET_SIZE, 0.0),
-        //         Vec3::new(0.0, OFFSET_SIZE, 0.0),
-        //     ];
-        //     let mut offset_distances = [FloatOrd(1.0); 5];
-        //     for scene in (scenes_head).union(&scenes_cam) {
-        //         let Ok((context, mut colliders)) = scene_colliders.get_mut(*scene) else {
-        //             continue;
-        //         };
-
-        //         for ix in 0..5 {
-        //             let origin = player_head + target_transform.rotation.mul_vec3(offsets[ix]);
-        //             if let Some(hit) = colliders.cast_ray_nearest(
-        //                 context.last_update_frame,
-        //                 origin,
-        //                 target_translation - origin,
-        //                 1.0,
-        //                 u32::MAX,
-        //                 false,
-        //                 false,
-        //                 None,
-        //             ) {
-        //                 offset_distances[ix] =
-        //                     FloatOrd(offset_distances[ix].0.min(hit.toi).max(0.0));
-        //             }
-        //         }
-        //     }
-        //     debug!(
-        //         "{distance} vs {:?}",
-        //         offset_distances.iter().map(|d| d.0).collect::<Vec<_>>()
-        //     );
-        //     distance *= offset_distances.iter().min().unwrap().0;
-        // }
-
-        target_transform.translation = player_head
-            + head_offset * base_distance.clamp(0.0, 3.0)
-            + target_direction * base_distance;
-
-        // if base_distance == distance {
-        //     user_global.0 = 0.0;
-        // } else {
-            user_global.0 = base_distance;
-        // }
+        commands.entity(camera_ent).insert(ViewUserValue(distance));
     }
 
     let changed = (prev_override.is_some() != options.scene_override.is_some())

--- a/crates/user_input/src/lib.rs
+++ b/crates/user_input/src/lib.rs
@@ -6,7 +6,7 @@ use bevy::{
     app::Propagate,
     ecs::query::Has,
     prelude::*,
-    render::{camera::CameraUpdateSystem, globals::UserGlobal, view::RenderLayers},
+    render::{camera::CameraUpdateSystem, view::RenderLayers},
     transform::TransformSystem,
 };
 
@@ -45,7 +45,6 @@ pub struct UserInputPlugin;
 
 impl Plugin for UserInputPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<UserGlobal>();
         app.add_systems(
             Update,
             (update_user_velocity, update_camera)


### PR DESCRIPTION
- fix prepass for native (disabled due to opaque optimisation not applied in webgpu, plus shader preprocessor definitions error) 
- apply screendoor depth based on view-based value instead of global, to avoid shadow / texturecam artifacts
- modify dither effect bounds a bit
- clamp camera distance/height to avoid floor transparency
- clamp partially-transparent output colors to 1 to avoid bloom saturation obliterating transparency 

prepass fix closes #417