### PR TITLE
Fix macOS livekit video stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6787,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "libwebrtc"
 version = "0.3.6"
-source = "git+https://github.com/robtfm/client-sdk-rust?branch=h264-true-prefixed#51284c63b4c0125e08544c425b35b7475d454262"
+source = "git+https://github.com/robtfm/client-sdk-rust?branch=decentraland-webrtc#3db4328ac42dee8e09c1b497f15a0cbe60ef90f1"
 dependencies = [
  "cxx",
  "jni",
@@ -6849,7 +6849,7 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 [[package]]
 name = "livekit"
 version = "0.5.2"
-source = "git+https://github.com/robtfm/client-sdk-rust?branch=h264-true-prefixed#51284c63b4c0125e08544c425b35b7475d454262"
+source = "git+https://github.com/robtfm/client-sdk-rust?branch=decentraland-webrtc#3db4328ac42dee8e09c1b497f15a0cbe60ef90f1"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6869,7 +6869,7 @@ dependencies = [
 [[package]]
 name = "livekit-api"
 version = "0.4.0"
-source = "git+https://github.com/robtfm/client-sdk-rust?branch=h264-true-prefixed#51284c63b4c0125e08544c425b35b7475d454262"
+source = "git+https://github.com/robtfm/client-sdk-rust?branch=decentraland-webrtc#3db4328ac42dee8e09c1b497f15a0cbe60ef90f1"
 dependencies = [
  "async-tungstenite",
  "futures-util",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "livekit-protocol"
 version = "0.3.5"
-source = "git+https://github.com/robtfm/client-sdk-rust?branch=h264-true-prefixed#51284c63b4c0125e08544c425b35b7475d454262"
+source = "git+https://github.com/robtfm/client-sdk-rust?branch=decentraland-webrtc#3db4328ac42dee8e09c1b497f15a0cbe60ef90f1"
 dependencies = [
  "futures-util",
  "livekit-runtime",
@@ -6909,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "livekit-runtime"
 version = "0.3.0"
-source = "git+https://github.com/robtfm/client-sdk-rust?branch=h264-true-prefixed#51284c63b4c0125e08544c425b35b7475d454262"
+source = "git+https://github.com/robtfm/client-sdk-rust?branch=decentraland-webrtc#3db4328ac42dee8e09c1b497f15a0cbe60ef90f1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12918,7 +12918,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys"
 version = "0.3.4"
-source = "git+https://github.com/robtfm/client-sdk-rust?branch=h264-true-prefixed#51284c63b4c0125e08544c425b35b7475d454262"
+source = "git+https://github.com/robtfm/client-sdk-rust?branch=decentraland-webrtc#3db4328ac42dee8e09c1b497f15a0cbe60ef90f1"
 dependencies = [
  "cc",
  "cxx",
@@ -12931,7 +12931,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys-build"
 version = "0.3.4"
-source = "git+https://github.com/robtfm/client-sdk-rust?branch=h264-true-prefixed#51284c63b4c0125e08544c425b35b7475d454262"
+source = "git+https://github.com/robtfm/client-sdk-rust?branch=decentraland-webrtc#3db4328ac42dee8e09c1b497f15a0cbe60ef90f1"
 dependencies = [
  "fs2",
  "regex",

--- a/crates/comms/Cargo.toml
+++ b/crates/comms/Cargo.toml
@@ -49,7 +49,7 @@ multipart = { version = "0.18.0", default-features = false, features = [
 image = "0.25"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-livekit = { git = "https://github.com/robtfm/client-sdk-rust", branch = "h264-true-prefixed", features = [
+livekit = { git = "https://github.com/robtfm/client-sdk-rust", branch = "decentraland-webrtc", features = [
   "native-tls",
 ], optional = true }
 cpal = "0.15.2"


### PR DESCRIPTION
## Summary
- macOS VideoToolbox handles H.264 decoding natively; having the bundled H.264 software decoder enabled (`rtc_use_h264=true`) in the libwebrtc prebuilt breaks it, causing `NativeVideoStream` to never produce frames
- Switches livekit dependency to the new `decentraland-webrtc` branch which selects the correct prebuilt per platform at build time: h264-disabled for macOS, h264-enabled for Linux/Windows
- Both prebuilts are the same webrtc version (based on upstream `webrtc-dac8015-5`), differing only in the `rtc_use_h264` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)