### PR TITLE
Fix unknown console command blocking all subsequent commands

### DIFF
--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -127,18 +127,18 @@ pub(crate) fn help_command(
     mut config: ResMut<ConsoleConfiguration>,
 ) {
     match cmd.take() {
-        Some(Ok(HelpCommand { command: Some(name) })) => {
-            match config.commands.get_mut(name.as_str()) {
-                Some(command_info) => {
-                    cmd.reply(command_info.render_long_help().to_string());
-                    cmd.ok();
-                }
-                None => {
-                    cmd.reply(format!("Command '{name}' does not exist"));
-                    cmd.failed();
-                }
+        Some(Ok(HelpCommand {
+            command: Some(name),
+        })) => match config.commands.get_mut(name.as_str()) {
+            Some(command_info) => {
+                cmd.reply(command_info.render_long_help().to_string());
+                cmd.ok();
             }
-        }
+            None => {
+                cmd.reply(format!("Command '{name}' does not exist"));
+                cmd.failed();
+            }
+        },
         Some(Ok(HelpCommand { command: None })) => {
             cmd.reply("Available commands:");
             let longest = config.commands.keys().map(|n| n.len()).max().unwrap_or(0);

--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -114,17 +114,47 @@ pub(crate) fn clear_command(
     }
 }
 
-//re-add default commands, unfortunately have to copy/paste
+/// List available commands, or show detailed help for a specific command
 #[derive(Parser, ConsoleCommand)]
 #[command(name = "/help")]
-pub(crate) struct HelpCommand;
+pub(crate) struct HelpCommand {
+    /// Command to show help for
+    command: Option<String>,
+}
 
 pub(crate) fn help_command(
     mut cmd: ConsoleCommand<HelpCommand>,
-    mut pending: ResMut<PendingCommands>,
+    mut config: ResMut<ConsoleConfiguration>,
 ) {
-    if let Some(Ok(_)) = cmd.take() {
-        pending.0.push("help".to_owned());
+    match cmd.take() {
+        Some(Ok(HelpCommand { command: Some(name) })) => {
+            match config.commands.get_mut(name.as_str()) {
+                Some(command_info) => {
+                    cmd.reply(command_info.render_long_help().to_string());
+                    cmd.ok();
+                }
+                None => {
+                    cmd.reply(format!("Command '{name}' does not exist"));
+                    cmd.failed();
+                }
+            }
+        }
+        Some(Ok(HelpCommand { command: None })) => {
+            cmd.reply("Available commands:");
+            let longest = config.commands.keys().map(|n| n.len()).max().unwrap_or(0);
+            for (name, command_info) in &config.commands {
+                let about = command_info
+                    .get_about()
+                    .map(|a| a.to_string())
+                    .unwrap_or_default();
+                cmd.reply(format!(
+                    "  {name}{} - {about}",
+                    " ".repeat(longest - name.len())
+                ));
+            }
+            cmd.ok();
+        }
+        _ => {}
     }
 }
 

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -599,6 +599,7 @@ fn debug_pointer_command(
     if let Some(Ok(command)) = input.take() {
         let new_state = command.show.unwrap_or(!debug.0);
         debug.0 = new_state;
+        input.ok();
     }
 }
 

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -8,9 +8,9 @@ use bevy::{
     ecs::{event::EventReader, system::Local},
     log::debug,
     math::Vec4,
-    prelude::{Event, EventWriter, ResMut, Resource},
+    prelude::{Event, EventWriter, Res, ResMut, Resource},
 };
-use bevy_console::{ConsoleCommandEntered, PrintConsoleLine};
+use bevy_console::{ConsoleCommandEntered, ConsoleConfiguration, PrintConsoleLine};
 use common::{
     inputs::{BindingsData, InputIdentifier, SystemActionEvent},
     rpc::{RpcResultSender, RpcStreamSender},
@@ -216,6 +216,7 @@ pub fn post_events(
     mut console_response: Local<Option<RpcResultSender<Result<String, String>>>>,
     mut replies: EventReader<PrintConsoleLine>,
     mut pending: Local<VecDeque<(String, Vec<String>, RpcResultSender<Result<String, String>>)>>,
+    console_config: Res<ConsoleConfiguration>,
 ) {
     while let Ok(ev) = bridge.receiver.try_recv() {
         if let SystemApi::ConsoleCommand(cmd, args, sender) = ev {
@@ -253,11 +254,18 @@ pub fn post_events(
             }
         }
     } else if let Some((cmd, args, sender)) = pending.pop_front() {
-        console.write(ConsoleCommandEntered {
-            command_name: cmd,
-            args,
-        });
-        *console_response = Some(sender);
+        if console_config.commands.contains_key(cmd.as_str()) {
+            console.write(ConsoleCommandEntered {
+                command_name: cmd,
+                args,
+            });
+            *console_response = Some(sender);
+        } else {
+            sender.send(Err(format!(
+                "Command not recognized: `{cmd}`. Recognized commands: {:?}",
+                console_config.commands.keys().collect::<Vec<_>>()
+            )));
+        }
     }
 
     replies.clear();

--- a/crates/system_ui/src/chat/mod.rs
+++ b/crates/system_ui/src/chat/mod.rs
@@ -194,6 +194,7 @@ fn debug_chat(
             }
             _ => (),
         }
+        input.ok();
     }
 }
 


### PR DESCRIPTION
## Summary

- When `engine_console_command` is called with an unrecognized command, `post_events` dispatches `ConsoleCommandEntered` and waits forever for an `[ok]`/`[failed]` `PrintConsoleLine` sentinel that never arrives, blocking the entire pending command queue. Fix: check `ConsoleConfiguration` before dispatching — unknown commands get an immediate `Err` response.
- `/help` now accepts an optional command name: with no arg it lists all commands with their one-line about text (from `/// doc comments`); with an arg it renders the full clap long-help including argument descriptions.
- Fix `/debug_pointer` and `/cdb` handlers that never emitted `[ok]`, which would also block `engine_console_command` indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)