### PR TITLE
fix: scope portable permissions to containing/parent scene (#715)

### DIFF
--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -781,15 +781,18 @@ fn spawn_portable(
                     continue;
                 };
 
-                new_portables.insert(
-                    hash.clone(),
-                    PortableSource {
-                        pid: hacked_urn,
-                        parent_scene: Some(parent_hash),
-                        ens: None,
-                        super_user: false,
-                    },
-                );
+                // don't re-claim an existing portable; just resolve to its current state
+                if current_portables.get(&hash).is_none() {
+                    new_portables.insert(
+                        hash.clone(),
+                        PortableSource {
+                            pid: hacked_urn,
+                            parent_scene: Some(parent_hash),
+                            ens: None,
+                            super_user: false,
+                        },
+                    );
+                }
                 pending_responses.insert(hash, Some(response.clone()));
             }
             PortableLocation::Ens(ens) => {
@@ -816,7 +819,10 @@ fn spawn_portable(
         if let Some(result) = task.complete() {
             match result {
                 Ok((hash, source)) => {
-                    new_portables.insert(hash.clone(), source);
+                    // don't re-claim an existing portable; just resolve to its current state
+                    if current_portables.get(&hash).is_none() {
+                        new_portables.insert(hash.clone(), source);
+                    }
                     pending_responses.insert(hash, response.take());
                 }
                 Err(e) => {
@@ -854,7 +860,7 @@ fn spawn_portable(
         }
 
         if let Some(context) = maybe_context {
-            if let Some(source) = current_portables.0.get(hash) {
+            if let Some(source) = current_portables.get(hash) {
                 sender.take().unwrap().send(Ok(SpawnResponse {
                     pid: source.pid.clone(),
                     parent_cid: source.parent_scene.clone().unwrap_or_default(),
@@ -878,16 +884,34 @@ fn spawn_portable(
     if !new_portables.is_empty() {
         commands.queue(move |world: &mut World| {
             let mut portables = world.resource_mut::<PortableScenes>();
-            portables.0.extend(new_portables);
+            portables.extend(new_portables);
         });
     }
     if !failed_portables.is_empty() {
         commands.queue(move |world: &mut World| {
             let mut portables = world.resource_mut::<PortableScenes>();
             for portable in failed_portables {
-                portables.0.remove(&portable);
+                portables.remove(&portable);
             }
         });
+    }
+}
+
+fn portable_matches_location(
+    hash: &str,
+    source: &PortableSource,
+    location: &PortableLocation,
+) -> bool {
+    match location {
+        PortableLocation::Urn(urn) => {
+            let hacked_urn = urn.replace('?', "?=&");
+            IpfsPath::new_from_urn::<EntityDefinition>(&hacked_urn)
+                .ok()
+                .and_then(|p| p.context_free_hash().ok().flatten())
+                .as_deref()
+                == Some(hash)
+        }
+        PortableLocation::Ens(ens) => source.ens.as_deref() == Some(ens.as_str()),
     }
 }
 
@@ -895,6 +919,9 @@ fn kill_portable(
     mut commands: Commands,
     portables: Res<PortableScenes>,
     mut events: EventReader<RpcCall>,
+    scenes: Query<&RendererSceneContext>,
+    player: Query<Entity, With<PrimaryUser>>,
+    containing_scene: ContainingScene,
     mut perms: Permission<(PortableLocation, RpcResultSender<bool>)>,
 ) {
     let mut kill_portables = HashSet::new();
@@ -907,6 +934,30 @@ fn kill_portable(
         } => Some((scene, location, response)),
         _ => None,
     }) {
+        // requesting scene may kill a portable only if it spawned the portable,
+        // or if some other scene spawned it and the player is currently within
+        // the requesting scene's bounds. startup / system portables (no parent
+        // scene) are never killable by scenes.
+        let is_parent = scenes.get(*scene).is_ok_and(|ctx| {
+            portables
+                .by_parent(&ctx.hash)
+                .any(|(hash, src)| portable_matches_location(hash, src, location))
+        });
+        let containing_other_owned = !is_parent && {
+            let player_in_scene = player
+                .single()
+                .ok()
+                .is_some_and(|p| containing_scene.get(p).contains(scene));
+            player_in_scene
+                && portables.iter().any(|(hash, src)| {
+                    src.parent_scene.is_some() && portable_matches_location(hash, src, location)
+                })
+        };
+        if !is_parent && !containing_other_owned {
+            response.send(false);
+            continue;
+        }
+
         perms.check(
             PermissionType::KillPortables,
             *scene,
@@ -931,7 +982,7 @@ fn kill_portable(
                     continue;
                 };
 
-                if portables.0.contains_key(&hash) {
+                if portables.contains_key(&hash) {
                     response.send(true);
                     kill_portables.insert(hash.clone());
                 } else {
@@ -954,7 +1005,7 @@ fn kill_portable(
         commands.queue(|world: &mut World| {
             let mut portables = world.resource_mut::<PortableScenes>();
             for killed in kill_portables {
-                portables.0.remove(&killed);
+                portables.remove(&killed);
             }
         })
     }
@@ -971,9 +1022,10 @@ fn list_portables(
         _ => None,
     }) {
         debug!("listing portables");
+        // hide startup / system portables (parent_scene = None) from scenes
         let portables = portables
-            .0
             .iter()
+            .filter(|(_, source)| source.parent_scene.is_some())
             .map(|(hash, source)| {
                 let context = live_scenes
                     .scenes
@@ -1754,11 +1806,11 @@ fn handle_spawned_command(
             match result {
                 Ok((hash, source)) => match action {
                     PortableAction::Spawn => {
-                        portables.0.insert(hash.clone(), source);
+                        portables.insert(hash.clone(), source);
                         reply.write(PrintConsoleLine::new("[ok]".into()));
                     }
                     PortableAction::Kill => {
-                        if portables.0.remove(&hash).is_some() {
+                        if portables.remove(&hash).is_some() {
                             reply.write(PrintConsoleLine::new("[ok]".into()));
                         } else {
                             reply.write(PrintConsoleLine::new("portable not running".into()));
@@ -1960,7 +2012,7 @@ pub fn process_startup_scenes(
 
             info!("added startup scene from {}", source.pid);
             scene.hash = Some(hash.clone());
-            portables.0.extend([(hash, source)]);
+            portables.extend([(hash, source)]);
 
             if scene.preview {
                 let sx = channel

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -293,7 +293,7 @@ pub(crate) fn load_scene_javascript(
             continue;
         };
 
-        let portable = portable_scenes.0.get(&definition.id);
+        let portable = portable_scenes.get(&definition.id);
 
         let (base_x, base_y) = meta.scene.base.split_once(',').unwrap();
         let base_x = base_x.parse::<i32>().unwrap();
@@ -717,7 +717,71 @@ pub struct PortableSource {
 }
 
 #[derive(Resource, Default)]
-pub struct PortableScenes(pub HashMap<String, PortableSource>);
+pub struct PortableScenes {
+    by_hash: HashMap<String, PortableSource>,
+    by_parent: HashMap<String, HashSet<String>>,
+}
+
+impl PortableScenes {
+    pub fn get(&self, hash: &str) -> Option<&PortableSource> {
+        self.by_hash.get(hash)
+    }
+
+    pub fn contains_key(&self, hash: &str) -> bool {
+        self.by_hash.contains_key(hash)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &PortableSource)> {
+        self.by_hash.iter()
+    }
+
+    /// portables spawned by the given scene hash
+    pub fn by_parent<'a>(
+        &'a self,
+        parent: &str,
+    ) -> impl Iterator<Item = (&'a String, &'a PortableSource)> {
+        self.by_parent
+            .get(parent)
+            .into_iter()
+            .flat_map(|hashes| hashes.iter())
+            .filter_map(|h| self.by_hash.get_key_value(h))
+    }
+
+    pub fn insert(&mut self, hash: String, source: PortableSource) -> Option<PortableSource> {
+        let prev = self.by_hash.insert(hash.clone(), source);
+        if let Some(prev_parent) = prev.as_ref().and_then(|p| p.parent_scene.as_ref()) {
+            if let Some(set) = self.by_parent.get_mut(prev_parent) {
+                set.remove(&hash);
+                if set.is_empty() {
+                    self.by_parent.remove(prev_parent);
+                }
+            }
+        }
+        if let Some(parent) = self.by_hash.get(&hash).and_then(|s| s.parent_scene.clone()) {
+            self.by_parent.entry(parent).or_default().insert(hash);
+        }
+        prev
+    }
+
+    pub fn remove(&mut self, hash: &str) -> Option<PortableSource> {
+        let source = self.by_hash.remove(hash)?;
+        if let Some(parent) = &source.parent_scene {
+            if let Some(set) = self.by_parent.get_mut(parent) {
+                set.remove(hash);
+                if set.is_empty() {
+                    self.by_parent.remove(parent);
+                }
+            }
+        }
+        Some(source)
+    }
+
+    pub fn extend<I: IntoIterator<Item = (String, PortableSource)>>(&mut self, iter: I) {
+        for (hash, source) in iter {
+            self.insert(hash, source);
+        }
+    }
+}
 
 pub const PARCEL_SIZE: f32 = 16.0;
 
@@ -1423,7 +1487,6 @@ pub fn process_scene_lifecycle(
     // add any portables to requirements
     required_scene_ids.extend(
         portables
-            .0
             .iter()
             .map(|(hash, source)| ((hash.clone(), Some(source.pid.clone())), source.super_user)),
     );

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -560,7 +560,6 @@ impl ContainingScene<'_, '_> {
 
     pub fn get_portables(&self, only_super: bool) -> HashSet<Entity> {
         self.portable_scenes
-            .0
             .iter()
             .flat_map(|(hash, source)| {
                 if !source.super_user && only_super {
@@ -628,7 +627,6 @@ impl ContainingScene<'_, '_> {
         // global scenes first
         let mut results: Vec<(Entity, f32)> = self
             .portable_scenes
-            .0
             .iter()
             .flat_map(|(hash, _)| self.live_scenes.scenes.get(hash))
             .map(|ent| (*ent, 0.0))


### PR DESCRIPTION
## Summary

Closes #715.

Three related leaks in the portable-experience permission flow:

1. **kill** — any scene that had `KillPortables` permission could kill any portable, regardless of whether it spawned that portable or whether the player was anywhere near it. Goerli was the user-visible case (prompted to kill portables across the map).
2. **list** — `listPortables` returned startup / system portables, leaking their existence to every scene.
3. **spawn** — calling `spawnPortable` for an already-running portable overwrote its `PortableSource`, letting any scene re-claim ownership (and its `parent_scene`) of any portable, including startup portables — which then made them killable and listable.

## Changes

- `kill_portable`: requesting scene must either be the portable's `parent_scene`, or the player must currently be inside the requesting scene's bounds *and* the portable was scene-spawned. Startup portables (`parent_scene = None`) are never killable.
- `list_portables`: filtered to portables with `parent_scene.is_some()`.
- `spawn_portable`: idempotent — if the resolved hash already exists, return its existing `SpawnResponse` without inserting / overwriting. Both URN and ENS paths.
- `PortableScenes`: wraps the inner map and adds a `by_parent: HashMap<String, HashSet<String>>` index, with `insert` / `remove` / `extend` keeping both maps consistent. Backs the new `by_parent(scene_hash)` lookup used by `kill_portable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)