### PR TITLE
Web agent console command API

### DIFF
--- a/deploy/web/engine.js
+++ b/deploy/web/engine.js
@@ -1,7 +1,7 @@
 // Engine logic - ES module
 // Handles WASM/WebGPU initialization and game execution
 
-import init, { engine_init, engine_run, gpu_cache_hash } from "./pkg/webgpu_build.js";
+import init, { engine_init, engine_run, engine_console_command, gpu_cache_hash } from "./pkg/webgpu_build.js";
 import { initGpuCache } from "./gpu_cache.js";
 
 // Re-export for main.js
@@ -261,5 +261,6 @@ export function start() {
   })();
 
   engine_run(platform, realmValue, positionValue, systemScene, true, preview, 1e7);
+  window.engine_console_command = engine_console_command;
   setTimeout(showCanvas,200)
 }

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -47,7 +47,9 @@ use ipfs::{map_realm_name, IpfsIoPlugin};
 use nft::{asset_source::NftReaderPlugin, NftShapePlugin};
 use platform::default_camera_components;
 use social::SocialPlugin;
-use system_bridge::{settings::NewCameraEvent, NativeUi, SystemApi, SystemBridge, SystemBridgePlugin};
+use system_bridge::{
+    settings::NewCameraEvent, NativeUi, SystemApi, SystemBridge, SystemBridgePlugin,
+};
 use system_ui::SystemUiPlugin;
 use texture_camera::TextureCameraPlugin;
 use tween::TweenPlugin;
@@ -483,10 +485,7 @@ use common::rpc::{RpcResultReceiver, RpcResultSender};
 #[command(name = "/login_guest")]
 struct LoginGuestCommand;
 
-fn login_guest(
-    mut input: ConsoleCommand<LoginGuestCommand>,
-    mut bridge: EventWriter<SystemApi>,
-) {
+fn login_guest(mut input: ConsoleCommand<LoginGuestCommand>, mut bridge: EventWriter<SystemApi>) {
     if let Some(Ok(_)) = input.take() {
         bridge.write(SystemApi::LoginGuest);
         input.reply_ok("logging in as guest");

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -47,7 +47,7 @@ use ipfs::{map_realm_name, IpfsIoPlugin};
 use nft::{asset_source::NftReaderPlugin, NftShapePlugin};
 use platform::default_camera_components;
 use social::SocialPlugin;
-use system_bridge::{settings::NewCameraEvent, NativeUi, SystemBridgePlugin};
+use system_bridge::{settings::NewCameraEvent, NativeUi, SystemApi, SystemBridge, SystemBridgePlugin};
 use system_ui::SystemUiPlugin;
 use texture_camera::TextureCameraPlugin;
 use tween::TweenPlugin;
@@ -328,6 +328,9 @@ fn main_inner(
 
     info!("Bevy-Explorer version {}", version);
 
+    let bridge_sender = app.world().resource::<SystemBridge>().sender.clone();
+    let _ = CONSOLE_BRIDGE_SENDER.set(bridge_sender);
+
     app.run();
 }
 
@@ -472,11 +475,14 @@ fn set_fps(mut input: ConsoleCommand<FpsCommand>, mut config: ResMut<AppConfig>)
     }
 }
 
+use common::rpc::RpcResultSender;
 use once_cell::sync::OnceCell;
 use wasm_bindgen::prelude::*;
 
 static WASM_ASSET_LOADER_HANDLE: OnceCell<bevy::asset::WasmLoaderHandle> = OnceCell::new();
 static INIT_DATA: OnceCell<AppConfig> = OnceCell::new();
+static CONSOLE_BRIDGE_SENDER: OnceCell<tokio::sync::mpsc::UnboundedSender<SystemApi>> =
+    OnceCell::new();
 
 /// call from a separate worker to initialize a channel for asset load processing
 #[wasm_bindgen]
@@ -533,6 +539,37 @@ pub fn engine_run(
         preview,
         rabpf,
     );
+}
+
+/// Send a console command to the engine from JavaScript.
+/// `command_line` is the full command string, e.g. `"/teleport 10 20"`.
+/// Returns a Promise that resolves with the command output or rejects with an error message.
+#[wasm_bindgen]
+pub async fn engine_console_command(command_line: String) -> Result<JsValue, JsValue> {
+    let mut parts = command_line.split_whitespace();
+    let Some(cmd) = parts.next() else {
+        return Err(JsValue::from_str("empty command"));
+    };
+    let cmd = if cmd.starts_with('/') {
+        cmd.to_string()
+    } else {
+        format!("/{cmd}")
+    };
+    let args: Vec<String> = parts.map(String::from).collect();
+
+    let Some(sender) = CONSOLE_BRIDGE_SENDER.get() else {
+        return Err(JsValue::from_str("engine not initialized"));
+    };
+
+    let (sx, rx) = RpcResultSender::channel();
+    sender
+        .send(SystemApi::ConsoleCommand(cmd, args, sx))
+        .map_err(|_| JsValue::from_str("engine channel closed"))?;
+
+    rx.await
+        .map_err(|_| JsValue::from_str("command response dropped"))?
+        .map(|s| JsValue::from_str(&s))
+        .map_err(|e| JsValue::from_str(&e))
 }
 
 pub fn update_winit_fps(config: Res<AppConfig>, mut winit: ResMut<WinitSettings>) {

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -325,6 +325,8 @@ fn main_inner(
     app.add_console_command::<SceneDistanceCommand, _>(scene_distance);
     app.add_console_command::<SceneThreadsCommand, _>(scene_threads);
     app.add_console_command::<FpsCommand, _>(set_fps);
+    app.add_console_command::<LoginGuestCommand, _>(login_guest);
+    app.add_console_command::<LoginPreviousCommand, _>(login_previous);
 
     info!("Bevy-Explorer version {}", version);
 
@@ -475,7 +477,48 @@ fn set_fps(mut input: ConsoleCommand<FpsCommand>, mut config: ResMut<AppConfig>)
     }
 }
 
