### PR TITLE
fix: bump parry to fix BVH crash from orphaned nodes after remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "parry3d-f64"
 version = "0.25.3"
-source = "git+https://github.com/robtfm/parry?branch=fix-bvh-negative-scale-0.25#9bf52a52cbaa8e71d76fb8ad4ce82f9f0b39461e"
+source = "git+https://github.com/robtfm/parry?branch=fix-bvh-negative-scale-0.25#8705700f2f176681c86a96be9083129690a46774"
 dependencies = [
  "approx",
  "arrayvec",


### PR DESCRIPTION
## Summary

- Bumps parry3d-f64 to pick up a fix for a crash (stack overflow / corrupt tree) in `optimize_incremental` caused by orphaned BVH nodes accumulating across multiple `remove` calls without an intervening `refit`.
- Upstream PR: https://github.com/dimforge/parry/pull/409
- The trigger was small-scale colliders (e.g. `TreeRoundPine_01_collider` at scale ~0.01) whose repeated insert/remove cycles would reduce the BVH to a single-leaf partial root with unreachable orphaned nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)