### PR TITLE
feat: movePlayerTo with duration/interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9646,6 +9646,7 @@ dependencies = [
  "tokio",
  "ui_core",
  "urlencoding",
+ "user_input",
  "wallet",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "bevy",
  "common",
  "dcl",
+ "dcl_component",
  "futures-lite 1.13.0",
  "ipfs",
  "js-sys",

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -127,6 +127,8 @@ pub enum RpcCall {
         scene: Entity,
         to: Vec3,
         looking_at: Option<Vec3>,
+        duration: Option<f32>,
+        response: Option<RpcResultSender<bool>>,
     },
     TeleportPlayer {
         scene: Option<Entity>,

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -980,6 +980,15 @@ impl SceneImposterBake {
 #[derive(Resource, Default)]
 pub struct CursorLocks(pub HashSet<&'static str>);
 
+/// Controls engine-level overrides to avatar movement, independent of scene-driven movement.
+#[derive(Resource, Default)]
+pub struct EngineMovementControl {
+    /// Non-empty means collision/clipping is disabled (e.g. "noclip" from /idnoclip)
+    pub suppress_clipping: HashSet<&'static str>,
+    /// Non-empty means avatar physics movement systems are suppressed (e.g. "move_player_to" during interpolation)
+    pub suppress_avatar_physics: HashSet<&'static str>,
+}
+
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub enum MoveKind {
     #[default]

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -1,18 +1,11 @@
 module.exports.movePlayerTo = async function (body) {
-    Deno.core.ops.op_move_player_to(
-        body.newRelativePosition.x, 
-        body.newRelativePosition.y, 
-        body.newRelativePosition.z, 
-        body.cameraTarget !== undefined, 
-        body.cameraTarget?.x ?? 0, 
-        body.cameraTarget?.y ?? 0, 
-        body.cameraTarget?.z ?? 0,
-        body.avatarTarget !== undefined,
-        body.avatarTarget?.x ?? 0, 
-        body.avatarTarget?.y ?? 0, 
-        body.avatarTarget?.z ?? 0,
+    const success = await Deno.core.ops.op_move_player_to(
+        body.newRelativePosition,
+        body.cameraTarget ?? null,
+        body.avatarTarget ?? null,
+        body.duration ?? null,
     );
-    return {} 
+    return { success }
 }
 
 module.exports.teleportTo = async function (body) { 

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -25,7 +25,8 @@ pub async fn op_move_player_to(
 
     let to = DclTranslation([position.x, position.y, position.z]).to_bevy_translation();
     let looking_at_source = avatar_target.or(camera_target);
-    let looking_at = looking_at_source.map(|t| DclTranslation([t.x, t.y, t.z]).to_bevy_translation());
+    let looking_at =
+        looking_at_source.map(|t| DclTranslation([t.x, t.y, t.z]).to_bevy_translation());
     let camera_rotation = camera_target.map(|camera| {
         let camera_target = DclTranslation([camera.x, camera.y, camera.z]).to_bevy_translation();
         Transform::IDENTITY
@@ -33,10 +34,12 @@ pub async fn op_move_player_to(
             .rotation
     });
 
-    let (response, rx) = duration.map(|_| {
-        let (sx, rx) = RpcResultSender::<bool>::channel();
-        (Some(sx), Some(rx))
-    }).unwrap_or((None, None));
+    let (response, rx) = duration
+        .map(|_| {
+            let (sx, rx) = RpcResultSender::<bool>::channel();
+            (Some(sx), Some(rx))
+        })
+        .unwrap_or((None, None));
 
     {
         let mut op_state = state.borrow_mut();

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -5,6 +5,7 @@ use bevy::{
     transform::components::Transform,
 };
 use common::rpc::{RpcCall, RpcResultSender, RpcUiFocusAction};
+use dcl_component::proto_components::common::Vector3 as DclVector3;
 use serde::Serialize;
 use std::{cell::RefCell, rc::Rc};
 
@@ -13,57 +14,51 @@ use dcl_component::transform_and_parent::DclTranslation;
 
 use super::{runtime::scene_information, State};
 
-#[allow(clippy::too_many_arguments)]
-pub fn op_move_player_to(
-    op_state: &mut impl State,
-    position_x: f32,
-    position_y: f32,
-    position_z: f32,
-    camera: bool,
-    maybe_camera_x: f32,
-    maybe_camera_y: f32,
-    maybe_camera_z: f32,
-    looking_at: bool,
-    maybe_looking_at_x: f32,
-    maybe_looking_at_y: f32,
-    maybe_looking_at_z: f32,
-) {
-    let position = [position_x, position_y, position_z];
-    let maybe_camera = if camera {
-        Some([maybe_camera_x, maybe_camera_y, maybe_camera_z])
-    } else {
-        None
-    };
-    let maybe_looking_at = if looking_at {
-        Some([maybe_looking_at_x, maybe_looking_at_y, maybe_looking_at_z])
-    } else {
-        None
-    };
+pub async fn op_move_player_to(
+    state: Rc<RefCell<impl State>>,
+    position: DclVector3,
+    camera_target: Option<DclVector3>,
+    avatar_target: Option<DclVector3>,
+    duration: Option<f32>,
+) -> bool {
+    debug!("move player to {position:?}, camera: {camera_target:?}, rotate: {avatar_target:?}, duration: {duration:?}");
 
-    debug!("move player to {position:?}, camera: {maybe_camera:?}, rotate: {maybe_looking_at:?}");
-    let scene = op_state.borrow::<CrdtContext>().scene_id.0;
-
-    let to = DclTranslation(position).to_bevy_translation();
-
-    let avatar_target = maybe_looking_at.or(maybe_camera);
-    let looking_at = avatar_target.map(|target| DclTranslation(target).to_bevy_translation());
-
-    op_state.borrow_mut::<RpcCalls>().push(RpcCall::MovePlayer {
-        scene,
-        to,
-        looking_at,
-    });
-
-    let camera_rotation = maybe_camera.map(|camera| {
-        let camera_target = DclTranslation(camera).to_bevy_translation();
+    let to = DclTranslation([position.x, position.y, position.z]).to_bevy_translation();
+    let looking_at_source = avatar_target.or(camera_target);
+    let looking_at = looking_at_source.map(|t| DclTranslation([t.x, t.y, t.z]).to_bevy_translation());
+    let camera_rotation = camera_target.map(|camera| {
+        let camera_target = DclTranslation([camera.x, camera.y, camera.z]).to_bevy_translation();
         Transform::IDENTITY
             .looking_at(camera_target - to, Vec3::Y)
             .rotation
     });
-    if let Some(facing) = camera_rotation {
-        op_state
-            .borrow_mut::<RpcCalls>()
-            .push(RpcCall::MoveCamera { scene, facing });
+
+    let (response, rx) = duration.map(|_| {
+        let (sx, rx) = RpcResultSender::<bool>::channel();
+        (Some(sx), Some(rx))
+    }).unwrap_or((None, None));
+
+    {
+        let mut op_state = state.borrow_mut();
+        let scene = op_state.borrow::<CrdtContext>().scene_id.0;
+        op_state.borrow_mut::<RpcCalls>().push(RpcCall::MovePlayer {
+            scene,
+            to,
+            looking_at,
+            duration,
+            response,
+        });
+        if let Some(facing) = camera_rotation {
+            op_state
+                .borrow_mut::<RpcCalls>()
+                .push(RpcCall::MoveCamera { scene, facing });
+        }
+    }
+
+    if let Some(rx) = rx {
+        matches!(rx.await, Ok(true))
+    } else {
+        true
     }
 }
 

--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -77,6 +77,7 @@ fn gen_sdk_components() -> Result<()> {
     let mut config = prost_build::Config::new();
     let serde_components = [
         "Vector2",
+        "Vector3",
         "Color3",
         "PBRealmInfo",
         "PBAvatarBase",

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -32,7 +32,8 @@ async fn op_move_player_to(
         camera_target,
         avatar_target,
         duration,
-    ).await
+    )
+    .await
 }
 
 #[op2(async)]

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -1,4 +1,5 @@
 use dcl::js::restricted_actions::UiFocusResult;
+use dcl_component::proto_components::common::Vector3 as DclVector3;
 use deno_core::{anyhow, error::AnyError, op2, OpDecl, OpState};
 use std::{cell::RefCell, rc::Rc};
 
@@ -17,36 +18,21 @@ pub fn ops() -> Vec<OpDecl> {
     ]
 }
 
-#[op2(fast)]
-#[allow(clippy::too_many_arguments)]
-fn op_move_player_to(
-    op_state: &mut OpState,
-    position_x: f32,
-    position_y: f32,
-    position_z: f32,
-    camera: bool,
-    maybe_camera_x: f32,
-    maybe_camera_y: f32,
-    maybe_camera_z: f32,
-    looking_at: bool,
-    maybe_looking_at_x: f32,
-    maybe_looking_at_y: f32,
-    maybe_looking_at_z: f32,
-) {
+#[op2(async)]
+async fn op_move_player_to(
+    state: Rc<RefCell<OpState>>,
+    #[serde] position: DclVector3,
+    #[serde] camera_target: Option<DclVector3>,
+    #[serde] avatar_target: Option<DclVector3>,
+    duration: Option<f32>,
+) -> bool {
     dcl::js::restricted_actions::op_move_player_to(
-        op_state,
-        position_x,
-        position_y,
-        position_z,
-        camera,
-        maybe_camera_x,
-        maybe_camera_y,
-        maybe_camera_z,
-        looking_at,
-        maybe_looking_at_x,
-        maybe_looking_at_y,
-        maybe_looking_at_z,
-    );
+        state,
+        position,
+        camera_target,
+        avatar_target,
+        duration,
+    ).await
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/Cargo.toml
+++ b/crates/dcl_wasm/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 [dependencies]
 common = { workspace = true }
 dcl = { workspace = true }
+dcl_component = { workspace = true }
 ipfs = { workspace = true }
 system_bridge = { workspace = true }
 

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -19,7 +19,8 @@ pub async fn op_move_player_to(
         camera_target,
         avatar_target,
         duration,
-    ).await
+    )
+    .await
 }
 
 #[wasm_bindgen]

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -1,36 +1,25 @@
 use crate::{serde_result, WasmError, WorkerContext};
+use dcl_component::proto_components::common::Vector3 as DclVector3;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-#[allow(clippy::too_many_arguments)]
-pub fn op_move_player_to(
+pub async fn op_move_player_to(
     op_state: &WorkerContext,
-    position_x: f32,
-    position_y: f32,
-    position_z: f32,
-    camera: bool,
-    maybe_camera_x: f32,
-    maybe_camera_y: f32,
-    maybe_camera_z: f32,
-    looking_at: bool,
-    maybe_looking_at_x: f32,
-    maybe_looking_at_y: f32,
-    maybe_looking_at_z: f32,
-) {
+    position: JsValue,
+    camera_target: JsValue,
+    avatar_target: JsValue,
+    duration: Option<f32>,
+) -> bool {
+    let position: DclVector3 = serde_wasm_bindgen::from_value(position).unwrap_or_default();
+    let camera_target: Option<DclVector3> = serde_wasm_bindgen::from_value(camera_target).ok();
+    let avatar_target: Option<DclVector3> = serde_wasm_bindgen::from_value(avatar_target).ok();
     dcl::js::restricted_actions::op_move_player_to(
-        &mut *op_state.state.borrow_mut(),
-        position_x,
-        position_y,
-        position_z,
-        camera,
-        maybe_camera_x,
-        maybe_camera_y,
-        maybe_camera_z,
-        looking_at,
-        maybe_looking_at_x,
-        maybe_looking_at_y,
-        maybe_looking_at_z,
-    );
+        op_state.rc(),
+        position,
+        camera_target,
+        avatar_target,
+        duration,
+    ).await
 }
 
 #[wasm_bindgen]

--- a/crates/restricted_actions/Cargo.toml
+++ b/crates/restricted_actions/Cargo.toml
@@ -16,6 +16,8 @@ dcl_component = { workspace = true }
 nft = { workspace = true }
 console = { workspace = true }
 
+user_input = { workspace = true }
+
 bevy = { workspace = true }
 bevy_dui = { workspace = true }
 bevy_console = { workspace = true }

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -121,7 +121,15 @@ pub fn move_player(
     mut commands: Commands,
     mut events: EventReader<RpcCall>,
     scenes: Query<&RendererSceneContext>,
-    mut player: Query<(Entity, &mut Transform, &mut AvatarDynamicState), With<PrimaryUser>>,
+    mut player: Query<
+        (
+            Entity,
+            &mut Transform,
+            &mut AvatarDynamicState,
+            Option<&PlayerMoveInterpolation>,
+        ),
+        With<PrimaryUser>,
+    >,
     containing_scene: ContainingScene,
     mut perms: Permission<(
         Entity,
@@ -132,7 +140,7 @@ pub fn move_player(
     )>,
     mut movement_control: ResMut<EngineMovementControl>,
 ) {
-    let Ok((player_entity, _, _)) = player.single() else {
+    let Ok((player_entity, _, _, _)) = player.single() else {
         return;
     };
 
@@ -187,43 +195,45 @@ pub fn move_player(
         let target_scenes = containing_scene.get_position(target_translation);
         if !target_scenes.contains(&root) {
             warn!("move player request from {root:?} was outside scene bounds");
-        } else if let Some(d) = duration {
-            let (player_entity, player_transform, _) = player.single().unwrap();
-            let from = player_transform.translation;
-            debug!(
-                "player interpolation start: {} -> {} over {}s",
-                from, target_translation, d
-            );
-            movement_control
-                .suppress_avatar_physics
-                .insert("move_player_to");
-            commands
-                .entity(player_entity)
-                .insert(PlayerMoveInterpolation {
-                    from,
-                    to: target_translation,
-                    elapsed: 0.0,
-                    duration: d,
-                    response: response.unwrap(),
-                });
-            // apply rotation immediately if requested
-            if let Some(looking_at) = looking_at {
-                let (_, mut player_transform, mut dynamics) = player.single_mut().unwrap();
-                let rotation = Transform::IDENTITY
-                    .looking_at(
-                        (looking_at - translation) * Vec3::new(1.0, 0.0, 1.0),
-                        Vec3::Y,
-                    )
-                    .rotation;
-                dynamics.velocity =
-                    rotation * player_transform.rotation.inverse() * dynamics.velocity;
-                player_transform.rotation = rotation;
-            }
         } else {
-            let (_, mut player_transform, mut dynamics) = player.single_mut().unwrap();
-            player_transform.translation = target_translation;
-            debug!("player transform to {}", target_translation);
+            let (_, mut player_transform, mut dynamics, maybe_previous_move) =
+                player.single_mut().unwrap();
 
+            if let Some(previous_move) = maybe_previous_move {
+                commands
+                    .entity(player_entity)
+                    .try_remove::<PlayerMoveInterpolation>();
+                movement_control
+                    .suppress_avatar_physics
+                    .remove("move_player_to");
+                previous_move.response.send(false);
+            }
+
+            if let Some(d) = duration {
+                let d = d.max(f32::EPSILON);
+                let from = player_transform.translation;
+                debug!(
+                    "player interpolation start: {} -> {} over {}s",
+                    from, target_translation, d
+                );
+                movement_control
+                    .suppress_avatar_physics
+                    .insert("move_player_to");
+                commands
+                    .entity(player_entity)
+                    .insert(PlayerMoveInterpolation {
+                        from,
+                        to: target_translation,
+                        elapsed: 0.0,
+                        duration: d,
+                        response: response.unwrap(),
+                    });
+            } else {
+                player_transform.translation = target_translation;
+                debug!("player transform to {}", target_translation);
+            }
+
+            // always apply rotation immediately if requested
             if let Some(looking_at) = looking_at {
                 let rotation = Transform::IDENTITY
                     .looking_at(
@@ -234,10 +244,6 @@ pub fn move_player(
                 dynamics.velocity =
                     rotation * player_transform.rotation.inverse() * dynamics.velocity;
                 player_transform.rotation = rotation;
-                debug!("player rotation to looking at {}", looking_at);
-            }
-            if let Some(r) = response {
-                r.send(true);
             }
         }
     }
@@ -267,14 +273,13 @@ pub fn update_player_interpolation(
     let Ok((entity, mut transform, mut interp, movement)) = player.single_mut() else {
         return;
     };
-
     // Cancel if the scene movement controller asserts a new non-zero x/z velocity or a jump.
     // Skip on the first tick (elapsed == 0) to avoid immediately cancelling due to the
     // movement component being changed when the interpolation was just inserted.
     if interp.elapsed > 0.0 && movement.is_changed() {
         let v = movement.component.velocity;
         if v.x != 0.0 || v.z != 0.0 || v.y.abs() > 2.0 {
-            error!("player interpolation cancelled by scene movement controller : {v}");
+            debug!("player interpolation cancelled by scene movement controller : {v}");
             interp.response.send(false);
             movement_control
                 .suppress_avatar_physics

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -116,29 +116,38 @@ pub struct PlayerMoveInterpolation {
     response: RpcResultSender<bool>,
 }
 
+#[allow(clippy::type_complexity)]
 pub fn move_player(
     mut commands: Commands,
     mut events: EventReader<RpcCall>,
     scenes: Query<&RendererSceneContext>,
     mut player: Query<(Entity, &mut Transform, &mut AvatarDynamicState), With<PrimaryUser>>,
     containing_scene: ContainingScene,
-    mut perms: Permission<(Entity, Vec3, Option<Vec3>, Option<f32>, Option<RpcResultSender<bool>>)>,
+    mut perms: Permission<(
+        Entity,
+        Vec3,
+        Option<Vec3>,
+        Option<f32>,
+        Option<RpcResultSender<bool>>,
+    )>,
     mut movement_control: ResMut<EngineMovementControl>,
 ) {
     let Ok((player_entity, _, _)) = player.single() else {
         return;
     };
 
-    for (root, translation, looking_at, duration, response) in events.read().filter_map(|ev| match ev {
-        RpcCall::MovePlayer {
-            scene,
-            to,
-            looking_at,
-            duration,
-            response,
-        } => Some((scene, to, looking_at, duration, response)),
-        _ => None,
-    }) {
+    for (root, translation, looking_at, duration, response) in
+        events.read().filter_map(|ev| match ev {
+            RpcCall::MovePlayer {
+                scene,
+                to,
+                looking_at,
+                duration,
+                response,
+            } => Some((scene, to, looking_at, duration, response)),
+            _ => None,
+        })
+    {
         let current_scenes = containing_scene.get(player_entity);
         if !current_scenes.contains(root) {
             warn!(
@@ -150,13 +159,21 @@ pub fn move_player(
         perms.check(
             PermissionType::MovePlayer,
             *root,
-            (*root, *translation, *looking_at, *duration, response.clone()),
+            (
+                *root,
+                *translation,
+                *looking_at,
+                *duration,
+                response.clone(),
+            ),
             None,
             false,
         );
     }
 
-    for (root, translation, looking_at, duration, response) in perms.drain_success(PermissionType::MovePlayer) {
+    for (root, translation, looking_at, duration, response) in
+        perms.drain_success(PermissionType::MovePlayer)
+    {
         let Ok(scene) = scenes.get(root) else {
             warn!("move player request from invalid scene {root:?}");
             continue;
@@ -173,15 +190,22 @@ pub fn move_player(
         } else if let Some(d) = duration {
             let (player_entity, player_transform, _) = player.single().unwrap();
             let from = player_transform.translation;
-            debug!("player interpolation start: {} -> {} over {}s", from, target_translation, d);
-            movement_control.suppress_avatar_physics.insert("move_player_to");
-            commands.entity(player_entity).insert(PlayerMoveInterpolation {
-                from,
-                to: target_translation,
-                elapsed: 0.0,
-                duration: d,
-                response: response.unwrap(),
-            });
+            debug!(
+                "player interpolation start: {} -> {} over {}s",
+                from, target_translation, d
+            );
+            movement_control
+                .suppress_avatar_physics
+                .insert("move_player_to");
+            commands
+                .entity(player_entity)
+                .insert(PlayerMoveInterpolation {
+                    from,
+                    to: target_translation,
+                    elapsed: 0.0,
+                    duration: d,
+                    response: response.unwrap(),
+                });
             // apply rotation immediately if requested
             if let Some(looking_at) = looking_at {
                 let (_, mut player_transform, mut dynamics) = player.single_mut().unwrap();
@@ -225,6 +249,7 @@ pub fn move_player(
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub fn update_player_interpolation(
     mut commands: Commands,
     mut player: Query<
@@ -251,7 +276,9 @@ pub fn update_player_interpolation(
         if v.x != 0.0 || v.z != 0.0 || v.y.abs() > 2.0 {
             error!("player interpolation cancelled by scene movement controller : {v}");
             interp.response.send(false);
-            movement_control.suppress_avatar_physics.remove("move_player_to");
+            movement_control
+                .suppress_avatar_physics
+                .remove("move_player_to");
             commands.entity(entity).remove::<PlayerMoveInterpolation>();
             return;
         }
@@ -264,7 +291,9 @@ pub fn update_player_interpolation(
     if t >= 1.0 {
         debug!("player interpolation complete");
         interp.response.send(true);
-        movement_control.suppress_avatar_physics.remove("move_player_to");
+        movement_control
+            .suppress_avatar_physics
+            .remove("move_player_to");
         commands.entity(entity).remove::<PlayerMoveInterpolation>();
     }
 }

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -67,6 +67,7 @@ impl Plugin for RestrictedActionsPlugin {
             (
                 (
                     move_player,
+                    update_player_interpolation.after(move_player),
                     move_camera,
                     change_realm,
                     external_url,
@@ -105,23 +106,35 @@ impl Plugin for RestrictedActionsPlugin {
     }
 }
 
+#[derive(Component)]
+pub struct PlayerMoveInterpolation {
+    from: Vec3,
+    to: Vec3,
+    elapsed: f32,
+    duration: f32,
+    response: RpcResultSender<bool>,
+}
+
 pub fn move_player(
+    mut commands: Commands,
     mut events: EventReader<RpcCall>,
     scenes: Query<&RendererSceneContext>,
     mut player: Query<(Entity, &mut Transform, &mut AvatarDynamicState), With<PrimaryUser>>,
     containing_scene: ContainingScene,
-    mut perms: Permission<(Entity, Vec3, Option<Vec3>)>,
+    mut perms: Permission<(Entity, Vec3, Option<Vec3>, Option<f32>, Option<RpcResultSender<bool>>)>,
 ) {
     let Ok((player_entity, _, _)) = player.single() else {
         return;
     };
 
-    for (root, translation, looking_at) in events.read().filter_map(|ev| match ev {
+    for (root, translation, looking_at, duration, response) in events.read().filter_map(|ev| match ev {
         RpcCall::MovePlayer {
             scene,
             to,
             looking_at,
-        } => Some((scene, to, looking_at)),
+            duration,
+            response,
+        } => Some((scene, to, looking_at, duration, response)),
         _ => None,
     }) {
         let current_scenes = containing_scene.get(player_entity);
@@ -135,13 +148,13 @@ pub fn move_player(
         perms.check(
             PermissionType::MovePlayer,
             *root,
-            (*root, *translation, *looking_at),
+            (*root, *translation, *looking_at, *duration, response.clone()),
             None,
             false,
         );
     }
 
-    for (root, translation, looking_at) in perms.drain_success(PermissionType::MovePlayer) {
+    for (root, translation, looking_at, duration, response) in perms.drain_success(PermissionType::MovePlayer) {
         let Ok(scene) = scenes.get(root) else {
             warn!("move player request from invalid scene {root:?}");
             continue;
@@ -154,6 +167,30 @@ pub fn move_player(
         let target_scenes = containing_scene.get_position(target_translation);
         if !target_scenes.contains(&root) {
             warn!("move player request from {root:?} was outside scene bounds");
+        } else if let Some(d) = duration {
+            let (player_entity, player_transform, _) = player.single().unwrap();
+            let from = player_transform.translation;
+            debug!("player interpolation start: {} -> {} over {}s", from, target_translation, d);
+            commands.entity(player_entity).insert(PlayerMoveInterpolation {
+                from,
+                to: target_translation,
+                elapsed: 0.0,
+                duration: d,
+                response: response.unwrap(),
+            });
+            // apply rotation immediately if requested
+            if let Some(looking_at) = looking_at {
+                let (_, mut player_transform, mut dynamics) = player.single_mut().unwrap();
+                let rotation = Transform::IDENTITY
+                    .looking_at(
+                        (looking_at - translation) * Vec3::new(1.0, 0.0, 1.0),
+                        Vec3::Y,
+                    )
+                    .rotation;
+                dynamics.velocity =
+                    rotation * player_transform.rotation.inverse() * dynamics.velocity;
+                player_transform.rotation = rotation;
+            }
         } else {
             let (_, mut player_transform, mut dynamics) = player.single_mut().unwrap();
             player_transform.translation = target_translation;
@@ -168,14 +205,40 @@ pub fn move_player(
                     .rotation;
                 dynamics.velocity =
                     rotation * player_transform.rotation.inverse() * dynamics.velocity;
-
                 player_transform.rotation = rotation;
                 debug!("player rotation to looking at {}", looking_at);
+            }
+            if let Some(r) = response {
+                r.send(true);
             }
         }
     }
 
-    for _ in perms.drain_fail(PermissionType::MovePlayer) {}
+    for (_, _, _, _, response) in perms.drain_fail(PermissionType::MovePlayer) {
+        if let Some(r) = response {
+            r.send(false);
+        }
+    }
+}
+
+pub fn update_player_interpolation(
+    mut commands: Commands,
+    mut player: Query<(Entity, &mut Transform, &mut PlayerMoveInterpolation), With<PrimaryUser>>,
+    time: Res<Time>,
+) {
+    let Ok((entity, mut transform, mut interp)) = player.single_mut() else {
+        return;
+    };
+
+    interp.elapsed += time.delta_secs();
+    let t = (interp.elapsed / interp.duration).min(1.0);
+    transform.translation = interp.from.lerp(interp.to, t);
+
+    if t >= 1.0 {
+        debug!("player interpolation complete");
+        interp.response.send(true);
+        commands.entity(entity).remove::<PlayerMoveInterpolation>();
+    }
 }
 
 pub fn move_camera(

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -23,8 +23,8 @@ use common::{
     },
     sets::SceneSets,
     structs::{
-        AvatarDynamicState, PermissionType, PreviewCommand, PrimaryCamera, PrimaryUser,
-        StartupScenes, ZOrder,
+        AvatarDynamicState, EngineMovementControl, PermissionType, PreviewCommand, PrimaryCamera,
+        PrimaryUser, StartupScenes, ZOrder,
     },
     util::{AsH160, TaskCompat, TaskExt},
 };
@@ -122,6 +122,7 @@ pub fn move_player(
     mut player: Query<(Entity, &mut Transform, &mut AvatarDynamicState), With<PrimaryUser>>,
     containing_scene: ContainingScene,
     mut perms: Permission<(Entity, Vec3, Option<Vec3>, Option<f32>, Option<RpcResultSender<bool>>)>,
+    mut movement_control: ResMut<EngineMovementControl>,
 ) {
     let Ok((player_entity, _, _)) = player.single() else {
         return;
@@ -163,6 +164,7 @@ pub fn move_player(
         let mut target_translation = translation;
         target_translation +=
             (scene.base * IVec2::new(1, -1)).as_vec2().extend(0.0).xzy() * PARCEL_SIZE;
+        target_translation.y = target_translation.y.max(0.0);
 
         let target_scenes = containing_scene.get_position(target_translation);
         if !target_scenes.contains(&root) {
@@ -171,6 +173,7 @@ pub fn move_player(
             let (player_entity, player_transform, _) = player.single().unwrap();
             let from = player_transform.translation;
             debug!("player interpolation start: {} -> {} over {}s", from, target_translation, d);
+            movement_control.suppress_avatar_physics.insert("move_player_to");
             commands.entity(player_entity).insert(PlayerMoveInterpolation {
                 from,
                 to: target_translation,
@@ -225,6 +228,7 @@ pub fn update_player_interpolation(
     mut commands: Commands,
     mut player: Query<(Entity, &mut Transform, &mut PlayerMoveInterpolation), With<PrimaryUser>>,
     time: Res<Time>,
+    mut movement_control: ResMut<EngineMovementControl>,
 ) {
     let Ok((entity, mut transform, mut interp)) = player.single_mut() else {
         return;
@@ -237,6 +241,7 @@ pub fn update_player_interpolation(
     if t >= 1.0 {
         debug!("player interpolation complete");
         interp.response.send(true);
+        movement_control.suppress_avatar_physics.remove("move_player_to");
         commands.entity(entity).remove::<PlayerMoveInterpolation>();
     }
 }

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -55,6 +55,7 @@ use scene_runner::{
 use serde_json::{json, Value};
 use teleport::{handle_out_of_world, teleport_player};
 use ui_core::button::DuiButton;
+use user_input::avatar_movement::{ActivePlayerComponent, AvatarMovement};
 use wallet::{browser_auth::remote_send_async, sign_request, Wallet};
 
 pub struct RestrictedActionsPlugin;
@@ -226,13 +227,35 @@ pub fn move_player(
 
 pub fn update_player_interpolation(
     mut commands: Commands,
-    mut player: Query<(Entity, &mut Transform, &mut PlayerMoveInterpolation), With<PrimaryUser>>,
+    mut player: Query<
+        (
+            Entity,
+            &mut Transform,
+            &mut PlayerMoveInterpolation,
+            Ref<ActivePlayerComponent<AvatarMovement>>,
+        ),
+        With<PrimaryUser>,
+    >,
     time: Res<Time>,
     mut movement_control: ResMut<EngineMovementControl>,
 ) {
-    let Ok((entity, mut transform, mut interp)) = player.single_mut() else {
+    let Ok((entity, mut transform, mut interp, movement)) = player.single_mut() else {
         return;
     };
+
+    // Cancel if the scene movement controller asserts a new non-zero x/z velocity or a jump.
+    // Skip on the first tick (elapsed == 0) to avoid immediately cancelling due to the
+    // movement component being changed when the interpolation was just inserted.
+    if interp.elapsed > 0.0 && movement.is_changed() {
+        let v = movement.component.velocity;
+        if v.x != 0.0 || v.z != 0.0 || v.y.abs() > 2.0 {
+            error!("player interpolation cancelled by scene movement controller : {v}");
+            interp.response.send(false);
+            movement_control.suppress_avatar_physics.remove("move_player_to");
+            commands.entity(entity).remove::<PlayerMoveInterpolation>();
+            return;
+        }
+    }
 
     interp.elapsed += time.delta_secs();
     let t = (interp.elapsed / interp.duration).min(1.0);

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -231,6 +231,9 @@ pub fn move_player(
             } else {
                 player_transform.translation = target_translation;
                 debug!("player transform to {}", target_translation);
+                if let Some(response) = response {
+                    response.send(true);
+                }
             }
 
             // always apply rotation immediately if requested

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -5,7 +5,7 @@ use bevy::{diagnostic::FrameCount, math::DVec3, platform::collections::HashMap, 
 use common::{
     dynamics::{PLAYER_COLLIDER_OVERLAP, PLAYER_COLLIDER_RADIUS, PLAYER_GROUND_THRESHOLD},
     sets::SceneSets,
-    structs::{AvatarDynamicState, PrimaryPlayerRes, PrimaryUser},
+    structs::{AvatarDynamicState, EngineMovementControl, PrimaryPlayerRes, PrimaryUser},
 };
 use comms::global_crdt::GlobalCrdtState;
 use dcl::interface::{ComponentPosition, CrdtType};
@@ -272,15 +272,20 @@ pub fn apply_movement(
     time_res: Res<Time>,
     mut info: ResMut<AvatarMovementInfo>,
     mut jumping: Local<bool>,
+    movement_control: Res<EngineMovementControl>,
 ) {
     let Ok((mut transform, mut dynamic_state, movement)) = player.single_mut() else {
         return;
     };
 
     info.0.step_time = time_res.delta_secs();
-    transform.rotation = Quat::from_rotation_y(movement.component.orientation / 360.0 * TAU);
 
-    if movement.component.velocity == Vec3::ZERO {
+    let suppress = !movement_control.suppress_avatar_physics.is_empty();
+    if !suppress {
+        transform.rotation = Quat::from_rotation_y(movement.component.orientation / 360.0 * TAU);
+    }
+
+    if suppress || movement.component.velocity == Vec3::ZERO {
         dynamic_state.velocity = Vec3::ZERO;
         let ground_height =
             scenes
@@ -322,22 +327,24 @@ pub fn apply_movement(
         steps += 1;
         let mut step_time = time;
         let mut contact_normal = DVec3::ZERO;
-        for (e, mut collider_data) in scenes.iter_mut() {
-            if let Some(hit) = collider_data.cast_avatar_nearest(
-                position,
-                velocity,
-                step_time,
-                ColliderLayer::ClPhysics as u32 | GROUND_COLLISION_MASK,
-                false,
-                false,
-                disabled
-                    .get(&e)
-                    .map(|d| d.iter().collect())
-                    .unwrap_or_default(),
-                -PLAYER_COLLIDER_OVERLAP,
-            ) {
-                step_time = hit.toi as f64;
-                contact_normal = hit.normal.as_dvec3();
+        if movement_control.suppress_clipping.is_empty() {
+            for (e, mut collider_data) in scenes.iter_mut() {
+                if let Some(hit) = collider_data.cast_avatar_nearest(
+                    position,
+                    velocity,
+                    step_time,
+                    ColliderLayer::ClPhysics as u32 | GROUND_COLLISION_MASK,
+                    false,
+                    false,
+                    disabled
+                        .get(&e)
+                        .map(|d| d.iter().collect())
+                        .unwrap_or_default(),
+                    -PLAYER_COLLIDER_OVERLAP,
+                ) {
+                    step_time = hit.toi as f64;
+                    contact_normal = hit.normal.as_dvec3();
+                }
             }
         }
 
@@ -359,7 +366,7 @@ pub fn apply_movement(
     let position = position.as_vec3();
     let velocity = velocity.as_vec3();
 
-    transform.translation = position;
+    transform.translation = position.with_y(position.y.max(0.0));
 
     // for now we hack in the old dynamic state values for animations
     dynamic_state.velocity = velocity;
@@ -433,7 +440,12 @@ fn apply_ground_collider_movement(
     frame: Res<FrameCount>,
     mut info: ResMut<AvatarMovementInfo>,
     time: Res<Time>,
+    movement_control: Res<EngineMovementControl>,
 ) {
+    if !movement_control.suppress_avatar_physics.is_empty() {
+        return;
+    }
+
     let Ok((mut transform, GroundCollider(Some((ground_entity, _, _))))) = player.single_mut()
     else {
         return;
@@ -495,7 +507,12 @@ fn resolve_collisions(
     mut scenes: Query<&mut SceneColliderData>,
     mut info: ResMut<AvatarMovementInfo>,
     time: Res<Time>,
+    movement_control: Res<EngineMovementControl>,
 ) {
+    if !movement_control.suppress_clipping.is_empty() {
+        return;
+    }
+
     let Ok(mut transform) = player.single_mut() else {
         return;
     };

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -46,13 +46,20 @@ impl Plugin for AvatarMovementPlugin {
         app.add_systems(Update, broadcast_movement_info.in_set(SceneSets::Init));
 
         app.add_systems(
+            Update,
+            (
+                ActivePlayerComponent::<AvatarMovement>::pick_latest_frame_only_by_priority,
+                ActivePlayerComponent::<AvatarLocomotionSettings>::pick_by_priority,
+                ActivePlayerComponent::<InputModifier>::pick_by_priority,
+            )
+                .in_set(SceneSets::PostLoop),
+        );
+
+        app.add_systems(
             PostUpdate,
             (
                 apply_ground_collider_movement,
                 resolve_collisions,
-                ActivePlayerComponent::<AvatarMovement>::pick_latest_frame_only_by_priority,
-                ActivePlayerComponent::<AvatarLocomotionSettings>::pick_by_priority,
-                ActivePlayerComponent::<InputModifier>::pick_by_priority,
                 apply_movement,
                 record_ground_collider,
             )

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -516,7 +516,9 @@ fn resolve_collisions(
     time: Res<Time>,
     movement_control: Res<EngineMovementControl>,
 ) {
-    if !movement_control.suppress_clipping.is_empty() {
+    if !movement_control.suppress_clipping.is_empty()
+        || !movement_control.suppress_avatar_physics.is_empty()
+    {
         return;
     }
 

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -113,7 +113,7 @@ pub struct ActivePlayerComponent<C: Component> {
     scene_last_update: u32,
     scene_start_tick: u32,
     scene_is_portable: bool,
-    component: C,
+    pub component: C,
 }
 
 impl<C: Component + Default> Default for ActivePlayerComponent<C> {

--- a/crates/user_input/src/lib.rs
+++ b/crates/user_input/src/lib.rs
@@ -9,7 +9,8 @@ use camera::update_cursor_lock;
 use common::{
     sets::SceneSets,
     structs::{
-        CursorLocks, PlayerModifiers, PrimaryCamera, PrimaryUser, PRIMARY_AVATAR_LIGHT_LAYER_INDEX,
+        CursorLocks, EngineMovementControl, PlayerModifiers, PrimaryCamera, PrimaryUser,
+        PRIMARY_AVATAR_LIGHT_LAYER_INDEX,
     },
 };
 use console::DoAddConsoleCommand;
@@ -46,7 +47,7 @@ impl Plugin for UserInputPlugin {
             )
                 .chain(),
         );
-        app.insert_resource(UserClipping(true))
+        app.init_resource::<EngineMovementControl>()
             .init_resource::<CursorLocks>();
         app.add_console_command::<NoClipCommand, _>(no_clip);
         app.add_console_command::<SpeedCommand, _>(speed_cmd);
@@ -104,9 +105,6 @@ fn manage_player_visibility(
     }
 }
 
-#[derive(Resource)]
-pub struct UserClipping(pub bool);
-
 // turn clipping on/off
 #[derive(clap::Parser, ConsoleCommand)]
 #[command(name = "/idnoclip")]
@@ -114,11 +112,19 @@ pub(crate) struct NoClipCommand {
     clip: Option<bool>,
 }
 
-pub(crate) fn no_clip(mut input: ConsoleCommand<NoClipCommand>, mut clip: ResMut<UserClipping>) {
+pub(crate) fn no_clip(
+    mut input: ConsoleCommand<NoClipCommand>,
+    mut control: ResMut<EngineMovementControl>,
+) {
     if let Some(Ok(command)) = input.take() {
-        let new_state = command.clip.unwrap_or(!clip.0);
-        clip.0 = new_state;
-        input.reply_ok(format!("clipping set to {}", clip.0));
+        let currently_clipping = !control.suppress_clipping.contains("noclip");
+        let new_clipping = command.clip.unwrap_or(!currently_clipping);
+        if new_clipping {
+            control.suppress_clipping.remove("noclip");
+        } else {
+            control.suppress_clipping.insert("noclip");
+        }
+        input.reply_ok(format!("clipping set to {}", new_clipping));
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `duration` parameter to `movePlayerTo` RPC for smooth interpolated movement
- Introduces `EngineMovementControl` resource (replacing `UserClipping`) with `suppress_clipping` and `suppress_avatar_physics` HashSets, allowing multiple independent suppressors
- Suppresses avatar physics systems during interpolation so the scene movement controller doesn't fight the engine
- Cancels interpolation if the scene movement controller asserts a non-zero velocity, allowing scenes to interrupt engine-controlled movement
- Moves `ActivePlayerComponent` pickers to `Update/SceneSets::PostLoop` (before `RestrictedActions`) so cancellation detection sees the current frame's picked data immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)