### PR TITLE
Apply scene-driven physics impulses and forces to the avatar

### DIFF
--- a/crates/assets/src/assets/shaders/bound_material.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material.wgsl
@@ -192,7 +192,7 @@ fn fragment(
     out.color = mix(out.color, vec4<f32>(out.color.rgb / cap_factor, out.color.a), saturate(cap_brightness * 2.0));
 
     if out.color.a < 0.001 {
-        // avoid writing to the depth buffer for alpha-blend materials with zero alpha
+        // avoid writing to the depth buffer for alpha-blend materials with low alpha
         discard;
     }
 

--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -64,6 +64,8 @@ fn gen_sdk_components() -> Result<()> {
         "avatar_movement_info",
         "avatar_movement",
         "avatar_locomotion_settings",
+        "physics_combined_force",
+        "physics_combined_impulse",
     ];
 
     let mut sources = components

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -214,6 +214,9 @@ impl SceneComponentId {
 
     pub const ASSET_LOAD: SceneComponentId = SceneComponentId(1213);
     pub const ASSET_LOAD_LOADING_STATE: SceneComponentId = SceneComponentId(1214);
+
+    pub const PHYSICS_COMBINED_IMPULSE: SceneComponentId = SceneComponentId(1215);
+    pub const PHYSICS_COMBINED_FORCE: SceneComponentId = SceneComponentId(1216);
 }
 
 #[derive(

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/physics_combined_force.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/physics_combined_force.proto
@@ -1,0 +1,21 @@
+﻿syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/common/vectors.proto";
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1216;
+
+/**
+ * This component applies a continuous physics force.
+
+ * @remarks Low-level component. Use Physics.applyForceToPlayer()/.removeForceToPlayer() instead.
+ * Direct manipulation will conflict with the force accumulation registry.
+ * Summary component: stores the accumulated result of all active forces registered by the scene in the current frame.
+
+ * State-like component: the force is applied every physics tick while the component is present on the entity.
+*/
+message PBPhysicsCombinedForce {
+    decentraland.common.Vector3 vector = 1; // Includes force direction and magnitude
+}

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/physics_combined_impulse.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/physics_combined_impulse.proto
@@ -1,0 +1,23 @@
+﻿syntax = "proto3";
+
+package decentraland.sdk.components;
+
+import "decentraland/common/vectors.proto";
+import "decentraland/sdk/components/common/id.proto";
+
+option (common.ecs_component_id) = 1215;
+
+/**
+ * This component applies a one-shot physics summary impulse.
+ 
+ * @remarks Low-level component. Use Physics.applyImpulseToPlayer() instead.
+ * Direct manipulation will conflict with the force accumulation registry.
+ * Summary component: stores the accumulated result of all impulses registered by the scene in the current frame.
+ 
+ * Event-like component: each new impulse must increment the eventID to ensure delivery via CRDT, even if the direction is identical to the previous one.
+ * Renderer processes impulse with the unique ID only once. Increase eventID of the component to apply another impulse.
+*/
+message PBPhysicsCombinedImpulse {
+    decentraland.common.Vector3 vector = 1; // Includes impulse direction and magnitude
+    uint32 event_id = 2; // Monotonic counter to distinguish different impulses.
+}

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -129,6 +129,8 @@ impl DclProtoComponent for sdk::components::PbAvatarLocomotionSettings {}
 impl DclProtoComponent for sdk::components::PbAvatarMovementInfo {}
 impl DclProtoComponent for sdk::components::PbAssetLoad {}
 impl DclProtoComponent for sdk::components::PbAssetLoadLoadingState {}
+impl DclProtoComponent for sdk::components::PbPhysicsCombinedForce {}
+impl DclProtoComponent for sdk::components::PbPhysicsCombinedImpulse {}
 
 // PositionFree markers for types used with GlobalCrdtState::update_crdt
 // (these contain no embedded position data requiring localization)

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -12,13 +12,12 @@ use common::{
 use comms::global_crdt::GlobalCrdtState;
 use dcl::interface::{ComponentPosition, CrdtType};
 use dcl_component::{
-    proto_components::{
+    SceneComponentId, SceneEntityId, proto_components::{
         common::Vector3,
         sdk::components::{
-            ColliderLayer, PbAvatarLocomotionSettings, PbAvatarMovement, PbAvatarMovementInfo,
+            ColliderLayer, PbAvatarLocomotionSettings, PbAvatarMovement, PbAvatarMovementInfo, PbPhysicsCombinedForce, PbPhysicsCombinedImpulse,
         },
-    },
-    SceneComponentId, SceneEntityId,
+    }
 };
 
 use scene_runner::{
@@ -198,6 +197,12 @@ impl<T: Default> FromConfig for T {
     }
 }
 
+#[derive(Component)]
+pub struct PhysicsCombinedForce(pub PbPhysicsCombinedForce);
+
+#[derive(Component)]
+pub struct PhysicsCombinedImpulse(pub PbPhysicsCombinedImpulse);
+
 #[derive(Resource, Default)]
 pub struct AvatarMovementInfo(pub PbAvatarMovementInfo);
 
@@ -345,6 +350,8 @@ pub fn apply_movement(
     mut info: ResMut<AvatarMovementInfo>,
     mut jumping: Local<bool>,
     movement_control: Res<EngineMovementControl>,
+    impulses: Query<&PhysicsCombinedImpulse>,
+    forces: Query<&PhysicsCombinedForce>,
 ) {
     let Ok((mut transform, mut dynamic_state, movement)) = player.single_mut() else {
         return;

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -1,7 +1,12 @@
 use core::f32;
 use std::f32::consts::TAU;
 
-use bevy::{diagnostic::FrameCount, math::DVec3, platform::collections::HashMap, prelude::*};
+use bevy::{
+    diagnostic::FrameCount,
+    math::DVec3,
+    platform::collections::{HashMap, HashSet},
+    prelude::*,
+};
 use common::{
     dynamics::{PLAYER_COLLIDER_OVERLAP, PLAYER_COLLIDER_RADIUS, PLAYER_GROUND_THRESHOLD},
     sets::SceneSets,
@@ -12,12 +17,14 @@ use common::{
 use comms::global_crdt::GlobalCrdtState;
 use dcl::interface::{ComponentPosition, CrdtType};
 use dcl_component::{
-    SceneComponentId, SceneEntityId, proto_components::{
+    proto_components::{
         common::Vector3,
         sdk::components::{
-            ColliderLayer, PbAvatarLocomotionSettings, PbAvatarMovement, PbAvatarMovementInfo, PbPhysicsCombinedForce, PbPhysicsCombinedImpulse,
+            ColliderLayer, PbAvatarLocomotionSettings, PbAvatarMovement, PbAvatarMovementInfo,
+            PbPhysicsCombinedForce, PbPhysicsCombinedImpulse,
         },
-    }
+    },
+    SceneComponentId, SceneEntityId,
 };
 
 use scene_runner::{
@@ -45,6 +52,14 @@ impl Plugin for AvatarMovementPlugin {
             SceneComponentId::AVATAR_LOCOMOTION_SETTINGS,
             ComponentPosition::EntityOnly,
         );
+        app.add_crdt_lww_component::<PbPhysicsCombinedImpulse, PhysicsCombinedImpulse>(
+            SceneComponentId::PHYSICS_COMBINED_IMPULSE,
+            ComponentPosition::EntityOnly,
+        );
+        app.add_crdt_lww_component::<PbPhysicsCombinedForce, PhysicsCombinedForce>(
+            SceneComponentId::PHYSICS_COMBINED_FORCE,
+            ComponentPosition::EntityOnly,
+        );
 
         app.init_resource::<AvatarMovementInfo>();
 
@@ -68,6 +83,7 @@ impl Plugin for AvatarMovementPlugin {
             (
                 apply_ground_collider_movement,
                 resolve_collisions,
+                apply_impulses,
                 apply_movement,
                 record_ground_collider,
             )
@@ -200,8 +216,20 @@ impl<T: Default> FromConfig for T {
 #[derive(Component)]
 pub struct PhysicsCombinedForce(pub PbPhysicsCombinedForce);
 
+impl From<PbPhysicsCombinedForce> for PhysicsCombinedForce {
+    fn from(value: PbPhysicsCombinedForce) -> Self {
+        Self(value)
+    }
+}
+
 #[derive(Component)]
 pub struct PhysicsCombinedImpulse(pub PbPhysicsCombinedImpulse);
+
+impl From<PbPhysicsCombinedImpulse> for PhysicsCombinedImpulse {
+    fn from(value: PbPhysicsCombinedImpulse) -> Self {
+        Self(value)
+    }
+}
 
 #[derive(Resource, Default)]
 pub struct AvatarMovementInfo(pub PbAvatarMovementInfo);
@@ -336,6 +364,52 @@ impl<C: Component + Clone + FromConfig> ActivePlayerComponent<C> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn apply_impulses(
+    impulses: Query<(&PhysicsCombinedImpulse, &SceneEntity)>,
+    forces: Query<(&PhysicsCombinedForce, &SceneEntity)>,
+    player: Res<PrimaryPlayerRes>,
+    containing_scenes: ContainingScene,
+    mut last_impulses: Local<HashMap<Entity, u32>>,
+    mut info: ResMut<AvatarMovementInfo>,
+    time: Res<Time>,
+    live_scenes: Query<Entity, With<RendererSceneContext>>,
+) {
+    let containing_scenes = containing_scenes.get(player.0);
+
+    let live: HashSet<Entity> = live_scenes.iter().collect();
+    last_impulses.retain(|k, _| live.contains(k));
+
+    for (impulse, entity) in impulses {
+        if last_impulses
+            .get(&entity.root)
+            .is_some_and(|prev_id| *prev_id == impulse.0.event_id)
+        {
+            continue;
+        }
+
+        last_impulses.insert(entity.root, impulse.0.event_id);
+        if !containing_scenes.contains(&entity.root) {
+            continue;
+        }
+
+        info.0.external_velocity = Some(
+            info.0.external_velocity.unwrap_or_default() + impulse.0.vector.unwrap_or_default(),
+        );
+    }
+
+    for (force, entity) in forces {
+        if !containing_scenes.contains(&entity.root) {
+            continue;
+        }
+
+        info.0.external_velocity = Some(
+            info.0.external_velocity.unwrap_or_default()
+                + force.0.vector.unwrap_or_default() * time.delta_secs(),
+        );
+    }
+}
+
 pub fn apply_movement(
     mut player: Query<
         (
@@ -350,8 +424,6 @@ pub fn apply_movement(
     mut info: ResMut<AvatarMovementInfo>,
     mut jumping: Local<bool>,
     movement_control: Res<EngineMovementControl>,
-    impulses: Query<&PhysicsCombinedImpulse>,
-    forces: Query<&PhysicsCombinedForce>,
 ) {
     let Ok((mut transform, mut dynamic_state, movement)) = player.single_mut() else {
         return;
@@ -517,8 +589,8 @@ fn apply_ground_collider_movement(
     ground_transforms: Query<(&GlobalTransform, &PreviousColliderTransform)>,
     mut player: Query<(&mut Transform, &GroundCollider), With<PrimaryUser>>,
     frame: Res<FrameCount>,
-    mut info: ResMut<AvatarMovementInfo>,
-    time: Res<Time>,
+    // mut info: ResMut<AvatarMovementInfo>,
+    // time: Res<Time>,
     movement_control: Res<EngineMovementControl>,
 ) {
     if !movement_control.suppress_avatar_physics.is_empty() {
@@ -562,18 +634,7 @@ fn apply_ground_collider_movement(
         );
 
         if (new_translation - transform.translation).length() < 5.0 {
-            let add_external_velocity =
-                (new_translation - transform.translation) / time.delta_secs();
-            let existing_external_velocity = info
-                .0
-                .external_velocity
-                .as_ref()
-                .map(Vector3::world_vec_to_vec3)
-                .unwrap_or_default();
-            info.0.external_velocity = Some(Vector3::world_vec_from_vec3(
-                &(existing_external_velocity + add_external_velocity),
-            ));
-
+            // don't add ground collider movement to external_velocity, else we bounce/slide off everything
             transform.translation = new_translation;
         } else {
             debug!("skipped");


### PR DESCRIPTION
## Summary
- Registers `PBPhysicsCombinedImpulse` (1215) and `PBPhysicsCombinedForce` (1216) as CRDT LWW (entity-only) components.
- Adds `apply_impulses`, scheduled between `resolve_collisions` and `apply_movement`, which folds scene-provided impulses and continuous forces into `AvatarMovementInfo.external_velocity`.
- Impulse dedup is keyed by `event_id` per scene root; the `last_impulses` map is pruned each frame against live `RendererSceneContext` entities so despawned scenes don't leak.
- Impulses raised while the player is outside the originating scene mark their `event_id` consumed and don't fire on re-entry (intentional — avoids queued impulses firing on scene enter).
- Stops `apply_ground_collider_movement` from contributing platform motion to `external_velocity`; that was causing the avatar to slide/bounce off every surface.

## Notes on rollout
This change is safe to merge ahead of the matching movement-scene update: the old movement-scene doesn't read `external_velocity` at all, so the new impulse/force paths are effectively no-ops for anyone not running the updated scene. The movement-scene PR should land only after this is deployed, since it now consumes `external_velocity` (which was previously populated for ground platforms).