### PR TITLE
Fix text input cursor and selection on HiDPI displays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "bevy_simple_text_input"
 version = "0.11.1"
-source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#a60012f1c52e963b426125cfd6996a8926b5c23d"
+source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#65edfe901393e0790e8e4a34c3f61aff54925a91"
 dependencies = [
  "bevy",
  "copypwasmta",

--- a/crates/ui_core/src/text_entry.rs
+++ b/crates/ui_core/src/text_entry.rs
@@ -171,7 +171,7 @@ pub fn pass_textinput_pointer_events(
     let position = window
         .single()
         .ok()
-        .and_then(|w| w.cursor_position())
+        .map(|w| w.cursor_position().unwrap_or_default() * w.scale_factor())
         .unwrap_or_default();
 
     if just_pressed && is_focussed {


### PR DESCRIPTION
## Summary
- Scale cursor position by `window.scale_factor()` in `text_entry.rs` so click-to-position works correctly on Retina/HiDPI screens
- Update `bevy_simple_text_input` dependency to include matching fix for selection highlight positioning (applies `inverse_scale_factor` to selection rectangles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)