### PR TITLE
Defensive filter against mirrored scene_driven_animation

### DIFF
--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -7,6 +7,7 @@ use dcl_component::{
     proto_components::kernel::comms::rfc4,
     transform_and_parent::{DclQuat, DclTranslation},
 };
+use wallet::Wallet;
 
 use crate::{
     global_crdt::GlobalCrdtState,
@@ -65,6 +66,7 @@ fn broadcast_position(
     mut last_anim: Local<LastAnim>,
     time: Res<Time>,
     global_crdt: Res<GlobalCrdtState>,
+    wallet: Res<Wallet>,
 ) {
     let Ok((player, dynamics, scene_anim)) = player.single() else {
         return;
@@ -170,14 +172,17 @@ fn broadcast_position(
 
     let movement_compressed = crate::movement_compressed::MovementCompressed { temporal, movement };
 
-    // Scene-driven animation fields. The hash pair is sent on transition (new clip, or
-    // an empty `anim_scene_hash` to clear a prior active anim) and re-sent every
+    // Scene-driven animation carrier. The hash pair is sent on transition (new clip, or
+    // an empty `scene_hash` to clear a prior active anim) and re-sent every
     // ANIM_URN_KEEPALIVE seconds while active so late joiners pick it up. The other
-    // fields ride along whenever an animation is active. `anim_playback_time` is only
-    // sent when the scene explicitly requested a seek this frame.
+    // fields ride along whenever an animation is active. `playback_time` is only sent
+    // when the scene explicitly requested a seek this frame. The nested message itself
+    // is only attached to the packet when there's something anim-related to say —
+    // that way a receiver that's not interested (or that never sees us transition out
+    // of an inactive state) costs no bytes.
     let active_anim = scene_anim.and_then(|s| s.active.as_ref());
     let keepalive_due = active_anim.is_some() && time - last_anim.sent_at >= ANIM_URN_KEEPALIVE;
-    let (anim_scene_hash, anim_content_hash) = if anim_changed {
+    let (scene_hash, content_hash) = if anim_changed {
         match &current_hashes {
             Some((s, c)) => (Some(s.clone()), Some(c.clone())),
             // Transition active → none: signal clear with an empty scene_hash.
@@ -191,24 +196,45 @@ fn broadcast_position(
     } else {
         (None, None)
     };
-    if anim_scene_hash.is_some() {
+    if scene_hash.is_some() {
         last_anim.sent_at = time;
     }
     last_anim.hashes = current_hashes;
 
-    let anim_speed = active_anim.map(|a| a.speed);
-    let anim_transition_seconds = active_anim.map(|a| a.transition_seconds);
-    let anim_loop = active_anim.map(|a| a.r#loop);
+    let speed = active_anim.map(|a| a.speed);
+    let transition_seconds = active_anim.map(|a| a.transition_seconds);
+    let r#loop = active_anim.map(|a| a.r#loop);
     // The latch above already mirrors the freshest `seek` seen since the last
     // broadcast. Only send if there's an active anim to apply it to.
-    let anim_playback_time = active_anim.and(last_anim.pending_seek.take());
-    // Drain pending sounds on every broadcast. Sounds depend on `anim_scene_hash`
-    // to identify their host scene, so only ship them while an anim is active.
-    let anim_sound_content_hashes = if active_anim.is_some() {
+    let playback_time = active_anim.and(last_anim.pending_seek.take());
+    // Drain pending sounds on every broadcast. Sounds depend on `scene_hash` to
+    // identify their host scene, so only ship them while an anim is active.
+    let sound_content_hashes = if active_anim.is_some() {
         std::mem::take(&mut last_anim.pending_sounds)
     } else {
         last_anim.pending_sounds.clear();
         Vec::new()
+    };
+
+    // Attach the nested message only when there's anim state to communicate — that is,
+    // when we have an active animation (ride-along, keepalive, or transition-in) or
+    // when we're transitioning out (scene_hash == Some("")). Otherwise leave it None
+    // so the field isn't serialized at all.
+    let scene_driven_animation = if active_anim.is_some() || scene_hash.is_some() {
+        Some(
+            dcl_component::proto_components::kernel::comms::rfc4::SceneDrivenAnimation {
+                scene_hash,
+                content_hash,
+                speed,
+                playback_time,
+                transition_seconds,
+                r#loop,
+                sound_content_hashes,
+                origin_address: wallet.address().map(|a| format!("{a:#x}")),
+            },
+        )
+    } else {
+        None
     };
 
     let movement_uncompressed = dcl_component::proto_components::kernel::comms::rfc4::Movement {
@@ -229,13 +255,7 @@ fn broadcast_position(
         is_falling: movement_compressed.temporal.falling(),
         is_stunned: movement_compressed.temporal.stunned(),
         is_emoting: dynamics.move_kind == MoveKind::Emote,
-        anim_scene_hash,
-        anim_content_hash,
-        anim_speed,
-        anim_playback_time,
-        anim_transition_seconds,
-        anim_loop,
-        anim_sound_content_hashes,
+        scene_driven_animation,
     };
 
     // let movement_packet = rfc4::MovementCompressed {

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -580,14 +580,9 @@ pub fn process_transport_updates(
                         );
                         let scene_anim = resolve_remote_anim(
                             entity,
+                            update.address,
                             &mut last_remote_anim_urn,
-                            m.anim_scene_hash,
-                            m.anim_content_hash,
-                            m.anim_speed,
-                            m.anim_playback_time,
-                            m.anim_transition_seconds,
-                            m.anim_loop,
-                            m.anim_sound_content_hashes,
+                            m.scene_driven_animation,
                         );
                         position_events.write(PlayerPositionEvent {
                             index: None,
@@ -607,14 +602,9 @@ pub fn process_transport_updates(
                         debug!("movement compressed data: {m:?}");
                         let scene_anim = resolve_remote_anim(
                             entity,
+                            update.address,
                             &mut last_remote_anim_urn,
-                            m.anim_scene_hash.clone(),
-                            m.anim_content_hash.clone(),
-                            m.anim_speed,
-                            m.anim_playback_time,
-                            m.anim_transition_seconds,
-                            m.anim_loop,
-                            m.anim_sound_content_hashes.clone(),
+                            m.scene_driven_animation.clone(),
                         );
                         let movement = MovementCompressed::from_proto(m);
                         let pos = movement.position(state.realm_bounds.0, state.realm_bounds.1);
@@ -694,44 +684,62 @@ pub fn process_transport_updates(
     }
 }
 
-// Resolves scene-driven animation fields from a Movement / MovementCompressed
-// packet into the full state. An empty `anim_scene_hash` clears the state; absent
-// hash fields (None) reuse the last cached pair for this entity so we keep
-// animating between keepalives. Returns `None` when the sender has no active
-// scene-driven animation. The resolved state rides on `PlayerPositionEvent` so
-// `foreign_dynamics` can apply it with the same interpolation delay as the
-// visible position.
-#[allow(clippy::too_many_arguments)]
+// Resolves the `SceneDrivenAnimation` nested message from a Movement /
+// MovementCompressed packet into the full state. An empty `scene_hash` clears the
+// state; absent hash fields (None) reuse the last cached pair for this entity so we
+// keep animating between keepalives. Returns `None` when the sender has no active
+// scene-driven animation, or when the nested message is absent entirely (the
+// common case for senders that don't speak our extension). The resolved state rides
+// on `PlayerPositionEvent` so `foreign_dynamics` can apply it with the same
+// interpolation delay as the visible position.
 fn resolve_remote_anim(
     entity: Entity,
+    sender: Address,
     last_hashes: &mut HashMap<Entity, (String, String)>,
-    anim_scene_hash: Option<String>,
-    anim_content_hash: Option<String>,
-    anim_speed: Option<f32>,
-    anim_playback_time: Option<f32>,
-    anim_transition_seconds: Option<f32>,
-    anim_loop: Option<bool>,
-    anim_sound_content_hashes: Vec<String>,
+    anim: Option<dcl_component::proto_components::kernel::comms::rfc4::SceneDrivenAnimation>,
 ) -> Option<SceneDrivenAnimationRequest> {
+    // Sender didn't attach the nested carrier; nothing to do (and nothing to clear,
+    // since we only cache hashes the sender itself told us about).
+    let anim = anim?;
+
+    // Guard against mirror-class bugs where a buggy remote re-emits someone else's
+    // nested message byte-for-byte (observed against a Unity client that pooled
+    // protobuf instances without discarding unknown fields). `origin_address` must be
+    // present and match the packet sender; anything else is either a mirror or a
+    // sender that predates this field and is therefore also potentially a mirror
+    // victim. Be strict and drop it.
+    let sender_str = format!("{sender:#x}");
+    match anim.origin_address.as_deref() {
+        Some(origin) if origin.eq_ignore_ascii_case(&sender_str) => {}
+        _ => {
+            debug!(
+                "dropping scene_driven_animation without matching origin_address: origin={:?} sender={}",
+                anim.origin_address, sender_str
+            );
+            last_hashes.remove(&entity);
+            return None;
+        }
+    }
+
     // Wire convention: on transition the sender ships both hashes (or an empty
     // scene_hash to clear); between transitions both are omitted and we re-apply the
     // cached pair so ride-along fields (speed, loop, seek) keep updating.
-    let (scene_hash, content_hash) = match anim_scene_hash {
+    let (scene_hash, content_hash) = match anim.scene_hash {
         Some(s) if s.is_empty() => {
             last_hashes.remove(&entity);
             return None;
         }
         Some(s) => {
-            let c = anim_content_hash?;
+            let c = anim.content_hash?;
             last_hashes.insert(entity, (s.clone(), c.clone()));
             (s, c)
         }
         None => last_hashes.get(&entity)?.clone(),
     };
 
-    let speed = anim_speed?;
-    let r#loop = anim_loop.unwrap_or(false);
-    let transition_seconds = anim_transition_seconds.unwrap_or(0.2);
+    let speed = anim.speed?;
+    let r#loop = anim.r#loop.unwrap_or(false);
+    let transition_seconds = anim.transition_seconds.unwrap_or(0.2);
     let urn = format!("urn:decentraland:off-chain:scene-emote:{scene_hash}-{content_hash}-false");
 
     Some(SceneDrivenAnimationRequest {
@@ -745,8 +753,8 @@ fn resolve_remote_anim(
         // players there's no triggerSceneEmote interaction so we don't need it.
         idle: false,
         transition_seconds,
-        seek: anim_playback_time,
-        sounds: anim_sound_content_hashes,
+        seek: anim.playback_time,
+        sounds: anim.sound_content_hashes,
     })
 }
 

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -61,44 +61,46 @@ message Movement {
   float rotation_y = 16;
   bool is_emoting = 18;
 
-  // Scene-driven movement animation (local extension, pending multi-clip-per-glb work).
-  // anim_scene_hash + anim_content_hash identify a scene-emote clip — the receiver wraps
-  // them as `urn:decentraland:off-chain:scene-emote:{scene}-{content}-false`. Sending the
-  // hashes directly keeps the fixed URN preamble off the wire. Both fields are omitted when
-  // unchanged since the last send (receivers cache them) and forced every ~1s as a
-  // keepalive for joiners. An empty anim_scene_hash clears a prior active anim. The other
-  // fields are sent every frame the animation is active.
-  // Tag numbers 19-28 are reserved upstream for head-sync / glide / jump_count / point-at,
-  // so these local extensions start at 29 to avoid wire collisions with upstream senders.
-  optional string anim_scene_hash = 29;
-  optional float anim_speed = 30;
-  optional float anim_playback_time = 31;
-  optional float anim_transition_seconds = 32;
-  optional bool anim_loop = 33;
-  optional string anim_content_hash = 34;
+  // Scene-driven movement animation (bevy-explorer local extension). Wrapped in a nested
+  // message at a high private tag so that other clients (Unity, web) can't accidentally
+  // populate these fields by reusing the same tag numbers at the Movement level — an
+  // unrelated payload at tag 10000 will fail to decode as SceneDrivenAnimation and prost
+  // drops the whole field, instead of handing us a plausible-looking string we'd try to
+  // resolve as a GLB hash.
+  optional SceneDrivenAnimation scene_driven_animation = 10000;
+}
 
-  // Scene-requested avatar-bus sound triggers that accumulated since the last broadcast.
-  // Each entry is the content_hash of an audio clip hosted in the same scene as the active
-  // animation (so `anim_scene_hash` — latched or re-asserted via keepalive — identifies the
-  // scene). Receivers play each hash once on receipt. Fire-and-forget; no stop mechanism.
-  repeated string anim_sound_content_hashes = 35;
+// Nested carrier for scene-driven movement animation state. All fields are optional so
+// that between transitions only ride-along fields (speed, loop, seek) need to be sent;
+// the hash pair is sent on transition or every ~1s as a keepalive for joiners. An empty
+// `scene_hash` clears a previously active animation.
+message SceneDrivenAnimation {
+  optional string scene_hash = 1;
+  optional string content_hash = 2;
+  optional float speed = 3;
+  optional float playback_time = 4;
+  optional float transition_seconds = 5;
+  optional bool loop = 6;
+  // Scene-requested avatar-bus sound triggers accumulated since the last broadcast. Each
+  // entry is the content_hash of an audio clip hosted in the same scene as the active
+  // animation (scene_hash — latched or re-asserted via keepalive — identifies the scene).
+  // Receivers play each hash once on receipt. Fire-and-forget; no stop mechanism.
+  repeated string sound_content_hashes = 7;
+  // Hex-encoded wallet address of the sender, e.g. "0x6f39…". Defence against buggy
+  // remotes that parse-then-re-emit this whole sub-message byte-for-byte (observed in
+  // the wild). Receivers drop the anim when this is set and doesn't match the packet
+  // sender's address. Absent on packets from old senders — in that case we accept,
+  // since those clients predate the mirror-class bug we're defending against.
+  optional string origin_address = 8;
 }
 
 message MovementCompressed {
   int32 temporal_data = 1; // bit-compressed: timestamp + animations
   int64 movement_data = 2; // bit-compressed: position + velocity
 
-  // See Movement.anim_* fields. Mirror here so the compressed variant can carry the same
-  // scene-driven animation state if/when MovementCompressed is re-enabled on the sender.
-  // Tags 3 and 4 are reserved upstream for head_sync_data / point_at_data, so local
-  // extensions start at 5.
-  optional string anim_scene_hash = 5;
-  optional float anim_speed = 6;
-  optional float anim_playback_time = 7;
-  optional float anim_transition_seconds = 8;
-  optional bool anim_loop = 9;
-  optional string anim_content_hash = 10;
-  repeated string anim_sound_content_hashes = 11;
+  // Mirror of Movement.scene_driven_animation — see that field for semantics and the
+  // collision-avoidance rationale behind the high nested tag.
+  optional SceneDrivenAnimation scene_driven_animation = 10000;
 }
 
 message PlayerEmote {


### PR DESCRIPTION
## Summary

Observed in the wild: a remote peer was emitting our local scene_driven_animation hash pair in its own outbound Movement packets — identity matched the remote, positions/velocities were genuine, but the anim hashes were ours verbatim. Root cause turned out to be in the Unity explorer's comms pipeline — it pooled protobuf messages and Google.Protobuf preserves unknown fields on parse by default, so bytes we'd sent once ended up re-serialized on Unity's next outbound. Fix PR over there: https://github.com/decentraland/unity-explorer/pull/8389.

This PR adds a defence-in-depth check so we don't rely on every other client to have that fix. `SceneDrivenAnimation` now carries `origin_address`, which the sender stamps with their wallet address. Receivers require it to match the packet's sender and drop the anim otherwise. Strict — absent counts as mismatch — because any sender that predates this field is itself a potential mirror victim. Once this ships, a non-mirror-fixed peer relaying our bytes is harmless: the `origin_address` still reads as ours, not theirs, so we reject.

## Changes

- `comms.proto`: `optional string origin_address = 8;` on `SceneDrivenAnimation`
- `broadcast_position.rs`: populate `origin_address` from `wallet.address()` as `{:#x}`
- `global_crdt.rs`: `resolve_remote_anim` takes the sender address and drops the anim unless `origin_address` is set and matches (case-insensitive); clears cached hashes for the entity on reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)