### PR TITLE
Return 'web' platform in WASM builds

### DIFF
--- a/crates/dcl/src/js/modules/EnvironmentApi.js
+++ b/crates/dcl/src/js/modules/EnvironmentApi.js
@@ -20,7 +20,7 @@ module.exports.isPreviewMode = async function (body) {
 
 module.exports.getPlatform = async function (body) {
     return {
-        platform: 'desktop' // TODO: Implement `vr`, `web`, `mobile` it's ready
+        platform: Deno.core.ops.op_get_platform()
     }
 }
 module.exports.areUnsafeRequestAllowed = async function (body) {

--- a/crates/dcl/src/js/modules/Runtime.js
+++ b/crates/dcl/src/js/modules/Runtime.js
@@ -24,7 +24,7 @@ module.exports.getSceneInformation = async function (body) {
 module.exports.getExplorerInformation = async function (body) {
     return {
         agent: 'bevy',
-        platform: 'desktop',
+        platform: Deno.core.ops.op_get_platform(),
         configurations: {}
     }
 }

--- a/crates/dcl/src/js/runtime.rs
+++ b/crates/dcl/src/js/runtime.rs
@@ -132,3 +132,14 @@ pub async fn op_world_time(op_state: Rc<RefCell<impl State>>) -> Result<WorldTim
     let TimeOfDay { time } = state.borrow::<TimeOfDay>();
     Ok(WorldTime { seconds: *time })
 }
+
+pub fn get_platform() -> &'static str {
+    #[cfg(target_arch = "wasm32")]
+    {
+        "web"
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        "desktop"
+    }
+}

--- a/crates/dcl_deno/src/js/op_wrappers/runtime.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/runtime.rs
@@ -11,6 +11,7 @@ pub fn ops() -> Vec<OpDecl> {
         op_scene_information(),
         op_realm_information(),
         op_world_time(),
+        op_get_platform(),
     ]
 }
 
@@ -41,4 +42,10 @@ async fn op_realm_information(op_state: Rc<RefCell<OpState>>) -> Result<PbRealmI
 #[serde]
 async fn op_world_time(op_state: Rc<RefCell<OpState>>) -> Result<WorldTime, AnyError> {
     dcl::js::runtime::op_world_time(op_state).await
+}
+
+#[op2]
+#[string]
+fn op_get_platform() -> &'static str {
+    dcl::js::runtime::get_platform()
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/runtime.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/runtime.rs
@@ -23,3 +23,8 @@ pub async fn op_realm_information(op_state: &WorkerContext) -> Result<JsValue, W
 pub async fn op_world_time(op_state: &WorkerContext) -> Result<JsValue, WasmError> {
     serde_result!(dcl::js::runtime::op_world_time(op_state.rc()).await)
 }
+
+#[wasm_bindgen]
+pub fn op_get_platform(_op_state: &WorkerContext) -> String {
+    dcl::js::runtime::get_platform().to_string()
+}


### PR DESCRIPTION
## Summary
- Add `op_get_platform` op that returns `"web"` for WASM builds and `"desktop"` for native builds using `cfg(target_arch = "wasm32")`
- Update `getExplorerInformation` (Runtime.js) and `getPlatform` (EnvironmentApi.js) to call the new op instead of hardcoding `"desktop"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)