### PR TITLE
Don't bypass 10Hz broadcast gate for pending seeks

### DIFF
--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -97,8 +97,10 @@ fn broadcast_position(
     }
 
     let elapsed = time - *last_sent;
-    // A pending seek bypasses the dynamic-rate gate so remotes receive it promptly.
-    if elapsed < DYNAMIC_FREQ && last_anim.pending_seek.is_none() {
+    // Pending seeks do NOT bypass the 10Hz gate — sending faster than that gets us
+    // shadowbanned. The latch above already holds the most recent seek; it rides out
+    // on the next scheduled broadcast.
+    if elapsed < DYNAMIC_FREQ {
         return;
     }
 


### PR DESCRIPTION
## Summary

Animation seeks were overriding the 10Hz broadcast rate gate in `broadcast_position` so they'd ship on the exact frame the scene published them. That pushes the outbound comms rate above the server's per-client limit and gets the client shadowbanned.

The seek latch on `LastAnim` already captures the freshest seek seen between broadcast ticks, so the fix is just to drop the `pending_seek.is_none()` escape hatch on the dynamic-rate gate — the latched seek will now ride out on the next scheduled 10Hz broadcast instead of forcing an immediate send.

The 1Hz static-keepalive bypass is intentionally left in place: it only fires when the avatar is otherwise idle, and without it a seek-while-idle could be delayed by up to a full second. With only the 10Hz gate enforced, a seek is sent at most on the next 10Hz boundary.