### PR TITLE
Fix: register AvatarLocomotionSettings as CRDT component

### DIFF
--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -195,7 +195,6 @@ impl SceneComponentId {
     pub const TWEEN_STATE: SceneComponentId = SceneComponentId(1103);
 
     pub const LIGHT_SOURCE: SceneComponentId = SceneComponentId(1079);
-    pub const SPOTLIGHT: SceneComponentId = SceneComponentId(1205);
     pub const GLOBAL_LIGHT: SceneComponentId = SceneComponentId(1206);
     pub const TEXTURE_CAMERA: SceneComponentId = SceneComponentId(1207);
     pub const CAMERA_LAYERS: SceneComponentId = SceneComponentId(1208);

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -125,6 +125,7 @@ impl DclProtoComponent for sdk::components::PbTriggerAreaResult {}
 impl DclProtoComponent for sdk::components::PbGltfNodeModifiers {}
 impl DclProtoComponent for sdk::components::PbSkyboxTime {}
 impl DclProtoComponent for sdk::components::PbAvatarMovement {}
+impl DclProtoComponent for sdk::components::PbAvatarLocomotionSettings {}
 impl DclProtoComponent for sdk::components::PbAvatarMovementInfo {}
 
 // PositionFree markers for types used with GlobalCrdtState::update_crdt

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -40,6 +40,10 @@ impl Plugin for AvatarMovementPlugin {
             SceneComponentId::AVATAR_MOVEMENT,
             ComponentPosition::EntityOnly,
         );
+        app.add_crdt_lww_component::<PbAvatarLocomotionSettings, AvatarLocomotionSettings>(
+            SceneComponentId::AVATAR_LOCOMOTION_SETTINGS,
+            ComponentPosition::EntityOnly,
+        );
 
         app.init_resource::<AvatarMovementInfo>();
 


### PR DESCRIPTION
## Summary
- **Register `AvatarLocomotionSettings`** via `add_crdt_lww_component` so scene-authored locomotion settings are actually applied. The component struct and `From` impl existed, and `ActivePlayerComponent::<AvatarLocomotionSettings>::pick_by_priority` was already running, but without CRDT registration the data never arrived from scenes.
- **Add missing `DclProtoComponent` impl** for `PbAvatarLocomotionSettings` (required for `FromDclReader`).
- **Remove dead `SPOTLIGHT` constant** (ID 1205) — no corresponding proto definition or registration existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)