### PR TITLE
Foot IK with pelvis lowering, ground tilt, and edge smoothing

### DIFF
--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -256,6 +256,24 @@ impl Default for ActiveEmote {
     }
 }
 
+impl ActiveEmote {
+    /// True when this represents an idle pose. For scene-driven anims the
+    /// movement scene's idle flag is mirrored on `overridable`; for engine
+    /// velocity-selected anims, the URN identifies it; triggered emotes
+    /// (dances etc.) are never considered idle.
+    pub fn is_idle(&self) -> bool {
+        match self.source {
+            ActiveEmoteSource::SceneMovementAnim => self.overridable,
+            ActiveEmoteSource::VelocitySelected => self.urn.as_str().contains("idle"),
+            ActiveEmoteSource::TriggeredEmote => false,
+        }
+    }
+
+    pub fn transition_seconds(&self) -> f32 {
+        self.transition_seconds
+    }
+}
+
 // TODO this function is a POS
 // lots of magic numbers that don't even deserve to be constants, needs reworking
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -3,7 +3,7 @@ use bevy::{
     transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
 use bevy_console::ConsoleCommand;
-use common::structs::{AvatarDynamicState, PrimaryUser};
+use common::structs::PrimaryUser;
 use console::DoAddConsoleCommand;
 use dcl_component::proto_components::sdk::components::ColliderLayer;
 use scene_runner::{
@@ -13,6 +13,8 @@ use scene_runner::{
     },
     ContainingScene,
 };
+
+use crate::animate::ActiveEmote;
 
 pub struct FootIkPlugin;
 
@@ -45,10 +47,6 @@ pub struct FootIkConfig {
     /// Local-space Y of the foot bone when planted on flat ground.
     /// Hardcoded guess; tune by observation.
     pub plant_y: f32,
-    /// Speed below which IK is at full strength.
-    pub idle_speed_threshold: f32,
-    /// Speed above which IK is fully off.
-    pub run_speed_threshold: f32,
     /// Start the down-cast this far above the animated foot.
     pub raycast_up: f32,
     /// Search this far below the animated foot.
@@ -60,6 +58,9 @@ pub struct FootIkConfig {
     /// gate going downward: if a leg would need a larger pelvis drop than this
     /// to plant, the leg disengages (e.g. dangling off a cliff edge).
     pub max_pelvis_drop: f32,
+    /// Floor on the per-emote transition_seconds used to ramp IK weight; avoids
+    /// instantaneous snaps when an emote declares 0s.
+    pub min_transition_seconds: f32,
 }
 
 impl Default for FootIkConfig {
@@ -67,12 +68,11 @@ impl Default for FootIkConfig {
         Self {
             enabled: false,
             plant_y: 0.091,
-            idle_speed_threshold: 0.1,
-            run_speed_threshold: 1.5,
             raycast_up: 0.3,
             raycast_down: 0.6,
             max_step_up: 0.4,
             max_pelvis_drop: 0.4,
+            min_transition_seconds: 0.05,
         }
     }
 }
@@ -245,38 +245,58 @@ struct LegPlan {
 #[allow(clippy::too_many_arguments)]
 fn apply_foot_ik(
     config: Res<FootIkConfig>,
-    primary: Query<(&FootIkRig, &AvatarDynamicState, &GlobalTransform), With<PrimaryUser>>,
+    time: Res<Time>,
+    primary: Query<(&FootIkRig, Option<&ActiveEmote>, &GlobalTransform), With<PrimaryUser>>,
     containing: ContainingScene,
     mut scenes: Query<&mut SceneColliderData>,
     parents: Query<&ChildOf>,
     globals: Query<&GlobalTransform>,
     mut transforms: Query<&mut Transform>,
+    mut anim_w: Local<f32>,
     mut log_tick: Local<u32>,
 ) {
     if !config.enabled {
+        // Reset the ramp so re-enabling doesn't pop in at full strength.
+        *anim_w = 0.0;
         return;
     }
     *log_tick = log_tick.wrapping_add(1);
     let log_now = *log_tick % 60 == 1;
 
-    let Ok((rig, dyn_state, player_global)) = primary.single() else {
+    let Ok((rig, active_emote, player_global)) = primary.single() else {
         if log_now {
             warn!("foot_ik: no primary user with FootIkRig");
         }
         return;
     };
 
-    let speed = Vec3::new(dyn_state.velocity.x, 0.0, dyn_state.velocity.z).length();
-    let w_speed = 1.0
-        - smoothstep(
-            config.idle_speed_threshold,
-            config.run_speed_threshold,
-            speed,
+    // Animation-driven IK strength: ramp toward 1.0 while the active emote is
+    // an idle pose, otherwise toward 0.0, at a rate set by the emote's
+    // declared transition_seconds. No active emote → ramp out.
+    let target = active_emote
+        .map(|e| if e.is_idle() { 1.0 } else { 0.0 })
+        .unwrap_or(0.0);
+    let transition = active_emote
+        .map(|e| e.transition_seconds())
+        .unwrap_or(config.min_transition_seconds)
+        .max(config.min_transition_seconds);
+    let step = time.delta_secs() / transition;
+    *anim_w = if target > *anim_w {
+        (*anim_w + step).min(target)
+    } else {
+        (*anim_w - step).max(target)
+    };
+    let w_anim = *anim_w;
+    if log_now {
+        info!(
+            "foot_ik: w_anim={:.2} target={:.1} transition={:.2}s emote={:?}",
+            w_anim,
+            target,
+            transition,
+            active_emote.map(|e| e.is_idle())
         );
-    if w_speed <= 0.0 {
-        if log_now {
-            info!("foot_ik: gated by speed ({:.2} m/s)", speed);
-        }
+    }
+    if w_anim <= 1e-3 {
         return;
     }
 
@@ -295,7 +315,7 @@ fn apply_foot_ik(
         "L",
         rig.left,
         &config,
-        w_speed,
+        w_anim,
         player_y,
         &scene_ents,
         &mut scenes,
@@ -306,7 +326,7 @@ fn apply_foot_ik(
         "R",
         rig.right,
         &config,
-        w_speed,
+        w_anim,
         player_y,
         &scene_ents,
         &mut scenes,
@@ -314,12 +334,12 @@ fn apply_foot_ik(
         log_now,
     );
 
-    // Pass 2: pelvis drop = max required across engaged legs, scaled by w_speed.
+    // Pass 2: pelvis drop = max required across engaged legs, scaled by w_anim.
     // Each engaged leg has finite required_drop ≤ max_pelvis_drop by
     // construction (others were filtered out in plan_leg).
     let mut pelvis_drop = 0.0f32;
     for plan in [plan_l.as_ref(), plan_r.as_ref()].into_iter().flatten() {
-        pelvis_drop = pelvis_drop.max(plan.required_drop * w_speed);
+        pelvis_drop = pelvis_drop.max(plan.required_drop * w_anim);
     }
     if log_now {
         info!("foot_ik: pelvis_drop={:.3}", pelvis_drop);
@@ -368,7 +388,7 @@ fn plan_leg(
     label: &str,
     leg: LegBones,
     config: &FootIkConfig,
-    w_speed: f32,
+    w_anim: f32,
     player_y: f32,
     scene_ents: &[Entity],
     scenes: &mut Query<&mut SceneColliderData>,
@@ -444,7 +464,7 @@ fn plan_leg(
         required_drop <= config.max_pelvis_drop
     };
     let reach_w = if reach_ok { 1.0 } else { 0.0 };
-    let w = (w_speed * reach_w).clamp(0.0, 1.0);
+    let w = (w_anim * reach_w).clamp(0.0, 1.0);
     if log_now {
         let dy_anim = target_c.y - c.y;
         info!(
@@ -544,9 +564,4 @@ fn apply_leg_ik(
     if let Ok(mut t) = transforms.get_mut(leg.lower) {
         t.rotation = new_knee_local_rot;
     }
-}
-
-fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
-    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
-    t * t * (3.0 - 2.0 * t)
 }

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -65,6 +65,16 @@ pub struct FootIkConfig {
     /// the contact-normal of the ground beneath it. Caps stylised aesthetics
     /// (toes don't dive into steep slopes).
     pub max_foot_tilt_deg: f32,
+    /// Time in seconds for a leg to engage/disengage when its reachability
+    /// flips (e.g. crossing a cliff edge while turning).
+    pub engage_transition_seconds: f32,
+    /// Maximum vertical change per second of the foot's final world Y (the
+    /// post-weight, post-IK output). Smooths step-discontinuities in the
+    /// raycast result (cliff edges traversed by foot xz while turning) and
+    /// is invariant under continuous platform motion (avatar moves with the
+    /// platform, so the *relative* offset doesn't change). Snaps on the
+    /// first engaged frame after a disengaged one.
+    pub target_velocity_limit: f32,
 }
 
 impl Default for FootIkConfig {
@@ -78,6 +88,8 @@ impl Default for FootIkConfig {
             max_pelvis_drop: 0.4,
             min_transition_seconds: 0.05,
             max_foot_tilt_deg: 30.0,
+            engage_transition_seconds: 0.5,
+            target_velocity_limit: 1.5,
         }
     }
 }
@@ -239,7 +251,9 @@ struct LegPlan {
     target_c: Vec3,
     l_ab: f32,
     l_bc: f32,
-    w: f32,
+    /// True if the leg can physically reach `target_c` within the configured
+    /// step-up / pelvis-drop limits this frame.
+    reach_ok: bool,
     /// Pelvis drop required for this leg to physically reach `target_c`.
     /// 0 if the leg can already reach without any drop.
     required_drop: f32,
@@ -248,6 +262,17 @@ struct LegPlan {
     cur_hip_global_rot: Quat,
     cur_knee_global_rot: Quat,
     cur_foot_global_rot: Quat,
+}
+
+#[derive(Default, Clone, Copy)]
+struct LegEngState {
+    /// Per-leg engagement, ramped over `engage_transition_seconds` toward
+    /// 1.0 while `reach_ok` and 0.0 otherwise.
+    engaged: f32,
+    /// Last frame's final foot Y (animated_y + (target_y - animated_y) * w)
+    /// after the velocity limit. Snapped to the desired value on the first
+    /// engaged frame, then rate-limited per-frame thereafter.
+    last_final_y: f32,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -261,11 +286,13 @@ fn apply_foot_ik(
     globals: Query<&GlobalTransform>,
     mut transforms: Query<&mut Transform>,
     mut anim_w: Local<f32>,
+    mut leg_state: Local<[LegEngState; 2]>,
     mut log_tick: Local<u32>,
 ) {
     if !config.enabled {
-        // Reset the ramp so re-enabling doesn't pop in at full strength.
+        // Reset ramps so re-enabling doesn't pop in at full strength.
         *anim_w = 0.0;
+        *leg_state = [LegEngState::default(); 2];
         return;
     }
     *log_tick = log_tick.wrapping_add(1);
@@ -288,25 +315,13 @@ fn apply_foot_ik(
         .map(|e| e.transition_seconds())
         .unwrap_or(config.min_transition_seconds)
         .max(config.min_transition_seconds);
-    let step = time.delta_secs() / transition;
+    let dt = time.delta_secs();
     *anim_w = if target > *anim_w {
-        (*anim_w + step).min(target)
+        (*anim_w + dt / transition).min(target)
     } else {
-        (*anim_w - step).max(target)
+        (*anim_w - dt / transition).max(target)
     };
     let w_anim = *anim_w;
-    if log_now {
-        info!(
-            "foot_ik: w_anim={:.2} target={:.1} transition={:.2}s emote={:?}",
-            w_anim,
-            target,
-            transition,
-            active_emote.map(|e| e.is_idle())
-        );
-    }
-    if w_anim <= 1e-3 {
-        return;
-    }
 
     let scene_ents: Vec<Entity> = containing
         .get_position(player_global.translation())
@@ -318,36 +333,136 @@ fn apply_foot_ik(
     let pole_dir = player_global.compute_transform().rotation * Vec3::NEG_Z;
     let player_y = player_global.translation().y;
 
-    // Pass 1: plan both legs (raycast, target, weights, lengths).
-    let plan_l = plan_leg(
-        "L",
-        rig.left,
-        &config,
-        w_anim,
-        player_y,
-        &scene_ents,
-        &mut scenes,
-        &globals,
-        log_now,
-    );
-    let plan_r = plan_leg(
-        "R",
-        rig.right,
-        &config,
-        w_anim,
-        player_y,
-        &scene_ents,
-        &mut scenes,
-        &globals,
-        log_now,
-    );
+    // Pass 1: per-leg raycast. plan_leg returns geometry + reach_ok; we
+    // always run it (even when w_anim is small) so engagement and rate-limit
+    // state stay current across walk→idle transitions.
+    let raw = [
+        plan_leg(
+            "L",
+            rig.left,
+            &config,
+            player_y,
+            &scene_ents,
+            &mut scenes,
+            &globals,
+            log_now,
+        ),
+        plan_leg(
+            "R",
+            rig.right,
+            &config,
+            player_y,
+            &scene_ents,
+            &mut scenes,
+            &globals,
+            log_now,
+        ),
+    ];
 
-    // Pass 2: pelvis drop = max required across engaged legs, scaled by w_anim.
-    // Each engaged leg has finite required_drop ≤ max_pelvis_drop by
-    // construction (others were filtered out in plan_leg).
+    let eng_step = dt / config.engage_transition_seconds.max(1e-3);
+    let mut effective: [Option<LegPlan>; 2] = [None, None];
+    let mut leg_w = [0.0f32; 2];
+
+    for i in 0..2 {
+        let state = &mut leg_state[i];
+        let was_engaged = state.engaged > 1e-3;
+
+        // Update engagement target.
+        let target_eng = match raw[i].as_ref() {
+            Some(p) if p.reach_ok => 1.0,
+            _ => 0.0,
+        };
+        state.engaged = if target_eng > state.engaged {
+            (state.engaged + eng_step).min(target_eng)
+        } else {
+            (state.engaged - eng_step).max(target_eng)
+        };
+
+        // Engagement clamped by (not multiplied with) the animation weight —
+        // both act as independent gates and the lower wins.
+        let w = w_anim.min(state.engaged);
+        leg_w[i] = w;
+
+        if state.engaged <= 1e-3 {
+            state.engaged = 0.0;
+            continue;
+        }
+        let Some(p) = raw[i].as_ref() else {
+            continue;
+        };
+
+        // Velocity limit on the foot's *final* world Y (linear approximation
+        // of IK output: animated_y + (target_y - animated_y) * w). On the
+        // first engaged frame, snap. Otherwise rate-limit the per-frame
+        // change. Then back-derive a new target_y for the IK math so the
+        // post-weight foot lands at the rate-limited final Y.
+        let animated_y = p.c.y;
+        let raw_target_y = p.target_c.y;
+        let desired_final_y = animated_y + (raw_target_y - animated_y) * w;
+        let final_y = if was_engaged {
+            let max_step = config.target_velocity_limit * dt;
+            let delta = (desired_final_y - state.last_final_y).clamp(-max_step, max_step);
+            state.last_final_y + delta
+        } else {
+            desired_final_y
+        };
+        state.last_final_y = final_y;
+
+        // Back-derive an IK target so that, after the slerp blend at weight w,
+        // the foot lands at final_y. The IK math itself clamps l_at to within
+        // physical reach, so we don't need (and must not apply) a hip-relative
+        // clamp here — the pelvis is about to drop, expanding the reach.
+        let new_target_y = if w > 1e-3 {
+            animated_y + (final_y - animated_y) / w
+        } else {
+            raw_target_y
+        };
+        let target_c = Vec3::new(p.target_c.x, new_target_y, p.target_c.z);
+
+        // Pelvis drop is sized to where the foot will *actually* end up
+        // (final_y), using the raw raycast XZ.
+        let total_reach = p.l_ab + p.l_bc;
+        let total = (total_reach - 1e-3).max(0.0);
+        let dx = p.a.x - p.target_c.x;
+        let dz = p.a.z - p.target_c.z;
+        let horiz2 = dx * dx + dz * dz;
+        let hv = p.a.y - final_y;
+        let inside = total * total - horiz2;
+        let required_drop = if inside > 0.0 {
+            (hv - inside.sqrt()).max(0.0)
+        } else {
+            0.0
+        };
+
+        effective[i] = Some(LegPlan {
+            a: p.a,
+            b: p.b,
+            c: p.c,
+            l_ab: p.l_ab,
+            l_bc: p.l_bc,
+            reach_ok: p.reach_ok,
+            target_c,
+            contact_normal: p.contact_normal,
+            required_drop,
+            cur_hip_global_rot: p.cur_hip_global_rot,
+            cur_knee_global_rot: p.cur_knee_global_rot,
+            cur_foot_global_rot: p.cur_foot_global_rot,
+        });
+    }
+
+    if log_now {
+        info!(
+            "foot_ik: w_anim={:.2} engaged=[{:.2},{:.2}] leg_w=[{:.2},{:.2}]",
+            w_anim, leg_state[0].engaged, leg_state[1].engaged, leg_w[0], leg_w[1]
+        );
+    }
+
+    // Pass 2: pelvis drop = max required across engaged legs, scaled per leg.
     let mut pelvis_drop = 0.0f32;
-    for plan in [plan_l.as_ref(), plan_r.as_ref()].into_iter().flatten() {
-        pelvis_drop = pelvis_drop.max(plan.required_drop * w_anim);
+    for i in 0..2 {
+        if let Some(eff) = &effective[i] {
+            pelvis_drop = pelvis_drop.max(eff.required_drop * leg_w[i]);
+        }
     }
     if log_now {
         info!("foot_ik: pelvis_drop={:.3}", pelvis_drop);
@@ -374,20 +489,23 @@ fn apply_foot_ik(
 
     let drop_vec = Vec3::new(0.0, pelvis_drop, 0.0);
 
-    // Pass 3: per-leg IK. Hip world position is shifted by the pelvis drop;
-    // bone rotations and lengths are unchanged, so we just translate (a, b, c).
-    for (leg, plan_opt) in [(rig.left, plan_l), (rig.right, plan_r)] {
-        if let Some(plan) = plan_opt {
-            apply_leg_ik(
-                leg,
-                plan,
-                drop_vec,
-                pole_dir,
-                &config,
-                &parents,
-                &globals,
-                &mut transforms,
-            );
+    // Pass 3: per-leg IK using the rate-limited effective plans.
+    let [eff_l, eff_r] = effective;
+    for (leg, eff, w) in [(rig.left, eff_l, leg_w[0]), (rig.right, eff_r, leg_w[1])] {
+        if let Some(plan) = eff {
+            if w > 1e-3 {
+                apply_leg_ik(
+                    leg,
+                    plan,
+                    w,
+                    drop_vec,
+                    pole_dir,
+                    &config,
+                    &parents,
+                    &globals,
+                    &mut transforms,
+                );
+            }
         }
     }
 }
@@ -397,7 +515,6 @@ fn plan_leg(
     label: &str,
     leg: LegBones,
     config: &FootIkConfig,
-    w_anim: f32,
     player_y: f32,
     scene_ents: &[Entity],
     scenes: &mut Query<&mut SceneColliderData>,
@@ -472,17 +589,12 @@ fn plan_leg(
     } else {
         required_drop <= config.max_pelvis_drop
     };
-    let reach_w = if reach_ok { 1.0 } else { 0.0 };
-    let w = (w_anim * reach_w).clamp(0.0, 1.0);
     if log_now {
         let dy_anim = target_c.y - c.y;
         info!(
-            "foot_ik[{label}]: foot_y={:.3} ground_y={:.3} target_y={:.3} dy_anim={:.3} dy_player={:.3} required_drop={:.3} reach_w={:.2} w={:.2}",
-            c.y, ground_y, target_c.y, dy_anim, dy_player, required_drop, reach_w, w
+            "foot_ik[{label}]: foot_y={:.3} ground_y={:.3} target_y={:.3} dy_anim={:.3} dy_player={:.3} required_drop={:.3} reach_ok={}",
+            c.y, ground_y, target_c.y, dy_anim, dy_player, required_drop, reach_ok
         );
-    }
-    if w <= 1e-3 {
-        return None;
     }
 
     Some(LegPlan {
@@ -492,7 +604,7 @@ fn plan_leg(
         target_c,
         l_ab,
         l_bc,
-        w,
+        reach_ok,
         required_drop,
         contact_normal,
         cur_hip_global_rot: hip_g.compute_transform().rotation,
@@ -505,6 +617,7 @@ fn plan_leg(
 fn apply_leg_ik(
     leg: LegBones,
     plan: LegPlan,
+    w: f32,
     drop_vec: Vec3,
     pole_dir: Vec3,
     config: &FootIkConfig,
@@ -554,8 +667,8 @@ fn apply_leg_ik(
     let new_dir_bc = (target_c - new_b).normalize_or_zero();
     let r_knee = Quat::from_rotation_arc(dir_bc_after_hip, new_dir_bc);
 
-    let r_hip_b = Quat::IDENTITY.slerp(r_hip, plan.w);
-    let r_knee_b = Quat::IDENTITY.slerp(r_knee, plan.w);
+    let r_hip_b = Quat::IDENTITY.slerp(r_hip, w);
+    let r_knee_b = Quat::IDENTITY.slerp(r_knee, w);
 
     let new_hip_global_rot = r_hip_b * plan.cur_hip_global_rot;
     let new_knee_global_rot = r_knee_b * r_hip_b * plan.cur_knee_global_rot;
@@ -578,7 +691,7 @@ fn apply_leg_ik(
     let (axis, angle) = align_full.to_axis_angle();
     let max_tilt = config.max_foot_tilt_deg.to_radians();
     let align_clamped = Quat::from_axis_angle(axis, angle.min(max_tilt));
-    let align_blended = Quat::IDENTITY.slerp(align_clamped, plan.w);
+    let align_blended = Quat::IDENTITY.slerp(align_clamped, w);
     let new_foot_global_rot = align_blended * plan.cur_foot_global_rot;
     let new_foot_local_rot = new_knee_global_rot.inverse() * new_foot_global_rot;
 

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -4,6 +4,7 @@ use bevy::{
 };
 use bevy_console::ConsoleCommand;
 use common::structs::PrimaryUser;
+use comms::global_crdt::ForeignPlayer;
 use console::DoAddConsoleCommand;
 use dcl_component::proto_components::sdk::components::ColliderLayer;
 use scene_runner::{
@@ -15,6 +16,8 @@ use scene_runner::{
 };
 
 use crate::animate::ActiveEmote;
+
+type AvatarFilter = Or<(With<PrimaryUser>, With<ForeignPlayer>)>;
 
 pub struct FootIkPlugin;
 
@@ -129,8 +132,8 @@ fn foot_ik_console_command(
 fn cache_foot_ik_rig(
     mut commands: Commands,
     config: Res<FootIkConfig>,
-    needs_rig: Query<Entity, (With<PrimaryUser>, Without<FootIkRig>)>,
-    has_rig: Query<(Entity, &FootIkRig), With<PrimaryUser>>,
+    needs_rig: Query<Entity, (AvatarFilter, Without<FootIkRig>)>,
+    has_rig: Query<(Entity, &FootIkRig), AvatarFilter>,
     children_q: Query<&Children>,
     name_q: Query<&Name>,
     globals: Query<&GlobalTransform>,
@@ -173,19 +176,22 @@ fn cache_foot_ik_rig(
                 "foot_ik: cached rig for {:?} (hips: {:?}, l: {:?}/{:?}/{:?}, r: {:?}/{:?}/{:?})",
                 avatar, hips, lu, ll, lf, ru, rl, rf
             );
-            commands.entity(avatar).try_insert(FootIkRig {
-                hips,
-                left: LegBones {
-                    upper: lu,
-                    lower: ll,
-                    foot: lf,
+            commands.entity(avatar).try_insert((
+                FootIkRig {
+                    hips,
+                    left: LegBones {
+                        upper: lu,
+                        lower: ll,
+                        foot: lf,
+                    },
+                    right: LegBones {
+                        upper: ru,
+                        lower: rl,
+                        foot: rf,
+                    },
                 },
-                right: LegBones {
-                    upper: ru,
-                    lower: rl,
-                    foot: rf,
-                },
-            });
+                FootIkRuntime::default(),
+            ));
         } else if config.enabled {
             *log_counter = log_counter.wrapping_add(1);
             if *log_counter % 120 == 1 {
@@ -275,236 +281,243 @@ struct LegEngState {
     last_final_y: f32,
 }
 
+/// Per-avatar runtime state for the IK system. Inserted alongside `FootIkRig`
+/// when the rig is first cached.
+#[derive(Component, Default)]
+struct FootIkRuntime {
+    /// Animation-driven IK strength, ramped toward 1.0 while in an idle pose.
+    anim_w: f32,
+    /// Per-leg engagement + rate-limited final-Y state.
+    legs: [LegEngState; 2],
+}
+
 #[allow(clippy::too_many_arguments)]
 fn apply_foot_ik(
     config: Res<FootIkConfig>,
     time: Res<Time>,
-    primary: Query<(&FootIkRig, Option<&ActiveEmote>, &GlobalTransform), With<PrimaryUser>>,
+    mut avatars: Query<
+        (
+            Entity,
+            &FootIkRig,
+            Option<&ActiveEmote>,
+            &GlobalTransform,
+            &mut FootIkRuntime,
+        ),
+        AvatarFilter,
+    >,
     containing: ContainingScene,
     mut scenes: Query<&mut SceneColliderData>,
     parents: Query<&ChildOf>,
     globals: Query<&GlobalTransform>,
     mut transforms: Query<&mut Transform>,
-    mut anim_w: Local<f32>,
-    mut leg_state: Local<[LegEngState; 2]>,
     mut log_tick: Local<u32>,
 ) {
     if !config.enabled {
-        // Reset ramps so re-enabling doesn't pop in at full strength.
-        *anim_w = 0.0;
-        *leg_state = [LegEngState::default(); 2];
+        // Reset all per-avatar runtime state so re-enabling doesn't pop in.
+        for (_, _, _, _, mut runtime) in &mut avatars {
+            *runtime = FootIkRuntime::default();
+        }
         return;
     }
     *log_tick = log_tick.wrapping_add(1);
     let log_now = *log_tick % 60 == 1;
-
-    let Ok((rig, active_emote, player_global)) = primary.single() else {
-        if log_now {
-            warn!("foot_ik: no primary user with FootIkRig");
-        }
-        return;
-    };
-
-    // Animation-driven IK strength: ramp toward 1.0 while the active emote is
-    // an idle pose, otherwise toward 0.0, at a rate set by the emote's
-    // declared transition_seconds. No active emote → ramp out.
-    let target = active_emote
-        .map(|e| if e.is_idle() { 1.0 } else { 0.0 })
-        .unwrap_or(0.0);
-    let transition = active_emote
-        .map(|e| e.transition_seconds())
-        .unwrap_or(config.min_transition_seconds)
-        .max(config.min_transition_seconds);
     let dt = time.delta_secs();
-    *anim_w = if target > *anim_w {
-        (*anim_w + dt / transition).min(target)
-    } else {
-        (*anim_w - dt / transition).max(target)
-    };
-    let w_anim = *anim_w;
 
-    let scene_ents: Vec<Entity> = containing
-        .get_position(player_global.translation())
-        .into_iter()
-        .collect();
-
-    // Pole hint: avatar's forward direction. The Decentraland avatar rig faces
-    // local -Z (knees bend toward -Z), so use that as the pole.
-    let pole_dir = player_global.compute_transform().rotation * Vec3::NEG_Z;
-    let player_y = player_global.translation().y;
-
-    // Pass 1: per-leg raycast. plan_leg returns geometry + reach_ok; we
-    // always run it (even when w_anim is small) so engagement and rate-limit
-    // state stay current across walk→idle transitions.
-    let raw = [
-        plan_leg(
-            "L",
-            rig.left,
-            &config,
-            player_y,
-            &scene_ents,
-            &mut scenes,
-            &globals,
-            log_now,
-        ),
-        plan_leg(
-            "R",
-            rig.right,
-            &config,
-            player_y,
-            &scene_ents,
-            &mut scenes,
-            &globals,
-            log_now,
-        ),
-    ];
-
-    let eng_step = dt / config.engage_transition_seconds.max(1e-3);
-    let mut effective: [Option<LegPlan>; 2] = [None, None];
-    let mut leg_w = [0.0f32; 2];
-
-    for i in 0..2 {
-        let state = &mut leg_state[i];
-        let was_engaged = state.engaged > 1e-3;
-
-        // Update engagement target.
-        let target_eng = match raw[i].as_ref() {
-            Some(p) if p.reach_ok => 1.0,
-            _ => 0.0,
-        };
-        state.engaged = if target_eng > state.engaged {
-            (state.engaged + eng_step).min(target_eng)
+    for (avatar_ent, rig, active_emote, avatar_global, mut runtime) in &mut avatars {
+        // Animation-driven IK strength: ramp toward 1.0 while the active emote
+        // is an idle pose, otherwise toward 0.0, at a rate set by the emote's
+        // declared transition_seconds. No active emote → ramp out.
+        let target = active_emote
+            .map(|e| if e.is_idle() { 1.0 } else { 0.0 })
+            .unwrap_or(0.0);
+        let transition = active_emote
+            .map(|e| e.transition_seconds())
+            .unwrap_or(config.min_transition_seconds)
+            .max(config.min_transition_seconds);
+        runtime.anim_w = if target > runtime.anim_w {
+            (runtime.anim_w + dt / transition).min(target)
         } else {
-            (state.engaged - eng_step).max(target_eng)
+            (runtime.anim_w - dt / transition).max(target)
         };
+        let w_anim = runtime.anim_w;
 
-        // Engagement clamped by (not multiplied with) the animation weight —
-        // both act as independent gates and the lower wins.
-        let w = w_anim.min(state.engaged);
-        leg_w[i] = w;
+        // Bound the raycasts to scenes containing *this* avatar's position.
+        let scene_ents: Vec<Entity> = containing
+            .get_position(avatar_global.translation())
+            .into_iter()
+            .collect();
 
-        if state.engaged <= 1e-3 {
-            state.engaged = 0.0;
-            continue;
+        let pole_dir = avatar_global.compute_transform().rotation * Vec3::NEG_Z;
+        let avatar_y = avatar_global.translation().y;
+
+        // Pass 1: per-leg raycast.
+        let raw = [
+            plan_leg(
+                "L",
+                rig.left,
+                &config,
+                avatar_y,
+                &scene_ents,
+                &mut scenes,
+                &globals,
+                log_now,
+            ),
+            plan_leg(
+                "R",
+                rig.right,
+                &config,
+                avatar_y,
+                &scene_ents,
+                &mut scenes,
+                &globals,
+                log_now,
+            ),
+        ];
+
+        let eng_step = dt / config.engage_transition_seconds.max(1e-3);
+        let mut effective: [Option<LegPlan>; 2] = [None, None];
+        let mut leg_w = [0.0f32; 2];
+
+        for i in 0..2 {
+            let state = &mut runtime.legs[i];
+            let was_engaged = state.engaged > 1e-3;
+
+            let target_eng = match raw[i].as_ref() {
+                Some(p) if p.reach_ok => 1.0,
+                _ => 0.0,
+            };
+            state.engaged = if target_eng > state.engaged {
+                (state.engaged + eng_step).min(target_eng)
+            } else {
+                (state.engaged - eng_step).max(target_eng)
+            };
+
+            // Engagement clamped by (not multiplied with) w_anim; both gate
+            // independently and the lower wins.
+            let w = w_anim.min(state.engaged);
+            leg_w[i] = w;
+
+            if state.engaged <= 1e-3 {
+                state.engaged = 0.0;
+                continue;
+            }
+            let Some(p) = raw[i].as_ref() else {
+                continue;
+            };
+
+            // Velocity-limit the foot's final world Y so step-discontinuities
+            // in the raycast (cliff edges traversed by foot xz while turning)
+            // don't snap. On (re-)engagement after a disengaged frame, snap.
+            let animated_y = p.c.y;
+            let raw_target_y = p.target_c.y;
+            let desired_final_y = animated_y + (raw_target_y - animated_y) * w;
+            let final_y = if was_engaged {
+                let max_step = config.target_velocity_limit * dt;
+                let delta = (desired_final_y - state.last_final_y).clamp(-max_step, max_step);
+                state.last_final_y + delta
+            } else {
+                desired_final_y
+            };
+            state.last_final_y = final_y;
+
+            // Back-derive the IK target so the slerped foot lands at final_y.
+            // No hip-relative clamp here — pelvis drop expands reach, and the
+            // IK math clamps l_at internally.
+            let new_target_y = if w > 1e-3 {
+                animated_y + (final_y - animated_y) / w
+            } else {
+                raw_target_y
+            };
+            let target_c = Vec3::new(p.target_c.x, new_target_y, p.target_c.z);
+
+            // Pelvis drop sized to final_y (where the foot actually ends up).
+            let total = (p.l_ab + p.l_bc - 1e-3).max(0.0);
+            let dx = p.a.x - p.target_c.x;
+            let dz = p.a.z - p.target_c.z;
+            let horiz2 = dx * dx + dz * dz;
+            let hv = p.a.y - final_y;
+            let inside = total * total - horiz2;
+            let required_drop = if inside > 0.0 {
+                (hv - inside.sqrt()).max(0.0)
+            } else {
+                0.0
+            };
+
+            effective[i] = Some(LegPlan {
+                a: p.a,
+                b: p.b,
+                c: p.c,
+                l_ab: p.l_ab,
+                l_bc: p.l_bc,
+                reach_ok: p.reach_ok,
+                target_c,
+                contact_normal: p.contact_normal,
+                required_drop,
+                cur_hip_global_rot: p.cur_hip_global_rot,
+                cur_knee_global_rot: p.cur_knee_global_rot,
+                cur_foot_global_rot: p.cur_foot_global_rot,
+            });
         }
-        let Some(p) = raw[i].as_ref() else {
-            continue;
-        };
 
-        // Velocity limit on the foot's *final* world Y (linear approximation
-        // of IK output: animated_y + (target_y - animated_y) * w). On the
-        // first engaged frame, snap. Otherwise rate-limit the per-frame
-        // change. Then back-derive a new target_y for the IK math so the
-        // post-weight foot lands at the rate-limited final Y.
-        let animated_y = p.c.y;
-        let raw_target_y = p.target_c.y;
-        let desired_final_y = animated_y + (raw_target_y - animated_y) * w;
-        let final_y = if was_engaged {
-            let max_step = config.target_velocity_limit * dt;
-            let delta = (desired_final_y - state.last_final_y).clamp(-max_step, max_step);
-            state.last_final_y + delta
-        } else {
-            desired_final_y
-        };
-        state.last_final_y = final_y;
-
-        // Back-derive an IK target so that, after the slerp blend at weight w,
-        // the foot lands at final_y. The IK math itself clamps l_at to within
-        // physical reach, so we don't need (and must not apply) a hip-relative
-        // clamp here — the pelvis is about to drop, expanding the reach.
-        let new_target_y = if w > 1e-3 {
-            animated_y + (final_y - animated_y) / w
-        } else {
-            raw_target_y
-        };
-        let target_c = Vec3::new(p.target_c.x, new_target_y, p.target_c.z);
-
-        // Pelvis drop is sized to where the foot will *actually* end up
-        // (final_y), using the raw raycast XZ.
-        let total_reach = p.l_ab + p.l_bc;
-        let total = (total_reach - 1e-3).max(0.0);
-        let dx = p.a.x - p.target_c.x;
-        let dz = p.a.z - p.target_c.z;
-        let horiz2 = dx * dx + dz * dz;
-        let hv = p.a.y - final_y;
-        let inside = total * total - horiz2;
-        let required_drop = if inside > 0.0 {
-            (hv - inside.sqrt()).max(0.0)
-        } else {
-            0.0
-        };
-
-        effective[i] = Some(LegPlan {
-            a: p.a,
-            b: p.b,
-            c: p.c,
-            l_ab: p.l_ab,
-            l_bc: p.l_bc,
-            reach_ok: p.reach_ok,
-            target_c,
-            contact_normal: p.contact_normal,
-            required_drop,
-            cur_hip_global_rot: p.cur_hip_global_rot,
-            cur_knee_global_rot: p.cur_knee_global_rot,
-            cur_foot_global_rot: p.cur_foot_global_rot,
-        });
-    }
-
-    if log_now {
-        info!(
-            "foot_ik: w_anim={:.2} engaged=[{:.2},{:.2}] leg_w=[{:.2},{:.2}]",
-            w_anim, leg_state[0].engaged, leg_state[1].engaged, leg_w[0], leg_w[1]
-        );
-    }
-
-    // Pass 2: pelvis drop = max required across engaged legs, scaled per leg.
-    let mut pelvis_drop = 0.0f32;
-    for i in 0..2 {
-        if let Some(eff) = &effective[i] {
-            pelvis_drop = pelvis_drop.max(eff.required_drop * leg_w[i]);
+        if log_now {
+            info!(
+                "foot_ik[{:?}]: w_anim={:.2} engaged=[{:.2},{:.2}] leg_w=[{:.2},{:.2}]",
+                avatar_ent,
+                w_anim,
+                runtime.legs[0].engaged,
+                runtime.legs[1].engaged,
+                leg_w[0],
+                leg_w[1]
+            );
         }
-    }
-    if log_now {
-        info!("foot_ik: pelvis_drop={:.3}", pelvis_drop);
-    }
 
-    // Apply pelvis drop to hips bone. Convert the world-Y delta into the hips'
-    // parent-local frame using the parent's full affine inverse — this accounts
-    // for cumulative ancestor scale (the avatar rig is imported with a ~0.01x
-    // scale, so a rotation-only conversion would produce a ~1cm-instead-of-1m
-    // delta).
-    if pelvis_drop > 1e-4 {
-        if let Ok(hips_parent) = parents.get(rig.hips) {
-            if let Ok(parent_global) = globals.get(hips_parent.parent()) {
-                if let Ok(mut t) = transforms.get_mut(rig.hips) {
-                    let local_delta = parent_global
-                        .affine()
-                        .inverse()
-                        .transform_vector3(Vec3::new(0.0, pelvis_drop, 0.0));
-                    t.translation -= local_delta;
+        // Pass 2: pelvis drop.
+        let mut pelvis_drop = 0.0f32;
+        for i in 0..2 {
+            if let Some(eff) = &effective[i] {
+                pelvis_drop = pelvis_drop.max(eff.required_drop * leg_w[i]);
+            }
+        }
+        if log_now {
+            info!("foot_ik[{:?}]: pelvis_drop={:.3}", avatar_ent, pelvis_drop);
+        }
+
+        // Apply pelvis drop. Convert the world-Y delta into hips' parent-local
+        // frame via the parent's full affine inverse — this accounts for the
+        // ~0.01x cumulative ancestor scale on the imported avatar rig.
+        if pelvis_drop > 1e-4 {
+            if let Ok(hips_parent) = parents.get(rig.hips) {
+                if let Ok(parent_global) = globals.get(hips_parent.parent()) {
+                    if let Ok(mut t) = transforms.get_mut(rig.hips) {
+                        let local_delta = parent_global
+                            .affine()
+                            .inverse()
+                            .transform_vector3(Vec3::new(0.0, pelvis_drop, 0.0));
+                        t.translation -= local_delta;
+                    }
                 }
             }
         }
-    }
 
-    let drop_vec = Vec3::new(0.0, pelvis_drop, 0.0);
+        let drop_vec = Vec3::new(0.0, pelvis_drop, 0.0);
 
-    // Pass 3: per-leg IK using the rate-limited effective plans.
-    let [eff_l, eff_r] = effective;
-    for (leg, eff, w) in [(rig.left, eff_l, leg_w[0]), (rig.right, eff_r, leg_w[1])] {
-        if let Some(plan) = eff {
-            if w > 1e-3 {
-                apply_leg_ik(
-                    leg,
-                    plan,
-                    w,
-                    drop_vec,
-                    pole_dir,
-                    &config,
-                    &parents,
-                    &globals,
-                    &mut transforms,
-                );
+        // Pass 3: per-leg IK using the rate-limited effective plans.
+        let [eff_l, eff_r] = effective;
+        for (leg, eff, w) in [(rig.left, eff_l, leg_w[0]), (rig.right, eff_r, leg_w[1])] {
+            if let Some(plan) = eff {
+                if w > 1e-3 {
+                    apply_leg_ik(
+                        leg,
+                        plan,
+                        w,
+                        drop_vec,
+                        pole_dir,
+                        &config,
+                        &parents,
+                        &globals,
+                        &mut transforms,
+                    );
+                }
             }
         }
     }

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -1,0 +1,528 @@
+use bevy::{
+    prelude::*,
+    transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
+};
+use bevy_console::ConsoleCommand;
+use common::structs::{AvatarDynamicState, PrimaryUser};
+use console::DoAddConsoleCommand;
+use dcl_component::proto_components::sdk::components::ColliderLayer;
+use scene_runner::{
+    update_world::{
+        mesh_collider::{SceneColliderData, GROUND_COLLISION_MASK},
+        transform_and_parent::PostUpdateSets,
+    },
+    ContainingScene,
+};
+
+pub struct FootIkPlugin;
+
+impl Plugin for FootIkPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<FootIkConfig>();
+        app.add_systems(
+            PostUpdate,
+            (
+                cache_foot_ik_rig,
+                apply_foot_ik,
+                (
+                    mark_dirty_trees,
+                    propagate_parent_transforms,
+                    sync_simple_transforms,
+                )
+                    .chain(),
+            )
+                .chain()
+                .after(PostUpdateSets::PlayerUpdate)
+                .before(PostUpdateSets::AttachSync),
+        );
+        app.add_console_command::<FootIkConsoleCommand, _>(foot_ik_console_command);
+    }
+}
+
+#[derive(Resource)]
+pub struct FootIkConfig {
+    pub enabled: bool,
+    /// Local-space Y of the foot bone when planted on flat ground.
+    /// Hardcoded guess; tune by observation.
+    pub plant_y: f32,
+    /// Speed below which IK is at full strength.
+    pub idle_speed_threshold: f32,
+    /// Speed above which IK is fully off.
+    pub run_speed_threshold: f32,
+    /// Start the down-cast this far above the animated foot.
+    pub raycast_up: f32,
+    /// Search this far below the animated foot.
+    pub raycast_down: f32,
+    /// Foot's target above the player by more than this → leg disengages
+    /// (target is "too high to step onto").
+    pub max_step_up: f32,
+    /// Maximum amount the hips will drop. Also acts as the per-leg "can reach"
+    /// gate going downward: if a leg would need a larger pelvis drop than this
+    /// to plant, the leg disengages (e.g. dangling off a cliff edge).
+    pub max_pelvis_drop: f32,
+}
+
+impl Default for FootIkConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            plant_y: 0.091,
+            idle_speed_threshold: 0.1,
+            run_speed_threshold: 1.5,
+            raycast_up: 0.3,
+            raycast_down: 0.6,
+            max_step_up: 0.4,
+            max_pelvis_drop: 0.4,
+        }
+    }
+}
+
+#[derive(Component)]
+pub struct FootIkRig {
+    pub hips: Entity,
+    pub left: LegBones,
+    pub right: LegBones,
+}
+
+#[derive(Clone, Copy)]
+pub struct LegBones {
+    pub upper: Entity,
+    pub lower: Entity,
+    pub foot: Entity,
+}
+
+#[derive(clap::Parser, ConsoleCommand)]
+#[command(name = "/footik")]
+struct FootIkConsoleCommand {}
+
+fn foot_ik_console_command(
+    mut input: ConsoleCommand<FootIkConsoleCommand>,
+    mut config: ResMut<FootIkConfig>,
+) {
+    if let Some(Ok(_)) = input.take() {
+        config.enabled = !config.enabled;
+        input.reply(format!(
+            "foot IK {}",
+            if config.enabled { "ON" } else { "OFF" }
+        ));
+    }
+}
+
+fn cache_foot_ik_rig(
+    mut commands: Commands,
+    config: Res<FootIkConfig>,
+    avatars: Query<Entity, (With<PrimaryUser>, Without<FootIkRig>)>,
+    children_q: Query<&Children>,
+    name_q: Query<&Name>,
+    mut log_counter: Local<u32>,
+) {
+    for avatar in &avatars {
+        let hips = find_bone(avatar, "avatar_hips", &children_q, &name_q);
+        let lu = find_bone(avatar, "avatar_leftupleg", &children_q, &name_q);
+        let ll = find_bone(avatar, "avatar_leftleg", &children_q, &name_q);
+        let lf = find_bone(avatar, "avatar_leftfoot", &children_q, &name_q);
+        let ru = find_bone(avatar, "avatar_rightupleg", &children_q, &name_q);
+        let rl = find_bone(avatar, "avatar_rightleg", &children_q, &name_q);
+        let rf = find_bone(avatar, "avatar_rightfoot", &children_q, &name_q);
+
+        if let (Some(hips), Some(lu), Some(ll), Some(lf), Some(ru), Some(rl), Some(rf)) =
+            (hips, lu, ll, lf, ru, rl, rf)
+        {
+            info!(
+                "foot_ik: cached rig for {:?} (hips: {:?}, l: {:?}/{:?}/{:?}, r: {:?}/{:?}/{:?})",
+                avatar, hips, lu, ll, lf, ru, rl, rf
+            );
+            commands.entity(avatar).try_insert(FootIkRig {
+                hips,
+                left: LegBones {
+                    upper: lu,
+                    lower: ll,
+                    foot: lf,
+                },
+                right: LegBones {
+                    upper: ru,
+                    lower: rl,
+                    foot: rf,
+                },
+            });
+        } else if config.enabled {
+            *log_counter = log_counter.wrapping_add(1);
+            if *log_counter % 120 == 1 {
+                let mut all_names = Vec::new();
+                collect_descendant_names(avatar, &children_q, &name_q, &mut all_names, 0);
+                warn!(
+                    "foot_ik: missing bones (hips={} lu={} ll={} lf={} ru={} rl={} rf={}); descendant names ({}): {:?}",
+                    hips.is_some(), lu.is_some(), ll.is_some(), lf.is_some(),
+                    ru.is_some(), rl.is_some(), rf.is_some(),
+                    all_names.len(),
+                    all_names.iter().take(80).collect::<Vec<_>>(),
+                );
+            }
+        }
+    }
+}
+
+fn collect_descendant_names(
+    root: Entity,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+    out: &mut Vec<String>,
+    depth: u32,
+) {
+    if depth > 8 {
+        return;
+    }
+    if let Ok(name) = names.get(root) {
+        out.push(name.as_str().to_string());
+    }
+    if let Ok(kids) = children.get(root) {
+        for k in kids {
+            collect_descendant_names(*k, children, names, out, depth + 1);
+        }
+    }
+}
+
+fn find_bone(
+    root: Entity,
+    target_lower: &str,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+) -> Option<Entity> {
+    if let Ok(name) = names.get(root) {
+        if name.as_str().to_lowercase() == target_lower {
+            return Some(root);
+        }
+    }
+    if let Ok(kids) = children.get(root) {
+        for k in kids {
+            if let Some(found) = find_bone(*k, target_lower, children, names) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+struct LegPlan {
+    a: Vec3,
+    b: Vec3,
+    c: Vec3,
+    target_c: Vec3,
+    l_ab: f32,
+    l_bc: f32,
+    w: f32,
+    /// Pelvis drop required for this leg to physically reach `target_c`.
+    /// 0 if the leg can already reach without any drop.
+    required_drop: f32,
+    cur_hip_global_rot: Quat,
+    cur_knee_global_rot: Quat,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_foot_ik(
+    config: Res<FootIkConfig>,
+    primary: Query<(&FootIkRig, &AvatarDynamicState, &GlobalTransform), With<PrimaryUser>>,
+    containing: ContainingScene,
+    mut scenes: Query<&mut SceneColliderData>,
+    parents: Query<&ChildOf>,
+    globals: Query<&GlobalTransform>,
+    mut transforms: Query<&mut Transform>,
+    mut log_tick: Local<u32>,
+) {
+    if !config.enabled {
+        return;
+    }
+    *log_tick = log_tick.wrapping_add(1);
+    let log_now = *log_tick % 60 == 1;
+
+    let Ok((rig, dyn_state, player_global)) = primary.single() else {
+        if log_now {
+            warn!("foot_ik: no primary user with FootIkRig");
+        }
+        return;
+    };
+
+    let speed = Vec3::new(dyn_state.velocity.x, 0.0, dyn_state.velocity.z).length();
+    let w_speed = 1.0
+        - smoothstep(
+            config.idle_speed_threshold,
+            config.run_speed_threshold,
+            speed,
+        );
+    if w_speed <= 0.0 {
+        if log_now {
+            info!("foot_ik: gated by speed ({:.2} m/s)", speed);
+        }
+        return;
+    }
+
+    let scene_ents: Vec<Entity> = containing
+        .get_position(player_global.translation())
+        .into_iter()
+        .collect();
+
+    // Pole hint: avatar's forward direction. The Decentraland avatar rig faces
+    // local -Z (knees bend toward -Z), so use that as the pole.
+    let pole_dir = player_global.compute_transform().rotation * Vec3::NEG_Z;
+    let player_y = player_global.translation().y;
+
+    // Pass 1: plan both legs (raycast, target, weights, lengths).
+    let plan_l = plan_leg(
+        "L",
+        rig.left,
+        &config,
+        w_speed,
+        player_y,
+        &scene_ents,
+        &mut scenes,
+        &globals,
+        log_now,
+    );
+    let plan_r = plan_leg(
+        "R",
+        rig.right,
+        &config,
+        w_speed,
+        player_y,
+        &scene_ents,
+        &mut scenes,
+        &globals,
+        log_now,
+    );
+
+    // Pass 2: pelvis drop = max required across engaged legs, scaled by w_speed.
+    // Each engaged leg has finite required_drop ≤ max_pelvis_drop by
+    // construction (others were filtered out in plan_leg).
+    let mut pelvis_drop = 0.0f32;
+    for plan in [plan_l.as_ref(), plan_r.as_ref()].into_iter().flatten() {
+        pelvis_drop = pelvis_drop.max(plan.required_drop * w_speed);
+    }
+    if log_now {
+        info!("foot_ik: pelvis_drop={:.3}", pelvis_drop);
+    }
+
+    // Apply pelvis drop to hips bone. Convert the world-Y delta into the hips'
+    // parent-local frame using the parent's full affine inverse — this accounts
+    // for cumulative ancestor scale (the avatar rig is imported with a ~0.01x
+    // scale, so a rotation-only conversion would produce a ~1cm-instead-of-1m
+    // delta).
+    if pelvis_drop > 1e-4 {
+        if let Ok(hips_parent) = parents.get(rig.hips) {
+            if let Ok(parent_global) = globals.get(hips_parent.parent()) {
+                if let Ok(mut t) = transforms.get_mut(rig.hips) {
+                    let local_delta = parent_global
+                        .affine()
+                        .inverse()
+                        .transform_vector3(Vec3::new(0.0, pelvis_drop, 0.0));
+                    t.translation -= local_delta;
+                }
+            }
+        }
+    }
+
+    let drop_vec = Vec3::new(0.0, pelvis_drop, 0.0);
+
+    // Pass 3: per-leg IK. Hip world position is shifted by the pelvis drop;
+    // bone rotations and lengths are unchanged, so we just translate (a, b, c).
+    for (leg, plan_opt) in [(rig.left, plan_l), (rig.right, plan_r)] {
+        if let Some(plan) = plan_opt {
+            apply_leg_ik(
+                leg,
+                plan,
+                drop_vec,
+                pole_dir,
+                &parents,
+                &globals,
+                &mut transforms,
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn plan_leg(
+    label: &str,
+    leg: LegBones,
+    config: &FootIkConfig,
+    w_speed: f32,
+    player_y: f32,
+    scene_ents: &[Entity],
+    scenes: &mut Query<&mut SceneColliderData>,
+    globals: &Query<&GlobalTransform>,
+    log_now: bool,
+) -> Option<LegPlan> {
+    let hip_g = globals.get(leg.upper).ok()?;
+    let knee_g = globals.get(leg.lower).ok()?;
+    let foot_g = globals.get(leg.foot).ok()?;
+    let a = hip_g.translation();
+    let b = knee_g.translation();
+    let c = foot_g.translation();
+
+    let origin = Vec3::new(c.x, c.y + config.raycast_up, c.z);
+    let dir = Vec3::NEG_Y;
+    let max_dist = config.raycast_up + config.raycast_down;
+
+    let mut best: Option<f32> = None;
+    for scene_ent in scene_ents {
+        let Ok(mut collider_data) = scenes.get_mut(*scene_ent) else {
+            continue;
+        };
+        if let Some(hit) = collider_data.cast_ray_nearest(
+            origin,
+            dir,
+            max_dist,
+            ColliderLayer::ClPhysics as u32 | GROUND_COLLISION_MASK,
+            true,
+            false,
+            None,
+        ) {
+            let hit_y = origin.y - hit.toi;
+            if best.is_none_or(|y| hit_y > y) {
+                best = Some(hit_y);
+            }
+        }
+    }
+
+    let Some(ground_y) = best else {
+        if log_now {
+            info!(
+                "foot_ik[{label}]: no ground hit (foot=({:.2},{:.2},{:.2}) origin_y={:.2} max_dist={:.2} scenes={})",
+                c.x, c.y, c.z, origin.y, max_dist, scene_ents.len()
+            );
+        }
+        return None;
+    };
+
+    let target_c = Vec3::new(c.x, ground_y + config.plant_y, c.z);
+
+    // Required pelvis drop for this leg to physically reach the target
+    // (leg fully extended, hip lowered just enough). 0 if reachable as-is.
+    let l_ab = (b - a).length();
+    let l_bc = (c - b).length();
+    let total = (l_ab + l_bc - 1e-3).max(0.0);
+    let dx = a.x - target_c.x;
+    let dz = a.z - target_c.z;
+    let horiz2 = dx * dx + dz * dz;
+    let hv = a.y - target_c.y;
+    let inside = total * total - horiz2;
+    let required_drop = if inside > 0.0 {
+        (hv - inside.sqrt()).max(0.0)
+    } else {
+        f32::INFINITY
+    };
+
+    // Reach gating: binary. Going up is gated by max_step_up; going down is
+    // gated by whether the leg can plant within max_pelvis_drop of hip drop.
+    let dy_player = target_c.y - player_y;
+    let reach_ok = if dy_player >= 0.0 {
+        dy_player <= config.max_step_up
+    } else {
+        required_drop <= config.max_pelvis_drop
+    };
+    let reach_w = if reach_ok { 1.0 } else { 0.0 };
+    let w = (w_speed * reach_w).clamp(0.0, 1.0);
+    if log_now {
+        let dy_anim = target_c.y - c.y;
+        info!(
+            "foot_ik[{label}]: foot_y={:.3} ground_y={:.3} target_y={:.3} dy_anim={:.3} dy_player={:.3} required_drop={:.3} reach_w={:.2} w={:.2}",
+            c.y, ground_y, target_c.y, dy_anim, dy_player, required_drop, reach_w, w
+        );
+    }
+    if w <= 1e-3 {
+        return None;
+    }
+
+    Some(LegPlan {
+        a,
+        b,
+        c,
+        target_c,
+        l_ab,
+        l_bc,
+        w,
+        required_drop,
+        cur_hip_global_rot: hip_g.compute_transform().rotation,
+        cur_knee_global_rot: knee_g.compute_transform().rotation,
+    })
+}
+
+fn apply_leg_ik(
+    leg: LegBones,
+    plan: LegPlan,
+    drop_vec: Vec3,
+    pole_dir: Vec3,
+    parents: &Query<&ChildOf>,
+    globals: &Query<&GlobalTransform>,
+    transforms: &mut Query<&mut Transform>,
+) {
+    // After pelvis drop, all leg bones translate by -drop_vec in world space.
+    let a = plan.a - drop_vec;
+    let b = plan.b - drop_vec;
+    let c = plan.c - drop_vec;
+    let target_c = plan.target_c;
+
+    let at = target_c - a;
+    let l_at_raw = at.length();
+    if l_at_raw < 1e-4 {
+        return;
+    }
+    let l_at = l_at_raw.clamp(1e-4, plan.l_ab + plan.l_bc - 1e-4);
+    let dir_at = at / l_at_raw;
+
+    let pole_perp = pole_dir - dir_at * dir_at.dot(pole_dir);
+    let pole_perp = pole_perp.normalize_or_zero();
+    let pole_perp = if pole_perp.length_squared() < 0.5 {
+        let alt = Vec3::Y.cross(dir_at).normalize_or_zero();
+        if alt.length_squared() < 0.5 {
+            Vec3::X
+        } else {
+            alt
+        }
+    } else {
+        pole_perp
+    };
+
+    let cos_a = ((plan.l_ab * plan.l_ab + l_at * l_at - plan.l_bc * plan.l_bc)
+        / (2.0 * plan.l_ab * l_at))
+        .clamp(-1.0, 1.0);
+    let sin_a = (1.0 - cos_a * cos_a).max(0.0).sqrt();
+    let new_b = a + dir_at * (plan.l_ab * cos_a) + pole_perp * (plan.l_ab * sin_a);
+
+    let cur_dir_ab = (b - a).normalize_or_zero();
+    let new_dir_ab = (new_b - a).normalize_or_zero();
+    let r_hip = Quat::from_rotation_arc(cur_dir_ab, new_dir_ab);
+
+    let cur_dir_bc = (c - b).normalize_or_zero();
+    let dir_bc_after_hip = r_hip * cur_dir_bc;
+    let new_dir_bc = (target_c - new_b).normalize_or_zero();
+    let r_knee = Quat::from_rotation_arc(dir_bc_after_hip, new_dir_bc);
+
+    let r_hip_b = Quat::IDENTITY.slerp(r_hip, plan.w);
+    let r_knee_b = Quat::IDENTITY.slerp(r_knee, plan.w);
+
+    let new_hip_global_rot = r_hip_b * plan.cur_hip_global_rot;
+    let new_knee_global_rot = r_knee_b * r_hip_b * plan.cur_knee_global_rot;
+
+    let Ok(parent_of_hip) = parents.get(leg.upper) else {
+        return;
+    };
+    let Ok(parent_global) = globals.get(parent_of_hip.parent()) else {
+        return;
+    };
+    let parent_global_rot = parent_global.compute_transform().rotation;
+
+    let new_hip_local_rot = parent_global_rot.inverse() * new_hip_global_rot;
+    let new_knee_local_rot = new_hip_global_rot.inverse() * new_knee_global_rot;
+
+    if let Ok(mut t) = transforms.get_mut(leg.upper) {
+        t.rotation = new_hip_local_rot;
+    }
+    if let Ok(mut t) = transforms.get_mut(leg.lower) {
+        t.rotation = new_knee_local_rot;
+    }
+}
+
+fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -108,15 +108,39 @@ fn foot_ik_console_command(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cache_foot_ik_rig(
     mut commands: Commands,
     config: Res<FootIkConfig>,
-    avatars: Query<Entity, (With<PrimaryUser>, Without<FootIkRig>)>,
+    needs_rig: Query<Entity, (With<PrimaryUser>, Without<FootIkRig>)>,
+    has_rig: Query<(Entity, &FootIkRig), With<PrimaryUser>>,
     children_q: Query<&Children>,
     name_q: Query<&Name>,
+    globals: Query<&GlobalTransform>,
     mut log_counter: Local<u32>,
 ) {
-    for avatar in &avatars {
+    // Invalidate any cached rig whose bones no longer exist (e.g. a wearable
+    // reload despawned the old armature). On the next frame the rebuild
+    // pass below installs a fresh rig.
+    for (avatar, rig) in &has_rig {
+        let alive = [
+            rig.hips,
+            rig.left.upper,
+            rig.left.lower,
+            rig.left.foot,
+            rig.right.upper,
+            rig.right.lower,
+            rig.right.foot,
+        ]
+        .iter()
+        .all(|e| globals.get(*e).is_ok());
+        if !alive {
+            info!("foot_ik: invalidating stale rig on {:?}", avatar);
+            commands.entity(avatar).remove::<FootIkRig>();
+        }
+    }
+
+    for avatar in &needs_rig {
         let hips = find_bone(avatar, "avatar_hips", &children_q, &name_q);
         let lu = find_bone(avatar, "avatar_leftupleg", &children_q, &name_q);
         let ll = find_bone(avatar, "avatar_leftleg", &children_q, &name_q);

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -3,8 +3,6 @@ use bevy::{
     transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
 use bevy_console::ConsoleCommand;
-use common::structs::PrimaryUser;
-use comms::global_crdt::ForeignPlayer;
 use console::DoAddConsoleCommand;
 use dcl_component::proto_components::sdk::components::ColliderLayer;
 use scene_runner::{
@@ -15,9 +13,7 @@ use scene_runner::{
     ContainingScene,
 };
 
-use crate::animate::ActiveEmote;
-
-type AvatarFilter = Or<(With<PrimaryUser>, With<ForeignPlayer>)>;
+use crate::{animate::ActiveEmote, AvatarShape};
 
 pub struct FootIkPlugin;
 
@@ -132,8 +128,8 @@ fn foot_ik_console_command(
 fn cache_foot_ik_rig(
     mut commands: Commands,
     config: Res<FootIkConfig>,
-    needs_rig: Query<Entity, (AvatarFilter, Without<FootIkRig>)>,
-    has_rig: Query<(Entity, &FootIkRig), AvatarFilter>,
+    needs_rig: Query<Entity, (With<AvatarShape>, Without<FootIkRig>)>,
+    has_rig: Query<(Entity, &FootIkRig), With<AvatarShape>>,
     children_q: Query<&Children>,
     name_q: Query<&Name>,
     globals: Query<&GlobalTransform>,
@@ -291,7 +287,7 @@ struct FootIkRuntime {
     legs: [LegEngState; 2],
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn apply_foot_ik(
     config: Res<FootIkConfig>,
     time: Res<Time>,
@@ -303,7 +299,7 @@ fn apply_foot_ik(
             &GlobalTransform,
             &mut FootIkRuntime,
         ),
-        AvatarFilter,
+        With<AvatarShape>,
     >,
     containing: ContainingScene,
     mut scenes: Query<&mut SceneColliderData>,

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -61,6 +61,10 @@ pub struct FootIkConfig {
     /// Floor on the per-emote transition_seconds used to ramp IK weight; avoids
     /// instantaneous snaps when an emote declares 0s.
     pub min_transition_seconds: f32,
+    /// Maximum angle (degrees) the foot will tilt away from world-up to match
+    /// the contact-normal of the ground beneath it. Caps stylised aesthetics
+    /// (toes don't dive into steep slopes).
+    pub max_foot_tilt_deg: f32,
 }
 
 impl Default for FootIkConfig {
@@ -73,6 +77,7 @@ impl Default for FootIkConfig {
             max_step_up: 0.4,
             max_pelvis_drop: 0.4,
             min_transition_seconds: 0.05,
+            max_foot_tilt_deg: 30.0,
         }
     }
 }
@@ -238,8 +243,11 @@ struct LegPlan {
     /// Pelvis drop required for this leg to physically reach `target_c`.
     /// 0 if the leg can already reach without any drop.
     required_drop: f32,
+    /// World-space normal of the ground surface beneath the foot.
+    contact_normal: Vec3,
     cur_hip_global_rot: Quat,
     cur_knee_global_rot: Quat,
+    cur_foot_global_rot: Quat,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -375,6 +383,7 @@ fn apply_foot_ik(
                 plan,
                 drop_vec,
                 pole_dir,
+                &config,
                 &parents,
                 &globals,
                 &mut transforms,
@@ -406,7 +415,7 @@ fn plan_leg(
     let dir = Vec3::NEG_Y;
     let max_dist = config.raycast_up + config.raycast_down;
 
-    let mut best: Option<f32> = None;
+    let mut best: Option<(f32, Vec3)> = None;
     for scene_ent in scene_ents {
         let Ok(mut collider_data) = scenes.get_mut(*scene_ent) else {
             continue;
@@ -421,13 +430,13 @@ fn plan_leg(
             None,
         ) {
             let hit_y = origin.y - hit.toi;
-            if best.is_none_or(|y| hit_y > y) {
-                best = Some(hit_y);
+            if best.is_none_or(|(y, _)| hit_y > y) {
+                best = Some((hit_y, hit.normal.try_normalize().unwrap_or(Vec3::Y)));
             }
         }
     }
 
-    let Some(ground_y) = best else {
+    let Some((ground_y, contact_normal)) = best else {
         if log_now {
             info!(
                 "foot_ik[{label}]: no ground hit (foot=({:.2},{:.2},{:.2}) origin_y={:.2} max_dist={:.2} scenes={})",
@@ -485,16 +494,20 @@ fn plan_leg(
         l_bc,
         w,
         required_drop,
+        contact_normal,
         cur_hip_global_rot: hip_g.compute_transform().rotation,
         cur_knee_global_rot: knee_g.compute_transform().rotation,
+        cur_foot_global_rot: foot_g.compute_transform().rotation,
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_leg_ik(
     leg: LegBones,
     plan: LegPlan,
     drop_vec: Vec3,
     pole_dir: Vec3,
+    config: &FootIkConfig,
     parents: &Query<&ChildOf>,
     globals: &Query<&GlobalTransform>,
     transforms: &mut Query<&mut Transform>,
@@ -558,10 +571,24 @@ fn apply_leg_ik(
     let new_hip_local_rot = parent_global_rot.inverse() * new_hip_global_rot;
     let new_knee_local_rot = new_hip_global_rot.inverse() * new_knee_global_rot;
 
+    // Foot orientation: tilt the animated foot pose toward the contact normal,
+    // capped at max_foot_tilt_deg, then write the foot's local rotation
+    // (parent = knee bone in world after our update).
+    let align_full = Quat::from_rotation_arc(Vec3::Y, plan.contact_normal);
+    let (axis, angle) = align_full.to_axis_angle();
+    let max_tilt = config.max_foot_tilt_deg.to_radians();
+    let align_clamped = Quat::from_axis_angle(axis, angle.min(max_tilt));
+    let align_blended = Quat::IDENTITY.slerp(align_clamped, plan.w);
+    let new_foot_global_rot = align_blended * plan.cur_foot_global_rot;
+    let new_foot_local_rot = new_knee_global_rot.inverse() * new_foot_global_rot;
+
     if let Ok(mut t) = transforms.get_mut(leg.upper) {
         t.rotation = new_hip_local_rot;
     }
     if let Ok(mut t) = transforms.get_mut(leg.lower) {
         t.rotation = new_knee_local_rot;
+    }
+    if let Ok(mut t) = transforms.get_mut(leg.foot) {
+        t.rotation = new_foot_local_rot;
     }
 }

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -79,7 +79,7 @@ pub struct FootIkConfig {
 impl Default for FootIkConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             plant_y: 0.091,
             raycast_up: 0.3,
             raycast_down: 0.6,
@@ -456,7 +456,7 @@ fn apply_foot_ik(
         }
 
         if log_now {
-            info!(
+            debug!(
                 "foot_ik[{:?}]: w_anim={:.2} engaged=[{:.2},{:.2}] leg_w=[{:.2},{:.2}]",
                 avatar_ent,
                 w_anim,
@@ -475,7 +475,7 @@ fn apply_foot_ik(
             }
         }
         if log_now {
-            info!("foot_ik[{:?}]: pelvis_drop={:.3}", avatar_ent, pelvis_drop);
+            debug!("foot_ik[{:?}]: pelvis_drop={:.3}", avatar_ent, pelvis_drop);
         }
 
         // Apply pelvis drop. Convert the world-Y delta into hips' parent-local
@@ -564,7 +564,7 @@ fn plan_leg(
 
     let Some((ground_y, contact_normal)) = best else {
         if log_now {
-            info!(
+            debug!(
                 "foot_ik[{label}]: no ground hit (foot=({:.2},{:.2},{:.2}) origin_y={:.2} max_dist={:.2} scenes={})",
                 c.x, c.y, c.z, origin.y, max_dist, scene_ents.len()
             );
@@ -600,7 +600,7 @@ fn plan_leg(
     };
     if log_now {
         let dy_anim = target_c.y - c.y;
-        info!(
+        debug!(
             "foot_ik[{label}]: foot_y={:.3} ground_y={:.3} target_y={:.3} dy_anim={:.3} dy_player={:.3} required_drop={:.3} reach_ok={}",
             c.y, ground_y, target_c.y, dy_anim, dy_player, required_drop, reach_ok
         );

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -29,6 +29,7 @@ pub mod attach;
 pub mod avatar_texture;
 pub mod colliders;
 mod dynamic_nametag;
+pub mod foot_ik;
 pub mod foreign_dynamics;
 pub mod mask_material;
 pub mod npc_dynamics;
@@ -67,7 +68,9 @@ use scene_runner::{
 use system_bridge::NativeUi;
 use world_ui::{spawn_world_ui_view, WorldUi};
 
-use crate::{animate::AvatarAnimPlayer, dynamic_nametag::DynamicNametagPlugin};
+use crate::{
+    animate::AvatarAnimPlayer, dynamic_nametag::DynamicNametagPlugin, foot_ik::FootIkPlugin,
+};
 
 use self::{
     animate::AvatarAnimationPlugin,
@@ -87,6 +90,7 @@ impl Plugin for AvatarPlugin {
         app.add_plugins(AvatarColliderPlugin);
         app.add_plugins(AvatarTexturePlugin);
         app.add_plugins(DynamicNametagPlugin);
+        app.add_plugins(FootIkPlugin);
         app.add_systems(
             Update,
             (


### PR DESCRIPTION
## Summary

Adds an idle-only inverse-kinematics pass that plants avatar feet on the actual ground beneath them — slopes, short steps, uneven terrain — so the avatar doesn't visibly hover or clip when standing on non-flat surfaces.

Toggle in-game with \`/footik\` (off by default). Applies to the primary user, foreign players, and scene NPCs.

## How it works

Runs in \`PostUpdate\`, after \`PlayerUpdate\` and before \`AttachSync\`, with a manual transform-propagate pass so attached items see post-IK bone positions:

1. **Bone discovery** — recursively finds \`avatar_hips\` and the six leg bones by name on each \`AvatarShape\`, caches them in a \`FootIkRig\` component. Self-heals when wearables reload (any cached bone going stale invalidates the rig and rebuilds the next frame).
2. **Per-foot raycast** — \`cast_ray_nearest\` (true ray, not capsule) downward through the scene colliders that contain the avatar. Captures the contact normal too.
3. **Pelvis lowering** — for each leg, computes the hip drop required to make the foot reach its plant target (law of cosines). The greater of the two becomes a world-Y translation on \`avatar_hips\`, converted to the bone's parent-local frame via the parent's full affine inverse (the rig is imported with a ~0.01x cumulative scale, so a rotation-only conversion would produce a ~1cm-instead-of-1m delta).
4. **Two-bone IK** — analytic solve for hip + knee rotations to plant each foot at its target, using the avatar's forward direction as a pole hint.
5. **Foot tilt** — rotates each foot bone toward the contact normal, axis-angle-clamped to \`max_foot_tilt_deg\` (default 30°).
6. **Engagement / weight blending**:
   - \`w_anim\` ramps toward 1.0 while the active emote is an idle pose, otherwise 0.0, at the rate set by the emote's declared \`transition_seconds\` (\`SceneMovementAnim\` overridable flag, or URN match for engine-default idle).
   - Per-leg \`engaged\` ramps toward \`reach_ok ? 1 : 0\` over \`engage_transition_seconds\`. Going up beyond \`max_step_up\` or down beyond \`max_pelvis_drop\` makes a leg disengage; rotation \`r_hip\`/\`r_knee\`/foot tilt slerp from identity by the per-leg weight.
   - Final per-leg weight is \`min(w_anim, engaged)\` — the gates clamp rather than compound.
7. **Velocity-limited final Y** — the foot's final world Y is rate-limited at \`target_velocity_limit\` m/s while engaged. Smooths the case where the foot's xz sweeps across a cliff edge during a turn-in-place (raycast result jumps but the foot output doesn't). Snaps on the first engaged frame after a disengaged one. Invariant under continuously-moving platforms (avatar moves with them, so the *relative* offset doesn't change).

## Scope

- Primary user, foreign players, NPCs (anything with \`AvatarShape\`).
- Idle only — fades out via \`w_anim\` once the avatar enters a non-idle emote.
- All knobs live in \`FootIkConfig\` with documented purposes; not yet exposed via console subcommands.

## Out of scope (could follow up)

- Foot-phase walking IK (engage during foot plants in walk/jog cycles — useful for stairs).
- Toe-joint bend.
- Console subcommands for live tuning.
- Visibility/distance-based culling on foreign avatars and NPCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)