### PR TITLE
locomotion and modifiers

### DIFF
--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -61,6 +61,7 @@ fn gen_sdk_components() -> Result<()> {
         "skybox_time",
         "avatar_movement_info",
         "avatar_movement",
+        "avatar_locomotion_settings",
     ];
 
     let mut sources = components

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -136,12 +136,13 @@ impl SceneComponentId {
     pub const CAMERA_LAYERS: SceneComponentId = SceneComponentId(1208);
     pub const PRIMARY_POINTER_INFO: SceneComponentId = SceneComponentId(1209);
     pub const SKYBOX_TIME: SceneComponentId = SceneComponentId(1210);
-    pub const CAMERA_LAYER: SceneComponentId = SceneComponentId(1211);
+    pub const CAMERA_LAYER: SceneComponentId = SceneComponentId(1503);
 
     pub const REALM_INFO: SceneComponentId = SceneComponentId(1106);
 
     pub const AVATAR_MOVEMENT_INFO: SceneComponentId = SceneComponentId(1500);
     pub const AVATAR_MOVEMENT: SceneComponentId = SceneComponentId(1501);
+    pub const AVATAR_LOCOMOTION_SETTINGS: SceneComponentId = SceneComponentId(1211);
 }
 
 #[derive(

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
@@ -1,0 +1,18 @@
+﻿syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1211;
+
+// The PBAvatarLocomotionSettings component allows scenes to modify locomotion settings defining things such
+// as the avatar movement speed, jump height etc.
+message PBAvatarLocomotionSettings {
+  optional float walk_speed = 1;            // Maximum speed when walking (in meters per second)
+  optional float jog_speed = 2;             // Maximum speed when jogging (in meters per second)
+  optional float run_speed = 3;             // Maximum speed when running (in meters per second)
+  optional float jump_height = 4;           // Height of a regular jump (in meters)
+  optional float run_jump_height = 5;       // Height of a jump while running (in meters)
+  optional float hard_landing_cooldown = 6; // Cooldown time after a hard landing before the avatar can move again (in seconds)
+}

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement_info.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement_info.proto
@@ -4,6 +4,8 @@ package decentraland.sdk.components;
 
 import "decentraland/sdk/components/common/id.proto";
 import "decentraland/common/vectors.proto";
+import "decentraland/sdk/components/avatar_locomotion_settings.proto";
+import "decentraland/sdk/components/input_modifier.proto";
 
 option (common.ecs_component_id) = 1500;
 
@@ -13,4 +15,6 @@ message PBAvatarMovementInfo {
   decentraland.common.Vector3 requested_velocity = 3;       // the velocity requested for the previous frame
   decentraland.common.Vector3 actual_velocity = 4;          // the resulting velocity taking collisions into account
   decentraland.common.Vector3 external_velocity = 5;        // the velocity imparted by movement of the "ground" platform or pushing from other moving colliders
+  decentraland.sdk.components.PBAvatarLocomotionSettings active_avatar_locomotion_settings = 6;
+  decentraland.sdk.components.PBInputModifier active_input_modifier = 7;
 }

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/camera_layer.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/camera_layer.proto
@@ -5,7 +5,7 @@ package decentraland.sdk.components;
 import "decentraland/sdk/components/common/id.proto";
 import "decentraland/common/colors.proto";
 
-option (common.ecs_component_id) = 1211;
+option (common.ecs_component_id) = 1503;
 
 message PBCameraLayer {
     // layer to which these settings apply. must be > 0

--- a/crates/scene_runner/src/update_world/avatar_modifier_area.rs
+++ b/crates/scene_runner/src/update_world/avatar_modifier_area.rs
@@ -39,12 +39,12 @@ impl From<PbAvatarModifierArea> for AvatarModifierArea {
     }
 }
 
-#[derive(Component, Debug)]
-pub struct InputModifier(pub PbInputModifier);
+#[derive(Component, Debug, Clone, Default)]
+pub struct InputModifier(pub Option<PbInputModifier>);
 
 impl From<PbInputModifier> for InputModifier {
     fn from(value: PbInputModifier) -> Self {
-        Self(value)
+        Self(Some(value))
     }
 }
 
@@ -294,8 +294,9 @@ fn update_avatar_modifier_area(
                 }
             }
 
-            if let Some(pb_input_modifier::Mode::Standard(modifier)) =
-                maybe_modifier.and_then(|m| m.0.mode.as_ref())
+            if let Some(pb_input_modifier::Mode::Standard(modifier)) = maybe_modifier
+                .and_then(|m| m.0.as_ref())
+                .and_then(|m| m.mode.as_ref())
             {
                 let permit = maybe_foreign.is_some()
                     || match active_area.allow_locomotion {


### PR DESCRIPTION
protocol:
- add AvatarLocomotionSettings
- add active settings and active modifiers to AvatarMovementInfo

engine:
- pick active AvatarLocomotionSettings and InputModifer by scene priority (parcel / portable recency)
- pass to all scenes via AvatarMovementInfo

char controller (already merged and uploaded to basiccontroller.dcl.eth)
- read locomotion settings and modifiers and apply