### PR TITLE
Fix mic toggling on Cmd+V paste in chat

### DIFF
--- a/crates/input_manager/src/lib.rs
+++ b/crates/input_manager/src/lib.rs
@@ -98,6 +98,7 @@ impl Plugin for InputManagerPlugin {
         app.add_systems(
             PreUpdate,
             (
+                clear_stuck_modifier_keys.after(bevy::input::InputSystem),
                 update_deltas,
                 handle_native_input,
                 handle_get_bindings,
@@ -405,6 +406,47 @@ impl InputManager<'_, '_> {
 struct CurrentNativeInputRequest {
     sender: RpcResultSender<InputIdentifier>,
     axes: HashMap<AxisIdentifier, Vec2>,
+}
+
+// macOS suppresses keyUp events for non-modifier keys while Cmd is held, leaving
+// those keys stuck as `pressed` in winit's input state (e.g. Cmd+V leaves V
+// stuck). This system tracks non-modifier keys pressed while any modifier is
+// held, then synthesizes releases for them once all modifiers are released.
+fn clear_stuck_modifier_keys(
+    mut key_input: ResMut<ButtonInput<KeyCode>>,
+    mut tracked: Local<HashSet<KeyCode>>,
+    mut had_modifier: Local<bool>,
+) {
+    const MODIFIERS: [KeyCode; 6] = [
+        KeyCode::SuperLeft,
+        KeyCode::SuperRight,
+        KeyCode::ControlLeft,
+        KeyCode::ControlRight,
+        KeyCode::AltLeft,
+        KeyCode::AltRight,
+    ];
+
+    let modifier_held = MODIFIERS.iter().any(|k| key_input.pressed(*k));
+
+    if modifier_held {
+        let newly_pressed: Vec<KeyCode> = key_input
+            .get_just_pressed()
+            .copied()
+            .filter(|k| !MODIFIERS.contains(k))
+            .collect();
+        for key in newly_pressed {
+            tracked.insert(key);
+        }
+        *had_modifier = true;
+    } else if *had_modifier {
+        *had_modifier = false;
+        let stuck: Vec<KeyCode> = tracked.drain().collect();
+        for key in stuck {
+            if key_input.pressed(key) {
+                key_input.release(key);
+            }
+        }
+    }
 }
 
 fn update_deltas(

--- a/crates/system_ui/src/mic.rs
+++ b/crates/system_ui/src/mic.rs
@@ -118,8 +118,13 @@ fn update_mic_ui(
         *button.single_mut().unwrap() = mic_images.inactive.clone_weak().into();
     }
 
-    if input_manager.is_down(SystemAction::Microphone, InputPriority::None) != *pressed {
-        *pressed = !*pressed;
+    if *pressed {
+        if input_manager.just_up(SystemAction::Microphone) {
+            *pressed = false;
+            mic_state.enabled = !mic_state.enabled;
+        }
+    } else if input_manager.just_down(SystemAction::Microphone, InputPriority::None) {
+        *pressed = true;
         mic_state.enabled = !mic_state.enabled;
     }
 


### PR DESCRIPTION
## Summary

Typing `Cmd+V` (paste) in the in-game chat, then hitting Enter, unexpectedly turns the microphone on. After that, every click on the chat field toggles the mic again, without the user pressing V.

### Root cause

Two layers:

1. **OS/winit:** on macOS, when Cmd is held, keyUp events for non-modifier keys are suppressed. So Cmd+V leaves `KeyV` stuck as `pressed` in `ButtonInput<KeyCode>` forever.
2. **`update_mic_ui`:** used level-based state tracking — `if is_down(Microphone, None) != *pressed` — gated by `InputPriority`. While the chat input reserves the keyboard at `TextEntry` priority, the stuck V is hidden. When Enter submits the chat and priority is released, `is_down` suddenly returns `true`, the compare fires, and the mic toggles. Each subsequent focus/unfocus flips the filtered view of the still-stuck key and toggles again.

Typing a plain `v` never reproduced because V's keyUp fires normally without Cmd held, so the key never got stuck.

### Fix

- **`crates/input_manager/src/lib.rs`** — new `clear_stuck_modifier_keys` PreUpdate system (ordered after `bevy::input::InputSystem`). Tracks non-modifier keys pressed while any of Super/Ctrl/Alt is held, and synthesizes releases when all modifiers go up. Addresses the root cause for every `is_down` caller, not just mic — Space (Cmd+Space → Spotlight) and any scene-forwarded inputs would have been similarly vulnerable.
- **`crates/system_ui/src/mic.rs`** — `update_mic_ui` switched from level-based `is_down != *pressed` to edge-triggered `just_down`/`just_up`. `*pressed` is retained to gate the up edge so priority changes can't be mistaken for key events and typing `v` in chat can't imbalance the toggle cycle. Push-to-talk (flip on both edges) semantics preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)