-use common::rpc::RpcResultSender;
+use common::rpc::{RpcResultReceiver, RpcResultSender};
+/// Login as guest (session-only, profile will not persist)
+#[derive(clap::Parser, ConsoleCommand)]
+#[command(name = "/login_guest")]
+struct LoginGuestCommand;
+
+fn login_guest(
+    mut input: ConsoleCommand<LoginGuestCommand>,
+    mut bridge: EventWriter<SystemApi>,
+) {
+    if let Some(Ok(_)) = input.take() {
+        bridge.write(SystemApi::LoginGuest);
+        input.reply_ok("logging in as guest");
+    }
+}
+
+/// Login using previously saved credentials
+#[derive(clap::Parser, ConsoleCommand)]
+#[command(name = "/login_previous")]
+struct LoginPreviousCommand;
+
+fn login_previous(
+    mut input: ConsoleCommand<LoginPreviousCommand>,
+    mut bridge: EventWriter<SystemApi>,
+    mut pending: Local<Option<RpcResultReceiver<Result<(), String>>>>,
+) {
+    if let Some(Ok(_)) = input.take() {
+        let (sx, rx) = RpcResultSender::<Result<(), String>>::channel();
+        bridge.write(SystemApi::LoginPrevious(sx));
+        *pending = Some(rx);
+    }
+
+    if let Some(mut rx) = pending.take() {
+        match rx.try_recv() {
+            Ok(Ok(())) => input.reply_ok("logged in with previous credentials"),
+            Ok(Err(e)) => input.reply_failed(e),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => *pending = Some(rx),
+            Err(_) => input.reply_failed("login task dropped"),
+        }
+    }
+}
+
 use once_cell::sync::OnceCell;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
## Summary

- Exposes `engine_console_command(commandLine)` as a `#[wasm_bindgen]` async function, allowing JS/agents to send any console command to the engine and await the result as a Promise
- Adds `/login_guest` and `/login_previous` console commands for agent-driven login in the web build
- Attaches `window.engine_console_command` in `engine.js` after `engine_run` so it's accessible from the browser console or external agents

## Usage

```js
await window.engine_console_command("/login_guest")
await window.engine_console_command("/login_previous")
await window.engine_console_command("/teleport 10 20")
```

## Test plan

- [ ] Build wasm (`wasm-pack build --target web --out-dir ./deploy/web/pkg --no-default-features --features="livekit"`)
- [ ] Verify `window.engine_console_command` is defined after engine starts
- [ ] Test `/login_guest` logs in as guest
- [ ] Test `/login_previous` succeeds with saved credentials, fails gracefully without them
- [ ] Test `/teleport` and other existing commands still work via the new function

🤖 Generated with [Claude Code](https://claude.com/claude-code)