### PR TITLE
fix blurry nametags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "async-broadcast",
  "async-channel 2.3.1",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1400,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1533,7 +1533,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1557,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "glam",
 ]
@@ -1565,7 +1565,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1637,12 +1637,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "async-channel 2.3.1",
  "bevy_app",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#6324c2ad3f6f08d29da8f7247a0e7f14de27d8db"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/assets/src/assets/shaders/bound_material.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material.wgsl
@@ -191,5 +191,10 @@ fn fragment(
     let cap_factor = max(max(out.color.r, out.color.g), max(out.color.b, 1.0));
     out.color = mix(out.color, vec4<f32>(out.color.rgb / cap_factor, out.color.a), saturate(cap_brightness * 2.0));
 
+    if out.color.a < 0.001 {
+        // avoid writing to the depth buffer for alpha-blend materials with zero alpha
+        discard;
+    }
+
     return out;
 }


### PR DESCRIPTION
fix blurry nametags when there is no opaque material behind them.
- enable depth write for alpha-blend materials, to avoid depth-of-field seeing very far distance
- explicitly discard when alpha=0 to avoid over-conservative depth writing
