### PR TITLE
Fix placeholderColor not being applied on Input update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "bevy_simple_text_input"
 version = "0.11.1"
-source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#65edfe901393e0790e8e4a34c3f61aff54925a91"
+source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#b4152ef499f8db65023d55a46adc528551a9d725"
 dependencies = [
  "bevy",
  "copypwasmta",


### PR DESCRIPTION
## Summary
- Bumps `bevy_simple_text_input` to pick up fix for `update_placeholder_style` ignoring `TextInputPlaceholder.text_color` and `text_font` fields
- The system was always overwriting with the base input color/font instead of respecting the placeholder's own values
- Fix applied upstream in robtfm/bevy_simple_text_input@b4152ef

🤖 Generated with [Claude Code](https://claude.com/claude-code)