### PR TITLE
Update assets build script to allow for hot reloading to work

### DIFF
--- a/crates/assets/build.rs
+++ b/crates/assets/build.rs
@@ -17,7 +17,7 @@ fn visit_dirs(writer: &mut BufWriter<File>, dir: &Path, base_dir: &Path) -> std:
                 let full_path = path.canonicalize()?;
                 let full_path = full_path.to_string_lossy().replace('\\', "\\\\");
 
-                writeln!(writer, "    embedded.insert_asset(PathBuf::default(), Path::new(\"{relative_path}\"), include_bytes!(\"{full_path}\"));")?;
+                writeln!(writer, "    embedded.insert_asset(PathBuf::from(\"crates/assets/src/assets/{relative_path}\"), Path::new(\"{relative_path}\"), include_bytes!(\"{full_path}\"));")?;
             }
         }
     }


### PR DESCRIPTION
With the `bevy/embedded_watcher` features it is now possible to hot reload shaders

Tested on linux and windows