### PR TITLE
allow bad topology triangles

### DIFF
--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -1180,7 +1180,7 @@ pub fn mesh_to_parry_shape(mesh_data: &Mesh) -> SharedShape {
         indices_parry,
         TriMeshFlags::DELETE_DEGENERATE_TRIANGLES
             | TriMeshFlags::DELETE_DUPLICATE_TRIANGLES
-            | TriMeshFlags::DELETE_BAD_TOPOLOGY_TRIANGLES,
+            | TriMeshFlags::MERGE_DUPLICATE_VERTICES,
     )
     .unwrap()
 }


### PR DESCRIPTION
fixes theatre stairs in genesis plaza.

detail: the theatre stairs had triangles with shared vertices and different winding order. this makes shapecasting and ccd return invalid normals when colliding with the shared edge, so the triangles are removed. but because our char controller relies only on the capsule normal (not the collided edge normal), we can safely include them without bad side effects.