### PR TITLE
Priority scene scheduling and fair init priority

### DIFF
--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -609,6 +609,7 @@ pub(crate) fn initialize_scene(
     testing_data: Res<TestingData>,
     preview_mode: Res<PreviewMode>,
     su_bridge: Res<SystemBridge>,
+    time: Res<Time>,
 ) {
     for (root, mut state, initial_data, mut context, super_user) in loading_scenes.iter_mut() {
         if !matches!(state.as_mut(), SceneLoading::Javascript { .. }) || context.tick_number != 1 {
@@ -683,6 +684,9 @@ pub(crate) fn initialize_scene(
         // mark context as in flight so we wait for initial RPC requests
         context.in_flight = true;
         context.inspected = inspected;
+        // set last_sent so the scene doesn't get extreme starvation priority
+        // when it first becomes eligible after initialization completes
+        context.last_sent = time.elapsed_secs();
 
         commands
             .entity(root)

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -85,6 +85,10 @@ pub struct SceneUpdates {
     pub eligible_jobs: usize,
     pub loop_end_time: Instant,
     pub scene_queue: VecDeque<(Entity, FloatOrd)>,
+    /// Named scene entities that must be scheduled every frame (e.g. the
+    /// movement controller). These scenes bypass the `scene_threads` limit
+    /// but still occupy slots, preventing non-priority scenes from running.
+    pub priority_scenes: HashMap<&'static str, Entity>,
 }
 
 // safety: struct is sync except for the receiver.
@@ -249,6 +253,7 @@ impl Plugin for SceneRunnerPlugin {
             eligible_jobs: 0,
             scene_queue: Default::default(),
             loop_end_time: Instant::now(),
+            priority_scenes: Default::default(),
         });
 
         app.add_event::<LoadSceneEvent>();
@@ -687,13 +692,20 @@ fn send_scene_updates(
 ) {
     let updates = &mut *updates;
 
-    if updates.jobs_in_flight.len() >= config.scene_threads {
+    // Peek at the next scene before popping. Priority scenes bypass the thread
+    // limit (but still occupy slots, preventing non-priority scenes from
+    // running). Non-priority scenes respect the limit.
+    let Some(&(ent, _)) = updates.scene_queue.front() else {
+        return;
+    };
+
+    if updates.jobs_in_flight.len() >= config.scene_threads
+        && !updates.priority_scenes.values().any(|&e| e == ent)
+    {
         return;
     }
 
-    let Some((ent, _)) = updates.scene_queue.pop_front() else {
-        return;
-    };
+    updates.scene_queue.pop_front();
 
     let (_, mut context, handle, scene_transform, is_super) = scenes.get_mut(ent).unwrap();
 

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -29,7 +29,7 @@ use scene_runner::{
         transform_and_parent::PostUpdateSets,
         AddCrdtInterfaceExt,
     },
-    ContainingScene, SceneEntity,
+    ContainingScene, SceneEntity, SceneUpdates,
 };
 
 pub struct AvatarMovementPlugin;
@@ -55,6 +55,9 @@ impl Plugin for AvatarMovementPlugin {
                 ActivePlayerComponent::<AvatarMovement>::pick_latest_frame_only_by_priority,
                 ActivePlayerComponent::<AvatarLocomotionSettings>::pick_by_priority,
                 ActivePlayerComponent::<InputModifier>::pick_by_priority,
+                update_priority_scene.after(
+                    ActivePlayerComponent::<AvatarMovement>::pick_latest_frame_only_by_priority,
+                ),
             )
                 .in_set(SceneSets::PostLoop),
         );
@@ -70,6 +73,26 @@ impl Plugin for AvatarMovementPlugin {
                 .chain()
                 .in_set(PostUpdateSets::PlayerUpdate),
         );
+    }
+}
+
+fn update_priority_scene(
+    player: Query<&ActivePlayerComponent<AvatarMovement>, With<PrimaryUser>>,
+    mut updates: ResMut<SceneUpdates>,
+) {
+    let scene = player
+        .single()
+        .ok()
+        .map(|active| active.scene())
+        .filter(|&e| e != Entity::PLACEHOLDER);
+
+    match scene {
+        Some(scene) => {
+            updates.priority_scenes.insert("movement_controller", scene);
+        }
+        None => {
+            updates.priority_scenes.remove("movement_controller");
+        }
     }
 }
 
@@ -129,6 +152,12 @@ pub struct ActivePlayerComponent<C: Component> {
     scene_start_tick: u32,
     scene_is_portable: bool,
     pub component: C,
+}
+
+impl<C: Component> ActivePlayerComponent<C> {
+    pub fn scene(&self) -> Entity {
+        self.scene
+    }
 }
 
 impl<C: Component + Default> Default for ActivePlayerComponent<C> {


### PR DESCRIPTION
## Summary
- Add `priority_scenes: HashMap<&'static str, Entity>` to `SceneUpdates` — named scenes that bypass the `scene_threads` limit while still occupying slots (so they crowd out non-priority scenes but are never starved themselves)
- Register the movement controller scene (the scene providing the highest-priority `AvatarMovement` component) as `"movement_controller"` after each frame's pick, ensuring it runs every frame regardless of thread pressure from slow distant scenes
- Set `last_sent = time.elapsed_secs()` when scenes complete initialization, so newly loaded scenes enter the queue with fair priority instead of an extreme starvation value from `last_sent = 0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)