### PR TITLE
Broadcast scene-driven anim idle so remotes can apply foot-IK

### DIFF
--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -206,6 +206,7 @@ fn broadcast_position(
     let speed = active_anim.map(|a| a.speed);
     let transition_seconds = active_anim.map(|a| a.transition_seconds);
     let r#loop = active_anim.map(|a| a.r#loop);
+    let idle = active_anim.map(|a| a.idle);
     // The latch above already mirrors the freshest `seek` seen since the last
     // broadcast. Only send if there's an active anim to apply it to.
     let playback_time = active_anim.and(last_anim.pending_seek.take());
@@ -233,6 +234,7 @@ fn broadcast_position(
                 r#loop,
                 sound_content_hashes,
                 origin_address: wallet.address().map(|a| format!("{a:#x}")),
+                idle,
             },
         )
     } else {

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -778,9 +778,10 @@ fn resolve_remote_anim(
         content_hash,
         r#loop,
         speed,
-        // `idle` is only consulted for primary-player overridability; for remote
-        // players there's no triggerSceneEmote interaction so we don't need it.
-        idle: false,
+        // Foot-IK on remote avatars gates on this — without it, remotes never apply
+        // foot-IK to a scene-driven animation. Defaults to false if the sender
+        // predates the field, which matches the conservative pre-field behaviour.
+        idle: anim.idle.unwrap_or(false),
         transition_seconds,
         seek: anim.playback_time,
         sounds: anim.sound_content_hashes,

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -108,6 +108,11 @@ message SceneDrivenAnimation {
   // sender's address. Absent on packets from old senders — in that case we accept,
   // since those clients predate the mirror-class bug we're defending against.
   optional string origin_address = 8;
+  // Mirrors `MovementAnimation.idle` from the local proto. Receivers need this to gate
+  // foot-IK on remote avatars (foot-IK is only applied while idle). Sent every broadcast
+  // that carries an active anim, the same as `speed` / `loop`; defaults to false when
+  // absent (older senders predating the field).
+  optional bool idle = 9;
 }
 
 message MovementCompressed {


### PR DESCRIPTION
## Summary
- Add `idle` to the `SceneDrivenAnimation` nested message in `rfc4` comms.
- Send it from the local broadcast alongside `speed` / `loop`.
- Use it on the receive side instead of hardcoding `idle: false`.

## Why
Foot-IK is gated on `ActiveEmote::is_idle()`, which for scene-driven anims returns `self.overridable` — set from `SceneDrivenAnimationRequest.idle`. On the receive path this was hardcoded to `false`, so remote avatars never got foot-IK applied to a scene-driven idle pose. The wire format had no `idle` field; this PR adds it.

The wire field defaults to `false` when absent, matching the previous behaviour for senders that predate it.