### PR TITLE
Fix HTTP request timeouts on wasm

### DIFF
--- a/crates/platform/src/wasm.rs
+++ b/crates/platform/src/wasm.rs
@@ -99,16 +99,11 @@ where
 }
 
 pub trait ReqwestBuilderExt {
-    fn timeout(self, timeout: Duration) -> Self;
     fn connect_timeout(self, timeout: Duration) -> Self;
     fn use_native_tls(self) -> Self;
 }
 
 impl ReqwestBuilderExt for reqwest::ClientBuilder {
-    fn timeout(self, _timeout: Duration) -> Self {
-        self
-    }
-
     fn connect_timeout(self, _timeout: Duration) -> Self {
         self
     }
@@ -119,10 +114,6 @@ impl ReqwestBuilderExt for reqwest::ClientBuilder {
 }
 
 impl ReqwestBuilderExt for reqwest::RequestBuilder {
-    fn timeout(self, _timeout: Duration) -> Self {
-        self
-    }
-
     fn connect_timeout(self, _timeout: Duration) -> Self {
         self
     }

--- a/crates/wallet/src/browser_auth.rs
+++ b/crates/wallet/src/browser_auth.rs
@@ -63,10 +63,10 @@ async fn fetch_server(req_id: String) -> Result<(H160, serde_json::Value), anyho
         let url = format!("{AUTH_SERVER_ENDPOINT_URL}/{req_id}");
         let response = reqwest::Client::builder()
             .use_native_tls()
-            .timeout(AUTH_SERVER_TIMEOUT)
             .build()
             .unwrap()
             .get(&url)
+            .timeout(AUTH_SERVER_TIMEOUT)
             .send()
             .await;
 
@@ -122,11 +122,11 @@ async fn init_request(request: CreateRequest) -> Result<InitializedRequest, anyh
 
     let response = reqwest::Client::builder()
         .use_native_tls()
-        .timeout(AUTH_SERVER_TIMEOUT)
         .build()
         .unwrap()
         .post(AUTH_SERVER_ENDPOINT_URL)
         .header("Content-Type", "application/json")
+        .timeout(AUTH_SERVER_TIMEOUT)
         .body(body)
         .send()
         .await?;


### PR DESCRIPTION
## Summary
- Remove no-op `timeout()` stub from wasm `ReqwestBuilderExt` trait — reqwest 0.12.13+ natively supports `RequestBuilder::timeout()` on wasm via `AbortController` + `setTimeout`
- Move `ClientBuilder.timeout()` calls in `browser_auth.rs` to `RequestBuilder.timeout()` since wasm's `ClientBuilder` doesn't have that method
- IPFS request timeouts (5-95s with retry), NFT request timeouts, and auth server timeouts now all work on wasm

## Context
The `ReqwestBuilderExt` trait was introduced to polyfill methods that didn't exist on reqwest's wasm backend. Since reqwest v0.12.13 (Jan 2025), `RequestBuilder::timeout()` and `Error::is_timeout()` work natively on wasm. This project uses reqwest 0.12.15, so the polyfill is no longer needed.

Previously, all HTTP requests in the wasm build could hang indefinitely if a server was unresponsive — no timeout would fire and no retry would trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)