### PR TITLE
Scene-driven movement animations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6171,6 +6171,7 @@ dependencies = [
  "base64 0.22.1",
  "bevy",
  "bevy_console",
+ "bevy_kira_audio",
  "clap",
  "common",
  "console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11777,6 +11777,7 @@ dependencies = [
  "dcl",
  "dcl_component",
  "input_manager",
+ "ipfs",
  "rapier3d-f64",
  "scene_runner",
  "tween",

--- a/crates/av/src/audio_loader.rs
+++ b/crates/av/src/audio_loader.rs
@@ -1,0 +1,51 @@
+use bevy::asset::{io::Reader, AssetLoader, LoadContext};
+use bevy_kira_audio::AudioSource;
+use kira::sound::{static_sound::StaticSoundData, FromFileError};
+use std::io::Cursor;
+use thiserror::Error;
+
+// Format-agnostic loader for scene-content audio assets served without a file
+// extension on the wire. Kira's `StaticSoundData::from_cursor` internally uses
+// symphonia's probe to sniff the container (mp3/ogg/wav/flac) from the byte
+// stream, so we don't need to know the original extension up front.
+#[derive(Default)]
+pub struct AudioAssetLoader;
+
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum AudioLoaderError {
+    #[error("Could not read audio asset: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Error decoding audio asset: {0}")]
+    FileError(#[from] FromFileError),
+}
+
+impl AssetLoader for AudioAssetLoader {
+    type Asset = AudioSource;
+    type Settings = ();
+    type Error = AudioLoaderError;
+
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        load_context: &mut LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await?;
+        let byte_count = bytes.len();
+        let sound = StaticSoundData::from_cursor(Cursor::new(bytes))?;
+        bevy::log::debug!(
+            "loaded .audio asset {:?} ({} bytes, {} frames @ {} Hz)",
+            load_context.path(),
+            byte_count,
+            sound.frames.len(),
+            sound.sample_rate,
+        );
+        Ok(AudioSource { sound })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["audio"]
+    }
+}

--- a/crates/av/src/audio_source.rs
+++ b/crates/av/src/audio_source.rs
@@ -33,6 +33,9 @@ impl Plugin for AudioSourcePlugin {
     fn build(&self, app: &mut App) {
         // we use kira for audio source asset management, regardless of native / wasm
         app.add_plugins(bevy_kira_audio::AudioPlugin);
+        // Custom `.audio` loader for scene-content clips fetched by content hash
+        // (no on-wire extension). Format is detected from the byte stream.
+        app.register_asset_loader(crate::audio_loader::AudioAssetLoader);
         app.add_event::<SystemAudio>();
         app.add_crdt_lww_component::<PbAudioSource, AudioSource>(
             SceneComponentId::AUDIO_SOURCE,

--- a/crates/av/src/audio_source_wasm.rs
+++ b/crates/av/src/audio_source_wasm.rs
@@ -165,7 +165,15 @@ fn manage_audio_sources(
             Option<&RenderLayers>,
             Option<&RetryEmitter>,
         ),
-        Or<(Changed<AudioEmitter>, With<Playing>)>,
+        Or<(
+            Changed<AudioEmitter>,
+            With<Playing>,
+            // Include entities queued for retry: on wasm we can't start
+            // playback until the web AudioBuffer is decoded, so the first
+            // frame often fails and we insert RetryEmitter without a Playing
+            // marker. Without this term the retry never fires.
+            With<RetryEmitter>,
+        )>,
     >,
     mut audio: NonSendMut<HtmlAudioContext>,
     containing_scene: ContainingScene,

--- a/crates/av/src/lib.rs
+++ b/crates/av/src/lib.rs
@@ -16,6 +16,7 @@ pub mod video_context;
 pub mod video_stream;
 
 // audio source (non-streaming audio)
+pub mod audio_loader;
 pub mod audio_source;
 #[cfg(not(feature = "html"))]
 pub mod audio_source_native;

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -59,6 +59,7 @@ impl Plugin for AvatarAnimationPlugin {
             (
                 (handle_trigger_emotes, broadcast_emote, receive_emotes).before(animate),
                 (animate, play_current_emote).chain().after(process_avatar),
+                play_scene_driven_sounds.after(process_avatar),
             )
                 .in_set(SceneSets::PostLoop),
         );
@@ -1164,4 +1165,52 @@ fn emote_console_command(
         };
         input.ok();
     }
+}
+
+// Plays avatar-bus audio clips requested by a scene-driven movement animation.
+// Dedups against the last observed sound list per avatar so that the scene holding
+// the same list across frames doesn't re-fire sounds — a new play is triggered
+// only when the list transitions to a different value (including the scene clearing
+// and re-asserting it on a later frame).
+fn play_scene_driven_sounds(
+    mut commands: Commands,
+    avatars: Query<(Entity, &SceneDrivenAnim)>,
+    ipfas: IpfsAssetServer,
+    mut last_sounds: Local<HashMap<Entity, Vec<String>>>,
+) {
+    let mut seen: HashSet<Entity> = HashSet::default();
+    for (entity, scene_anim) in avatars.iter() {
+        seen.insert(entity);
+        let Some(active) = scene_anim.active.as_ref() else {
+            last_sounds.remove(&entity);
+            continue;
+        };
+        let prev = last_sounds.get(&entity);
+        if prev.map(|v| v.as_slice()) == Some(active.sounds.as_slice()) {
+            continue;
+        }
+        for content_hash in &active.sounds {
+            let handle = ipfas.load_scene_content_hash::<bevy_kira_audio::AudioSource>(
+                &active.scene_hash,
+                content_hash,
+            );
+            let audio_entity = commands
+                .spawn((
+                    Transform::default(),
+                    Visibility::default(),
+                    AudioEmitter {
+                        handle,
+                        ty: AudioType::Avatar,
+                        ..Default::default()
+                    },
+                ))
+                .id();
+            if let Ok(mut entity_commands) = commands.get_entity(entity) {
+                entity_commands.try_push_children(&[audio_entity]);
+            }
+        }
+        last_sounds.insert(entity, active.sounds.clone());
+    }
+    // Drop tracked state for avatars that no longer have the component.
+    last_sounds.retain(|e, _| seen.contains(e));
 }

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -350,10 +350,15 @@ fn animate(
                 .get(&avatar_ent)
                 .copied()
                 .unwrap_or_default();
+            // A non-idle scene-driven animation takes precedence over a triggered emote.
+            let scene_cancels = scene_anim.is_some_and(|req| !req.idle);
             // Scene-driven animations handle their own motion semantics; don't cancel on move.
             let velocity_cancels =
                 scene_anim.is_none() && active_emote.source != ActiveEmoteSource::SceneMovementAnim;
-            if velocity_cancels && damped_velocity_len * 0.9 > playing_min_vel {
+            if scene_cancels {
+                debug!("clear on scene anim {:?}", active_emote.urn);
+                requested_emote = None;
+            } else if velocity_cancels && damped_velocity_len * 0.9 > playing_min_vel {
                 // stop emotes on move
                 debug!(
                     "clear on motion {} > {}",

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -19,7 +19,7 @@ use common::{
     sets::SceneSets,
     structs::{
         AudioEmitter, AudioType, AvatarDynamicState, EmoteCommand, MoveKind, PlayerModifiers,
-        PrimaryUser, SceneDrivenAnimation, SceneDrivenAnimationFeedback,
+        PrimaryUser, SceneDrivenAnim, SceneDrivenAnimationFeedback,
         SceneDrivenAnimationFeedbackState,
     },
     util::TryPushChildrenEx,
@@ -265,6 +265,7 @@ fn animate(
         Option<&ContainerEntity>,
         Option<&PrimaryUser>,
         Option<&mut LastEmoteCommand>,
+        Option<&SceneDrivenAnim>,
     )>,
     mut velocities: Local<HashMap<Entity, Vec3>>,
     mut current_emote_min_velocities: Local<HashMap<Entity, f32>>,
@@ -272,7 +273,6 @@ fn animate(
     player: Query<(&PrimaryUser, Option<&PlayerModifiers>)>,
     containing_scene: ContainingScene,
     mut scenes: Query<&mut RendererSceneContext>,
-    scene_driven_animation: Res<SceneDrivenAnimation>,
 ) {
     let (gravity, jump_height) = player
         .single()
@@ -295,6 +295,7 @@ fn animate(
         maybe_container,
         maybe_primary,
         last_emote,
+        maybe_scene_anim,
     ) in avatars.iter_mut()
     {
         let Some(mut active_emote) = active_emote else {
@@ -316,11 +317,7 @@ fn animate(
         let damped_velocity_len = damped_velocity.xz().length();
         velocities.insert(avatar_ent, damped_velocity);
 
-        // A scene-driven movement animation is only meaningful for the primary player.
-        let scene_anim = maybe_primary
-            .is_some()
-            .then(|| scene_driven_animation.active.as_ref())
-            .flatten();
+        let scene_anim = maybe_scene_anim.and_then(|a| a.active.as_ref());
 
         // get requested emote
         let (mut requested_emote, given_urn, request_loop) =
@@ -434,21 +431,19 @@ fn animate(
                 source: ActiveEmoteSource::TriggeredEmote,
                 ..Default::default()
             }
-        } else if let Some(scene_anim_req) = scene_anim.and_then(|req| {
-            let urn_str = format!(
-                "urn:decentraland:off-chain:scene-emote:{}-{}-false",
-                req.scene_hash, req.content_hash
-            );
-            EmoteUrn::new(urn_str.as_str()).ok().map(|urn| (req, urn))
-        }) {
+        } else if let Some(scene_anim_req) =
+            scene_anim.and_then(|req| EmoteUrn::new(req.urn.as_str()).ok().map(|urn| (req, urn)))
+        {
             let (req, urn) = scene_anim_req;
             dynamic_state.move_kind = if req.idle {
                 MoveKind::Idle
             } else {
                 MoveKind::Walk
             };
+            // Detect anim change via URN (stable across local/remote sources) rather than src,
+            // which is empty for requests received over the network.
             let is_new_anim = active_emote.source != ActiveEmoteSource::SceneMovementAnim
-                || active_emote.scene_anim_src.as_deref() != Some(req.src.as_str());
+                || active_emote.urn != urn;
             ActiveEmote {
                 urn,
                 speed: req.speed,
@@ -814,11 +809,7 @@ fn play_current_emote(
                 }
             } else {
                 let wrapper = commands
-                    .spawn((
-                        Transform::default(),
-                        Visibility::Hidden,
-                        ChildOf(entity),
-                    ))
+                    .spawn((Transform::default(), Visibility::Hidden, ChildOf(entity)))
                     .id();
                 let scene = scene_spawner.spawn_as_child(props, wrapper);
                 spawned_extras

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -230,6 +230,10 @@ pub struct ActiveEmote {
     /// Source path from `MovementAnimation.src`; used to populate feedback and detect
     /// cross-fade boundaries between scene-driven animations.
     scene_anim_src: Option<String>,
+    /// Alternate state to play if the primary URN fails to resolve. Populated by
+    /// `animate` for scene-driven selections with the velocity-based choice;
+    /// `play_current_emote` swaps to it on resolution failure.
+    fallback: Option<Box<ActiveEmote>>,
 }
 
 impl Default for ActiveEmote {
@@ -246,6 +250,7 @@ impl Default for ActiveEmote {
             pending_seek: None,
             source: ActiveEmoteSource::VelocitySelected,
             scene_anim_src: None,
+            fallback: None,
         }
     }
 }
@@ -375,6 +380,89 @@ fn animate(
             current_emote_min_velocities.insert(avatar_ent, damped_velocity_len);
         }
 
+        // Precompute the velocity-based selection up-front so we can use it both as the
+        // fallback for scene-driven anims (in case the URN fails to resolve) and as the
+        // final default when nothing else claims the avatar.
+        let time_to_peak = (jump_height * -gravity * 2.0).sqrt() / -gravity;
+        let just_jumped =
+            dynamic_state.jump_time > (time.elapsed_secs() - time_to_peak / 2.0).max(0.0);
+        let (velocity_emote, velocity_move_kind) = if dynamic_state.ground_height > 0.2
+            || (dynamic_state.velocity.y > 0.0 && just_jumped)
+        {
+            let move_kind = if just_jumped {
+                MoveKind::Jump
+            } else {
+                MoveKind::Falling
+            };
+            (
+                ActiveEmote {
+                    urn: EmoteUrn::new("jump").unwrap(),
+                    speed: time_to_peak.recip() * 0.5,
+                    repeat: true,
+                    restart: dynamic_state.jump_time > time.elapsed_secs() - time.delta_secs(),
+                    transition_seconds: 0.1,
+                    initial_audio_mark: if !just_jumped { Some(0.1) } else { None },
+                    ..Default::default()
+                },
+                move_kind,
+            )
+        } else if active_emote.urn == EmoteUrn::new("jump").unwrap() && !active_emote.finished {
+            (
+                ActiveEmote {
+                    urn: EmoteUrn::new("jump").unwrap(),
+                    speed: 1.5,
+                    repeat: false,
+                    restart: false,
+                    transition_seconds: 0.1,
+                    initial_audio_mark: Some(0.1),
+                    ..Default::default()
+                },
+                dynamic_state.move_kind,
+            )
+        } else {
+            let directional_velocity_len =
+                (damped_velocity * (Vec3::X + Vec3::Z)).dot(gt.forward().as_vec3());
+            if damped_velocity_len.abs() > 0.1 {
+                if damped_velocity_len.abs() <= 2.6 {
+                    (
+                        ActiveEmote {
+                            urn: EmoteUrn::new("walk").unwrap(),
+                            speed: directional_velocity_len / 1.5,
+                            restart: false,
+                            repeat: true,
+                            transition_seconds: 0.4,
+                            ..Default::default()
+                        },
+                        MoveKind::Walk,
+                    )
+                } else {
+                    (
+                        ActiveEmote {
+                            urn: EmoteUrn::new("run").unwrap(),
+                            speed: directional_velocity_len / 4.5,
+                            restart: false,
+                            repeat: true,
+                            transition_seconds: 0.4,
+                            ..Default::default()
+                        },
+                        MoveKind::Jog,
+                    )
+                }
+            } else {
+                (
+                    ActiveEmote {
+                        urn: EmoteUrn::new("idle_male").unwrap(),
+                        speed: 1.0,
+                        restart: false,
+                        repeat: true,
+                        transition_seconds: 0.4,
+                        ..Default::default()
+                    },
+                    MoveKind::Idle,
+                )
+            }
+        };
+
         // play requested emote
         *active_emote = if let Some(requested_emote) = requested_emote {
             if emote_changed {
@@ -456,77 +544,11 @@ fn animate(
                 pending_seek: req.seek,
                 source: ActiveEmoteSource::SceneMovementAnim,
                 scene_anim_src: Some(req.src.clone()),
+                fallback: Some(Box::new(velocity_emote)),
             }
         } else {
-            // otherwise play a default emote based on motion
-            let time_to_peak = (jump_height * -gravity * 2.0).sqrt() / -gravity;
-            let just_jumped =
-                dynamic_state.jump_time > (time.elapsed_secs() - time_to_peak / 2.0).max(0.0);
-            if dynamic_state.ground_height > 0.2 || (dynamic_state.velocity.y > 0.0 && just_jumped)
-            {
-                if just_jumped {
-                    dynamic_state.move_kind = MoveKind::Jump;
-                } else {
-                    dynamic_state.move_kind = MoveKind::Falling;
-                }
-                ActiveEmote {
-                    urn: EmoteUrn::new("jump").unwrap(),
-                    speed: time_to_peak.recip() * 0.5,
-                    repeat: true,
-                    restart: dynamic_state.jump_time > time.elapsed_secs() - time.delta_secs(),
-                    transition_seconds: 0.1,
-                    initial_audio_mark: if !just_jumped { Some(0.1) } else { None },
-                    ..Default::default()
-                }
-            } else if active_emote.urn == EmoteUrn::new("jump").unwrap() && !active_emote.finished {
-                // finish the jump - we use `repeat: false` to signal that we are landing...
-                ActiveEmote {
-                    urn: EmoteUrn::new("jump").unwrap(),
-                    speed: 1.5,
-                    repeat: false,
-                    restart: false,
-                    transition_seconds: 0.1,
-                    initial_audio_mark: Some(0.1),
-                    ..Default::default()
-                }
-            } else {
-                let directional_velocity_len =
-                    (damped_velocity * (Vec3::X + Vec3::Z)).dot(gt.forward().as_vec3());
-
-                if damped_velocity_len.abs() > 0.1 {
-                    if damped_velocity_len.abs() <= 2.6 {
-                        dynamic_state.move_kind = MoveKind::Walk;
-                        ActiveEmote {
-                            urn: EmoteUrn::new("walk").unwrap(),
-                            speed: directional_velocity_len / 1.5,
-                            restart: false,
-                            repeat: true,
-                            transition_seconds: 0.4,
-                            ..Default::default()
-                        }
-                    } else {
-                        dynamic_state.move_kind = MoveKind::Jog;
-                        ActiveEmote {
-                            urn: EmoteUrn::new("run").unwrap(),
-                            speed: directional_velocity_len / 4.5,
-                            restart: false,
-                            repeat: true,
-                            transition_seconds: 0.4,
-                            ..Default::default()
-                        }
-                    }
-                } else {
-                    dynamic_state.move_kind = MoveKind::Idle;
-                    ActiveEmote {
-                        urn: EmoteUrn::new("idle_male").unwrap(),
-                        speed: 1.0,
-                        restart: false,
-                        repeat: true,
-                        transition_seconds: 0.4,
-                        ..Default::default()
-                    }
-                }
-            }
+            dynamic_state.move_kind = velocity_move_kind;
+            velocity_emote
         }
     }
 }
@@ -620,121 +642,159 @@ fn play_current_emote(
         let ent = target_entity.0;
         let bodyshape = &definition.body_shape;
 
-        if let Some(scene_emote) = active_emote.urn.scene_emote() {
-            debug!("got {scene_emote:?}");
-            let mut split = scene_emote.split('-').peekable();
-            // take_hash reads a hash, recombining "b64-<payload>" back into one
-            // token because we used '-' as the separator and b64 hashes also
-            // contain '-'. for non-b64 hashes it just takes the next token.
-            let take_hash = |split: &mut std::iter::Peekable<std::str::Split<'_, char>>| {
-                let first = split.next()?;
-                if first == "b64" {
-                    let tail = split.next()?;
-                    Some(format!("b64-{tail}"))
-                } else {
-                    Some(first.to_owned())
-                }
-            };
-            let Some(scene_hash) = take_hash(&mut split) else {
-                debug!("failed to split scene emote {scene_emote:?}");
-                active_emote.finished = true;
-                continue;
-            };
-            let Some(hash) = take_hash(&mut split) else {
-                debug!("failed to split scene emote {scene_emote:?}");
-                active_emote.finished = true;
-                continue;
-            };
-
-            if emote_loader
-                .get_representation(&active_emote.urn, bodyshape.as_str())
-                .is_err()
-            {
-                // load the gltf through the scene's modifier context so b64
-                // hashes (local preview / portable) resolve to the scene's
-                // origin rather than the realm content URL.
-                let handle = ipfas.load_scene_content_hash::<Gltf>(&scene_hash, &hash);
-                let gltf = match gltfs.get_mut(handle.id()) {
-                    Some(gltf) => {
-                        cached_gltf_handles.remove(&handle);
-                        gltf
+        // Resolve the URN. On permanent failure, if a fallback is present (populated by
+        // `animate` for scene-driven anims with the velocity-based choice), swap to it
+        // and retry. The swap persists so downstream `SceneDrivenAnimationFeedback`
+        // publishing reports the fallback source, not the failed scene-driven one.
+        enum Outcome {
+            Ready,
+            Loading,
+            Failed,
+        }
+        let outcome = 'resolve: loop {
+            if let Some(scene_emote) = active_emote.urn.scene_emote() {
+                debug!("got {scene_emote:?}");
+                let mut split = scene_emote.split('-').peekable();
+                // take_hash reads a hash, recombining "b64-<payload>" back into one
+                // token because we used '-' as the separator and b64 hashes also
+                // contain '-'. for non-b64 hashes it just takes the next token.
+                let take_hash =
+                    |split: &mut std::iter::Peekable<std::str::Split<'_, char>>| -> Option<String> {
+                        let first = split.next()?;
+                        if first == "b64" {
+                            let tail = split.next()?;
+                            Some(format!("b64-{tail}"))
+                        } else {
+                            Some(first.to_owned())
+                        }
+                    };
+                let Some(scene_hash) = take_hash(&mut split) else {
+                    debug!("failed to split scene emote {scene_emote:?}");
+                    if let Some(fb) = active_emote.fallback.take() {
+                        *active_emote = *fb;
+                        continue 'resolve;
                     }
-                    None => {
-                        cached_gltf_handles.insert(handle);
-                        continue;
+                    break 'resolve Outcome::Failed;
+                };
+                let Some(hash) = take_hash(&mut split) else {
+                    debug!("failed to split scene emote {scene_emote:?}");
+                    if let Some(fb) = active_emote.fallback.take() {
+                        *active_emote = *fb;
+                        continue 'resolve;
                     }
+                    break 'resolve Outcome::Failed;
                 };
 
-                // fix up the gltf if possible/required
-                if !gltf.named_animations.keys().any(|k| k.ends_with("_Avatar")) {
-                    let Some(anim) = gltf.animations.first() else {
-                        warn!("scene emote has no animations");
-                        active_emote.finished = true;
-                        continue;
+                if emote_loader
+                    .get_representation(&active_emote.urn, bodyshape.as_str())
+                    .is_err()
+                {
+                    // load the gltf through the scene's modifier context so b64
+                    // hashes (local preview / portable) resolve to the scene's
+                    // origin rather than the realm content URL.
+                    let handle = ipfas.load_scene_content_hash::<Gltf>(&scene_hash, &hash);
+                    let gltf = match gltfs.get_mut(handle.id()) {
+                        Some(gltf) => {
+                            cached_gltf_handles.remove(&handle);
+                            gltf
+                        }
+                        None => {
+                            cached_gltf_handles.insert(handle);
+                            break 'resolve Outcome::Loading;
+                        }
                     };
 
-                    gltf.named_animations.insert("_Avatar".into(), anim.clone());
-                }
+                    // fix up the gltf if possible/required
+                    if !gltf.named_animations.keys().any(|k| k.ends_with("_Avatar")) {
+                        let Some(anim) = gltf.animations.first() else {
+                            warn!("scene emote has no animations");
+                            if let Some(fb) = active_emote.fallback.take() {
+                                *active_emote = *fb;
+                                continue 'resolve;
+                            }
+                            break 'resolve Outcome::Failed;
+                        };
 
-                // add repr
-                emote_loader.add_builtin(
-                    active_emote.urn.clone(),
-                    Collectible {
-                        representations: HashMap::from_iter([(
-                            bodyshape.to_owned(),
-                            Emote {
-                                gltf: handle,
-                                default_repeat: false,
-                                sound: Vec::default(),
+                        gltf.named_animations.insert("_Avatar".into(), anim.clone());
+                    }
+
+                    // add repr
+                    emote_loader.add_builtin(
+                        active_emote.urn.clone(),
+                        Collectible {
+                            representations: HashMap::from_iter([(
+                                bodyshape.to_owned(),
+                                Emote {
+                                    gltf: handle,
+                                    default_repeat: false,
+                                    sound: Vec::default(),
+                                },
+                            )]),
+                            data: CollectibleData::<Emote> {
+                                hash: hash.to_owned(),
+                                urn: active_emote.urn.as_str().to_owned(),
+                                thumbnail: "embedded://images/redx.png".to_owned(),
+                                available_representations: HashSet::from_iter([
+                                    bodyshape.to_owned()
+                                ]),
+                                name: active_emote.urn.to_string(),
+                                description: active_emote.urn.to_string(),
+                                extra_data: (),
                             },
-                        )]),
-                        data: CollectibleData::<Emote> {
-                            hash: hash.to_owned(),
-                            urn: active_emote.urn.as_str().to_owned(),
-                            thumbnail: "embedded://images/redx.png".to_owned(),
-                            available_representations: HashSet::from_iter([bodyshape.to_owned()]),
-                            name: active_emote.urn.to_string(),
-                            description: active_emote.urn.to_string(),
-                            extra_data: (),
                         },
-                    },
-                );
+                    );
+                }
+            }
+
+            match emote_loader.get_representation(&active_emote.urn, bodyshape.as_str()) {
+                Ok(emote) => match emote.avatar_animation(&gltfs) {
+                    Ok(Some(_)) => break 'resolve Outcome::Ready,
+                    Err(e) => {
+                        debug!("animation error: {:?}", e);
+                        break 'resolve Outcome::Loading;
+                    }
+                    Ok(None) => {
+                        debug!("{} -> no clip", active_emote.urn);
+                        if let Some(fb) = active_emote.fallback.take() {
+                            *active_emote = *fb;
+                            continue 'resolve;
+                        }
+                        break 'resolve Outcome::Failed;
+                    }
+                },
+                Err(CollectibleError::Loading) => {
+                    debug!("{} -> loading", active_emote.urn);
+                    break 'resolve Outcome::Loading;
+                }
+                Err(e) => {
+                    debug!("{} -> {:?}", active_emote.urn, e);
+                    if let Some(fb) = active_emote.fallback.take() {
+                        *active_emote = *fb;
+                        continue 'resolve;
+                    }
+                    break 'resolve Outcome::Failed;
+                }
+            }
+        };
+
+        match outcome {
+            Outcome::Ready => {}
+            Outcome::Loading => continue,
+            Outcome::Failed => {
+                active_emote.finished = true;
+                continue;
             }
         }
 
         let emote = match emote_loader.get_representation(&active_emote.urn, bodyshape.as_str()) {
             Ok(emote) => emote,
-            e @ Err(CollectibleError::Failed)
-            | e @ Err(CollectibleError::Missing)
-            | e @ Err(CollectibleError::NoRepresentation) => {
-                debug!("{} -> {:?}", active_emote.urn, e);
-                active_emote.finished = true;
-                continue;
-            }
-            Err(CollectibleError::Loading) => {
-                debug!("{} -> loading", active_emote.urn);
-                continue;
-            }
+            _ => continue,
         };
         active_emote.repeat |= emote.default_repeat;
 
         let clip = match emote.avatar_animation(&gltfs) {
-            Err(e) => {
-                debug!("animation error: {:?}", e);
-                continue;
-            }
-            Ok(None) => {
-                debug!("{} -> no clip", active_emote.urn);
-                debug!(
-                    "available : {:?}",
-                    gltfs
-                        .get(emote.gltf.id())
-                        .map(|gltf| gltf.named_animations.keys().collect::<Vec<_>>())
-                );
-                active_emote.finished = true;
-                continue;
-            }
             Ok(Some(clip)) => clip,
+            _ => continue,
         };
 
         // extract props and prop anim

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -969,8 +969,13 @@ fn play_current_emote(
                 active_animation.set_speed(active_emote.speed);
 
                 if let Some(seek) = pending_seek {
-                    active_animation.seek_to(seek.clamp(0.0, clip_duration));
+                    // `replay()` in bevy_animation resets `seek_time` to 0.0
+                    // (among other state), so it must run BEFORE `seek_to`
+                    // or the seek is clobbered. We still call it so a non-
+                    // looping clip that has completed can be restarted by a
+                    // new seek.
                     active_animation.replay();
+                    active_animation.seek_to(seek.clamp(0.0, clip_duration));
                 }
 
                 // nasty hack for falling animation

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -533,7 +533,7 @@ fn animate(
 
 struct SpawnedExtras {
     urn: EmoteUrn,
-    scene: Option<InstanceId>,
+    scene: Option<(Entity, InstanceId)>,
     scene_initialized: bool,
     audio: Option<(Entity, f32)>,
     clip: Option<(AnimationNodeIndex, Handle<AnimationGraph>)>,
@@ -600,8 +600,11 @@ fn play_current_emote(
         // clean up old extras
         if let Some(extras) = prev_spawned_extras.remove(&entity) {
             if extras.urn != active_emote.urn {
-                if let Some(scene) = extras.scene {
+                if let Some((wrapper, scene)) = extras.scene {
                     scene_spawner.despawn_instance(scene);
+                    if let Ok(mut commands) = commands.get_entity(wrapper) {
+                        commands.despawn();
+                    }
                 }
 
                 if let Some((audio_ent, _)) = extras.audio.as_ref() {
@@ -739,7 +742,7 @@ fn play_current_emote(
         if let Ok(Some(props)) = emote.prop_scene(&gltfs) {
             debug!("got props");
             if let Some(extras) = spawned_extras.get_mut(&entity) {
-                let Some(instance) = extras.scene else {
+                let Some((wrapper, instance)) = extras.scene else {
                     continue;
                 };
 
@@ -764,19 +767,18 @@ fn play_current_emote(
                                 }
                             }
 
-                            if parent.parent() == entity {
+                            if parent.parent() == wrapper {
                                 // children of root nodes -> rotate
-                                if parent.parent() == entity {
-                                    let mut rotated = *transform;
-                                    rotated.rotate_around(
-                                        Vec3::ZERO,
-                                        Quat::from_rotation_y(std::f32::consts::PI),
-                                    );
-                                    commands.entity(spawned_ent).try_insert(rotated);
-                                }
+                                let mut rotated = *transform;
+                                rotated.rotate_around(
+                                    Vec3::ZERO,
+                                    Quat::from_rotation_y(std::f32::consts::PI),
+                                );
+                                commands.entity(spawned_ent).try_insert(rotated);
                             }
                         }
                     }
+                    commands.entity(wrapper).try_insert(Visibility::Inherited);
                     extras.scene_initialized = true;
                 }
 
@@ -806,11 +808,18 @@ fn play_current_emote(
                     }
                 }
             } else {
-                let scene = scene_spawner.spawn_as_child(props, entity);
+                let wrapper = commands
+                    .spawn((
+                        Transform::default(),
+                        Visibility::Hidden,
+                        ChildOf(entity),
+                    ))
+                    .id();
+                let scene = scene_spawner.spawn_as_child(props, wrapper);
                 spawned_extras
                     .entry(entity)
                     .or_insert_with(|| SpawnedExtras::new(active_emote.urn.clone()))
-                    .scene = Some(scene);
+                    .scene = Some((wrapper, scene));
                 continue;
             }
         }

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -19,7 +19,8 @@ use common::{
     sets::SceneSets,
     structs::{
         AudioEmitter, AudioType, AvatarDynamicState, EmoteCommand, MoveKind, PlayerModifiers,
-        PrimaryUser,
+        PrimaryUser, SceneDrivenAnimation, SceneDrivenAnimationFeedback,
+        SceneDrivenAnimationFeedbackState,
     },
     util::TryPushChildrenEx,
 };
@@ -196,6 +197,19 @@ fn receive_emotes(mut commands: Commands, mut chat_events: EventReader<ChatEvent
     }
 }
 
+/// Where the current ActiveEmote came from. Controls override precedence and whether
+/// the `SceneDrivenAnimationFeedback` resource is updated from this emote's playback.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ActiveEmoteSource {
+    /// Engine-selected from velocity heuristics (the historical default).
+    #[default]
+    VelocitySelected,
+    /// A scene invoked triggerSceneEmote.
+    TriggeredEmote,
+    /// The movement scene published a `MovementAnimation` block in `AvatarMovement`.
+    SceneMovementAnim,
+}
+
 #[derive(Component)]
 pub struct ActiveEmote {
     urn: EmoteUrn,
@@ -205,6 +219,17 @@ pub struct ActiveEmote {
     finished: bool,
     transition_seconds: f32,
     initial_audio_mark: Option<f32>,
+    /// Whether a `triggerSceneEmote` should be allowed to take over. Mirrors the movement
+    /// scene's `idle` flag when `source == SceneMovementAnim`; otherwise unused.
+    overridable: bool,
+    /// Set by the animate system when the scene publishes a `playback_time` this frame.
+    /// Consumed exactly once by `play_current_emote`.
+    pending_seek: Option<f32>,
+    /// Origin of the current selection; dictates override rules and feedback publishing.
+    source: ActiveEmoteSource,
+    /// Source path from `MovementAnimation.src`; used to populate feedback and detect
+    /// cross-fade boundaries between scene-driven animations.
+    scene_anim_src: Option<String>,
 }
 
 impl Default for ActiveEmote {
@@ -217,6 +242,10 @@ impl Default for ActiveEmote {
             finished: false,
             transition_seconds: 0.2,
             initial_audio_mark: None,
+            overridable: true,
+            pending_seek: None,
+            source: ActiveEmoteSource::VelocitySelected,
+            scene_anim_src: None,
         }
     }
 }
@@ -243,6 +272,7 @@ fn animate(
     player: Query<(&PrimaryUser, Option<&PlayerModifiers>)>,
     containing_scene: ContainingScene,
     mut scenes: Query<&mut RendererSceneContext>,
+    scene_driven_animation: Res<SceneDrivenAnimation>,
 ) {
     let (gravity, jump_height) = player
         .single()
@@ -286,6 +316,12 @@ fn animate(
         let damped_velocity_len = damped_velocity.xz().length();
         velocities.insert(avatar_ent, damped_velocity);
 
+        // A scene-driven movement animation is only meaningful for the primary player.
+        let scene_anim = maybe_primary
+            .is_some()
+            .then(|| scene_driven_animation.active.as_ref())
+            .flatten();
+
         // get requested emote
         let (mut requested_emote, given_urn, request_loop) =
             if let Some(EmoteCommand { urn, r#loop, .. }) = emote {
@@ -301,13 +337,23 @@ fn animate(
             requested_emote = None;
         }
 
+        // If the current animation is a non-overridable scene-driven one, silently drop
+        // any triggerSceneEmote request so the movement scene retains control.
+        if active_emote.source == ActiveEmoteSource::SceneMovementAnim && !active_emote.overridable
+        {
+            requested_emote = None;
+        }
+
         // check / cancel requested emote
         if Some(&active_emote.urn) == requested_emote.as_ref() {
             let playing_min_vel = prior_min_velocities
                 .get(&avatar_ent)
                 .copied()
                 .unwrap_or_default();
-            if damped_velocity_len * 0.9 > playing_min_vel {
+            // Scene-driven animations handle their own motion semantics; don't cancel on move.
+            let velocity_cancels =
+                scene_anim.is_none() && active_emote.source != ActiveEmoteSource::SceneMovementAnim;
+            if velocity_cancels && damped_velocity_len * 0.9 > playing_min_vel {
                 // stop emotes on move
                 debug!(
                     "clear on motion {} > {}",
@@ -380,7 +426,36 @@ fn animate(
                 urn: requested_emote,
                 restart: emote_changed,
                 repeat: request_loop,
+                source: ActiveEmoteSource::TriggeredEmote,
                 ..Default::default()
+            }
+        } else if let Some(scene_anim_req) = scene_anim.and_then(|req| {
+            let urn_str = format!(
+                "urn:decentraland:off-chain:scene-emote:{}-{}-false",
+                req.scene_hash, req.content_hash
+            );
+            EmoteUrn::new(urn_str.as_str()).ok().map(|urn| (req, urn))
+        }) {
+            let (req, urn) = scene_anim_req;
+            dynamic_state.move_kind = if req.idle {
+                MoveKind::Idle
+            } else {
+                MoveKind::Walk
+            };
+            let is_new_anim = active_emote.source != ActiveEmoteSource::SceneMovementAnim
+                || active_emote.scene_anim_src.as_deref() != Some(req.src.as_str());
+            ActiveEmote {
+                urn,
+                speed: req.speed,
+                restart: is_new_anim,
+                repeat: req.r#loop,
+                finished: false,
+                transition_seconds: req.transition_seconds,
+                initial_audio_mark: None,
+                overridable: req.idle,
+                pending_seek: req.seek,
+                source: ActiveEmoteSource::SceneMovementAnim,
+                scene_anim_src: Some(req.src.clone()),
             }
         } else {
             // otherwise play a default emote based on motion
@@ -479,7 +554,13 @@ impl SpawnedExtras {
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn play_current_emote(
     mut commands: Commands,
-    mut q: Query<(Entity, &mut ActiveEmote, &AvatarAnimPlayer, &Children)>,
+    mut q: Query<(
+        Entity,
+        &mut ActiveEmote,
+        &AvatarAnimPlayer,
+        &Children,
+        Option<&PrimaryUser>,
+    )>,
     definitions: Query<&AvatarDefinition>,
     mut emote_loader: CollectibleManager<Emote>,
     mut gltfs: ResMut<Assets<Gltf>>,
@@ -501,11 +582,15 @@ fn play_current_emote(
     ),
     mut emitters: Query<&mut AudioEmitter>,
     prop_details: Query<(Option<&Name>, &Transform, &ChildOf)>,
+    (mut feedback, mut frozen_feedback): (
+        ResMut<SceneDrivenAnimationFeedback>,
+        Local<Option<SceneDrivenAnimationFeedbackState>>,
+    ),
 ) {
     let prior_playing = std::mem::take(&mut *playing);
     let mut prev_spawned_extras = std::mem::take(&mut *spawned_extras);
 
-    for (entity, mut active_emote, target_entity, children) in q.iter_mut() {
+    for (entity, mut active_emote, target_entity, children, maybe_primary) in q.iter_mut() {
         debug!("emote {}", active_emote.urn);
         let Some(definition) = children.iter().flat_map(|c| definitions.get(c).ok()).next() else {
             warn!("no definition");
@@ -534,15 +619,25 @@ fn play_current_emote(
 
         if let Some(scene_emote) = active_emote.urn.scene_emote() {
             debug!("got {scene_emote:?}");
-            let mut split = scene_emote.split('-');
-            let maybe_hash = if split.next() == Some("b64") {
-                // stupid to have "-" as a separator and also part of the hash itself for local hashes
-                let parts = split.skip(1).take(2).collect::<Vec<_>>();
-                (parts.len() == 2).then_some(parts.join("-"))
-            } else {
-                split.next().map(ToOwned::to_owned)
+            let mut split = scene_emote.split('-').peekable();
+            // take_hash reads a hash, recombining "b64-<payload>" back into one
+            // token because we used '-' as the separator and b64 hashes also
+            // contain '-'. for non-b64 hashes it just takes the next token.
+            let take_hash = |split: &mut std::iter::Peekable<std::str::Split<'_, char>>| {
+                let first = split.next()?;
+                if first == "b64" {
+                    let tail = split.next()?;
+                    Some(format!("b64-{tail}"))
+                } else {
+                    Some(first.to_owned())
+                }
             };
-            let Some(hash) = maybe_hash.as_ref() else {
+            let Some(scene_hash) = take_hash(&mut split) else {
+                debug!("failed to split scene emote {scene_emote:?}");
+                active_emote.finished = true;
+                continue;
+            };
+            let Some(hash) = take_hash(&mut split) else {
                 debug!("failed to split scene emote {scene_emote:?}");
                 active_emote.finished = true;
                 continue;
@@ -552,8 +647,10 @@ fn play_current_emote(
                 .get_representation(&active_emote.urn, bodyshape.as_str())
                 .is_err()
             {
-                // load the gltf
-                let handle = ipfas.load_hash::<Gltf>(hash);
+                // load the gltf through the scene's modifier context so b64
+                // hashes (local preview / portable) resolve to the scene's
+                // origin rather than the realm content URL.
+                let handle = ipfas.load_scene_content_hash::<Gltf>(&scene_hash, &hash);
                 let gltf = match gltfs.get_mut(handle.id()) {
                     Some(gltf) => {
                         cached_gltf_handles.remove(&handle);
@@ -772,7 +869,8 @@ fn play_current_emote(
         let play = |transitions: Option<Mut<AnimationTransitions>>,
                     player: &mut AnimationPlayer,
                     clip_ix: AnimationNodeIndex,
-                    active_emote: &ActiveEmote|
+                    active_emote: &ActiveEmote,
+                    pending_seek: Option<f32>|
          -> f32 {
             let active_animation =
                 if Some(&active_emote.urn) != prior_playing.get(&ent) || active_emote.restart {
@@ -803,6 +901,11 @@ fn play_current_emote(
 
                 // println!("active weight {}", active_animation.weight());
                 active_animation.set_speed(active_emote.speed);
+
+                if let Some(seek) = pending_seek {
+                    active_animation.seek_to(seek.clamp(0.0, clip_duration));
+                    active_animation.replay();
+                }
 
                 // nasty hack for falling animation
                 if active_emote.urn.as_str() == "urn:decentraland:off-chain:base-emotes:jump"
@@ -843,7 +946,14 @@ fn play_current_emote(
                 (graph.add_clip(clip, 1.0, graph.root), 0.0)
             });
 
-        let elapsed = play(transitions, &mut player, *clip_ix, &active_emote);
+        let pending_seek = active_emote.pending_seek.take();
+        let elapsed = play(
+            transitions,
+            &mut player,
+            *clip_ix,
+            &active_emote,
+            pending_seek,
+        );
         // reset audio mark if we've rewound (jump hacks again)
         if let Some(mark) = spawned_extras
             .get_mut(&entity)
@@ -862,7 +972,43 @@ fn play_current_emote(
         if let Some((prop_player_ents, clip_ix)) = prop_player_and_clip {
             for ent in prop_player_ents {
                 if let Ok((mut player, transitions, _, _)) = players.get_mut(ent) {
-                    play(transitions, &mut player, clip_ix, &active_emote);
+                    play(transitions, &mut player, clip_ix, &active_emote, None);
+                }
+            }
+        }
+
+        if maybe_primary.is_some() {
+            match active_emote.source {
+                ActiveEmoteSource::SceneMovementAnim => {
+                    let loops = elapsed / clip_duration;
+                    let playback_time = if active_emote.repeat && clip_duration > 0.0 {
+                        elapsed - loops.floor() * clip_duration
+                    } else {
+                        elapsed.min(clip_duration)
+                    };
+                    let loop_count = if clip_duration > 0.0 {
+                        loops.floor().max(0.0) as u32
+                    } else {
+                        0
+                    };
+                    let state = SceneDrivenAnimationFeedbackState {
+                        src: active_emote.scene_anim_src.clone().unwrap_or_default(),
+                        r#loop: active_emote.repeat,
+                        speed: active_emote.speed,
+                        idle: active_emote.overridable,
+                        playback_time,
+                        duration: clip_duration,
+                        loop_count,
+                    };
+                    *frozen_feedback = Some(state.clone());
+                    feedback.state = Some(state);
+                }
+                ActiveEmoteSource::TriggeredEmote => {
+                    feedback.state = frozen_feedback.clone();
+                }
+                ActiveEmoteSource::VelocitySelected => {
+                    *frozen_feedback = None;
+                    feedback.state = None;
                 }
             }
         }

--- a/crates/avatar/src/foreign_dynamics.rs
+++ b/crates/avatar/src/foreign_dynamics.rs
@@ -94,6 +94,15 @@ fn update_foreign_user_target_position(
                     let update_freq = LAG_DECAY_SECS
                         / ((LAG_DECAY_SECS - delta).max(0.0) / pos.update_freq
                             + (LAG_DECAY_SECS / delta).min(1.0));
+                    // Apply-before-overwrite: if the previous event's scene_anim never
+                    // reached its deadline, push it now so bursts of events (stalls,
+                    // multi-event frames) don't silently drop one-shot seeks or
+                    // intermediate transitions.
+                    if !pos.anim_applied {
+                        commands.entity(ev.player).try_insert(SceneDrivenAnim {
+                            active: pos.scene_anim.clone(),
+                        });
+                    }
                     *pos = PlayerTargetPosition {
                         time: ev.time,
                         timestamp: ev.timestamp,

--- a/crates/avatar/src/foreign_dynamics.rs
+++ b/crates/avatar/src/foreign_dynamics.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
 
-use common::{structs::AvatarDynamicState, util::QuatNormalizeExt};
+use common::{
+    structs::{AvatarDynamicState, SceneDrivenAnim, SceneDrivenAnimationRequest},
+    util::QuatNormalizeExt,
+};
 
 use comms::{
     global_crdt::{ForeignPlayer, PlayerPositionEvent},
@@ -35,6 +38,12 @@ struct PlayerTargetPosition {
     update_freq: f32,
     grounded: Option<bool>,
     jumping: Option<bool>,
+    // Scene-driven animation state carried with this target. Applied to
+    // `SceneDrivenAnim` at `anim_apply_at` so it lines up with the interpolated
+    // position, then `anim_applied` blocks re-application until the next packet.
+    scene_anim: Option<SceneDrivenAnimationRequest>,
+    anim_apply_at: f32,
+    anim_applied: bool,
 }
 
 fn update_foreign_user_target_position(
@@ -95,6 +104,9 @@ fn update_foreign_user_target_position(
                         update_freq,
                         grounded: ev.grounded,
                         jumping: ev.jumping,
+                        scene_anim: ev.scene_anim.clone(),
+                        anim_apply_at: ev.time + update_freq,
+                        anim_applied: false,
                     }
                 }
             } else {
@@ -109,6 +121,9 @@ fn update_foreign_user_target_position(
                         update_freq: 0.01,
                         grounded: ev.grounded,
                         jumping: ev.jumping,
+                        scene_anim: ev.scene_anim.clone(),
+                        anim_apply_at: ev.time + 0.01,
+                        anim_applied: false,
                     },
                     AvatarDynamicState::default(),
                 ));
@@ -118,9 +133,10 @@ fn update_foreign_user_target_position(
 }
 
 fn update_foreign_user_actual_position(
+    mut commands: Commands,
     mut avatars: Query<(
         Entity,
-        &PlayerTargetPosition,
+        &mut PlayerTargetPosition,
         &mut Transform,
         &mut AvatarDynamicState,
     )>,
@@ -128,7 +144,7 @@ fn update_foreign_user_actual_position(
     containing_scene: ContainingScene,
     time: Res<Time>,
 ) {
-    for (foreign_ent, target, mut actual, mut dynamic_state) in avatars.iter_mut() {
+    for (foreign_ent, mut target, mut actual, mut dynamic_state) in avatars.iter_mut() {
         debug!(
             "positioning foreign {foreign_ent:?}, target {}, current {}",
             target.translation, actual.translation
@@ -231,6 +247,18 @@ fn update_foreign_user_actual_position(
                 dynamic_state.ground_height += updated_y - actual.translation.y;
                 actual.translation.y = updated_y;
             }
+        }
+
+        // Push the scene-driven animation state once the interpolation has had
+        // time to line up with this target. Ensures jump/walk/etc. transitions
+        // fire when the avatar visibly does the motion, not when the packet
+        // lands. `anim_apply_at` was set to `ev.time + update_freq` so it
+        // tracks the same catch-up window as the position blend.
+        if !target.anim_applied && time.elapsed_secs() >= target.anim_apply_at {
+            commands.entity(foreign_ent).try_insert(SceneDrivenAnim {
+                active: target.scene_anim.clone(),
+            });
+            target.anim_applied = true;
         }
     }
 }

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -246,8 +246,13 @@ pub struct SceneDrivenAnimationRequest {
     // scene. Empty for remote requests received over the network.
     pub src: String,
     // Pre-built scene-emote URN encoding scene_hash + content_hash. For local requests
-    // this is constructed by user_input; for remote requests it arrives on the wire.
+    // this is constructed by user_input; for remote requests it's reassembled from the
+    // hash pair received on the wire.
     pub urn: String,
+    // The two hashes that compose the URN. Kept alongside `urn` so the broadcaster can
+    // ship them to remotes without repeating the fixed URN preamble on every packet.
+    pub scene_hash: String,
+    pub content_hash: String,
     pub r#loop: bool,
     pub speed: f32,
     pub idle: bool,

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -230,6 +230,46 @@ pub struct EmoteCommand {
     pub r#loop: bool,
 }
 
+// Current scene-driven movement animation request for the primary player.
+// Written by the bridge system in `user_input` (after resolving the scene-relative
+// path against the active scene's content map) and read by `animate` in the avatar crate.
+#[derive(Resource, Default)]
+pub struct SceneDrivenAnimation {
+    pub active: Option<SceneDrivenAnimationRequest>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SceneDrivenAnimationRequest {
+    pub src: String,
+    pub scene_hash: String,
+    pub content_hash: String,
+    pub r#loop: bool,
+    pub speed: f32,
+    pub idle: bool,
+    pub transition_seconds: f32,
+    pub seek: Option<f32>,
+}
+
+// Current scene-driven animation playback state, written by `play_current_emote` in
+// the avatar crate and mirrored into `AvatarMovementInfo.active_animation_state` by
+// `broadcast_movement_info` in `user_input`.
+// `playback_time` freezes while a triggerSceneEmote overrides the animation.
+#[derive(Resource, Default)]
+pub struct SceneDrivenAnimationFeedback {
+    pub state: Option<SceneDrivenAnimationFeedbackState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SceneDrivenAnimationFeedbackState {
+    pub src: String,
+    pub r#loop: bool,
+    pub speed: f32,
+    pub idle: bool,
+    pub playback_time: f32,
+    pub duration: f32,
+    pub loop_count: u32,
+}
+
 // main camera entity
 #[derive(Component)]
 pub struct PrimaryCamera {

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -258,6 +258,11 @@ pub struct SceneDrivenAnimationRequest {
     pub idle: bool,
     pub transition_seconds: f32,
     pub seek: Option<f32>,
+    // Scene-requested avatar-bus sound clips to play this update. Each entry is the
+    // content_hash of a file hosted in the same scene as the animation. The consumer
+    // dedups per-avatar so leaving identical entries across consecutive updates doesn't
+    // re-fire; the scene clears the list on frames it doesn't want sound.
+    pub sounds: Vec<String>,
 }
 
 // Current scene-driven animation playback state, written by `play_current_emote` in

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -230,19 +230,24 @@ pub struct EmoteCommand {
     pub r#loop: bool,
 }
 
-// Current scene-driven movement animation request for the primary player.
-// Written by the bridge system in `user_input` (after resolving the scene-relative
-// path against the active scene's content map) and read by `animate` in the avatar crate.
-#[derive(Resource, Default)]
-pub struct SceneDrivenAnimation {
+// Current scene-driven movement animation request for a player avatar. For the
+// primary player, written by the bridge system in `user_input` (after resolving
+// the scene-relative path against the active scene's content map). For foreign
+// players, written by the comms crate when a Movement packet with anim fields
+// arrives. Read by `animate` in the avatar crate uniformly for both.
+#[derive(Component, Default, Clone, Debug)]
+pub struct SceneDrivenAnim {
     pub active: Option<SceneDrivenAnimationRequest>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SceneDrivenAnimationRequest {
+    // scene-relative path (e.g. "assets/walk.glb") — used for feedback to the controlling
+    // scene. Empty for remote requests received over the network.
     pub src: String,
-    pub scene_hash: String,
-    pub content_hash: String,
+    // Pre-built scene-emote URN encoding scene_hash + content_hash. For local requests
+    // this is constructed by user_input; for remote requests it arrives on the wire.
+    pub urn: String,
     pub r#loop: bool,
     pub speed: f32,
     pub idle: bool,

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -2,7 +2,7 @@ use std::f32::consts::TAU;
 
 use bevy::prelude::*;
 
-use common::structs::{AvatarDynamicState, MoveKind, PrimaryUser};
+use common::structs::{AvatarDynamicState, MoveKind, PrimaryUser, SceneDrivenAnim};
 use dcl_component::{
     proto_components::kernel::comms::rfc4,
     transform_and_parent::{DclQuat, DclTranslation},
@@ -26,22 +26,54 @@ impl Plugin for BroadcastPositionPlugin {
 
 const STATIC_FREQ: f64 = 1.0;
 const DYNAMIC_FREQ: f64 = 0.1;
+// Re-send anim_urn at least this often so late joiners pick up the active clip.
+const ANIM_URN_KEEPALIVE: f64 = 1.0;
 
+#[derive(Default)]
+struct LastAnim {
+    urn: Option<String>,
+    sent_at: f64,
+    // Latched seek from the scene. The scene publishes `seek` for a single frame;
+    // we hold it here until a broadcast goes out so we don't miss it between the
+    // 10Hz dynamic / 1Hz static broadcast intervals.
+    pending_seek: Option<f32>,
+}
+
+#[allow(clippy::too_many_arguments)]
 fn broadcast_position(
-    player: Query<(&GlobalTransform, &AvatarDynamicState), With<PrimaryUser>>,
+    player: Query<
+        (
+            &GlobalTransform,
+            &AvatarDynamicState,
+            Option<&SceneDrivenAnim>,
+        ),
+        With<PrimaryUser>,
+    >,
     transports: Query<&Transport>,
     mut last_position: Local<(Vec3, Quat, Vec3)>,
     mut last_sent: Local<f64>,
     mut last_index: Local<u32>,
+    mut last_anim: Local<LastAnim>,
     time: Res<Time>,
     global_crdt: Res<GlobalCrdtState>,
 ) {
-    let Ok((player, dynamics)) = player.single() else {
+    let Ok((player, dynamics, scene_anim)) = player.single() else {
         return;
     };
     let time = time.elapsed_secs_f64();
+
+    // Latch any single-frame seek from the scene so we still send it even if the
+    // broadcast cadence skipped the frame it was published on.
+    if let Some(seek) = scene_anim
+        .and_then(|s| s.active.as_ref())
+        .and_then(|a| a.seek)
+    {
+        last_anim.pending_seek = Some(seek);
+    }
+
     let elapsed = time - *last_sent;
-    if elapsed < DYNAMIC_FREQ {
+    // A pending seek bypasses the dynamic-rate gate so remotes receive it promptly.
+    if elapsed < DYNAMIC_FREQ && last_anim.pending_seek.is_none() {
         return;
     }
 
@@ -50,6 +82,7 @@ fn broadcast_position(
         && (translation - last_position.0).length_squared() < 0.01
         && rotation == last_position.1
         && (dynamics.velocity - last_position.2).length_squared() < 0.01
+        && last_anim.pending_seek.is_none()
     {
         return;
     }
@@ -106,6 +139,36 @@ fn broadcast_position(
 
     let movement_compressed = crate::movement_compressed::MovementCompressed { temporal, movement };
 
+    // Scene-driven animation fields. `anim_urn` is sent on transition (new clip,
+    // or clearing with empty string to signal stop) and re-sent every
+    // ANIM_URN_KEEPALIVE seconds while active so late joiners pick it up. The
+    // other fields ride along whenever an animation is active.
+    // `anim_playback_time` is only sent when the scene explicitly requested a
+    // seek this frame.
+    let active_anim = scene_anim.and_then(|s| s.active.as_ref());
+    let current_urn = active_anim.map(|a| a.urn.clone());
+    let urn_changed = current_urn != last_anim.urn;
+    let keepalive_due = active_anim.is_some() && time - last_anim.sent_at >= ANIM_URN_KEEPALIVE;
+    let anim_urn = if urn_changed {
+        // Send current URN (or empty string to clear a prior active anim).
+        Some(current_urn.clone().unwrap_or_default())
+    } else if keepalive_due {
+        current_urn.clone()
+    } else {
+        None
+    };
+    if anim_urn.is_some() {
+        last_anim.sent_at = time;
+    }
+    last_anim.urn = current_urn;
+
+    let anim_speed = active_anim.map(|a| a.speed);
+    let anim_transition_seconds = active_anim.map(|a| a.transition_seconds);
+    let anim_loop = active_anim.map(|a| a.r#loop);
+    // The latch above already mirrors the freshest `seek` seen since the last
+    // broadcast. Only send if there's an active anim to apply it to.
+    let anim_playback_time = active_anim.and(last_anim.pending_seek.take());
+
     let movement_uncompressed = dcl_component::proto_components::kernel::comms::rfc4::Movement {
         timestamp: time as f32,
         position_x: dcl_position.0[0],
@@ -124,6 +187,11 @@ fn broadcast_position(
         is_falling: movement_compressed.temporal.falling(),
         is_stunned: movement_compressed.temporal.stunned(),
         is_emoting: dynamics.move_kind == MoveKind::Emote,
+        anim_urn,
+        anim_speed,
+        anim_playback_time,
+        anim_transition_seconds,
+        anim_loop,
     };
 
     // let movement_packet = rfc4::MovementCompressed {

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -78,11 +78,19 @@ fn broadcast_position(
     }
 
     let (_, rotation, translation) = player.to_scale_rotation_translation();
+    // A URN change (e.g. jump → idle on landing) must go out promptly: when the
+    // player comes to rest, velocity/position stop changing, and without this
+    // bypass the transition would wait on the STATIC_FREQ keepalive.
+    let current_urn = scene_anim
+        .and_then(|s| s.active.as_ref())
+        .map(|a| a.urn.clone());
+    let urn_changed = current_urn != last_anim.urn;
     if elapsed < STATIC_FREQ
         && (translation - last_position.0).length_squared() < 0.01
         && rotation == last_position.1
         && (dynamics.velocity - last_position.2).length_squared() < 0.01
         && last_anim.pending_seek.is_none()
+        && !urn_changed
     {
         return;
     }
@@ -146,8 +154,6 @@ fn broadcast_position(
     // `anim_playback_time` is only sent when the scene explicitly requested a
     // seek this frame.
     let active_anim = scene_anim.and_then(|s| s.active.as_ref());
-    let current_urn = active_anim.map(|a| a.urn.clone());
-    let urn_changed = current_urn != last_anim.urn;
     let keepalive_due = active_anim.is_some() && time - last_anim.sent_at >= ANIM_URN_KEEPALIVE;
     let anim_urn = if urn_changed {
         // Send current URN (or empty string to clear a prior active anim).

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -39,6 +39,13 @@ struct LastAnim {
     // we hold it here until a broadcast goes out so we don't miss it between the
     // 10Hz dynamic / 1Hz static broadcast intervals.
     pending_seek: Option<f32>,
+    // Latched sound content hashes from the scene. Accumulated across frames so
+    // single-frame sound triggers still make it out on the next broadcast; drained
+    // on send.
+    pending_sounds: Vec<String>,
+    // Previous frame's sound list, used to avoid re-latching the same list multiple
+    // times when the scene holds it across frames between broadcasts.
+    last_seen_sounds: Vec<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -71,6 +78,20 @@ fn broadcast_position(
         .and_then(|a| a.seek)
     {
         last_anim.pending_seek = Some(seek);
+    }
+
+    // Latch new sound triggers from the scene. Scene owns the lifecycle: a new list
+    // (including a one-frame write that clears next frame) gets accumulated once per
+    // transition. Holding the same list across frames doesn't re-latch.
+    let current_sounds: &[String] = scene_anim
+        .and_then(|s| s.active.as_ref())
+        .map(|a| a.sounds.as_slice())
+        .unwrap_or(&[]);
+    if current_sounds != last_anim.last_seen_sounds.as_slice() {
+        last_anim
+            .pending_sounds
+            .extend(current_sounds.iter().cloned());
+        last_anim.last_seen_sounds = current_sounds.to_vec();
     }
 
     let elapsed = time - *last_sent;
@@ -181,6 +202,14 @@ fn broadcast_position(
     // The latch above already mirrors the freshest `seek` seen since the last
     // broadcast. Only send if there's an active anim to apply it to.
     let anim_playback_time = active_anim.and(last_anim.pending_seek.take());
+    // Drain pending sounds on every broadcast. Sounds depend on `anim_scene_hash`
+    // to identify their host scene, so only ship them while an anim is active.
+    let anim_sound_content_hashes = if active_anim.is_some() {
+        std::mem::take(&mut last_anim.pending_sounds)
+    } else {
+        last_anim.pending_sounds.clear();
+        Vec::new()
+    };
 
     let movement_uncompressed = dcl_component::proto_components::kernel::comms::rfc4::Movement {
         timestamp: time as f32,
@@ -206,6 +235,7 @@ fn broadcast_position(
         anim_playback_time,
         anim_transition_seconds,
         anim_loop,
+        anim_sound_content_hashes,
     };
 
     // let movement_packet = rfc4::MovementCompressed {

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -26,12 +26,14 @@ impl Plugin for BroadcastPositionPlugin {
 
 const STATIC_FREQ: f64 = 1.0;
 const DYNAMIC_FREQ: f64 = 0.1;
-// Re-send anim_urn at least this often so late joiners pick up the active clip.
+// Re-send the anim hash pair at least this often so late joiners pick up the active clip.
 const ANIM_URN_KEEPALIVE: f64 = 1.0;
 
 #[derive(Default)]
 struct LastAnim {
-    urn: Option<String>,
+    // The (scene_hash, content_hash) pair we last broadcast. Tracked as one unit so we
+    // can detect transitions between clips and drive keepalives.
+    hashes: Option<(String, String)>,
     sent_at: f64,
     // Latched seek from the scene. The scene publishes `seek` for a single frame;
     // we hold it here until a broadcast goes out so we don't miss it between the
@@ -78,19 +80,19 @@ fn broadcast_position(
     }
 
     let (_, rotation, translation) = player.to_scale_rotation_translation();
-    // A URN change (e.g. jump → idle on landing) must go out promptly: when the
+    // An anim change (e.g. jump → idle on landing) must go out promptly: when the
     // player comes to rest, velocity/position stop changing, and without this
     // bypass the transition would wait on the STATIC_FREQ keepalive.
-    let current_urn = scene_anim
+    let current_hashes = scene_anim
         .and_then(|s| s.active.as_ref())
-        .map(|a| a.urn.clone());
-    let urn_changed = current_urn != last_anim.urn;
+        .map(|a| (a.scene_hash.clone(), a.content_hash.clone()));
+    let anim_changed = current_hashes != last_anim.hashes;
     if elapsed < STATIC_FREQ
         && (translation - last_position.0).length_squared() < 0.01
         && rotation == last_position.1
         && (dynamics.velocity - last_position.2).length_squared() < 0.01
         && last_anim.pending_seek.is_none()
-        && !urn_changed
+        && !anim_changed
     {
         return;
     }
@@ -147,26 +149,31 @@ fn broadcast_position(
 
     let movement_compressed = crate::movement_compressed::MovementCompressed { temporal, movement };
 
-    // Scene-driven animation fields. `anim_urn` is sent on transition (new clip,
-    // or clearing with empty string to signal stop) and re-sent every
-    // ANIM_URN_KEEPALIVE seconds while active so late joiners pick it up. The
-    // other fields ride along whenever an animation is active.
-    // `anim_playback_time` is only sent when the scene explicitly requested a
-    // seek this frame.
+    // Scene-driven animation fields. The hash pair is sent on transition (new clip, or
+    // an empty `anim_scene_hash` to clear a prior active anim) and re-sent every
+    // ANIM_URN_KEEPALIVE seconds while active so late joiners pick it up. The other
+    // fields ride along whenever an animation is active. `anim_playback_time` is only
+    // sent when the scene explicitly requested a seek this frame.
     let active_anim = scene_anim.and_then(|s| s.active.as_ref());
     let keepalive_due = active_anim.is_some() && time - last_anim.sent_at >= ANIM_URN_KEEPALIVE;
-    let anim_urn = if urn_changed {
-        // Send current URN (or empty string to clear a prior active anim).
-        Some(current_urn.clone().unwrap_or_default())
+    let (anim_scene_hash, anim_content_hash) = if anim_changed {
+        match &current_hashes {
+            Some((s, c)) => (Some(s.clone()), Some(c.clone())),
+            // Transition active → none: signal clear with an empty scene_hash.
+            None => (Some(String::new()), None),
+        }
     } else if keepalive_due {
-        current_urn.clone()
+        current_hashes
+            .as_ref()
+            .map(|(s, c)| (Some(s.clone()), Some(c.clone())))
+            .unwrap_or((None, None))
     } else {
-        None
+        (None, None)
     };
-    if anim_urn.is_some() {
+    if anim_scene_hash.is_some() {
         last_anim.sent_at = time;
     }
-    last_anim.urn = current_urn;
+    last_anim.hashes = current_hashes;
 
     let anim_speed = active_anim.map(|a| a.speed);
     let anim_transition_seconds = active_anim.map(|a| a.transition_seconds);
@@ -193,7 +200,8 @@ fn broadcast_position(
         is_falling: movement_compressed.temporal.falling(),
         is_stunned: movement_compressed.temporal.stunned(),
         is_emoting: dynamics.move_kind == MoveKind::Emote,
-        anim_urn,
+        anim_scene_hash,
+        anim_content_hash,
         anim_speed,
         anim_playback_time,
         anim_transition_seconds,

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -353,7 +353,7 @@ pub fn process_transport_updates(
     mut subscribers: EventReader<RpcCall>,
     mut profile_meta_cache: ResMut<ProfileMetaCache>,
     mut duplicate_chat_filter: Local<HashMap<Entity, f64>>,
-    mut last_remote_anim_urn: Local<HashMap<Entity, String>>,
+    mut last_remote_anim_urn: Local<HashMap<Entity, (String, String)>>,
 ) {
     // gather any event receivers
     for ev in subscribers.read() {
@@ -581,7 +581,8 @@ pub fn process_transport_updates(
                         let scene_anim = resolve_remote_anim(
                             entity,
                             &mut last_remote_anim_urn,
-                            m.anim_urn,
+                            m.anim_scene_hash,
+                            m.anim_content_hash,
                             m.anim_speed,
                             m.anim_playback_time,
                             m.anim_transition_seconds,
@@ -606,7 +607,8 @@ pub fn process_transport_updates(
                         let scene_anim = resolve_remote_anim(
                             entity,
                             &mut last_remote_anim_urn,
-                            m.anim_urn.clone(),
+                            m.anim_scene_hash.clone(),
+                            m.anim_content_hash.clone(),
                             m.anim_speed,
                             m.anim_playback_time,
                             m.anim_transition_seconds,
@@ -691,40 +693,49 @@ pub fn process_transport_updates(
 }
 
 // Resolves scene-driven animation fields from a Movement / MovementCompressed
-// packet into the full state. An empty `anim_urn` clears the state; an absent
-// `anim_urn` (None) reuses the last cached URN for this entity so we keep
+// packet into the full state. An empty `anim_scene_hash` clears the state; absent
+// hash fields (None) reuse the last cached pair for this entity so we keep
 // animating between keepalives. Returns `None` when the sender has no active
 // scene-driven animation. The resolved state rides on `PlayerPositionEvent` so
 // `foreign_dynamics` can apply it with the same interpolation delay as the
 // visible position.
+#[allow(clippy::too_many_arguments)]
 fn resolve_remote_anim(
     entity: Entity,
-    last_urn: &mut HashMap<Entity, String>,
-    anim_urn: Option<String>,
+    last_hashes: &mut HashMap<Entity, (String, String)>,
+    anim_scene_hash: Option<String>,
+    anim_content_hash: Option<String>,
     anim_speed: Option<f32>,
     anim_playback_time: Option<f32>,
     anim_transition_seconds: Option<f32>,
     anim_loop: Option<bool>,
 ) -> Option<SceneDrivenAnimationRequest> {
-    let effective_urn = match anim_urn {
-        Some(u) if u.is_empty() => {
-            last_urn.remove(&entity);
+    // Wire convention: on transition the sender ships both hashes (or an empty
+    // scene_hash to clear); between transitions both are omitted and we re-apply the
+    // cached pair so ride-along fields (speed, loop, seek) keep updating.
+    let (scene_hash, content_hash) = match anim_scene_hash {
+        Some(s) if s.is_empty() => {
+            last_hashes.remove(&entity);
             return None;
         }
-        Some(u) => {
-            last_urn.insert(entity, u.clone());
-            u
+        Some(s) => {
+            let c = anim_content_hash?;
+            last_hashes.insert(entity, (s.clone(), c.clone()));
+            (s, c)
         }
-        None => last_urn.get(&entity)?.clone(),
+        None => last_hashes.get(&entity)?.clone(),
     };
 
     let speed = anim_speed?;
     let r#loop = anim_loop.unwrap_or(false);
     let transition_seconds = anim_transition_seconds.unwrap_or(0.2);
+    let urn = format!("urn:decentraland:off-chain:scene-emote:{scene_hash}-{content_hash}-false");
 
     Some(SceneDrivenAnimationRequest {
         src: String::new(),
-        urn: effective_urn,
+        urn,
+        scene_hash,
+        content_hash,
         r#loop,
         speed,
         // `idle` is only consulted for primary-player overridability; for remote

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -587,6 +587,7 @@ pub fn process_transport_updates(
                             m.anim_playback_time,
                             m.anim_transition_seconds,
                             m.anim_loop,
+                            m.anim_sound_content_hashes,
                         );
                         position_events.write(PlayerPositionEvent {
                             index: None,
@@ -613,6 +614,7 @@ pub fn process_transport_updates(
                             m.anim_playback_time,
                             m.anim_transition_seconds,
                             m.anim_loop,
+                            m.anim_sound_content_hashes.clone(),
                         );
                         let movement = MovementCompressed::from_proto(m);
                         let pos = movement.position(state.realm_bounds.0, state.realm_bounds.1);
@@ -709,6 +711,7 @@ fn resolve_remote_anim(
     anim_playback_time: Option<f32>,
     anim_transition_seconds: Option<f32>,
     anim_loop: Option<bool>,
+    anim_sound_content_hashes: Vec<String>,
 ) -> Option<SceneDrivenAnimationRequest> {
     // Wire convention: on transition the sender ships both hashes (or an empty
     // scene_hash to clear); between transitions both are omitted and we re-apply the
@@ -743,6 +746,7 @@ fn resolve_remote_anim(
         idle: false,
         transition_seconds,
         seek: anim_playback_time,
+        sounds: anim_sound_content_hashes,
     })
 }
 

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -9,7 +9,9 @@ use bevy::{
 use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender, RpcStreamSender},
-    structs::{AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate},
+    structs::{
+        AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, SceneDrivenAnimationRequest,
+    },
 };
 use ethers_core::types::Address;
 use serde::{Deserialize, Serialize};
@@ -309,6 +311,12 @@ pub struct PlayerPositionEvent {
     pub velocity: Option<Vec3>,
     pub grounded: Option<bool>,
     pub jumping: Option<bool>,
+    /// Resolved scene-driven animation state carried alongside this position packet.
+    /// `None` means the sender is not running a scene-driven animation. `Some` is
+    /// the full state (after URN latching for keepalive resolution). Applied with
+    /// interpolation delay in `foreign_dynamics` so the animation lines up with
+    /// the visibly-interpolated position.
+    pub scene_anim: Option<SceneDrivenAnimationRequest>,
 }
 
 pub enum ProfileEventType {
@@ -345,6 +353,7 @@ pub fn process_transport_updates(
     mut subscribers: EventReader<RpcCall>,
     mut profile_meta_cache: ResMut<ProfileMetaCache>,
     mut duplicate_chat_filter: Local<HashMap<Entity, f64>>,
+    mut last_remote_anim_urn: Local<HashMap<Entity, String>>,
 ) {
     // gather any event receivers
     for ev in subscribers.read() {
@@ -507,6 +516,7 @@ pub fn process_transport_updates(
                             velocity: None,
                             grounded: None,
                             jumping: None,
+                            scene_anim: None,
                         });
                     }
                     PlayerMessage::PlayerData(Message::ProfileVersion(version)) => {
@@ -568,6 +578,15 @@ pub fn process_transport_updates(
                             scene_id,
                             &dcl_transform,
                         );
+                        let scene_anim = resolve_remote_anim(
+                            entity,
+                            &mut last_remote_anim_urn,
+                            m.anim_urn,
+                            m.anim_speed,
+                            m.anim_playback_time,
+                            m.anim_transition_seconds,
+                            m.anim_loop,
+                        );
                         position_events.write(PlayerPositionEvent {
                             index: None,
                             time: time.elapsed_secs(),
@@ -579,10 +598,20 @@ pub fn process_transport_updates(
                             grounded: Some(m.is_grounded),
                             // Some(true) if either is Some(true), else Some(false) if either is Some(false), else None
                             jumping: Some(m.is_jumping || m.is_long_jump),
+                            scene_anim,
                         });
                     }
                     PlayerMessage::PlayerData(Message::MovementCompressed(m)) => {
                         debug!("movement compressed data: {m:?}");
+                        let scene_anim = resolve_remote_anim(
+                            entity,
+                            &mut last_remote_anim_urn,
+                            m.anim_urn.clone(),
+                            m.anim_speed,
+                            m.anim_playback_time,
+                            m.anim_transition_seconds,
+                            m.anim_loop,
+                        );
                         let movement = MovementCompressed::from_proto(m);
                         let pos = movement.position(state.realm_bounds.0, state.realm_bounds.1);
                         let vel = movement.velocity();
@@ -617,6 +646,7 @@ pub fn process_transport_updates(
                                 .jump_or_err()
                                 .ok()
                                 .max(movement.temporal.long_jump_or_err().ok()),
+                            scene_anim,
                         });
                     }
                     PlayerMessage::PlayerData(Message::PlayerEmote(emote)) => {
@@ -658,6 +688,51 @@ pub fn process_transport_updates(
             }
         }
     }
+}
+
+// Resolves scene-driven animation fields from a Movement / MovementCompressed
+// packet into the full state. An empty `anim_urn` clears the state; an absent
+// `anim_urn` (None) reuses the last cached URN for this entity so we keep
+// animating between keepalives. Returns `None` when the sender has no active
+// scene-driven animation. The resolved state rides on `PlayerPositionEvent` so
+// `foreign_dynamics` can apply it with the same interpolation delay as the
+// visible position.
+fn resolve_remote_anim(
+    entity: Entity,
+    last_urn: &mut HashMap<Entity, String>,
+    anim_urn: Option<String>,
+    anim_speed: Option<f32>,
+    anim_playback_time: Option<f32>,
+    anim_transition_seconds: Option<f32>,
+    anim_loop: Option<bool>,
+) -> Option<SceneDrivenAnimationRequest> {
+    let effective_urn = match anim_urn {
+        Some(u) if u.is_empty() => {
+            last_urn.remove(&entity);
+            return None;
+        }
+        Some(u) => {
+            last_urn.insert(entity, u.clone());
+            u
+        }
+        None => last_urn.get(&entity)?.clone(),
+    };
+
+    let speed = anim_speed?;
+    let r#loop = anim_loop.unwrap_or(false);
+    let transition_seconds = anim_transition_seconds.unwrap_or(0.2);
+
+    Some(SceneDrivenAnimationRequest {
+        src: String::new(),
+        urn: effective_urn,
+        r#loop,
+        speed,
+        // `idle` is only consulted for primary-player overridability; for remote
+        // players there's no triggerSceneEmote interaction so we don't need it.
+        idle: false,
+        transition_seconds,
+        seek: anim_playback_time,
+    })
 }
 
 fn process_messagebus(

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -62,14 +62,18 @@ message Movement {
   bool is_emoting = 18;
 
   // Scene-driven movement animation (local extension, pending multi-clip-per-glb work).
-  // anim_urn is a scene-emote URN encoding scene_hash + content_hash; omitted when unchanged
-  // since the last send (receivers cache it) and forced every ~1s as a keepalive for joiners.
-  // The other fields are sent every frame the animation is active.
-  optional string anim_urn = 19;
+  // anim_scene_hash + anim_content_hash identify a scene-emote clip — the receiver wraps
+  // them as `urn:decentraland:off-chain:scene-emote:{scene}-{content}-false`. Sending the
+  // hashes directly keeps the fixed URN preamble off the wire. Both fields are omitted when
+  // unchanged since the last send (receivers cache them) and forced every ~1s as a
+  // keepalive for joiners. An empty anim_scene_hash clears a prior active anim. The other
+  // fields are sent every frame the animation is active.
+  optional string anim_scene_hash = 19;
   optional float anim_speed = 20;
   optional float anim_playback_time = 21;
   optional float anim_transition_seconds = 22;
   optional bool anim_loop = 23;
+  optional string anim_content_hash = 24;
 }
 
 message MovementCompressed {
@@ -78,11 +82,12 @@ message MovementCompressed {
 
   // See Movement.anim_* fields. Mirror here so the compressed variant can carry the same
   // scene-driven animation state if/when MovementCompressed is re-enabled on the sender.
-  optional string anim_urn = 3;
+  optional string anim_scene_hash = 3;
   optional float anim_speed = 4;
   optional float anim_playback_time = 5;
   optional float anim_transition_seconds = 6;
   optional bool anim_loop = 7;
+  optional string anim_content_hash = 8;
 }
 
 message PlayerEmote {

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -57,14 +57,32 @@ message Movement {
   bool is_falling = 14;
 
   bool is_stunned = 15;
-  
+
   float rotation_y = 16;
   bool is_emoting = 18;
+
+  // Scene-driven movement animation (local extension, pending multi-clip-per-glb work).
+  // anim_urn is a scene-emote URN encoding scene_hash + content_hash; omitted when unchanged
+  // since the last send (receivers cache it) and forced every ~1s as a keepalive for joiners.
+  // The other fields are sent every frame the animation is active.
+  optional string anim_urn = 19;
+  optional float anim_speed = 20;
+  optional float anim_playback_time = 21;
+  optional float anim_transition_seconds = 22;
+  optional bool anim_loop = 23;
 }
 
 message MovementCompressed {
-  int32 temporal_data = 1; // bit-compressed: timestamp + animations 
-  int64 movement_data = 2; // bit-compressed: position + velocity 
+  int32 temporal_data = 1; // bit-compressed: timestamp + animations
+  int64 movement_data = 2; // bit-compressed: position + velocity
+
+  // See Movement.anim_* fields. Mirror here so the compressed variant can carry the same
+  // scene-driven animation state if/when MovementCompressed is re-enabled on the sender.
+  optional string anim_urn = 3;
+  optional float anim_speed = 4;
+  optional float anim_playback_time = 5;
+  optional float anim_transition_seconds = 6;
+  optional bool anim_loop = 7;
 }
 
 message PlayerEmote {

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -74,6 +74,12 @@ message Movement {
   optional float anim_transition_seconds = 22;
   optional bool anim_loop = 23;
   optional string anim_content_hash = 24;
+
+  // Scene-requested avatar-bus sound triggers that accumulated since the last broadcast.
+  // Each entry is the content_hash of an audio clip hosted in the same scene as the active
+  // animation (so `anim_scene_hash` — latched or re-asserted via keepalive — identifies the
+  // scene). Receivers play each hash once on receipt. Fire-and-forget; no stop mechanism.
+  repeated string anim_sound_content_hashes = 25;
 }
 
 message MovementCompressed {
@@ -88,6 +94,7 @@ message MovementCompressed {
   optional float anim_transition_seconds = 6;
   optional bool anim_loop = 7;
   optional string anim_content_hash = 8;
+  repeated string anim_sound_content_hashes = 9;
 }
 
 message PlayerEmote {

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -68,18 +68,20 @@ message Movement {
   // unchanged since the last send (receivers cache them) and forced every ~1s as a
   // keepalive for joiners. An empty anim_scene_hash clears a prior active anim. The other
   // fields are sent every frame the animation is active.
-  optional string anim_scene_hash = 19;
-  optional float anim_speed = 20;
-  optional float anim_playback_time = 21;
-  optional float anim_transition_seconds = 22;
-  optional bool anim_loop = 23;
-  optional string anim_content_hash = 24;
+  // Tag numbers 19-28 are reserved upstream for head-sync / glide / jump_count / point-at,
+  // so these local extensions start at 29 to avoid wire collisions with upstream senders.
+  optional string anim_scene_hash = 29;
+  optional float anim_speed = 30;
+  optional float anim_playback_time = 31;
+  optional float anim_transition_seconds = 32;
+  optional bool anim_loop = 33;
+  optional string anim_content_hash = 34;
 
   // Scene-requested avatar-bus sound triggers that accumulated since the last broadcast.
   // Each entry is the content_hash of an audio clip hosted in the same scene as the active
   // animation (so `anim_scene_hash` — latched or re-asserted via keepalive — identifies the
   // scene). Receivers play each hash once on receipt. Fire-and-forget; no stop mechanism.
-  repeated string anim_sound_content_hashes = 25;
+  repeated string anim_sound_content_hashes = 35;
 }
 
 message MovementCompressed {
@@ -88,13 +90,15 @@ message MovementCompressed {
 
   // See Movement.anim_* fields. Mirror here so the compressed variant can carry the same
   // scene-driven animation state if/when MovementCompressed is re-enabled on the sender.
-  optional string anim_scene_hash = 3;
-  optional float anim_speed = 4;
-  optional float anim_playback_time = 5;
-  optional float anim_transition_seconds = 6;
-  optional bool anim_loop = 7;
-  optional string anim_content_hash = 8;
-  repeated string anim_sound_content_hashes = 9;
+  // Tags 3 and 4 are reserved upstream for head_sync_data / point_at_data, so local
+  // extensions start at 5.
+  optional string anim_scene_hash = 5;
+  optional float anim_speed = 6;
+  optional float anim_playback_time = 7;
+  optional float anim_transition_seconds = 8;
+  optional bool anim_loop = 9;
+  optional string anim_content_hash = 10;
+  repeated string anim_sound_content_hashes = 11;
 }
 
 message PlayerEmote {

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
@@ -25,6 +25,7 @@ message MovementAnimation {
   bool idle = 4;                                            // true: a triggerSceneEmote may take over; false: emotes are suppressed while this animation plays
   optional float transition_seconds = 5;                    // cross-fade duration when `src` changes; defaults to 0.2 when unset. Not applied to loop/speed/idle changes.
   optional float playback_time = 6;                         // if set, the engine seeks to this position (in seconds) this frame. Clear on subsequent frames to allow normal playback. The scene can read `AvatarAnimationState.playback_time` first to decide.
+  repeated string sounds = 7;                               // scene-relative paths to audio clips (.mp3/.ogg) to play this frame on the avatar audio bus. Fire-and-forget: each listed clip plays once per frame it appears; leaving a clip set for multiple frames re-triggers it. No stop mechanism. Use `AvatarAnimationState.playback_time` to trigger sounds at the right point in the clip (e.g. foot plants).
 }
 
 // engine behaviour (uses only capsule shapecasts and GJK closest point for portability):

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
@@ -9,38 +9,51 @@ option (common.ecs_component_id) = 1501;
 
 message PBAvatarMovement {
   decentraland.common.Vector3 velocity = 1;
-  float orientation = 2; // 0-360, we don't allow pitch/roll
+  float orientation = 2;                                    // 0-360, we don't allow pitch/roll
   optional decentraland.common.Vector3 ground_direction = 3;
-  optional bool walk_success = 4; // set for one frame when a walk_target ends: true = reached target, false = failed; absent = in progress or no walk
+  optional bool walk_success = 4;                           // set for one frame when a walk_target ends: true = reached target, false = failed; absent = in progress or no walk
+  optional MovementAnimation animation = 5;                 // if set, the engine plays this animation instead of selecting one from velocity heuristics
+}
+
+// Describes the animation the movement scene wants the avatar to play.
+// One GLB = one clip (following the scene-emote convention: single clip, or a clip named with `_Avatar` suffix).
+// When absent the engine falls back to its built-in velocity-based selection (walk/run/jump/idle).
+message MovementAnimation {
+  string src = 1;                                           // scene-relative path to the gltf/glb asset (resolved via the scene content map)
+  bool loop = 2;                                            // whether the clip repeats once it reaches the end
+  float speed = 3;                                          // playback speed multiplier (1.0 = clip's native rate)
+  bool idle = 4;                                            // true: a triggerSceneEmote may take over; false: emotes are suppressed while this animation plays
+  optional float transition_seconds = 5;                    // cross-fade duration when `src` changes; defaults to 0.2 when unset. Not applied to loop/speed/idle changes.
+  optional float playback_time = 6;                         // if set, the engine seeks to this position (in seconds) this frame. Clear on subsequent frames to allow normal playback. The scene can read `AvatarAnimationState.playback_time` first to decide.
 }
 
 // engine behaviour (uses only capsule shapecasts and GJK closest point for portability):
-// 1: set avatar orientation from movement info -> P0
-// 2: apply velocity (collide and slide)
-//   disable anything we are initially colliding with
-//   shapecast avatar from P3+N to p3+N+velocity*timestep
-//   on impact:
-//       project velocity onto slide plane (standard "Collide & Slide")
-//       velocity = old velocity - (normal * dot(velocity, normal))
-//       continue with residual velocity and residual time
-//    -> P1
-// 3: record "ground collider" - nearest collider within threshold distance in ground_direction using avatar collider shapecast from P1
-// 4: update all colliders, record previous transform and new transform.
-// 5: apply ground collider movement: take collider closest point, modify P1 translation and rotation by closest point translation and rotation change -> P2
-// 6: apply all other pseudo-ground collider movement:
-//   for each collider[i] that collides with the P2 player:
-//       let CTC = collider translation change
-//       if length(CTC) > max_move_threshold
-//           ignore / continue
-//       if dot(CTC, ground_direction) < 0 (i.e. collider is moving into the player from the ground direction)
-//           calculate collider_impact[i] => shapecast avatar from P2 + CTC[i] to P2. collider_impact[i] = CTC * (1 - time of impact)
-//   add max_by_length(collider_impact[i]) to player translation -> P3
-// 7: resolve collisions using position-based-dynamics
-//   while still colliding / until iteration N = max iterations
+// 1: set avatar orientation from movement info -> P1
+// 2: record "ground collider" - nearest collider within threshold distance in ground_direction using avatar collider shapecast
+// 3: update all colliders, record previous transform and new transform.
+// 4: apply ground collider movement: take collider closest point, modify P1 translation and rotation by closest point translation and rotation change -> P2
+// 5: resolve collisions using position-based constraints
+//   initialize constraints to -inf, +inf
+//   repeat
 //       for each collider[i] that collides with the P3+N player:
 //           if closest point = capsule middle (i.e. collider collides with P3 collider but with radius 0), 
 //               ignore / continue
 //           else 
-//               calculate depenetration vector[i] => closest point avatar - closest point collider
-//       add average(depenetration vector) to P3 -> P3+N
-//   repeat
+//               update constraints based on minimum movement to escape collision
+//               e.g. if avatar is 1cm into the floor, constraint_min = max(constraint_min, vec3(0, 0.01, 0))
+//       reposition player to satisfy constraints for each axis:
+//           y: satsify floor before ceiling: new position = max(constraint_min, min(constraint_max, current position))
+//           x and z: if squashed, take average, else satisfy the required constraint
+//           if constraint_min > constraint_max then new position = average(constraint_min, constraint_max) 
+//           else new position = clamp(current position, constraint_min, constraint_max)
+//   while position !~= previous position
+// 6: apply velocity (collide and slide)
+//   disable anything we are initially colliding with
+//   shapecast avatar from position to position + velocity * timestep
+//   on impact:
+//       project velocity onto slide plane (standard "Collide & Slide")
+//       velocity = old velocity - (normal * dot(velocity, normal))
+//       repeat continue with residual velocity and residual time
+// 7: provide AvatarMovementInfo values
+//      actual velocity = (final - P3+N) / timestep
+//      external_velocity = (P3+N - P1) / timestep

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement_info.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement_info.proto
@@ -18,5 +18,19 @@ message PBAvatarMovementInfo {
   decentraland.sdk.components.PBAvatarLocomotionSettings active_avatar_locomotion_settings = 6;
   decentraland.sdk.components.PBInputModifier active_input_modifier = 7;
   optional decentraland.common.Vector3 walk_target = 8;    // if set, the movement scene should walk the player to this scene-relative position
-  optional float walk_threshold = 9;                        // stop distance for walk_target
+  optional float walk_threshold = 9;                        // stop distance for walk_target; considered reached when within this distance
+  optional AvatarAnimationState active_animation_state = 10; // current state of a scene-driven movement animation. Absent when the engine is using its velocity-based fallback. `playback_time` freezes while a triggerSceneEmote is overriding the animation.
+}
+
+// Mirror of the scene-driven movement animation currently playing, reported by the engine.
+// Readable by any scene (not just the controller) so niche effects (e.g. dust cloud on landing) can react.
+// Active emotes are not represented here — scenes already have their own way to read them.
+message AvatarAnimationState {
+  string src = 1;                                           // same scene-relative path the controlling scene supplied
+  bool loop = 2;                                            // mirrors the request
+  float speed = 3;                                          // mirrors the request
+  bool idle = 4;                                            // mirrors the request
+  float playback_time = 5;                                  // seconds into the clip; wraps on loop; frozen while an emote override is playing
+  float duration = 6;                                       // total clip length in seconds
+  uint32 loop_count = 7;                                    // how many times the clip has completed since it started
 }

--- a/crates/ipfs/Cargo.toml
+++ b/crates/ipfs/Cargo.toml
@@ -16,6 +16,7 @@ platform = { workspace = true }
 bevy = { workspace = true }
 anyhow = { workspace = true }
 bevy_console = { workspace = true }
+bevy_kira_audio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -59,6 +59,15 @@ impl IpfsAsset for bevy::gltf::Gltf {
     }
 }
 
+// Loaded via the custom `.audio` AssetLoader in the `av` crate: kira's
+// symphonia pipeline already sniffs the container format, so we strip the real
+// extension on the wire and pick it back up by MIME on the client.
+impl IpfsAsset for bevy_kira_audio::AudioSource {
+    fn ext() -> &'static str {
+        "audio"
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IpfsType {
     ContentFile {

--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -69,6 +69,14 @@ pub enum IpfsType {
         hash: String,
         ext: String,
     },
+    // A content hash loaded in the context of a scene. Routes through the
+    // scene's registered modifier (e.g. a portable's local content server)
+    // rather than falling back to the realm content URL.
+    SceneContent {
+        scene_hash: String,
+        content_hash: String,
+        ext: String,
+    },
     UrlCached {
         url: String,
         ext: String,
@@ -93,7 +101,9 @@ impl IpfsType {
 
     fn base_url_extension(&self) -> &str {
         match self {
-            IpfsType::ContentFile { .. } | IpfsType::Entity { .. } => "/contents/",
+            IpfsType::ContentFile { .. }
+            | IpfsType::Entity { .. }
+            | IpfsType::SceneContent { .. } => "/contents/",
             IpfsType::UrlCached { .. } => "",
             IpfsType::UrlUncached { .. } => "",
             IpfsType::IndexDb { .. } => "",
@@ -124,6 +134,9 @@ impl IpfsType {
                     anyhow::anyhow!("file not found in content map: {file_path:?} in {scene_hash}")
                 }),
             IpfsType::Entity { hash, .. } => Ok(format!("{base_url}{hash}")),
+            IpfsType::SceneContent { content_hash, .. } => {
+                Ok(format!("{base_url}{content_hash}"))
+            }
             IpfsType::UrlCached { url, .. } | IpfsType::UrlUncached { url, .. } => {
                 Ok(format!("{}", urlencoding::decode(url)?))
             }
@@ -149,6 +162,7 @@ impl IpfsType {
                 }),
             IpfsType::UrlCached { hash, .. } => Some(Cow::Borrowed(hash)),
             IpfsType::Entity { hash, .. } => Some(Cow::Borrowed(hash)),
+            IpfsType::SceneContent { content_hash, .. } => Some(Cow::Borrowed(content_hash)),
             IpfsType::UrlUncached { .. } | IpfsType::IndexDb { .. } => None,
         };
         x
@@ -162,6 +176,7 @@ impl IpfsType {
             | IpfsType::UrlUncached { .. }
             | IpfsType::IndexDb { .. } => None,
             IpfsType::Entity { hash, .. } => Some(hash),
+            IpfsType::SceneContent { scene_hash, .. } => Some(scene_hash),
         }
     }
 
@@ -169,6 +184,9 @@ impl IpfsType {
         match self {
             IpfsType::ContentFile { .. } => {
                 anyhow::bail!("Can't get hash for content files without context")
+            }
+            IpfsType::SceneContent { .. } => {
+                anyhow::bail!("Can't get hash for scene content without context")
             }
             IpfsType::UrlCached { .. }
             | IpfsType::UrlUncached { .. }
@@ -204,6 +222,13 @@ impl From<&IpfsType> for PathBuf {
             IpfsType::Entity { hash, ext } => {
                 PathBuf::from("$entity").join(format!("{hash}.{ext}"))
             }
+            IpfsType::SceneContent {
+                scene_hash,
+                content_hash,
+                ext,
+            } => PathBuf::from("$scene_content")
+                .join(scene_hash)
+                .join(format!("{content_hash}.{ext}")),
             IpfsType::UrlCached { url, ext, .. } => PathBuf::from("$urlc").join(format!(
                 "{}.{}",
                 urlencoding::encode(url).into_owned(),
@@ -268,6 +293,23 @@ where
                     .ok_or(anyhow::anyhow!("entity specified malformed (no '.')"))?;
                 Ok(IpfsType::Entity {
                     hash: hash.to_owned(),
+                    ext: ext.to_owned(),
+                })
+            }
+            "$scene_content" => {
+                let scene_hash = components
+                    .next()
+                    .ok_or(anyhow::anyhow!("scene content specifier missing scene hash"))?
+                    .to_owned();
+                let hash_ext: &str = components
+                    .next()
+                    .ok_or(anyhow::anyhow!("scene content specifier missing content hash"))?;
+                let (content_hash, ext) = hash_ext
+                    .split_once('.')
+                    .ok_or(anyhow::anyhow!("scene content specified malformed (no '.')"))?;
+                Ok(IpfsType::SceneContent {
+                    scene_hash,
+                    content_hash: content_hash.to_owned(),
                     ext: ext.to_owned(),
                 })
             }

--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -134,9 +134,7 @@ impl IpfsType {
                     anyhow::anyhow!("file not found in content map: {file_path:?} in {scene_hash}")
                 }),
             IpfsType::Entity { hash, .. } => Ok(format!("{base_url}{hash}")),
-            IpfsType::SceneContent { content_hash, .. } => {
-                Ok(format!("{base_url}{content_hash}"))
-            }
+            IpfsType::SceneContent { content_hash, .. } => Ok(format!("{base_url}{content_hash}")),
             IpfsType::UrlCached { url, .. } | IpfsType::UrlUncached { url, .. } => {
                 Ok(format!("{}", urlencoding::decode(url)?))
             }
@@ -299,14 +297,16 @@ where
             "$scene_content" => {
                 let scene_hash = components
                     .next()
-                    .ok_or(anyhow::anyhow!("scene content specifier missing scene hash"))?
+                    .ok_or(anyhow::anyhow!(
+                        "scene content specifier missing scene hash"
+                    ))?
                     .to_owned();
-                let hash_ext: &str = components
-                    .next()
-                    .ok_or(anyhow::anyhow!("scene content specifier missing content hash"))?;
-                let (content_hash, ext) = hash_ext
-                    .split_once('.')
-                    .ok_or(anyhow::anyhow!("scene content specified malformed (no '.')"))?;
+                let hash_ext: &str = components.next().ok_or(anyhow::anyhow!(
+                    "scene content specifier missing content hash"
+                ))?;
+                let (content_hash, ext) = hash_ext.split_once('.').ok_or(anyhow::anyhow!(
+                    "scene content specified malformed (no '.')"
+                ))?;
                 Ok(IpfsType::SceneContent {
                     scene_hash,
                     content_hash: content_hash.to_owned(),

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -332,6 +332,20 @@ impl IpfsAssetServer<'_, '_> {
         self.server.load(path)
     }
 
+    // Load a raw content hash that lives inside a scene's collection. Routes
+    // the request through the scene's registered modifier (e.g. a portable's
+    // local content server) so b64-prefixed content hashes resolve to the
+    // scene's origin rather than the realm content URL.
+    pub fn load_scene_content_hash<T: IpfsAsset>(
+        &self,
+        scene_hash: &str,
+        content_hash: &str,
+    ) -> Handle<T> {
+        let ext = T::ext();
+        let path = format!("$ipfs/$scene_content/{scene_hash}/{content_hash}.{ext}");
+        self.server.load(path)
+    }
+
     pub fn active_endpoint(&self) -> Option<String> {
         self.ipfs()
             .realm_config_receiver

--- a/crates/user_input/Cargo.toml
+++ b/crates/user_input/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 common = { workspace = true }
 input_manager = { workspace = true }
+ipfs = { workspace = true }
 scene_runner = { workspace = true }
 dcl = { workspace = true }
 dcl_component = { workspace = true }

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -12,6 +12,7 @@ use common::{
     sets::SceneSets,
     structs::{
         AppConfig, AvatarDynamicState, EngineMovementControl, PrimaryPlayerRes, PrimaryUser,
+        SceneDrivenAnimation, SceneDrivenAnimationFeedback, SceneDrivenAnimationRequest,
     },
 };
 use comms::global_crdt::GlobalCrdtState;
@@ -20,11 +21,16 @@ use dcl_component::{
     proto_components::{
         common::Vector3,
         sdk::components::{
-            ColliderLayer, PbAvatarLocomotionSettings, PbAvatarMovement, PbAvatarMovementInfo,
-            PbPhysicsCombinedForce, PbPhysicsCombinedImpulse,
+            AvatarAnimationState, ColliderLayer, MovementAnimation, PbAvatarLocomotionSettings,
+            PbAvatarMovement, PbAvatarMovementInfo, PbPhysicsCombinedForce,
+            PbPhysicsCombinedImpulse,
         },
     },
     SceneComponentId, SceneEntityId,
+};
+use ipfs::{
+    ipfs_path::{IpfsPath, IpfsType},
+    IpfsAssetServer,
 };
 
 use scene_runner::{
@@ -62,6 +68,8 @@ impl Plugin for AvatarMovementPlugin {
         );
 
         app.init_resource::<AvatarMovementInfo>();
+        app.init_resource::<SceneDrivenAnimation>();
+        app.init_resource::<SceneDrivenAnimationFeedback>();
 
         app.add_systems(Update, broadcast_movement_info.in_set(SceneSets::Init));
 
@@ -72,6 +80,9 @@ impl Plugin for AvatarMovementPlugin {
                 ActivePlayerComponent::<AvatarLocomotionSettings>::pick_by_priority,
                 ActivePlayerComponent::<InputModifier>::pick_by_priority,
                 update_priority_scene.after(
+                    ActivePlayerComponent::<AvatarMovement>::pick_latest_frame_only_by_priority,
+                ),
+                update_scene_driven_animation.after(
                     ActivePlayerComponent::<AvatarMovement>::pick_latest_frame_only_by_priority,
                 ),
             )
@@ -113,13 +124,62 @@ fn update_priority_scene(
     }
 }
 
-#[derive(Component, Clone, Copy, Debug)]
+// Resolves the active scene's `MovementAnimation.src` against the scene content map
+// (path -> content hash) and publishes a ready-to-play request in the
+// `SceneDrivenAnimation` resource for the avatar animation system to consume.
+fn update_scene_driven_animation(
+    player: Query<&ActivePlayerComponent<AvatarMovement>, With<PrimaryUser>>,
+    scenes: Query<&RendererSceneContext>,
+    ipfas: IpfsAssetServer,
+    mut resource: ResMut<SceneDrivenAnimation>,
+    mut logged_failures: Local<HashSet<String>>,
+) {
+    let request = player.single().ok().and_then(|active| {
+        let anim = active.component.animation.as_ref()?;
+        let scene_ent = active.scene();
+        if scene_ent == Entity::PLACEHOLDER {
+            return None;
+        }
+        let ctx = scenes.get(scene_ent).ok()?;
+        let ipfs_path = IpfsPath::new(IpfsType::new_content_file(
+            ctx.hash.clone(),
+            anim.src.to_lowercase(),
+        ));
+        let ipfs_ctx = ipfas.ipfs().context.blocking_read();
+        let Some(content_hash) = ipfs_path.hash(&ipfs_ctx) else {
+            if logged_failures.insert(anim.src.clone()) {
+                warn!(
+                    "scene-driven movement animation path not found in scene content map: {}",
+                    anim.src
+                );
+            }
+            return None;
+        };
+
+        Some(SceneDrivenAnimationRequest {
+            src: anim.src.clone(),
+            scene_hash: ctx.hash.clone(),
+            content_hash,
+            r#loop: anim.r#loop,
+            speed: anim.speed,
+            idle: anim.idle,
+            transition_seconds: anim.transition_seconds.unwrap_or(0.2),
+            seek: anim.playback_time,
+        })
+    });
+
+    resource.active = request;
+}
+
+#[derive(Component, Clone, Debug)]
 pub struct AvatarMovement {
     pub velocity: Vec3,
     pub orientation: f32,
     pub ground_direction: Vec3,
     /// set for one frame when a walk_target ends: true = reached target, false = failed
     pub walk_success: Option<bool>,
+    /// scene-driven movement animation request; if absent, engine falls back to velocity-based selection
+    pub animation: Option<MovementAnimation>,
 }
 
 impl Default for AvatarMovement {
@@ -129,6 +189,7 @@ impl Default for AvatarMovement {
             orientation: 0.0,
             ground_direction: Vec3::NEG_Y,
             walk_success: None,
+            animation: None,
         }
     }
 }
@@ -167,6 +228,7 @@ impl From<PbAvatarMovement> for AvatarMovement {
                 .map(Vec3::normalize_or_zero)
                 .unwrap_or(Vec3::NEG_Y),
             walk_success: value.walk_success,
+            animation: value.animation,
         }
     }
 }
@@ -735,6 +797,7 @@ fn broadcast_movement_info(
         ),
         With<PrimaryUser>,
     >,
+    feedback: Res<SceneDrivenAnimationFeedback>,
     mut global_crdt: ResMut<GlobalCrdtState>,
     time: Res<Time>,
 ) {
@@ -742,6 +805,15 @@ fn broadcast_movement_info(
 
     info.0.active_avatar_locomotion_settings = maybe_locomotion.map(|l| l.component.0.clone());
     info.0.active_input_modifier = maybe_modifier.and_then(|l| l.component.0.clone());
+    info.0.active_animation_state = feedback.state.as_ref().map(|s| AvatarAnimationState {
+        src: s.src.clone(),
+        r#loop: s.r#loop,
+        speed: s.speed,
+        idle: s.idle,
+        playback_time: s.playback_time,
+        duration: s.duration,
+        loop_count: s.loop_count,
+    });
 
     debug!("broadcast {:?}", info.0);
 
@@ -761,5 +833,6 @@ fn broadcast_movement_info(
         active_input_modifier: None,
         walk_target: None,
         walk_threshold: None,
+        active_animation_state: None,
     }
 }

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -167,6 +167,8 @@ fn update_scene_driven_animation(
         Some(SceneDrivenAnimationRequest {
             src: anim.src.clone(),
             urn,
+            scene_hash: ctx.hash.clone(),
+            content_hash,
             r#loop: anim.r#loop,
             speed: anim.speed,
             idle: anim.idle,

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -12,7 +12,7 @@ use common::{
     sets::SceneSets,
     structs::{
         AppConfig, AvatarDynamicState, EngineMovementControl, PrimaryPlayerRes, PrimaryUser,
-        SceneDrivenAnimation, SceneDrivenAnimationFeedback, SceneDrivenAnimationRequest,
+        SceneDrivenAnim, SceneDrivenAnimationFeedback, SceneDrivenAnimationRequest,
     },
 };
 use comms::global_crdt::GlobalCrdtState;
@@ -68,7 +68,6 @@ impl Plugin for AvatarMovementPlugin {
         );
 
         app.init_resource::<AvatarMovementInfo>();
-        app.init_resource::<SceneDrivenAnimation>();
         app.init_resource::<SceneDrivenAnimationFeedback>();
 
         app.add_systems(Update, broadcast_movement_info.in_set(SceneSets::Init));
@@ -125,16 +124,19 @@ fn update_priority_scene(
 }
 
 // Resolves the active scene's `MovementAnimation.src` against the scene content map
-// (path -> content hash) and publishes a ready-to-play request in the
-// `SceneDrivenAnimation` resource for the avatar animation system to consume.
+// (path -> content hash) and writes a ready-to-play request onto the primary player's
+// `SceneDrivenAnim` component for the avatar animation system to consume.
 fn update_scene_driven_animation(
-    player: Query<&ActivePlayerComponent<AvatarMovement>, With<PrimaryUser>>,
+    mut commands: Commands,
+    player: Query<(Entity, &ActivePlayerComponent<AvatarMovement>), With<PrimaryUser>>,
     scenes: Query<&RendererSceneContext>,
     ipfas: IpfsAssetServer,
-    mut resource: ResMut<SceneDrivenAnimation>,
     mut logged_failures: Local<HashSet<String>>,
 ) {
-    let request = player.single().ok().and_then(|active| {
+    let Ok((primary, active)) = player.single() else {
+        return;
+    };
+    let request = (|| {
         let anim = active.component.animation.as_ref()?;
         let scene_ent = active.scene();
         if scene_ent == Entity::PLACEHOLDER {
@@ -156,19 +158,26 @@ fn update_scene_driven_animation(
             return None;
         };
 
+        // The `-false` suffix is a fixed part of the scene-emote URN format here;
+        // loop behavior is carried separately in SceneDrivenAnimationRequest.r#loop.
+        let urn = format!(
+            "urn:decentraland:off-chain:scene-emote:{}-{}-false",
+            ctx.hash, content_hash
+        );
         Some(SceneDrivenAnimationRequest {
             src: anim.src.clone(),
-            scene_hash: ctx.hash.clone(),
-            content_hash,
+            urn,
             r#loop: anim.r#loop,
             speed: anim.speed,
             idle: anim.idle,
             transition_seconds: anim.transition_seconds.unwrap_or(0.2),
             seek: anim.playback_time,
         })
-    });
+    })();
 
-    resource.active = request;
+    commands
+        .entity(primary)
+        .try_insert(SceneDrivenAnim { active: request });
 }
 
 #[derive(Component, Clone, Debug)]

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -158,6 +158,30 @@ fn update_scene_driven_animation(
             return None;
         };
 
+        // Resolve each scene-relative audio path to a content hash against the same
+        // scene content map. Drop (and warn once per src) any path that doesn't resolve.
+        let sounds = anim
+            .sounds
+            .iter()
+            .filter_map(|sound_src| {
+                let sound_path = IpfsPath::new(IpfsType::new_content_file(
+                    ctx.hash.clone(),
+                    sound_src.to_lowercase(),
+                ));
+                match sound_path.hash(&ipfs_ctx) {
+                    Some(h) => Some(h),
+                    None => {
+                        if logged_failures.insert(sound_src.clone()) {
+                            warn!(
+                                "scene-driven movement sound path not found in scene content map: {sound_src}"
+                            );
+                        }
+                        None
+                    }
+                }
+            })
+            .collect();
+
         // The `-false` suffix is a fixed part of the scene-emote URN format here;
         // loop behavior is carried separately in SceneDrivenAnimationRequest.r#loop.
         let urn = format!(
@@ -174,6 +198,7 @@ fn update_scene_driven_animation(
             idle: anim.idle,
             transition_seconds: anim.transition_seconds.unwrap_or(0.2),
             seek: anim.playback_time,
+            sounds,
         })
     })();
 


### PR DESCRIPTION
## Summary

Routes avatar movement animation selection through the movement scene via a nested `MovementAnimation` block on `PbAvatarMovement`, resolved through the existing emote loader pipeline. The engine still picks from velocity heuristics when the scene hasn't supplied one.

**Protocol dependency:** this PR depends on decentraland/protocol#392. Once that lands and the protocol-squad artifact is cut, we'll bump `dcl-protocol` here.

### Pipeline
- New `MovementAnimation` nested on `PbAvatarMovement` (scene → engine): `src`, `loop`, `speed`, `idle`, optional `transition_seconds`, optional `playback_time` seek.
- New `AvatarAnimationState` on `PbAvatarMovementInfo` (engine → scenes): mirrors the currently-playing scene-driven clip plus `playback_time`, `duration`, `loop_count`. Any scene can read it.
- A single `SceneDrivenAnim` component covers both primary and foreign players.
- Scene-emote URNs resolve relative to the scene's `baseUrl` via a new `IpfsType::SceneContent`, fixing asset 404s for portables whose content lives outside the realm.

### Interaction with triggered emotes
- `idle: true` lets `triggerSceneEmote` take over; `idle: false` suppresses emotes while the movement animation plays.
- A non-idle scene-driven request clears any matching triggered emote so the movement scene can seize control mid-play.
- `AvatarAnimationState.playback_time` freezes while a triggered emote is overriding the clip.

### Remote sync
- Latch single-frame `playback_time` seeks in `broadcast_position` so they aren't dropped between 10Hz/1Hz send gates.
- Bypass the STATIC_FREQ skip when the active URN changes so jump→idle transitions reach remotes promptly when the player comes to rest.
- Defer `SceneDrivenAnim` insertion on foreign avatars until the interpolated position catches up to the target, so the clip change visibly lines up with the motion rather than with the packet arrival.
- Flush any unapplied `scene_anim` before overwriting the target position so bursts of events don't silently drop one-shot seeks or intermediate transitions.

### Resilience
- Precompute the velocity-based `ActiveEmote` and stash it as a fallback; on permanent URN resolution failure (parse/missing clip/Failed/Missing/NoRepresentation/no `_Avatar`) the engine swaps to the fallback and retries.

### Unrelated (bundled)
- Emote prop scene: spawn an invisible wrapper entity between the avatar and the prop scene so instantiated scene entities inherit `Hidden` the moment they appear. Avoids a one-frame flash of `_reference` / `_basemesh` / `m_mask_*` children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)