### PR TITLE
Apply scene-driven playback seek to emote prop animation

### DIFF
--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -1043,7 +1043,13 @@ fn play_current_emote(
         if let Some((prop_player_ents, clip_ix)) = prop_player_and_clip {
             for ent in prop_player_ents {
                 if let Ok((mut player, transitions, _, _)) = players.get_mut(ent) {
-                    play(transitions, &mut player, clip_ix, &active_emote, None);
+                    play(
+                        transitions,
+                        &mut player,
+                        clip_ix,
+                        &active_emote,
+                        pending_seek,
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

`play_current_emote` passes `pending_seek` through to the avatar's animation player but hard-codes `None` for the prop player (`crates/avatar/src/animate.rs:1046`). When a scene-driven animation publishes a `playbackTime` — e.g. `speed: 0` + `playbackTime` to freeze on a specific pose — the avatar seeks to the target frame but the prop stays at whatever time it happened to be on, breaking sync for any prop whose pose matters at that frame.

Fix: pass the same `pending_seek` value to the prop play call. `pending_seek: Option<f32>` is `Copy`, so reusing it after the avatar call is fine. Speed is already propagated correctly (the shared `play` closure calls `set_speed(active_emote.speed)` for both).

Surfaced while wiring a glide prop in the movement scene — the avatar freezes on the intended frame but the glider stays in the wrong position until we let the clip play at non-zero speed.