### PR TITLE
fix: trigger scene emote incorrect parameter name `looping`->`loop`

### DIFF
--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -26,7 +26,7 @@ module.exports.triggerEmote = async function (body) {
 }
 
 module.exports.triggerSceneEmote = async function (body) { 
-    Deno.core.ops.op_scene_emote(body.src, body.looping)
+    Deno.core.ops.op_scene_emote(body.src, body.loop)
     return {} 
 }
 


### PR DESCRIPTION
We had the same issue on Godot.

We can check here:

https://github.com/decentraland/protocol/blob/814b279004cf8d4f95f82f04e8f496fcce5e5584/proto/decentraland/kernel/apis/restricted_actions.proto#L42

Note: We used in Godot
```const loop = body.loop ?? false;```

just for defaulting if loop is undefined