### PR TITLE
feat(ui_input): support multi-line text input from scenes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 [[package]]
 name = "bevy_simple_text_input"
 version = "0.11.1"
-source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#b4152ef499f8db65023d55a46adc528551a9d725"
+source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#b4602cd531de4047d1c7f7ceb88acf45b20519a1"
 dependencies = [
  "bevy",
  "copypwasmta",

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/ui_input.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/ui_input.proto
@@ -17,4 +17,5 @@ message PBUiInput {
   optional common.Font font = 11; // default=0
   optional int32 font_size = 12; // default=10
   optional string value = 13;
+  optional bool multi_line = 14; // default=false; when true, the input accepts newlines and behaves as a textarea
 }

--- a/crates/scene_runner/src/update_world/scene_ui/ui_input.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_input.rs
@@ -56,6 +56,7 @@ pub fn set_ui_input(
             components::common::Font::FMonospace => FontName::Mono,
         };
         let font_size = input.0.font_size.unwrap_or(10).max(1) as f32;
+        let multiline = input.0.multi_line.unwrap_or(false);
 
         let ui_entity = link.ui_entity;
         let root = scene_ent.root;
@@ -118,6 +119,7 @@ pub fn set_ui_input(
                 enabled: !input.0.disabled,
                 content: input.0.value.clone().unwrap_or_default(),
                 accept_line: true,
+                multiline: if multiline { 2 } else { 1 },
                 text_style: Some((
                     TextFont {
                         font: user_font(font_name, ui_core::WeightName::Regular),


### PR DESCRIPTION
## Summary
- Threads the new `multi_line` flag from `PBUiInput` (decentraland/protocol#394) through to `TextEntry`. When true the text input becomes a multi-line textarea.
- Bumps `bevy_simple_text_input` (robtfm/bevy_simple_text_input branch 0.16) to:
  - Flip Enter/Shift+Enter bindings: in multi-line mode plain Enter inserts a newline and Shift+Enter / NumpadEnter submits.
  - Drop the active selection on submit so a held Shift modifier doesn't leave a stale cursor anchor on a buffer that just shrank — cosmic-text was panicking trying to shape that anchor.
  - Fix a cursor-clamp off-by-one (`clamp(0, lines.len())` → `min(lines.len() - 1)`) that allowed `cursor.line == lines.len()` through, which cosmic-text rejects with `shape_until_cursor invalid cursor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)