### PR TITLE
add walkPlayerTo RPC

### DIFF
--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -130,6 +130,13 @@ pub enum RpcCall {
         duration: Option<f32>,
         response: Option<RpcResultSender<bool>>,
     },
+    WalkPlayer {
+        scene: Entity,
+        to: Vec3,
+        stop_threshold: f32,
+        timeout: Option<f32>,
+        response: RpcResultSender<bool>,
+    },
     TeleportPlayer {
         scene: Option<Entity>,
         to: IVec2,

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -8,7 +8,16 @@ module.exports.movePlayerTo = async function (body) {
     return { success }
 }
 
-module.exports.teleportTo = async function (body) { 
+module.exports.walkPlayerTo = async function (body) {
+    const success = await Deno.core.ops.op_walk_player_to(
+        body.newRelativePosition,
+        body.stopThreshold,
+        body.timeout ?? null,
+    );
+    return { success }
+}
+
+module.exports.teleportTo = async function (body) {
     await Deno.core.ops.op_teleport_to(Number(body.worldCoordinates.x), Number(body.worldCoordinates.y));
     return {} 
 }

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -65,6 +65,32 @@ pub async fn op_move_player_to(
     }
 }
 
+pub async fn op_walk_player_to(
+    state: Rc<RefCell<impl State>>,
+    position: DclVector3,
+    stop_threshold: f32,
+    timeout: Option<f32>,
+) -> bool {
+    debug!("walk player to {position:?}, stop_threshold: {stop_threshold:?}, timeout: {timeout:?}");
+
+    let to = DclTranslation([position.x, position.y, position.z]).to_bevy_translation();
+    let (sx, rx) = RpcResultSender::<bool>::channel();
+
+    {
+        let mut op_state = state.borrow_mut();
+        let scene = op_state.borrow::<CrdtContext>().scene_id.0;
+        op_state.borrow_mut::<RpcCalls>().push(RpcCall::WalkPlayer {
+            scene,
+            to,
+            stop_threshold,
+            timeout,
+            response: sx,
+        });
+    }
+
+    matches!(rx.await, Ok(true))
+}
+
 pub async fn op_teleport_to(
     state: Rc<RefCell<impl State>>,
     position_x: i32,

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
@@ -11,6 +11,7 @@ message PBAvatarMovement {
   decentraland.common.Vector3 velocity = 1;
   float orientation = 2; // 0-360, we don't allow pitch/roll
   optional decentraland.common.Vector3 ground_direction = 3;
+  optional bool walk_success = 4; // set for one frame when a walk_target ends: true = reached target, false = failed; absent = in progress or no walk
 }
 
 // engine behaviour (uses only capsule shapecasts and GJK closest point for portability):

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement_info.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement_info.proto
@@ -17,4 +17,6 @@ message PBAvatarMovementInfo {
   decentraland.common.Vector3 external_velocity = 5;        // the velocity imparted by movement of the "ground" platform or pushing from other moving colliders
   decentraland.sdk.components.PBAvatarLocomotionSettings active_avatar_locomotion_settings = 6;
   decentraland.sdk.components.PBInputModifier active_input_modifier = 7;
+  optional decentraland.common.Vector3 walk_target = 8;    // if set, the movement scene should walk the player to this scene-relative position
+  optional float walk_threshold = 9;                        // stop distance for walk_target
 }

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -7,6 +7,7 @@ use std::{cell::RefCell, rc::Rc};
 pub fn ops() -> Vec<OpDecl> {
     vec![
         op_move_player_to(),
+        op_walk_player_to(),
         op_teleport_to(),
         op_change_realm(),
         op_external_url(),
@@ -34,6 +35,16 @@ async fn op_move_player_to(
         duration,
     )
     .await
+}
+
+#[op2(async)]
+async fn op_walk_player_to(
+    state: Rc<RefCell<OpState>>,
+    #[serde] position: DclVector3,
+    stop_threshold: f32,
+    timeout: Option<f32>,
+) -> bool {
+    dcl::js::restricted_actions::op_walk_player_to(state, position, stop_threshold, timeout).await
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -24,6 +24,17 @@ pub async fn op_move_player_to(
 }
 
 #[wasm_bindgen]
+pub async fn op_walk_player_to(
+    op_state: &WorkerContext,
+    position: JsValue,
+    stop_threshold: f32,
+    timeout: Option<f32>,
+) -> bool {
+    let position: DclVector3 = serde_wasm_bindgen::from_value(position).unwrap_or_default();
+    dcl::js::restricted_actions::op_walk_player_to(op_state.rc(), position, stop_threshold, timeout).await
+}
+
+#[wasm_bindgen]
 pub async fn op_teleport_to(state: &WorkerContext, position_x: i32, position_y: i32) -> bool {
     dcl::js::restricted_actions::op_teleport_to(state.rc(), position_x, position_y).await
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -31,7 +31,8 @@ pub async fn op_walk_player_to(
     timeout: Option<f32>,
 ) -> bool {
     let position: DclVector3 = serde_wasm_bindgen::from_value(position).unwrap_or_default();
-    dcl::js::restricted_actions::op_walk_player_to(op_state.rc(), position, stop_threshold, timeout).await
+    dcl::js::restricted_actions::op_walk_player_to(op_state.rc(), position, stop_threshold, timeout)
+        .await
 }
 
 #[wasm_bindgen]

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -115,7 +115,10 @@ enum PlayerMoveKind {
     Interpolate { from: Vec3, duration: f32 },
     /// Movement-scene-driven walk to `target`; the engine broadcasts the target each frame and
     /// waits for the movement scene to confirm completion via `AvatarMovement::walk_success`.
-    Walk { stop_threshold: f32, timeout: Option<f32> },
+    Walk {
+        stop_threshold: f32,
+        timeout: Option<f32>,
+    },
 }
 
 /// Active engine-driven move request, attached to the player entity until resolved.
@@ -155,7 +158,9 @@ impl PendingPlayerMove {
 
     fn send_fail(self) {
         match self {
-            Self::Move { response: Some(r), .. } => r.send(false),
+            Self::Move {
+                response: Some(r), ..
+            } => r.send(false),
             Self::Walk { response, .. } => response.send(false),
             _ => {}
         }
@@ -171,7 +176,9 @@ fn cancel_active_move(
 ) {
     active.response.send(false);
     if matches!(active.kind, PlayerMoveKind::Interpolate { .. }) {
-        movement_control.suppress_avatar_physics.remove("player_move");
+        movement_control
+            .suppress_avatar_physics
+            .remove("player_move");
     }
     movement_info.0.walk_target = None;
     movement_info.0.walk_threshold = None;
@@ -203,29 +210,43 @@ pub fn handle_player_move_requests(
 
     for ev in events.read() {
         let pending = match ev {
-            RpcCall::MovePlayer { scene, to, looking_at, duration, response } => {
-                PendingPlayerMove::Move {
-                    scene: *scene,
-                    target: *to,
-                    looking_at: *looking_at,
-                    duration: *duration,
-                    response: response.clone(),
-                }
-            }
-            RpcCall::WalkPlayer { scene, to, stop_threshold, timeout, response } => {
-                PendingPlayerMove::Walk {
-                    scene: *scene,
-                    target: *to,
-                    stop_threshold: *stop_threshold,
-                    timeout: *timeout,
-                    response: response.clone(),
-                }
-            }
+            RpcCall::MovePlayer {
+                scene,
+                to,
+                looking_at,
+                duration,
+                response,
+            } => PendingPlayerMove::Move {
+                scene: *scene,
+                target: *to,
+                looking_at: *looking_at,
+                duration: *duration,
+                response: response.clone(),
+            },
+            RpcCall::WalkPlayer {
+                scene,
+                to,
+                stop_threshold,
+                timeout,
+                response,
+            } => PendingPlayerMove::Walk {
+                scene: *scene,
+                target: *to,
+                stop_threshold: *stop_threshold,
+                timeout: *timeout,
+                response: response.clone(),
+            },
             _ => continue,
         };
 
-        if !containing_scene.get(player_entity).contains(&pending.scene()) {
-            warn!("player move request from {:?}: player not in scene", pending.scene());
+        if !containing_scene
+            .get(player_entity)
+            .contains(&pending.scene())
+        {
+            warn!(
+                "player move request from {:?}: player not in scene",
+                pending.scene()
+            );
             pending.send_fail();
             continue;
         }
@@ -242,17 +263,23 @@ pub fn handle_player_move_requests(
             continue;
         };
 
-        let base_offset = (scene.base * IVec2::new(1, -1)).as_vec2().extend(0.0).xzy() * PARCEL_SIZE;
+        let base_offset =
+            (scene.base * IVec2::new(1, -1)).as_vec2().extend(0.0).xzy() * PARCEL_SIZE;
 
         // Compute world-space target and validate bounds before doing anything else.
         // An invalid request must not cancel the currently active move.
         let raw_target = match &pending {
-            PendingPlayerMove::Move { target, .. } | PendingPlayerMove::Walk { target, .. } => *target,
+            PendingPlayerMove::Move { target, .. } | PendingPlayerMove::Walk { target, .. } => {
+                *target
+            }
         };
         let mut world_target = raw_target + base_offset;
         world_target.y = world_target.y.max(0.0);
 
-        if !containing_scene.get_position(world_target).contains(&scene_entity) {
+        if !containing_scene
+            .get_position(world_target)
+            .contains(&scene_entity)
+        {
             warn!("player move request from {scene_entity:?}: target is outside scene bounds");
             pending.send_fail();
             continue;
@@ -261,16 +288,30 @@ pub fn handle_player_move_requests(
         // Target is valid — cancel any existing active move and apply the new one.
         let (_, mut player_transform, mut dynamics, maybe_active) = player.single_mut().unwrap();
         if let Some(active) = maybe_active {
-            cancel_active_move(&mut commands, player_entity, active, &mut movement_control, &mut movement_info);
+            cancel_active_move(
+                &mut commands,
+                player_entity,
+                active,
+                &mut movement_control,
+                &mut movement_info,
+            );
         }
 
         match pending {
-            PendingPlayerMove::Move { target, looking_at, duration, response, .. } => {
+            PendingPlayerMove::Move {
+                target,
+                looking_at,
+                duration,
+                response,
+                ..
+            } => {
                 if let Some(d) = duration {
                     let d = d.max(f32::EPSILON);
                     let from = player_transform.translation;
                     debug!("player interpolation start: {from} -> {world_target} over {d}s");
-                    movement_control.suppress_avatar_physics.insert("player_move");
+                    movement_control
+                        .suppress_avatar_physics
+                        .insert("player_move");
                     commands.entity(player_entity).insert(ActivePlayerMove {
                         target: world_target,
                         elapsed: 0.0,
@@ -280,25 +321,36 @@ pub fn handle_player_move_requests(
                 } else {
                     player_transform.translation = world_target;
                     debug!("player teleported to {world_target}");
-                    if let Some(r) = response { r.send(true); }
+                    if let Some(r) = response {
+                        r.send(true);
+                    }
                 }
 
                 if let Some(looking_at) = looking_at {
                     let rotation = Transform::IDENTITY
                         .looking_at((looking_at - target) * Vec3::new(1.0, 0.0, 1.0), Vec3::Y)
                         .rotation;
-                    dynamics.velocity = rotation * player_transform.rotation.inverse() * dynamics.velocity;
+                    dynamics.velocity =
+                        rotation * player_transform.rotation.inverse() * dynamics.velocity;
                     player_transform.rotation = rotation;
                 }
             }
 
-            PendingPlayerMove::Walk { stop_threshold, timeout, response, .. } => {
+            PendingPlayerMove::Walk {
+                stop_threshold,
+                timeout,
+                response,
+                ..
+            } => {
                 debug!("walk player started: target={world_target}, threshold={stop_threshold}");
                 commands.entity(player_entity).insert(ActivePlayerMove {
                     target: world_target,
                     elapsed: 0.0,
                     response,
-                    kind: PlayerMoveKind::Walk { stop_threshold, timeout },
+                    kind: PlayerMoveKind::Walk {
+                        stop_threshold,
+                        timeout,
+                    },
                 });
             }
         }
@@ -342,7 +394,9 @@ pub fn update_player_move(
                 if v.x != 0.0 || v.z != 0.0 || v.y.abs() > 2.0 {
                     debug!("player interpolation cancelled by scene movement controller: {v}");
                     active.response.send(false);
-                    movement_control.suppress_avatar_physics.remove("player_move");
+                    movement_control
+                        .suppress_avatar_physics
+                        .remove("player_move");
                     commands.entity(entity).remove::<ActivePlayerMove>();
                     return;
                 }
@@ -354,17 +408,24 @@ pub fn update_player_move(
             if t >= 1.0 {
                 debug!("player interpolation complete");
                 active.response.send(true);
-                movement_control.suppress_avatar_physics.remove("player_move");
+                movement_control
+                    .suppress_avatar_physics
+                    .remove("player_move");
                 commands.entity(entity).remove::<ActivePlayerMove>();
             }
         }
 
-        PlayerMoveKind::Walk { stop_threshold, timeout } => {
+        PlayerMoveKind::Walk {
+            stop_threshold,
+            timeout,
+        } => {
             // Broadcast walk_target in world space each frame so the movement scene can drive the player.
             // AvatarMovementInfo is sent to all scenes (which have different origins), so world space
             // is the correct coordinate space here.
             movement_info.0.walk_target = Some(
-                dcl_component::proto_components::common::Vector3::world_vec_from_vec3(&active.target),
+                dcl_component::proto_components::common::Vector3::world_vec_from_vec3(
+                    &active.target,
+                ),
             );
             movement_info.0.walk_threshold = Some(*stop_threshold);
 

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -67,10 +67,8 @@ impl Plugin for RestrictedActionsPlugin {
             Update,
             (
                 (
-                    move_player,
-                    update_player_interpolation.after(move_player),
-                    walk_player,
-                    update_player_walk.after(walk_player),
+                    handle_player_move_requests,
+                    update_player_move.after(handle_player_move_requests),
                     move_camera,
                     change_realm,
                     external_url,
@@ -111,17 +109,77 @@ impl Plugin for RestrictedActionsPlugin {
     }
 }
 
+/// The kind of active player move, each with its own completion and cancellation semantics.
+enum PlayerMoveKind {
+    /// Physics-suppressed linear interpolation from `from` to `target` over `duration` seconds.
+    Interpolate { from: Vec3, duration: f32 },
+    /// Movement-scene-driven walk to `target`; the engine broadcasts the target each frame and
+    /// waits for the movement scene to confirm completion via `AvatarMovement::walk_success`.
+    Walk { stop_threshold: f32, timeout: Option<f32> },
+}
+
+/// Active engine-driven move request, attached to the player entity until resolved.
+/// Any new MovePlayer or WalkPlayer request cancels the existing one (sends false).
 #[derive(Component)]
-pub struct PlayerMoveInterpolation {
-    from: Vec3,
-    to: Vec3,
+pub struct ActivePlayerMove {
+    target: Vec3,
     elapsed: f32,
-    duration: f32,
     response: RpcResultSender<bool>,
+    kind: PlayerMoveKind,
+}
+
+/// Pending move data queued through the permission system.
+pub enum PendingPlayerMove {
+    Move {
+        scene: Entity,
+        target: Vec3,
+        looking_at: Option<Vec3>,
+        duration: Option<f32>,
+        response: Option<RpcResultSender<bool>>,
+    },
+    Walk {
+        scene: Entity,
+        target: Vec3,
+        stop_threshold: f32,
+        timeout: Option<f32>,
+        response: RpcResultSender<bool>,
+    },
+}
+
+impl PendingPlayerMove {
+    fn scene(&self) -> Entity {
+        match self {
+            Self::Move { scene, .. } | Self::Walk { scene, .. } => *scene,
+        }
+    }
+
+    fn send_fail(self) {
+        match self {
+            Self::Move { response: Some(r), .. } => r.send(false),
+            Self::Walk { response, .. } => response.send(false),
+            _ => {}
+        }
+    }
+}
+
+fn cancel_active_move(
+    commands: &mut Commands,
+    entity: Entity,
+    active: &ActivePlayerMove,
+    movement_control: &mut EngineMovementControl,
+    movement_info: &mut AvatarMovementInfo,
+) {
+    active.response.send(false);
+    if matches!(active.kind, PlayerMoveKind::Interpolate { .. }) {
+        movement_control.suppress_avatar_physics.remove("player_move");
+    }
+    movement_info.0.walk_target = None;
+    movement_info.0.walk_threshold = None;
+    commands.entity(entity).remove::<ActivePlayerMove>();
 }
 
 #[allow(clippy::type_complexity)]
-pub fn move_player(
+pub fn handle_player_move_requests(
     mut commands: Commands,
     mut events: EventReader<RpcCall>,
     scenes: Query<&RendererSceneContext>,
@@ -130,348 +188,220 @@ pub fn move_player(
             Entity,
             &mut Transform,
             &mut AvatarDynamicState,
-            Option<&PlayerMoveInterpolation>,
+            Option<&ActivePlayerMove>,
         ),
         With<PrimaryUser>,
     >,
     containing_scene: ContainingScene,
-    mut perms: Permission<(
-        Entity,
-        Vec3,
-        Option<Vec3>,
-        Option<f32>,
-        Option<RpcResultSender<bool>>,
-    )>,
+    mut perms: Permission<PendingPlayerMove>,
     mut movement_control: ResMut<EngineMovementControl>,
+    mut movement_info: ResMut<AvatarMovementInfo>,
 ) {
     let Ok((player_entity, _, _, _)) = player.single() else {
         return;
     };
 
-    for (root, translation, looking_at, duration, response) in
-        events.read().filter_map(|ev| match ev {
-            RpcCall::MovePlayer {
-                scene,
-                to,
-                looking_at,
-                duration,
-                response,
-            } => Some((scene, to, looking_at, duration, response)),
-            _ => None,
-        })
-    {
-        let current_scenes = containing_scene.get(player_entity);
-        if !current_scenes.contains(root) {
-            warn!(
-                "move player request from {root:?} was requested with player outside scene bounds"
-            );
+    for ev in events.read() {
+        let pending = match ev {
+            RpcCall::MovePlayer { scene, to, looking_at, duration, response } => {
+                PendingPlayerMove::Move {
+                    scene: *scene,
+                    target: *to,
+                    looking_at: *looking_at,
+                    duration: *duration,
+                    response: response.clone(),
+                }
+            }
+            RpcCall::WalkPlayer { scene, to, stop_threshold, timeout, response } => {
+                PendingPlayerMove::Walk {
+                    scene: *scene,
+                    target: *to,
+                    stop_threshold: *stop_threshold,
+                    timeout: *timeout,
+                    response: response.clone(),
+                }
+            }
+            _ => continue,
+        };
+
+        if !containing_scene.get(player_entity).contains(&pending.scene()) {
+            warn!("player move request from {:?}: player not in scene", pending.scene());
+            pending.send_fail();
             continue;
         }
 
-        perms.check(
-            PermissionType::MovePlayer,
-            *root,
-            (
-                *root,
-                *translation,
-                *looking_at,
-                *duration,
-                response.clone(),
-            ),
-            None,
-            false,
-        );
+        let scene = pending.scene();
+        perms.check(PermissionType::MovePlayer, scene, pending, None, false);
     }
 
-    for (root, translation, looking_at, duration, response) in
-        perms.drain_success(PermissionType::MovePlayer)
-    {
-        let Ok(scene) = scenes.get(root) else {
-            warn!("move player request from invalid scene {root:?}");
+    for pending in perms.drain_success(PermissionType::MovePlayer) {
+        let scene_entity = pending.scene();
+        let Ok(scene) = scenes.get(scene_entity) else {
+            warn!("player move request from invalid scene {scene_entity:?}");
+            pending.send_fail();
             continue;
         };
 
-        let mut target_translation = translation;
-        target_translation +=
-            (scene.base * IVec2::new(1, -1)).as_vec2().extend(0.0).xzy() * PARCEL_SIZE;
-        target_translation.y = target_translation.y.max(0.0);
+        let base_offset = (scene.base * IVec2::new(1, -1)).as_vec2().extend(0.0).xzy() * PARCEL_SIZE;
 
-        let target_scenes = containing_scene.get_position(target_translation);
-        if !target_scenes.contains(&root) {
-            warn!("move player request from {root:?} was outside scene bounds");
-        } else {
-            let (_, mut player_transform, mut dynamics, maybe_previous_move) =
-                player.single_mut().unwrap();
+        // Compute world-space target and validate bounds before doing anything else.
+        // An invalid request must not cancel the currently active move.
+        let raw_target = match &pending {
+            PendingPlayerMove::Move { target, .. } | PendingPlayerMove::Walk { target, .. } => *target,
+        };
+        let mut world_target = raw_target + base_offset;
+        world_target.y = world_target.y.max(0.0);
 
-            if let Some(previous_move) = maybe_previous_move {
-                commands
-                    .entity(player_entity)
-                    .try_remove::<PlayerMoveInterpolation>();
-                movement_control
-                    .suppress_avatar_physics
-                    .remove("move_player_to");
-                previous_move.response.send(false);
-            }
+        if !containing_scene.get_position(world_target).contains(&scene_entity) {
+            warn!("player move request from {scene_entity:?}: target is outside scene bounds");
+            pending.send_fail();
+            continue;
+        }
 
-            if let Some(d) = duration {
-                let d = d.max(f32::EPSILON);
-                let from = player_transform.translation;
-                debug!(
-                    "player interpolation start: {} -> {} over {}s",
-                    from, target_translation, d
-                );
-                movement_control
-                    .suppress_avatar_physics
-                    .insert("move_player_to");
-                commands
-                    .entity(player_entity)
-                    .insert(PlayerMoveInterpolation {
-                        from,
-                        to: target_translation,
+        // Target is valid — cancel any existing active move and apply the new one.
+        let (_, mut player_transform, mut dynamics, maybe_active) = player.single_mut().unwrap();
+        if let Some(active) = maybe_active {
+            cancel_active_move(&mut commands, player_entity, active, &mut movement_control, &mut movement_info);
+        }
+
+        match pending {
+            PendingPlayerMove::Move { target, looking_at, duration, response, .. } => {
+                if let Some(d) = duration {
+                    let d = d.max(f32::EPSILON);
+                    let from = player_transform.translation;
+                    debug!("player interpolation start: {from} -> {world_target} over {d}s");
+                    movement_control.suppress_avatar_physics.insert("player_move");
+                    commands.entity(player_entity).insert(ActivePlayerMove {
+                        target: world_target,
                         elapsed: 0.0,
-                        duration: d,
                         response: response.unwrap(),
+                        kind: PlayerMoveKind::Interpolate { from, duration: d },
                     });
-            } else {
-                player_transform.translation = target_translation;
-                debug!("player transform to {}", target_translation);
-                if let Some(response) = response {
-                    response.send(true);
+                } else {
+                    player_transform.translation = world_target;
+                    debug!("player teleported to {world_target}");
+                    if let Some(r) = response { r.send(true); }
+                }
+
+                if let Some(looking_at) = looking_at {
+                    let rotation = Transform::IDENTITY
+                        .looking_at((looking_at - target) * Vec3::new(1.0, 0.0, 1.0), Vec3::Y)
+                        .rotation;
+                    dynamics.velocity = rotation * player_transform.rotation.inverse() * dynamics.velocity;
+                    player_transform.rotation = rotation;
                 }
             }
 
-            // always apply rotation immediately if requested
-            if let Some(looking_at) = looking_at {
-                let rotation = Transform::IDENTITY
-                    .looking_at(
-                        (looking_at - translation) * Vec3::new(1.0, 0.0, 1.0),
-                        Vec3::Y,
-                    )
-                    .rotation;
-                dynamics.velocity =
-                    rotation * player_transform.rotation.inverse() * dynamics.velocity;
-                player_transform.rotation = rotation;
+            PendingPlayerMove::Walk { stop_threshold, timeout, response, .. } => {
+                debug!("walk player started: target={world_target}, threshold={stop_threshold}");
+                commands.entity(player_entity).insert(ActivePlayerMove {
+                    target: world_target,
+                    elapsed: 0.0,
+                    response,
+                    kind: PlayerMoveKind::Walk { stop_threshold, timeout },
+                });
             }
         }
     }
 
-    for (_, _, _, _, response) in perms.drain_fail(PermissionType::MovePlayer) {
-        if let Some(r) = response {
-            r.send(false);
-        }
+    for pending in perms.drain_fail(PermissionType::MovePlayer) {
+        pending.send_fail();
     }
 }
 
 #[allow(clippy::type_complexity)]
-pub fn update_player_interpolation(
+pub fn update_player_move(
     mut commands: Commands,
     mut player: Query<
         (
             Entity,
             &mut Transform,
-            &mut PlayerMoveInterpolation,
+            &mut ActivePlayerMove,
             Ref<ActivePlayerComponent<AvatarMovement>>,
         ),
         With<PrimaryUser>,
     >,
     time: Res<Time>,
     mut movement_control: ResMut<EngineMovementControl>,
-) {
-    let Ok((entity, mut transform, mut interp, movement)) = player.single_mut() else {
-        return;
-    };
-    // Cancel if the scene movement controller asserts a new non-zero x/z velocity or a jump.
-    // Skip on the first tick (elapsed == 0) to avoid immediately cancelling due to the
-    // movement component being changed when the interpolation was just inserted.
-    if interp.elapsed > 0.0 && movement.is_changed() {
-        let v = movement.component.velocity;
-        if v.x != 0.0 || v.z != 0.0 || v.y.abs() > 2.0 {
-            debug!("player interpolation cancelled by scene movement controller : {v}");
-            interp.response.send(false);
-            movement_control
-                .suppress_avatar_physics
-                .remove("move_player_to");
-            commands.entity(entity).remove::<PlayerMoveInterpolation>();
-            return;
-        }
-    }
-
-    interp.elapsed += time.delta_secs();
-    let t = (interp.elapsed / interp.duration).min(1.0);
-    transform.translation = interp.from.lerp(interp.to, t);
-
-    if t >= 1.0 {
-        debug!("player interpolation complete");
-        interp.response.send(true);
-        movement_control
-            .suppress_avatar_physics
-            .remove("move_player_to");
-        commands.entity(entity).remove::<PlayerMoveInterpolation>();
-    }
-}
-
-/// Active walk-to-target request, attached to the player entity while a walkPlayerTo is pending.
-#[derive(Component)]
-pub struct PlayerWalkRequest {
-    /// World-space target position (scene-relative position converted to world space).
-    target: Vec3,
-    stop_threshold: f32,
-    elapsed: f32,
-    timeout: Option<f32>,
-    response: RpcResultSender<bool>,
-}
-
-#[allow(clippy::type_complexity)]
-pub fn walk_player(
-    mut commands: Commands,
-    mut events: EventReader<RpcCall>,
-    scenes: Query<&RendererSceneContext>,
-    mut player: Query<(Entity, &Transform, Option<&PlayerWalkRequest>), With<PrimaryUser>>,
-    containing_scene: ContainingScene,
-    mut perms: Permission<(Entity, Vec3, f32, Option<f32>, RpcResultSender<bool>)>,
     mut movement_info: ResMut<AvatarMovementInfo>,
 ) {
-    let Ok((player_entity, _, _)) = player.single() else {
+    let Ok((entity, mut transform, mut active, movement)) = player.single_mut() else {
+        movement_info.0.walk_target = None;
+        movement_info.0.walk_threshold = None;
         return;
     };
 
-    for (root, to, stop_threshold, timeout, response) in
-        events.read().filter_map(|ev| match ev {
-            RpcCall::WalkPlayer {
-                scene,
-                to,
-                stop_threshold,
-                timeout,
-                response,
-            } => Some((scene, to, stop_threshold, timeout, response)),
-            _ => None,
-        })
-    {
-        let current_scenes = containing_scene.get(player_entity);
-        if !current_scenes.contains(root) {
-            warn!("walk player request from {root:?} was requested with player outside scene bounds");
-            response.send(false);
-            continue;
+    active.elapsed += time.delta_secs();
+
+    match &active.kind {
+        PlayerMoveKind::Interpolate { from, duration } => {
+            // Cancel if the scene movement controller asserts a new non-zero x/z velocity or jump.
+            // Skip the first tick (elapsed just became > 0) to avoid cancelling immediately.
+            if active.elapsed > time.delta_secs() && movement.is_changed() {
+                let v = movement.component.velocity;
+                if v.x != 0.0 || v.z != 0.0 || v.y.abs() > 2.0 {
+                    debug!("player interpolation cancelled by scene movement controller: {v}");
+                    active.response.send(false);
+                    movement_control.suppress_avatar_physics.remove("player_move");
+                    commands.entity(entity).remove::<ActivePlayerMove>();
+                    return;
+                }
+            }
+
+            let t = (active.elapsed / duration).min(1.0);
+            transform.translation = from.lerp(active.target, t);
+
+            if t >= 1.0 {
+                debug!("player interpolation complete");
+                active.response.send(true);
+                movement_control.suppress_avatar_physics.remove("player_move");
+                commands.entity(entity).remove::<ActivePlayerMove>();
+            }
         }
 
-        perms.check(
-            PermissionType::MovePlayer,
-            *root,
-            (*root, *to, *stop_threshold, *timeout, response.clone()),
-            None,
-            false,
-        );
-    }
+        PlayerMoveKind::Walk { stop_threshold, timeout } => {
+            // Broadcast walk_target in world space each frame so the movement scene can drive the player.
+            // AvatarMovementInfo is sent to all scenes (which have different origins), so world space
+            // is the correct coordinate space here.
+            movement_info.0.walk_target = Some(
+                dcl_component::proto_components::common::Vector3::world_vec_from_vec3(&active.target),
+            );
+            movement_info.0.walk_threshold = Some(*stop_threshold);
 
-    for (root, to, stop_threshold, timeout, response) in
-        perms.drain_success(PermissionType::MovePlayer)
-    {
-        let Ok(scene) = scenes.get(root) else {
-            warn!("walk player request from invalid scene {root:?}");
-            response.send(false);
-            continue;
-        };
+            // The movement scene signals completion via walk_success on AvatarMovement.
+            if movement.is_changed() {
+                if let Some(success) = movement.component.walk_success {
+                    debug!("walk player completed via walk_success={success}");
+                    active.response.send(success);
+                    movement_info.0.walk_target = None;
+                    movement_info.0.walk_threshold = None;
+                    commands.entity(entity).remove::<ActivePlayerMove>();
+                    return;
+                }
+            }
 
-        let mut target = to;
-        target += (scene.base * IVec2::new(1, -1)).as_vec2().extend(0.0).xzy() * PARCEL_SIZE;
-        target.y = target.y.max(0.0);
+            // Timeout.
+            if let Some(t) = timeout {
+                if active.elapsed >= *t {
+                    debug!("walk player timed out after {}s", active.elapsed);
+                    active.response.send(false);
+                    movement_info.0.walk_target = None;
+                    movement_info.0.walk_threshold = None;
+                    commands.entity(entity).remove::<ActivePlayerMove>();
+                    return;
+                }
+            }
 
-        let target_scenes = containing_scene.get_position(target);
-        if !target_scenes.contains(&root) {
-            warn!("walk player request target from {root:?} is outside scene bounds");
-            response.send(false);
-            continue;
+            // Fallback proximity check (handles movement scene being absent).
+            let xz_dist = (transform.translation - active.target).xz().length();
+            if xz_dist <= *stop_threshold {
+                debug!("walk player reached target (engine-side check), dist={xz_dist}");
+                active.response.send(true);
+                movement_info.0.walk_target = None;
+                movement_info.0.walk_threshold = None;
+                commands.entity(entity).remove::<ActivePlayerMove>();
+            }
         }
-
-        let (_, _, maybe_previous) = player.single_mut().unwrap();
-        if let Some(previous) = maybe_previous {
-            previous.response.send(false);
-        }
-
-        commands.entity(player_entity).insert(PlayerWalkRequest {
-            target,
-            stop_threshold,
-            elapsed: 0.0,
-            timeout,
-            response,
-        });
-        debug!("walk player started: target={target}, threshold={stop_threshold}");
-    }
-
-    for (_, _, _, _, response) in perms.drain_fail(PermissionType::MovePlayer) {
-        response.send(false);
-    }
-
-    // Broadcast walk_target into AvatarMovementInfo each frame while active.
-    // The target is in world space (Bevy coords). AvatarMovementInfo is broadcast to all scenes,
-    // which have different origins, so we cannot use scene-relative coordinates here.
-    // The movement scene reads world-space positions from playerPosition (via Transform) and
-    // interprets walk_target the same way — as a world-space position.
-    if let Ok((_, _, Some(req))) = player.single() {
-        movement_info.0.walk_target = Some(
-            dcl_component::proto_components::common::Vector3::world_vec_from_vec3(&req.target),
-        );
-        movement_info.0.walk_threshold = Some(req.stop_threshold);
-    } else {
-        movement_info.0.walk_target = None;
-        movement_info.0.walk_threshold = None;
-    }
-}
-
-#[allow(clippy::type_complexity)]
-pub fn update_player_walk(
-    mut commands: Commands,
-    mut player: Query<
-        (
-            Entity,
-            &Transform,
-            &mut PlayerWalkRequest,
-            Ref<ActivePlayerComponent<AvatarMovement>>,
-        ),
-        With<PrimaryUser>,
-    >,
-    time: Res<Time>,
-    mut movement_info: ResMut<AvatarMovementInfo>,
-) {
-    let Ok((entity, transform, mut req, movement)) = player.single_mut() else {
-        return;
-    };
-
-    req.elapsed += time.delta_secs();
-
-    // Check for walk_success response from the movement scene.
-    // The movement scene sets walk_success on AvatarMovement for one frame when the walk ends.
-    if movement.is_changed() {
-        if let Some(success) = movement.component.walk_success {
-            debug!("walk player completed via walk_success={success}");
-            req.response.send(success);
-            commands.entity(entity).remove::<PlayerWalkRequest>();
-            movement_info.0.walk_target = None;
-            movement_info.0.walk_threshold = None;
-            return;
-        }
-    }
-
-    // Check timeout.
-    if let Some(timeout) = req.timeout {
-        if req.elapsed >= timeout {
-            debug!("walk player timed out after {}s", req.elapsed);
-            req.response.send(false);
-            commands.entity(entity).remove::<PlayerWalkRequest>();
-            movement_info.0.walk_target = None;
-            movement_info.0.walk_threshold = None;
-            return;
-        }
-    }
-
-    // Fallback: check if close enough directly (handles case where movement scene is absent).
-    let xz_dist = (transform.translation - req.target).xz().length();
-    if xz_dist <= req.stop_threshold {
-        debug!("walk player reached target (engine-side check), dist={xz_dist}");
-        req.response.send(true);
-        commands.entity(entity).remove::<PlayerWalkRequest>();
-        movement_info.0.walk_target = None;
-        movement_info.0.walk_threshold = None;
     }
 }
 

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -55,7 +55,7 @@ use scene_runner::{
 use serde_json::{json, Value};
 use teleport::{handle_out_of_world, teleport_player};
 use ui_core::button::DuiButton;
-use user_input::avatar_movement::{ActivePlayerComponent, AvatarMovement};
+use user_input::avatar_movement::{ActivePlayerComponent, AvatarMovement, AvatarMovementInfo};
 use wallet::{browser_auth::remote_send_async, sign_request, Wallet};
 
 pub struct RestrictedActionsPlugin;
@@ -69,6 +69,8 @@ impl Plugin for RestrictedActionsPlugin {
                 (
                     move_player,
                     update_player_interpolation.after(move_player),
+                    walk_player,
+                    update_player_walk.after(walk_player),
                     move_camera,
                     change_realm,
                     external_url,
@@ -76,6 +78,8 @@ impl Plugin for RestrictedActionsPlugin {
                     kill_portable,
                     list_portables,
                     get_user_data,
+                ),
+                (
                     get_connected_players,
                     get_players_in_scene,
                     event_player_connected,
@@ -303,6 +307,171 @@ pub fn update_player_interpolation(
             .suppress_avatar_physics
             .remove("move_player_to");
         commands.entity(entity).remove::<PlayerMoveInterpolation>();
+    }
+}
+
+/// Active walk-to-target request, attached to the player entity while a walkPlayerTo is pending.
+#[derive(Component)]
+pub struct PlayerWalkRequest {
+    /// World-space target position (scene-relative position converted to world space).
+    target: Vec3,
+    stop_threshold: f32,
+    elapsed: f32,
+    timeout: Option<f32>,
+    response: RpcResultSender<bool>,
+}
+
+#[allow(clippy::type_complexity)]
+pub fn walk_player(
+    mut commands: Commands,
+    mut events: EventReader<RpcCall>,
+    scenes: Query<&RendererSceneContext>,
+    mut player: Query<(Entity, &Transform, Option<&PlayerWalkRequest>), With<PrimaryUser>>,
+    containing_scene: ContainingScene,
+    mut perms: Permission<(Entity, Vec3, f32, Option<f32>, RpcResultSender<bool>)>,
+    mut movement_info: ResMut<AvatarMovementInfo>,
+) {
+    let Ok((player_entity, _, _)) = player.single() else {
+        return;
+    };
+
+    for (root, to, stop_threshold, timeout, response) in
+        events.read().filter_map(|ev| match ev {
+            RpcCall::WalkPlayer {
+                scene,
+                to,
+                stop_threshold,
+                timeout,
+                response,
+            } => Some((scene, to, stop_threshold, timeout, response)),
+            _ => None,
+        })
+    {
+        let current_scenes = containing_scene.get(player_entity);
+        if !current_scenes.contains(root) {
+            warn!("walk player request from {root:?} was requested with player outside scene bounds");
+            response.send(false);
+            continue;
+        }
+
+        perms.check(
+            PermissionType::MovePlayer,
+            *root,
+            (*root, *to, *stop_threshold, *timeout, response.clone()),
+            None,
+            false,
+        );
+    }
+
+    for (root, to, stop_threshold, timeout, response) in
+        perms.drain_success(PermissionType::MovePlayer)
+    {
+        let Ok(scene) = scenes.get(root) else {
+            warn!("walk player request from invalid scene {root:?}");
+            response.send(false);
+            continue;
+        };
+
+        let mut target = to;
+        target += (scene.base * IVec2::new(1, -1)).as_vec2().extend(0.0).xzy() * PARCEL_SIZE;
+        target.y = target.y.max(0.0);
+
+        let target_scenes = containing_scene.get_position(target);
+        if !target_scenes.contains(&root) {
+            warn!("walk player request target from {root:?} is outside scene bounds");
+            response.send(false);
+            continue;
+        }
+
+        let (_, _, maybe_previous) = player.single_mut().unwrap();
+        if let Some(previous) = maybe_previous {
+            previous.response.send(false);
+        }
+
+        commands.entity(player_entity).insert(PlayerWalkRequest {
+            target,
+            stop_threshold,
+            elapsed: 0.0,
+            timeout,
+            response,
+        });
+        debug!("walk player started: target={target}, threshold={stop_threshold}");
+    }
+
+    for (_, _, _, _, response) in perms.drain_fail(PermissionType::MovePlayer) {
+        response.send(false);
+    }
+
+    // Broadcast walk_target into AvatarMovementInfo each frame while active.
+    // The target is in world space (Bevy coords). AvatarMovementInfo is broadcast to all scenes,
+    // which have different origins, so we cannot use scene-relative coordinates here.
+    // The movement scene reads world-space positions from playerPosition (via Transform) and
+    // interprets walk_target the same way — as a world-space position.
+    if let Ok((_, _, Some(req))) = player.single() {
+        movement_info.0.walk_target = Some(
+            dcl_component::proto_components::common::Vector3::world_vec_from_vec3(&req.target),
+        );
+        movement_info.0.walk_threshold = Some(req.stop_threshold);
+    } else {
+        movement_info.0.walk_target = None;
+        movement_info.0.walk_threshold = None;
+    }
+}
+
+#[allow(clippy::type_complexity)]
+pub fn update_player_walk(
+    mut commands: Commands,
+    mut player: Query<
+        (
+            Entity,
+            &Transform,
+            &mut PlayerWalkRequest,
+            Ref<ActivePlayerComponent<AvatarMovement>>,
+        ),
+        With<PrimaryUser>,
+    >,
+    time: Res<Time>,
+    mut movement_info: ResMut<AvatarMovementInfo>,
+) {
+    let Ok((entity, transform, mut req, movement)) = player.single_mut() else {
+        return;
+    };
+
+    req.elapsed += time.delta_secs();
+
+    // Check for walk_success response from the movement scene.
+    // The movement scene sets walk_success on AvatarMovement for one frame when the walk ends.
+    if movement.is_changed() {
+        if let Some(success) = movement.component.walk_success {
+            debug!("walk player completed via walk_success={success}");
+            req.response.send(success);
+            commands.entity(entity).remove::<PlayerWalkRequest>();
+            movement_info.0.walk_target = None;
+            movement_info.0.walk_threshold = None;
+            return;
+        }
+    }
+
+    // Check timeout.
+    if let Some(timeout) = req.timeout {
+        if req.elapsed >= timeout {
+            debug!("walk player timed out after {}s", req.elapsed);
+            req.response.send(false);
+            commands.entity(entity).remove::<PlayerWalkRequest>();
+            movement_info.0.walk_target = None;
+            movement_info.0.walk_threshold = None;
+            return;
+        }
+    }
+
+    // Fallback: check if close enough directly (handles case where movement scene is absent).
+    let xz_dist = (transform.translation - req.target).xz().length();
+    if xz_dist <= req.stop_threshold {
+        debug!("walk player reached target (engine-side check), dist={xz_dist}");
+        req.response.send(true);
+        commands.entity(entity).remove::<PlayerWalkRequest>();
+        movement_info.0.walk_target = None;
+        movement_info.0.walk_threshold = None;
     }
 }
 

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -185,7 +185,7 @@ fn cancel_active_move(
     commands.entity(entity).remove::<ActivePlayerMove>();
 }
 
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn handle_player_move_requests(
     mut commands: Commands,
     mut events: EventReader<RpcCall>,

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -74,6 +74,8 @@ pub struct AvatarMovement {
     pub velocity: Vec3,
     pub orientation: f32,
     pub ground_direction: Vec3,
+    /// set for one frame when a walk_target ends: true = reached target, false = failed
+    pub walk_success: Option<bool>,
 }
 
 impl Default for AvatarMovement {
@@ -82,6 +84,7 @@ impl Default for AvatarMovement {
             velocity: Vec3::ZERO,
             orientation: 0.0,
             ground_direction: Vec3::NEG_Y,
+            walk_success: None,
         }
     }
 }
@@ -106,6 +109,7 @@ impl From<PbAvatarMovement> for AvatarMovement {
                 .map(Vector3::world_vec_to_vec3)
                 .map(Vec3::normalize_or_zero)
                 .unwrap_or(Vec3::NEG_Y),
+            walk_success: value.walk_success,
         }
     }
 }
@@ -626,5 +630,7 @@ fn broadcast_movement_info(
         external_velocity: None,
         active_avatar_locomotion_settings: None,
         active_input_modifier: None,
+        walk_target: None,
+        walk_threshold: None,
     }
 }


### PR DESCRIPTION
## Summary

- Add `RpcCall::WalkPlayer` variant and `op_walk_player_to` op (Deno + WASM wrappers)
- Add `walk_target` and `walk_threshold` fields to `PBAvatarMovementInfo` (broadcast to the movement scene each frame while walk is active)
- Add `walk_success` optional bool to `PBAvatarMovement` (read from scene for one frame on completion)
- Unify `move_player` and `walk_player` into a single `ActivePlayerMove` component with a `PlayerMoveKind` enum (`Interpolate` | `Walk`), handled by one `update_player_move` system
- Cancellation: any new move/walk request cancels the active one; invalid (out-of-bounds) requests do not cancel
- Walk target is broadcast in **world space** (Bevy coords, Z-flipped to DCL convention) because `AvatarMovementInfo` is sent to all scenes which have different origins

> **Note:** depends on decentraland/js-sdk-toolchain#1349 for the updated proto-generated types in the movement scene. The Rust side has no SDK dependency — proto files are vendored in `crates/dcl_component/src/proto/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)