### PR TITLE
relax GltfNodeModifer path matching

### DIFF
--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -1277,7 +1277,7 @@ fn debug_modifiers(
         }
 
         if !unused.is_empty() {
-            error!(
+            warn!(
                 "no match for gltf modifiers {unused:?} in nodes {:?}",
                 processed.named_nodes.keys().collect::<Vec<_>>()
             )

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -12,7 +12,7 @@ use bevy::{
     asset::LoadState,
     gltf::{Gltf, GltfExtras, GltfLoaderSettings},
     pbr::{ExtendedMaterial, NotShadowCaster},
-    platform::collections::HashMap,
+    platform::collections::{HashMap, HashSet},
     prelude::*,
     render::{
         mesh::{skinning::SkinnedMesh, Indices, VertexAttributeValues},
@@ -1184,7 +1184,7 @@ fn debug_modifiers(
     mut removed_components: RemovedComponents<GltfNodeModifiers>,
 ) {
     for (modifiers, processed) in q {
-        let modifiers = modifiers
+        let mut modifiers = modifiers
             .0
             .modifiers
             .iter()
@@ -1192,35 +1192,68 @@ fn debug_modifiers(
                 let path = if modifier.path.is_empty() {
                     None
                 } else {
-                    Some(modifier.path.as_str())
+                    Some(modifier.path.as_str().split('/').collect::<Vec<_>>())
                 };
 
-                (
-                    path,
-                    (modifier.cast_shadows.unwrap_or(true), &modifier.material),
-                )
+                (path, (modifier.cast_shadows, &modifier.material))
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<Vec<_>>();
 
-        let mut found = false;
+        // sort by segment length to apply most specific last
+        modifiers.sort_by_key(|(path, _)| {
+            path.as_ref()
+                .map(|path| {
+                    (
+                        path.len(),
+                        path.iter().map(|segment| segment.len()).sum::<usize>(),
+                    )
+                })
+                .unwrap_or_default()
+        });
+
+        let mut unused = modifiers
+            .iter()
+            .flat_map(|(path, _)| path)
+            .collect::<HashSet<_>>();
 
         for (path, child) in processed.named_nodes.iter() {
             let Ok((existing_material, _)) = child_nodes.get(*child) else {
                 continue;
             };
 
-            found = true;
+            let node_path_components = path.split('/').collect::<Vec<_>>();
 
-            let maybe_path_modifiers = modifiers
-                .get(&Some(path.as_str()))
-                .or_else(|| modifiers.get(&None));
+            commands.entity(*child).try_remove::<NotShadowCaster>();
 
-            if let Some((shadows, maybe_material)) = maybe_path_modifiers {
-                if !shadows {
-                    commands.entity(*child).try_insert(NotShadowCaster);
+            let mut material_modified = false;
+            for (modifier_path, (shadows, maybe_material)) in
+                modifiers.iter().filter(|(modifier_path_components, _)| {
+                    modifier_path_components
+                        .as_ref()
+                        .is_none_or(|modifier_path_components| {
+                            node_path_components.len() >= modifier_path_components.len()
+                                && (0..modifier_path_components.len() - node_path_components.len())
+                                    .any(|ix| {
+                                        node_path_components[ix..ix + node_path_components.len()]
+                                            == node_path_components
+                                    })
+                        })
+                })
+            {
+                if let Some(modifier_path) = modifier_path {
+                    unused.remove(modifier_path);
+                }
+
+                if let Some(shadows) = shadows {
+                    if *shadows {
+                        commands.entity(*child).try_remove::<NotShadowCaster>();
+                    } else {
+                        commands.entity(*child).try_insert(NotShadowCaster);
+                    }
                 }
 
                 if let Some(material) = maybe_material {
+                    material_modified = true;
                     if let Some(existing) = existing_material {
                         commands
                             .entity(*child)
@@ -1230,17 +1263,25 @@ fn debug_modifiers(
                         .entity(*child)
                         .try_insert(PbMaterialComponent(material.clone()));
                 }
-            } else {
+            }
+
+            if !material_modified {
                 commands
                     .entity(*child)
-                    .try_remove::<(NotShadowCaster, HiddenMaterial, PbMaterialComponent)>();
+                    .try_remove::<(HiddenMaterial, PbMaterialComponent)>();
+
                 if let Ok((_, Some(prev_material))) = child_nodes.get(*child) {
                     commands.entity(*child).try_insert(prev_material.0.clone());
                 }
             }
         }
 
-        debug!("applying GltfNodeModifiers (found a path match = {found}): {modifiers:?}");
+        if !unused.is_empty() {
+            error!(
+                "no match for gltf modifiers {unused:?} in nodes {:?}",
+                processed.named_nodes.keys().collect::<Vec<_>>()
+            )
+        }
     }
 
     for removed in removed_components.read() {

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -1192,7 +1192,14 @@ fn debug_modifiers(
                 let path = if modifier.path.is_empty() {
                     None
                 } else {
-                    Some(modifier.path.as_str().split('/').collect::<Vec<_>>())
+                    Some(
+                        modifier
+                            .path
+                            .as_str()
+                            .split('/')
+                            .filter(|segment| !segment.is_empty())
+                            .collect::<Vec<_>>(),
+                    )
                 };
 
                 (path, (modifier.cast_shadows, &modifier.material))
@@ -1221,7 +1228,10 @@ fn debug_modifiers(
                 continue;
             };
 
-            let node_path_components = path.split('/').collect::<Vec<_>>();
+            let node_path_components = path
+                .split('/')
+                .filter(|segment| !segment.is_empty())
+                .collect::<Vec<_>>();
 
             commands.entity(*child).try_remove::<NotShadowCaster>();
 


### PR DESCRIPTION
in order to make as much compatiblity as possible, we allow node paths to match a subset of the tree node segments:

- `name` matches nodes like `name`, `prefix/name/postfix`, etc
- `name` does not match `prefixname` or `namepostfix`
- `name1/name2` matches nodes like `name1/name2`, `prefix/name1/name2/postfix`, etc
- `name1/name2` does not match `name2/name1`