### PR TITLE
fix web avatarshape dynamics

### DIFF
--- a/crates/avatar/src/npc_dynamics.rs
+++ b/crates/avatar/src/npc_dynamics.rs
@@ -49,7 +49,11 @@ fn update_npc_velocity(
         let velocity = (current_translation - prev_translation) / scene.last_update_dt;
 
         commands.entity(ent).insert(AvatarDynamicState {
-            velocity,
+            velocity: if velocity.is_finite() {
+                velocity
+            } else {
+                Vec3::ZERO
+            },
             ground_height: 0.0,
             ..Default::default()
         });

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -9,7 +9,7 @@ use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{CrdtComponentInterfaces, CrdtStore},
     js::{CommunicatedWithRenderer, SceneResponseSender, ShuttingDown, SuperUserScene},
-    RendererResponse, SceneId,
+    RendererResponse, SceneElapsedTime, SceneId,
 };
 use gotham_state::GothamState;
 use ipfs::SceneJsFile;
@@ -219,6 +219,11 @@ impl From<WasmError> for JsValue {
     fn from(value: WasmError) -> Self {
         js_sys::Error::new(&value.0.to_string()).into()
     }
+}
+
+#[wasm_bindgen]
+pub fn op_set_elapsed(state: &WorkerContext, elapsed: f32) {
+    state.state.borrow_mut().put(SceneElapsedTime(elapsed));
 }
 
 #[wasm_bindgen]

--- a/deploy/web/sandbox_worker.js
+++ b/deploy/web/sandbox_worker.js
@@ -312,6 +312,7 @@ self.onmessage = async (event) => {
       var consecutiveErrorsWithoutInteraction = 0;
       while (ops.op_continue_running()) {
         const dt = (elapsed - prevElapsed) / 1000;
+        ops.op_set_elapsed(elapsed / 1000);
         try {
           await module.onUpdate(dt);
           consecutiveErrorsWithoutInteraction = 0;


### PR DESCRIPTION
scene elapsed time was not reported back from the sandbox worker to the main thread, so avatarshape velocity was not calculated correctly.