### PR TITLE
Add generic CRDT localization for global broadcasts

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1150,7 +1150,7 @@ pub struct DebugInfo {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub enum GlobalCrdtStateUpdate {
-    Crdt(Vec<u8>),
+    Crdt(Vec<u8>, dcl_component::Localizer),
     Time(f32),
 }
 

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -30,7 +30,7 @@ use dcl_component::{
         sdk::components::PbPlayerIdentityData,
     },
     transform_and_parent::{DclQuat, DclTransformAndParent, DclTranslation},
-    DclReader, DclWriter, SceneComponentId, SceneEntityId, ToDclWriter,
+    DclReader, DclWriter, GlobalCrdtData, Localizer, SceneComponentId, SceneEntityId, SceneOrigin,
 };
 
 use crate::{
@@ -59,6 +59,7 @@ impl Plugin for GlobalCrdtPlugin {
             store: Default::default(),
             lookup: Default::default(),
             realm_bounds: (IVec2::MAX, IVec2::MIN),
+            localizers: Default::default(),
         });
 
         let (sender, _) = tokio::sync::broadcast::channel(1_000);
@@ -143,6 +144,8 @@ pub struct GlobalCrdtState {
     store: CrdtStore,
     lookup: BiMap<Address, Entity>,
     pub(crate) realm_bounds: (IVec2, IVec2),
+    // per-component localizer registry (populated as components are first sent)
+    localizers: HashMap<SceneComponentId, Localizer>,
 }
 
 impl GlobalCrdtState {
@@ -151,9 +154,30 @@ impl GlobalCrdtState {
         self.ext_sender.clone()
     }
 
-    // get a channel from which crdt updates can be received
-    pub fn subscribe(&self) -> (CrdtStore, broadcast::Receiver<GlobalCrdtStateUpdate>) {
-        (self.store.clone(), self.int_sender.subscribe())
+    /// Get a clone of the current CRDT store (with position data localized for the given
+    /// scene origin) and a channel from which future updates can be received.
+    pub fn subscribe(
+        &self,
+        scene_origin: bevy::prelude::Vec3,
+    ) -> (CrdtStore, broadcast::Receiver<GlobalCrdtStateUpdate>) {
+        let mut store = self.store.clone();
+        let origin = SceneOrigin(scene_origin);
+
+        // Localize position-containing entries in the initial store snapshot
+        for (component_id, localizer) in &self.localizers {
+            if matches!(localizer, Localizer::None | Localizer::Unimplemented) {
+                continue;
+            }
+            if let Some(lww_state) = store.lww.get_mut(component_id) {
+                for entry in lww_state.last_write.values_mut() {
+                    if entry.is_some && !entry.data.is_empty() {
+                        entry.data = localizer.localize_payload(&entry.data, &origin);
+                    }
+                }
+            }
+        }
+
+        (store, self.int_sender.subscribe())
     }
 
     pub fn set_bounds(&mut self, min: IVec2, max: IVec2) {
@@ -161,13 +185,24 @@ impl GlobalCrdtState {
         self.realm_bounds = (min, max);
     }
 
-    pub fn update_crdt(
+    pub fn update_crdt<T: GlobalCrdtData>(
         &mut self,
         component_id: SceneComponentId,
         crdt_type: CrdtType,
         id: SceneEntityId,
-        data: &impl ToDclWriter,
+        data: &T,
     ) {
+        let localizer = T::localizer();
+        assert!(
+            matches!(crdt_type, CrdtType::LWW(_)) || matches!(localizer, Localizer::None),
+            "GO components with explicit localization are not supported"
+        );
+        if !matches!(localizer, Localizer::None) {
+            self.localizers
+                .entry(component_id)
+                .or_insert_with(|| localizer.clone());
+        }
+
         let mut buf = Vec::new();
         DclWriter::new(&mut buf).write(data);
         let timestamp =
@@ -179,7 +214,7 @@ impl GlobalCrdtState {
         };
         if let Err(e) = self
             .int_sender
-            .send(GlobalCrdtStateUpdate::Crdt(crdt_message))
+            .send(GlobalCrdtStateUpdate::Crdt(crdt_message, localizer))
         {
             error!("failed to send foreign player update to scenes: {e}");
         }
@@ -190,7 +225,7 @@ impl GlobalCrdtState {
         let crdt_message = delete_entity(&id);
         if let Err(e) = self
             .int_sender
-            .send(GlobalCrdtStateUpdate::Crdt(crdt_message))
+            .send(GlobalCrdtStateUpdate::Crdt(crdt_message, Localizer::None))
         {
             error!("failed to send foreign player update to scenes: {e}");
         }

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -5,7 +5,7 @@ use bevy::log::{debug, info, warn};
 #[cfg(feature = "span_scene_loop")]
 use bevy::log::{info_span, tracing::span::EnteredSpan};
 use common::structs::{GlobalCrdtStateUpdate, TimeOfDay};
-use dcl_component::DclReader;
+use dcl_component::{DclReader, Localizer, SceneOrigin};
 use tokio::sync::{broadcast::error::TryRecvError, Mutex};
 
 use crate::{
@@ -17,6 +17,45 @@ use crate::{
 };
 
 use super::State;
+
+/// Localize the payload within a CRDT wire-format message.
+/// CRDT PutComponent format: length(4) + type(4) + entity(4) + component(4) + timestamp(4) + content_len(4) + payload
+fn localize_crdt_message(
+    data: Vec<u8>,
+    localizer: &Localizer,
+    scene_origin: &SceneOrigin,
+) -> Vec<u8> {
+    // Minimum size for a PutComponent message with payload: 24 bytes header + payload
+    if data.len() < 24 {
+        return data;
+    }
+
+    let content_len = u32::from_le_bytes([data[20], data[21], data[22], data[23]]) as usize;
+    let payload_start = 24;
+    let payload_end = payload_start + content_len;
+
+    if payload_end > data.len() || content_len == 0 {
+        return data;
+    }
+
+    let new_payload = localizer.localize_payload(&data[payload_start..payload_end], scene_origin);
+
+    // Rebuild the message with the new payload
+    let entity_id: dcl_component::SceneEntityId = {
+        let mut r = DclReader::new(&data[8..12]);
+        r.read().unwrap()
+    };
+    let component_id: dcl_component::SceneComponentId = {
+        let mut r = DclReader::new(&data[12..16]);
+        r.read().unwrap()
+    };
+    let timestamp: dcl_component::SceneCrdtTimestamp = {
+        let mut r = DclReader::new(&data[16..20]);
+        r.read().unwrap()
+    };
+
+    put_component(&entity_id, &component_id, &timestamp, Some(&new_payload))
+}
 
 pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8]) {
     let mut op_state = op_state.borrow_mut();
@@ -124,7 +163,18 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
     loop {
         match global_update_receiver.try_recv() {
             Ok(next) => match next {
-                GlobalCrdtStateUpdate::Crdt(data) => {
+                GlobalCrdtStateUpdate::Crdt(data, localizer) => {
+                    let data = match localizer {
+                        Localizer::None => data,
+                        Localizer::Unimplemented => {
+                            warn!("received global CRDT update with Unimplemented localizer");
+                            data
+                        }
+                        _ => {
+                            let scene_origin = op_state.borrow::<SceneOrigin>();
+                            localize_crdt_message(data, &localizer, scene_origin)
+                        }
+                    };
                     let mut stream = DclReader::new(&data);
                     renderer_state.0.process_message_stream(
                         &mut entity_map,

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -126,7 +126,6 @@ impl State for deno_core::OpState {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub fn init_state(
     state: &mut impl State,
     initial_crdt_store: CrdtStore,

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -126,6 +126,7 @@ impl State for deno_core::OpState {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub fn init_state(
     state: &mut impl State,
     initial_crdt_store: CrdtStore,
@@ -141,6 +142,7 @@ pub fn init_state(
     testing: bool,
     preview: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
+    scene_origin: bevy::prelude::Vec3,
 ) {
     let scene_context = CrdtContext::new(scene_id, scene_hash, testing, preview);
     state.put(scene_context);
@@ -156,6 +158,7 @@ pub fn init_state(
     state.put(Vec::<SceneLogMessage>::default());
     state.put(SceneElapsedTime(0.0));
     state.put(TimeOfDay { time: 0. });
+    state.put(dcl_component::SceneOrigin(scene_origin));
     if let Some(super_user) = super_user {
         state.put(SuperUserScene(super_user));
     }

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -12,6 +12,75 @@ pub use reader::{DclReader, DclReaderError, FromDclReader};
 use serde::{Deserialize, Serialize};
 pub use writer::{DclWriter, ToDclWriter};
 
+/// Scene origin in bevy world-space, stored in scene thread state for localizer access.
+pub struct SceneOrigin(pub Vec3);
+
+/// Describes how to localize a component's position data when delivering to a scene.
+/// Each variant corresponds to a known component layout so the receiver can
+/// deserialize, adjust, and re-encode position fields relative to the scene origin.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Localizer {
+    /// No localization needed (component contains no position data).
+    None,
+    /// Localization strategy not yet defined. Acceptable at scene startup (initial CRDT store
+    /// may contain pre-localized static data), but will cause an error at global update receipt.
+    Unimplemented,
+    /// Localize `PbAvatarMovementInfo`: offset `walk_target` (field 8) by scene origin.
+    AvatarMovementInfo,
+}
+
+impl Localizer {
+    /// Localize a proto component payload by deserializing, adjusting position
+    /// fields, and re-encoding. `scene_origin` is in bevy world-space.
+    pub fn localize_payload(&self, payload: &[u8], scene_origin: &SceneOrigin) -> Vec<u8> {
+        match self {
+            Localizer::None => payload.to_vec(),
+            Localizer::Unimplemented => payload.to_vec(),
+            Localizer::AvatarMovementInfo => {
+                use prost::Message;
+                use proto_components::sdk::components::PbAvatarMovementInfo;
+
+                let Ok(mut info) = PbAvatarMovementInfo::decode(payload) else {
+                    return payload.to_vec();
+                };
+
+                let origin = &scene_origin.0;
+                // Convert bevy scene_origin to DCL proto coords (z negated)
+                let ox = origin.x;
+                let oy = origin.y;
+                let oz = -origin.z;
+
+                // walk_target is a world-space position → make scene-relative
+                if let Some(ref mut target) = info.walk_target {
+                    target.x -= ox;
+                    target.y -= oy;
+                    target.z -= oz;
+                }
+
+                let mut buf = Vec::with_capacity(payload.len());
+                info.encode(&mut buf).expect("re-encode failed");
+                buf
+            }
+        }
+    }
+}
+
+/// Trait for types that can be sent via `GlobalCrdtState::update_crdt`.
+/// Provides type-safe enforcement that localization has been considered.
+pub trait GlobalCrdtData: ToDclWriter {
+    fn localizer() -> Localizer;
+}
+
+/// Marker trait for types sent via global CRDT that contain no position data.
+/// Automatically implements `GlobalCrdtData` with `Localizer::None`.
+pub trait PositionFree: ToDclWriter {}
+
+impl<T: PositionFree> GlobalCrdtData for T {
+    fn localizer() -> Localizer {
+        Localizer::None
+    }
+}
+
 #[derive(
     PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Clone, Copy, Default, Serialize, Deserialize,
 )]

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -12,7 +12,7 @@ pub use reader::{DclReader, DclReaderError, FromDclReader};
 use serde::{Deserialize, Serialize};
 pub use writer::{DclWriter, ToDclWriter};
 
-/// Scene origin in bevy world-space, stored in scene thread state for localizer access.
+/// Scene origin in DCL proto-space (z-forward), stored in scene thread state for localizer access.
 pub struct SceneOrigin(pub Vec3);
 
 /// Describes how to localize a component's position data when delivering to a scene.
@@ -31,7 +31,7 @@ pub enum Localizer {
 
 impl Localizer {
     /// Localize a proto component payload by deserializing, adjusting position
-    /// fields, and re-encoding. `scene_origin` is in bevy world-space.
+    /// fields, and re-encoding. `scene_origin` is in DCL proto-space (z-forward).
     pub fn localize_payload(&self, payload: &[u8], scene_origin: &SceneOrigin) -> Vec<u8> {
         match self {
             Localizer::None => payload.to_vec(),
@@ -45,16 +45,12 @@ impl Localizer {
                 };
 
                 let origin = &scene_origin.0;
-                // Convert bevy scene_origin to DCL proto coords (z negated)
-                let ox = origin.x;
-                let oy = origin.y;
-                let oz = -origin.z;
 
                 // walk_target is a world-space position → make scene-relative
                 if let Some(ref mut target) = info.walk_target {
-                    target.x -= ox;
-                    target.y -= oy;
-                    target.z -= oz;
+                    target.x -= origin.x;
+                    target.y -= origin.y;
+                    target.z -= origin.z;
                 }
 
                 let mut buf = Vec::with_capacity(payload.len());

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -1,6 +1,6 @@
 use bevy::math::FloatOrd;
 
-use super::{FromDclReader, ToDclWriter};
+use super::{FromDclReader, GlobalCrdtData, Localizer, PositionFree, ToDclWriter};
 
 pub mod sdk {
     #[allow(clippy::all)]
@@ -126,6 +126,19 @@ impl DclProtoComponent for sdk::components::PbGltfNodeModifiers {}
 impl DclProtoComponent for sdk::components::PbSkyboxTime {}
 impl DclProtoComponent for sdk::components::PbAvatarMovement {}
 impl DclProtoComponent for sdk::components::PbAvatarMovementInfo {}
+
+// PositionFree markers for types used with GlobalCrdtState::update_crdt
+// (these contain no embedded position data requiring localization)
+impl PositionFree for sdk::components::PbPlayerIdentityData {}
+impl PositionFree for sdk::components::PbAvatarBase {}
+impl PositionFree for sdk::components::PbAvatarEquippedData {}
+
+// GlobalCrdtData impl for PbAvatarMovementInfo (contains velocity vectors that need localization)
+impl GlobalCrdtData for sdk::components::PbAvatarMovementInfo {
+    fn localizer() -> Localizer {
+        Localizer::AvatarMovementInfo
+    }
+}
 
 // VECTOR2 conversions
 impl Copy for common::Vector2 {}

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -133,7 +133,7 @@ impl PositionFree for sdk::components::PbPlayerIdentityData {}
 impl PositionFree for sdk::components::PbAvatarBase {}
 impl PositionFree for sdk::components::PbAvatarEquippedData {}
 
-// GlobalCrdtData impl for PbAvatarMovementInfo (contains velocity vectors that need localization)
+// GlobalCrdtData impl for PbAvatarMovementInfo (walk_target is a world-space position that needs localization)
 impl GlobalCrdtData for sdk::components::PbAvatarMovementInfo {
     fn localizer() -> Localizer {
         Localizer::AvatarMovementInfo

--- a/crates/dcl_component/src/transform_and_parent.rs
+++ b/crates/dcl_component/src/transform_and_parent.rs
@@ -2,7 +2,7 @@ use std::ops::{Add, Sub};
 
 use bevy::prelude::{Quat, Transform, Vec3};
 
-use super::{DclReader, DclReaderError, FromDclReader, SceneEntityId, ToDclWriter};
+use super::{DclReader, DclReaderError, FromDclReader, PositionFree, SceneEntityId, ToDclWriter};
 
 // for dcl: +z -> forward
 // for bevy: +z -> backward
@@ -161,3 +161,6 @@ impl ToDclWriter for DclTransformAndParent {
         buf.write(&self.parent);
     }
 }
+
+// Transforms are localized via WORLD_ORIGIN parenting, not payload adjustment
+impl PositionFree for DclTransformAndParent {}

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -197,6 +197,7 @@ pub(crate) fn scene_thread(
     testing: bool,
     preview: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
+    scene_origin: bevy::prelude::Vec3,
 ) {
     let (mut runtime, inspector) = create_runtime(inspect, super_user.is_some(), &storage_root);
 
@@ -222,6 +223,7 @@ pub(crate) fn scene_thread(
         testing,
         preview,
         super_user,
+        scene_origin,
     );
 
     // store deno permission objects

--- a/crates/dcl_deno/src/lib.rs
+++ b/crates/dcl_deno/src/lib.rs
@@ -44,6 +44,7 @@ pub fn spawn_scene(
     testing: bool,
     preview: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
+    scene_origin: bevy::prelude::Vec3,
 ) -> Sender<RendererResponse> {
     let (main_sx, thread_rx) = tokio::sync::mpsc::channel::<RendererResponse>(1);
 
@@ -66,6 +67,7 @@ pub fn spawn_scene(
                     testing,
                     preview,
                     super_user,
+                    scene_origin,
                 )
             }));
 

--- a/crates/dcl_deno_ipc/src/lib.rs
+++ b/crates/dcl_deno_ipc/src/lib.rs
@@ -37,6 +37,7 @@ pub struct NewSceneInfo {
     pub testing: bool,
     pub preview: bool,
     pub is_super: bool,
+    pub scene_origin: bevy::prelude::Vec3,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -282,6 +283,7 @@ pub fn spawn_scene(
     testing: bool,
     preview: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
+    scene_origin: bevy::prelude::Vec3,
 ) -> tokio::sync::mpsc::Sender<RendererResponse> {
     let is_super = super_user.is_some();
 
@@ -304,6 +306,7 @@ pub fn spawn_scene(
                 testing,
                 preview,
                 is_super,
+                scene_origin,
             },
             renderer_channel: thread_rx,
             global_channel: global_update_receiver,

--- a/crates/dcl_deno_ipc/src/main.rs
+++ b/crates/dcl_deno_ipc/src/main.rs
@@ -135,6 +135,7 @@ async fn scene_ipc_in(
                     new_scene_info.testing,
                     new_scene_info.preview,
                     new_scene_info.is_super.then(|| system_api_sx.clone()),
+                    new_scene_info.scene_origin,
                 );
 
                 renderer_senders.insert(id, response_sx);

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -34,6 +34,7 @@ pub struct SceneInitializationData {
     pub testing: bool,
     pub preview: bool,
     pub super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
+    pub scene_origin: bevy::prelude::Vec3,
 }
 
 // Static storage shared data
@@ -59,6 +60,7 @@ pub fn spawn_scene(
     testing: bool,
     preview: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
+    scene_origin: bevy::prelude::Vec3,
 ) -> Sender<RendererResponse> {
     // create engine channel
     let (thread_sx, thread_rx) = channel(1);
@@ -85,6 +87,7 @@ pub fn spawn_scene(
                     testing,
                     preview,
                     super_user,
+                    scene_origin,
                 });
 
             // spin up a scene thread to consume it
@@ -132,6 +135,7 @@ pub async fn wasm_init_scene() -> Result<WorkerContext, JsValue> {
         scene_initialization_data.testing,
         scene_initialization_data.preview,
         scene_initialization_data.super_user,
+        scene_initialization_data.scene_origin,
     );
 
     local_storage::init(&context).await;

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -123,7 +123,10 @@ pub enum SceneLoading {
     MainCrdt {
         crdt: Option<Handle<SerializedCrdtStore>>,
     },
-    Javascript(Option<tokio::sync::broadcast::Receiver<GlobalCrdtStateUpdate>>),
+    Javascript {
+        global_updates: Option<tokio::sync::broadcast::Receiver<GlobalCrdtStateUpdate>>,
+        scene_origin: Vec3,
+    },
     Failed,
 }
 
@@ -409,8 +412,9 @@ pub(crate) fn load_scene_javascript(
 
         scene_updates.scene_ids.insert(scene_id, root);
 
-        // start from the global shared crdt state
-        let (mut initial_crdt, global_updates) = global_scene.subscribe();
+        // start from the global shared crdt state, with position data localized for this scene
+        let scene_origin = Vec3::new(initial_position.x, 0.0, -initial_position.y);
+        let (mut initial_crdt, global_updates) = global_scene.subscribe(scene_origin);
 
         // set the world origin (for parents of world-space entities, using world-space coords as local coords)
         let mut buf = Vec::new();
@@ -525,7 +529,10 @@ pub(crate) fn load_scene_javascript(
 
         commands.entity(root).try_insert((
             SceneInitialData { js: h_code },
-            SceneLoading::Javascript(Some(global_updates)),
+            SceneLoading::Javascript {
+                global_updates: Some(global_updates),
+                scene_origin,
+            },
         ));
     }
 }
@@ -596,7 +603,7 @@ pub(crate) fn initialize_scene(
     su_bridge: Res<SystemBridge>,
 ) {
     for (root, mut state, initial_data, mut context, super_user) in loading_scenes.iter_mut() {
-        if !matches!(state.as_mut(), SceneLoading::Javascript(_)) || context.tick_number != 1 {
+        if !matches!(state.as_mut(), SceneLoading::Javascript { .. }) || context.tick_number != 1 {
             continue;
         }
 
@@ -624,11 +631,13 @@ pub(crate) fn initialize_scene(
 
         let thread_sx = scene_updates.sender.clone();
 
-        let global_updates = match *state {
-            SceneLoading::Javascript(ref mut global_updates) => global_updates.take(),
+        let (global_updates, scene_origin) = match *state {
+            SceneLoading::Javascript {
+                ref mut global_updates,
+                scene_origin,
+            } => (global_updates.take().unwrap(), scene_origin),
             _ => panic!("bad state"),
-        }
-        .unwrap();
+        };
 
         let crdt_component_interfaces = CrdtComponentInterfaces(HashMap::from_iter(
             crdt_component_interfaces
@@ -657,6 +666,7 @@ pub(crate) fn initialize_scene(
             testing_data.test_mode,
             preview_mode.is_preview,
             super_user.map(|_| su_bridge.sender.clone()),
+            scene_origin,
         );
 
         // mark context as in flight so we wait for initial RPC requests

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -413,7 +413,8 @@ pub(crate) fn load_scene_javascript(
         scene_updates.scene_ids.insert(scene_id, root);
 
         // start from the global shared crdt state, with position data localized for this scene
-        let scene_origin = Vec3::new(initial_position.x, 0.0, -initial_position.y);
+        // Scene origin in DCL proto-space (z-forward, matching proto Vector3 coordinates)
+        let scene_origin = Vec3::new(initial_position.x, 0.0, initial_position.y);
         let (mut initial_crdt, global_updates) = global_scene.subscribe(scene_origin);
 
         // set the world origin (for parents of world-space entities, using world-space coords as local coords)


### PR DESCRIPTION
## Summary
- Adds a `Localizer` enum and `GlobalCrdtData` trait to enforce at compile time that every globally-broadcast component has considered whether its payload contains position data needing per-scene adjustment
- Scene origins are computed in DCL proto-space and threaded through all three execution paths (dcl_deno, dcl_deno_ipc, dcl_wasm)
- `subscribe()` localizes the initial CRDT store snapshot; runtime messages are localized on receipt via CRDT header parsing + proto decode/modify/re-encode
- First localizer implemented: `AvatarMovementInfo` (offsets `walk_target` from world-space to scene-relative)

## Follow-ups
- Move `CanvasInfo` and `RealmInfo` to broadcast with appropriate localizers
- Consider moving avatar and camera positions to broadcast (potentially removing WORLD_ORIGIN entity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)