### PR TITLE
fix invalid collider geometry

### DIFF
--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -1162,12 +1162,19 @@ pub fn mesh_to_parry_shape(mesh_data: &Mesh) -> SharedShape {
         Some(Indices::U16(ixs)) => ixs.iter().map(|ix| *ix as u32).collect(),
         Some(Indices::U32(ixs)) => ixs.to_vec(),
     };
-    let indices_parry = indices
+    let indices_parry: Vec<_> = indices
         .chunks_exact(3)
         .map(|chunk| chunk.try_into().unwrap())
         .collect();
 
-    SharedShape::trimesh_with_flags(positions_parry, indices_parry, TriMeshFlags::empty()).unwrap()
+    SharedShape::trimesh_with_flags(
+        positions_parry,
+        indices_parry,
+        TriMeshFlags::DELETE_DEGENERATE_TRIANGLES
+            | TriMeshFlags::DELETE_DUPLICATE_TRIANGLES
+            | TriMeshFlags::DELETE_BAD_TOPOLOGY_TRIANGLES,
+    )
+    .unwrap()
 }
 
 #[derive(Component, Debug)]

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -334,6 +334,12 @@ impl SceneColliderData {
 
                     let mut new_scale = *init_scale;
                     if (req_scale - *init_scale).length_squared() > SCALE_EPSILON {
+                        if req_scale.min_element() < 0.001 {
+                            // disable 0-sized colliders
+                            collider.set_enabled(false);
+                        } else {
+                            collider.set_enabled(true);
+                        }
                         new_scale = req_scale;
                         // colliders don't have a scale, we have to modify the shape directly when scale changes (significantly)
                         collider.set_shape(base_collider.shape().scale_ext(req_scale));


### PR DESCRIPTION
rapier bvh chokes on zero-scale or degenerate colliders. 
filter for mesh-level degeneracy, and disable colliders when scale is dynamically set very small.