### PR TITLE
Add getAvatarModifiers SystemApi for system scene

### DIFF
--- a/crates/avatar/src/colliders.rs
+++ b/crates/avatar/src/colliders.rs
@@ -26,7 +26,7 @@ use scene_runner::{
     update_world::mesh_collider::ColliderId,
 };
 use serde_json::json;
-use system_bridge::{NativeUi, PointerTargetType};
+use system_bridge::{AvatarModifierState, NativeUi, PointerTargetType, SystemApi};
 
 pub struct AvatarColliderPlugin;
 
@@ -37,6 +37,7 @@ impl Plugin for AvatarColliderPlugin {
             (
                 update_avatar_colliders.in_set(SceneSets::PostInit),
                 update_avatar_collider_actions.in_set(SceneSets::Input),
+                handle_avatar_modifier_requests,
             ),
         );
     }
@@ -216,4 +217,24 @@ fn update_avatar_collider_actions(
     }
 
     senders.retain(|s| !s.is_closed());
+}
+
+fn handle_avatar_modifier_requests(
+    mut events: EventReader<SystemApi>,
+    players: Query<(&ForeignPlayer, &PlayerModifiers)>,
+) {
+    for ev in events.read() {
+        if let SystemApi::GetAvatarModifiers(sender) = ev {
+            let response: Vec<AvatarModifierState> = players
+                .iter()
+                .filter(|(_, m)| m.hide || m.hide_profile)
+                .map(|(fp, m)| AvatarModifierState {
+                    user_id: format!("{:#x}", fp.address),
+                    hide_avatar: m.hide,
+                    hide_profile: m.hide_profile,
+                })
+                .collect();
+            sender.send(response);
+        }
+    }
 }

--- a/crates/dcl/src/js/modules/SystemApi.js
+++ b/crates/dcl/src/js/modules/SystemApi.js
@@ -315,6 +315,11 @@ module.exports.setMicEnabled = function(enabled) {
     Deno.core.ops.op_set_mic_enabled(enabled);
 }
 
+// [{ userId: string, hideAvatar: bool, hideProfile: bool }]
+module.exports.getAvatarModifiers = async function() {
+    return await Deno.core.ops.op_get_avatar_modifiers();
+}
+
 // get voice stream / mic activations as a stream
 // type MicActivation = {
 //   senderAddress: string,

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, rc::Rc};
 use strum::IntoEnumIterator;
 use system_bridge::{
-    settings::SettingInfo, ChatMessage, HomeScene, HoverEvent, LiveSceneInfo,
+    settings::SettingInfo, AvatarModifierState, ChatMessage, HomeScene, HoverEvent, LiveSceneInfo,
     PermanentPermissionItem, PermissionRequest, SceneLoadingUi, SetAvatarData,
     SetPermanentPermission, SetSinglePermission, SystemApi, VoiceMessage,
 };
@@ -755,4 +755,17 @@ pub async fn op_read_scene_loading_ui_stream(
     state.borrow_mut().put(receiver);
 
     res
+}
+
+pub async fn op_get_avatar_modifiers(
+    state: Rc<RefCell<impl State>>,
+) -> Result<Vec<AvatarModifierState>, anyhow::Error> {
+    let (sx, rx) = RpcResultSender::channel();
+
+    state
+        .borrow_mut()
+        .borrow_mut::<SuperUserScene>()
+        .send(SystemApi::GetAvatarModifiers(sx))?;
+
+    Ok(rx.await?)
 }

--- a/crates/dcl_deno/src/js/op_wrappers/system_api.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/system_api.rs
@@ -10,7 +10,7 @@ use dcl_component::proto_components::{
 use deno_core::{anyhow, error::AnyError, op2, OpDecl, OpState};
 use std::{cell::RefCell, rc::Rc};
 use system_bridge::{
-    settings::SettingInfo, ChatMessage, HomeScene, HoverEvent, LiveSceneInfo,
+    settings::SettingInfo, AvatarModifierState, ChatMessage, HomeScene, HoverEvent, LiveSceneInfo,
     PermanentPermissionItem, PermissionRequest, SceneLoadingUi, VoiceMessage,
 };
 
@@ -63,6 +63,7 @@ pub fn ops(super_user: bool) -> Vec<OpDecl> {
             op_read_hover_stream(),
             op_get_scene_loading_ui_stream(),
             op_read_scene_loading_ui_stream(),
+            op_get_avatar_modifiers(),
         ]
     } else {
         Vec::default()
@@ -391,4 +392,12 @@ pub async fn op_read_scene_loading_ui_stream(
     rid: u32,
 ) -> Result<Option<SceneLoadingUi>, deno_core::anyhow::Error> {
     dcl::js::system_api::op_read_scene_loading_ui_stream(state, rid).await
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_get_avatar_modifiers(
+    state: Rc<RefCell<OpState>>,
+) -> Result<Vec<AvatarModifierState>, anyhow::Error> {
+    dcl::js::system_api::op_get_avatar_modifiers(state).await
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
@@ -350,3 +350,15 @@ pub async fn op_read_scene_loading_ui_stream(
 ) -> Result<JsValue, WasmError> {
     serde_result!(dcl::js::system_api::op_read_scene_loading_ui_stream(state.rc(), rid).await)
 }
+
+#[wasm_bindgen]
+pub async fn op_get_avatar_modifiers(state: &WorkerContext) -> Result<js_sys::Array, WasmError> {
+    dcl::js::system_api::op_get_avatar_modifiers(state.rc())
+        .await
+        .map(|r| {
+            r.into_iter()
+                .map(|v| serde_wasm_bindgen::to_value(&v).unwrap())
+                .collect()
+        })
+        .map_err(WasmError::from)
+}

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -162,6 +162,15 @@ pub enum SystemApi {
     SetInteractableArea(Vec4),
     GetMicState(RpcResultSender<MicState>),
     SetMicEnabled(bool),
+    GetAvatarModifiers(RpcResultSender<Vec<AvatarModifierState>>),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AvatarModifierState {
+    pub user_id: String,
+    pub hide_avatar: bool,
+    pub hide_profile: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## Summary
- Adds a `getAvatarModifiers` SystemApi call that returns the active avatar modifier state (`hideAvatar`, `hideProfile`) for all affected foreign players
- Enables the system scene to respect `AvatarModifierArea` with `AMT_DISABLE_PASSPORTS`, which was previously only enforced by the native UI path

🤖 Generated with [Claude Code](https://claude.com/claude-code)