### PR TITLE
Fallback materials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1400,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1533,7 +1533,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1557,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "glam",
 ]
@@ -1565,7 +1565,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#dfc0e0ccc469983eb961bce5b1be7765709b8a47"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1637,12 +1637,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d2ec0194089677da8e9ae10a450c9937c8576817"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4b84ebd6458722b31817cf3cdb5c4302e9656875"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2264,10 +2264,10 @@ dependencies = [
 [[package]]
 name = "boimp"
 version = "0.1.1"
-source = "git+https://github.com/robtfm/boimp?branch=0.3#ebc8ca90534ce7d3b712cfc38c110acc599e8ed8"
+source = "git+https://github.com/robtfm/boimp?branch=0.3#015702725f33dc381e0970dffc07f17e8436473b"
 dependencies = [
  "anyhow",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "bevy",
  "bytemuck",
  "crossbeam-channel",

--- a/crates/imposters/src/floor_imposter.rs
+++ b/crates/imposters/src/floor_imposter.rs
@@ -16,6 +16,8 @@ pub struct FloorMaterialExt {
 }
 
 impl MaterialExtension for FloorMaterialExt {
+    type Base = Imposter;
+
     fn vertex_shader() -> bevy::render::render_resource::ShaderRef {
         "embedded://shaders/floor_vertex.wgsl".into()
     }
@@ -39,7 +41,7 @@ impl ImposterBakeMaterialExtension for FloorMaterialExt {
     }
 }
 
-pub type FloorImposter = ExtendedMaterial<Imposter, FloorMaterialExt>;
+pub type FloorImposter = ExtendedMaterial<FloorMaterialExt>;
 
 #[derive(Default)]
 pub struct FloorImposterLoader;
@@ -61,7 +63,7 @@ impl AssetLoader for FloorImposterLoader {
                 &ImposterLoaderSettings {
                     multisample: true,
                     alpha_blend: 0.5,
-                    transfer_priority: bevy::asset::RenderAssetTransferPriority::Priority(-1),
+                    transfer_priority: bevy::asset::RenderAssetTransferPriority::Immediate,
                     asset_usages: RenderAssetUsages::RENDER_WORLD,
                     ..Default::default()
                 },

--- a/crates/imposters/src/imposter_mesh.rs
+++ b/crates/imposters/src/imposter_mesh.rs
@@ -90,7 +90,7 @@ impl MeshBuilder for ImposterMesh {
         mesh = mesh
             .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
             .with_inserted_indices(indices);
-        mesh.transfer_priority = RenderAssetTransferPriority::Priority(-1);
+        mesh.transfer_priority = RenderAssetTransferPriority::Immediate;
 
         mesh
     }

--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -946,9 +946,7 @@ impl<'w, 's> ImposterSpecManager<'w, 's> {
                                         alpha: 1.0,
                                         alpha_blend: 0.0, // blend
                                         multisample_amount: 0.0,
-                                        transfer_priority: RenderAssetTransferPriority::Priority(
-                                            -1,
-                                        ),
+                                        transfer_priority: RenderAssetTransferPriority::Immediate,
                                         asset_usages: RenderAssetUsages::RENDER_WORLD,
                                     }
                                 },
@@ -1194,8 +1192,9 @@ fn load_imposters(
                     let (mesh, aabb) = if error == 0 {
                         (imposter_meshes.cube.clone(), imposter_meshes.aabb)
                     } else {
-                        let mesh = ImposterMesh::from_spec(&spec, base_imposter);
+                        let mut mesh = ImposterMesh::from_spec(&spec, base_imposter);
                         let aabb = mesh.compute_aabb().unwrap();
+                        mesh.transfer_priority = RenderAssetTransferPriority::Immediate;
 
                         (meshes.add(mesh), aabb)
                     };
@@ -1251,7 +1250,7 @@ fn load_imposters(
                             uv[1] = 0.0 / 18.0
                                 + 17.0 / 18.0 * (1.0 - bottomleft.y - (1.0 - uv[1]) * parcel_size);
                         }
-                        floor.transfer_priority = RenderAssetTransferPriority::Priority(-1);
+                        floor.transfer_priority = RenderAssetTransferPriority::Immediate;
 
                         meshes.add(floor)
                     };

--- a/crates/scene_material/src/lib.rs
+++ b/crates/scene_material/src/lib.rs
@@ -269,7 +269,10 @@ impl MaterialExtension for SceneBound {
 
     fn fallback_asset(&self, _base: &Self::Base) -> Option<ExtendedMaterial<Self>> {
         let (base_color, emissive) = if self.data.flags & SCENE_MATERIAL_OUTLINE != 0 {
-            (Color::srgba(1.0, 1.0, 4.0, 1.0), Color::srgba(1.0, 1.0, 4.0, 1.0))
+            (
+                Color::srgba(1.0, 1.0, 4.0, 1.0),
+                Color::srgba(1.0, 1.0, 4.0, 1.0),
+            )
         } else {
             (Color::srgba(1.25, 0.25, 1.25, 0.75), Color::BLACK)
         };

--- a/crates/scene_material/src/lib.rs
+++ b/crates/scene_material/src/lib.rs
@@ -6,7 +6,7 @@ use bevy::{
 use boimp::bake::{ImposterBakeMaterialExtension, ImposterBakeMaterialPlugin};
 use common::structs::PreviewMode;
 
-pub type SceneMaterial = ExtendedMaterial<StandardMaterial, SceneBound>;
+pub type SceneMaterial = ExtendedMaterial<SceneBound>;
 
 pub const SCENE_MATERIAL_SHOW_OUTSIDE: u32 = 1;
 pub const SCENE_MATERIAL_OUTLINE: u32 = 2;
@@ -250,6 +250,8 @@ mod test {
 }
 
 impl MaterialExtension for SceneBound {
+    type Base = StandardMaterial;
+
     fn fragment_shader() -> bevy::render::render_resource::ShaderRef {
         ShaderRef::Path("embedded://shaders/bound_material.wgsl".into())
     }
@@ -263,6 +265,26 @@ impl MaterialExtension for SceneBound {
 
     fn prepass_fragment_shader() -> ShaderRef {
         ShaderRef::Path("embedded://shaders/bound_prepass.wgsl".into())
+    }
+
+    fn fallback_asset(&self, _base: &Self::Base) -> Option<ExtendedMaterial<Self>> {
+        let (base_color, emissive) = if self.data.flags & SCENE_MATERIAL_OUTLINE != 0 {
+            (Color::srgba(1.0, 1.0, 4.0, 1.0), Color::srgba(1.0, 1.0, 4.0, 1.0))
+        } else {
+            (Color::srgba(1.25, 0.25, 1.25, 0.75), Color::BLACK)
+        };
+
+        Some(ExtendedMaterial::<Self> {
+            base: StandardMaterial {
+                base_color,
+                emissive: emissive.to_linear(),
+                double_sided: true,
+                unlit: true,
+                alpha_mode: AlphaMode::Blend,
+                ..Default::default()
+            },
+            extension: self.clone(),
+        })
     }
 
     fn specialize(

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -573,6 +573,11 @@ fn update_ready_gltfs(
                         continue;
                     };
 
+                    if read_only_mesh_data.count_vertices() == 0 {
+                        commands.entity(spawned_ent).try_remove::<Mesh3d>();
+                        continue;
+                    }
+
                     // get or create hash
                     // note we must use the handle lookup rather than recomputing the hash as we may modify the mesh on first load,
                     // then recalculating would yield a different hash result

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -271,7 +271,7 @@ pub fn update_worldui_materials(
         .collect();
 }
 
-pub type TextShapeMaterial = ExtendedMaterial<SceneMaterial, TextQuad>;
+pub type TextShapeMaterial = ExtendedMaterial<TextQuad>;
 
 #[derive(Asset, TypePath, Clone, AsBindGroup)]
 pub struct TextQuad {
@@ -299,6 +299,8 @@ mod decl {
 pub use decl::*;
 
 impl MaterialExtension for TextQuad {
+    type Base = SceneMaterial;
+
     fn vertex_shader() -> bevy::render::render_resource::ShaderRef {
         ShaderRef::Path("embedded://shaders/text_quad_vertex.wgsl".into())
     }

--- a/deploy/web/main.js
+++ b/deploy/web/main.js
@@ -304,7 +304,7 @@ function start() {
     return "unknown";
   })();
 
-  engine_run(platform, initialRealm, location, systemScene, true, preview, 5e7);
+  engine_run(platform, initialRealm, location, systemScene, true, preview, 1e7);
 }
 
 initButton.onclick = start;


### PR DESCRIPTION
- use a fallback material when images are not yet available on gpu, to avoid showing avatar heads without bodies. partial fix for #473 and #367 (probably still need to place a dummy avatar to render before wearables are downloaded)
- bump imposter transfer priority up again, as the fallback materials means we can be more tolerant of asset load delays, and imposter popping was very bad
- fix a panic when scenes contain meshes with no vertices (closes #371)
