### PR TITLE
Look-at and point-at avatar gestures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ dependencies = [
  "console",
  "dcl",
  "dcl_component",
+ "ethers-core",
  "input_manager",
  "ipfs",
  "platform",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,6 +2706,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "serde_repr",
  "smallvec",
  "strum 0.27.2",
  "strum_macros 0.27.2",

--- a/crates/avatar/Cargo.toml
+++ b/crates/avatar/Cargo.toml
@@ -31,3 +31,4 @@ bevy_console = { workspace = true }
 tokio = { workspace = true }
 rapier3d-f64 = { workspace = true }
 bevy_dui = { workspace = true }
+ethers-core = { workspace = true }

--- a/crates/avatar/src/colliders.rs
+++ b/crates/avatar/src/colliders.rs
@@ -9,7 +9,8 @@ use common::{
     rpc::{RpcCall, RpcEventSender},
     sets::SceneSets,
     structs::{
-        PlayerModifiers, PrimaryCamera, PrimaryUser, ShowProfileEvent, ToolTips, TooltipSource,
+        PlayerModifiers, PointerTargetType, PrimaryCamera, PrimaryUser, ShowProfileEvent, ToolTips,
+        TooltipSource,
     },
     util::AsH160,
 };
@@ -26,7 +27,7 @@ use scene_runner::{
     update_world::mesh_collider::ColliderId,
 };
 use serde_json::json;
-use system_bridge::{AvatarModifierState, NativeUi, PointerTargetType, SystemApi};
+use system_bridge::{AvatarModifierState, NativeUi, SystemApi};
 
 pub struct AvatarColliderPlugin;
 

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -1,7 +1,4 @@
-use bevy::{
-    prelude::*,
-    transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
-};
+use bevy::prelude::*;
 use bevy_console::ConsoleCommand;
 use common::sets::PostUpdateSets;
 use console::DoAddConsoleCommand;
@@ -11,7 +8,7 @@ use scene_runner::{
     ContainingScene,
 };
 
-use crate::{animate::ActiveEmote, AvatarShape};
+use crate::{animate::ActiveEmote, two_bone_ik::solve_two_bone, AvatarShape};
 
 pub struct FootIkPlugin;
 
@@ -20,16 +17,7 @@ impl Plugin for FootIkPlugin {
         app.init_resource::<FootIkConfig>();
         app.add_systems(
             PostUpdate,
-            (
-                cache_foot_ik_rig,
-                apply_foot_ik,
-                (
-                    mark_dirty_trees,
-                    propagate_parent_transforms,
-                    sync_simple_transforms,
-                )
-                    .chain(),
-            )
+            (cache_foot_ik_rig, apply_foot_ik)
                 .chain()
                 .in_set(PostUpdateSets::InverseKinematics),
         );
@@ -709,41 +697,7 @@ fn compute_leg_ik(
     let c = plan.c - drop_vec;
     let target_c = plan.target_c;
 
-    let at = target_c - a;
-    let l_at_raw = at.length();
-    if l_at_raw < 1e-4 {
-        return None;
-    }
-    let l_at = l_at_raw.clamp(1e-4, plan.l_ab + plan.l_bc - 1e-4);
-    let dir_at = at / l_at_raw;
-
-    let pole_perp = pole_dir - dir_at * dir_at.dot(pole_dir);
-    let pole_perp = pole_perp.normalize_or_zero();
-    let pole_perp = if pole_perp.length_squared() < 0.5 {
-        let alt = Vec3::Y.cross(dir_at).normalize_or_zero();
-        if alt.length_squared() < 0.5 {
-            Vec3::X
-        } else {
-            alt
-        }
-    } else {
-        pole_perp
-    };
-
-    let cos_a = ((plan.l_ab * plan.l_ab + l_at * l_at - plan.l_bc * plan.l_bc)
-        / (2.0 * plan.l_ab * l_at))
-        .clamp(-1.0, 1.0);
-    let sin_a = (1.0 - cos_a * cos_a).max(0.0).sqrt();
-    let new_b = a + dir_at * (plan.l_ab * cos_a) + pole_perp * (plan.l_ab * sin_a);
-
-    let cur_dir_ab = (b - a).normalize_or_zero();
-    let new_dir_ab = (new_b - a).normalize_or_zero();
-    let r_hip = Quat::from_rotation_arc(cur_dir_ab, new_dir_ab);
-
-    let cur_dir_bc = (c - b).normalize_or_zero();
-    let dir_bc_after_hip = r_hip * cur_dir_bc;
-    let new_dir_bc = (target_c - new_b).normalize_or_zero();
-    let r_knee = Quat::from_rotation_arc(dir_bc_after_hip, new_dir_bc);
+    let (r_hip, r_knee) = solve_two_bone(a, b, c, target_c, plan.l_ab, plan.l_bc, pole_dir)?;
 
     let r_hip_b = Quat::IDENTITY.slerp(r_hip, w);
     let r_knee_b = Quat::IDENTITY.slerp(r_knee, w);

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -31,7 +31,7 @@ impl Plugin for FootIkPlugin {
                     .chain(),
             )
                 .chain()
-                .in_set(PostUpdateSets::FootIk),
+                .in_set(PostUpdateSets::InverseKinematics),
         );
         app.add_console_command::<FootIkConsoleCommand, _>(foot_ik_console_command);
     }

--- a/crates/avatar/src/foot_ik.rs
+++ b/crates/avatar/src/foot_ik.rs
@@ -136,7 +136,7 @@ fn cache_foot_ik_rig(
         .iter()
         .all(|e| globals.get(*e).is_ok());
         if !alive {
-            info!("foot_ik: invalidating stale rig on {:?}", avatar);
+            debug!("foot_ik: invalidating stale rig on {:?}", avatar);
             commands.entity(avatar).remove::<FootIkRig>();
         }
     }
@@ -153,7 +153,7 @@ fn cache_foot_ik_rig(
         if let (Some(hips), Some(lu), Some(ll), Some(lf), Some(ru), Some(rl), Some(rf)) =
             (hips, lu, ll, lf, ru, rl, rf)
         {
-            info!(
+            debug!(
                 "foot_ik: cached rig for {:?} (hips: {:?}, l: {:?}/{:?}/{:?}, r: {:?}/{:?}/{:?})",
                 avatar, hips, lu, ll, lf, ru, rl, rf
             );

--- a/crates/avatar/src/head_ik.rs
+++ b/crates/avatar/src/head_ik.rs
@@ -25,6 +25,13 @@ pub struct HeadIkRig {
     /// parent. The attach point is reparented onto the bone during avatar
     /// build (see `lib.rs::reparent_attach_point`).
     pub head: Entity,
+    /// Bones that share the gaze swing, ordered root→tip (e.g.
+    /// `[upper_chest, neck, head]`). Each entry is `(bone, yaw_weight,
+    /// pitch_weight)`; weights per axis sum to ~1 across the chain so the
+    /// total swing is preserved. Spine takes more yaw, head takes more
+    /// pitch — matches Unity's TwistChain split without needing a generic
+    /// chain solver.
+    chain: Vec<(Entity, f32, f32)>,
     /// Smoothed yaw stored as an offset from the avatar's body forward
     /// (DCL convention). Storing relative — not absolute world yaw — means
     /// body rotation propagates to the head instantly without the smoother
@@ -93,12 +100,34 @@ fn cache_head_ik_rig(
         if head_bone == avatar {
             continue;
         }
+        // Walk up to find neck (parent of head) and an upper-chest/spine bone
+        // (grandparent). Bail out of the chain at any step that lands on the
+        // avatar entity itself — that means we've run out of skeleton.
+        let neck = parents
+            .get(head_bone)
+            .map(|c| c.parent())
+            .ok()
+            .filter(|e| *e != avatar);
+        let chest = neck
+            .and_then(|n| parents.get(n).map(|c| c.parent()).ok())
+            .filter(|e| *e != avatar);
+
+        let chain = match (chest, neck) {
+            (Some(chest), Some(neck)) => {
+                vec![(chest, 0.3, 0.2), (neck, 0.3, 0.3), (head_bone, 0.4, 0.5)]
+            }
+            (None, Some(neck)) => vec![(neck, 0.5, 0.4), (head_bone, 0.5, 0.6)],
+            _ => vec![(head_bone, 1.0, 1.0)],
+        };
+
         info!(
-            "head_ik: cached rig for {:?} (head bone: {:?})",
-            avatar, head_bone
+            "head_ik: cached rig for {:?} (chain: {:?})",
+            avatar,
+            chain.iter().map(|(e, _, _)| e).collect::<Vec<_>>()
         );
         commands.entity(avatar).try_insert(HeadIkRig {
             head: head_bone,
+            chain,
             yaw_offset_deg: 0.0,
             pitch_deg: 0.0,
         });
@@ -149,34 +178,48 @@ fn apply_head_ik(
         rig.yaw_offset_deg = smooth_angle(rig.yaw_offset_deg, target_yaw_offset, alpha);
         rig.pitch_deg = smooth_angle(rig.pitch_deg, target_pitch, alpha);
 
-        // Wire format: DCL yaw (N=0, E=90, S=180, W=270) in a left-handed,
-        // +Z-forward frame. To render in bevy's right-handed -Z-forward frame
-        // we mirror the Z-axis (negates the Y-rotation sign) and add 180° so
-        // the head bone's rest-pose forward aligns with the gaze target.
-        let world_yaw_dcl = dcl_avatar_yaw + rig.yaw_offset_deg;
-        let yaw = -world_yaw_dcl.to_radians() + std::f32::consts::PI;
-        let pitch = rig
+        // World-space swing applied as a delta to each bone's rest pose.
+        // Yaw axis is world up; pitch axis is the avatar's right vector
+        // (perpendicular to body forward in the horizontal plane). Sign on
+        // yaw flips DCL → bevy handedness.
+        let bevy_yaw_swing = -rig.yaw_offset_deg.to_radians();
+        let pitch_swing = -rig
             .pitch_deg
             .clamp(-PITCH_CLAMP_DEG, PITCH_CLAMP_DEG)
             .to_radians();
-        let target_world = Quat::from_euler(EulerRot::YXZ, yaw, pitch, 0.0);
+        let avatar_world_rot = avatar_global.rotation();
+        let avatar_right_world = avatar_world_rot * Vec3::X;
 
-        // Convert world target into local space: parent's current world rotation
-        // is the basis the bone's local rotation is composed against.
-        let Ok(head_parent) = parents.get(rig.head).map(|c| c.parent()) else {
-            continue;
-        };
-        let Ok(parent_global) = tx.p1().compute_global_transform(head_parent) else {
-            continue;
-        };
-        let parent_world_rot = parent_global.compute_transform().rotation;
-        let target_local = parent_world_rot.inverse() * target_world;
-        writes.push((rig.head, target_local));
+        for &(bone, w_yaw, w_pitch) in &rig.chain {
+            // Each bone gets a fraction of the total swing applied in WORLD
+            // space, then conjugated into its parent's local frame so writing
+            // a local rotation gives the intended world delta. Computing all
+            // contributions against the pre-IK parent globals (TransformHelper
+            // sees no writes until after this loop) keeps the chain math
+            // consistent: the cumulative world rotation at the head equals
+            // the sum of weighted yaw/pitch around the same axes.
+            let Ok(parent) = parents.get(bone).map(|c| c.parent()) else {
+                continue;
+            };
+            let Ok(parent_global) = tx.p1().compute_global_transform(parent) else {
+                continue;
+            };
+            let Ok(bone_global) = tx.p1().compute_global_transform(bone) else {
+                continue;
+            };
+            let parent_world_rot = parent_global.rotation();
+            let bone_local_rot = parent_world_rot.inverse() * bone_global.rotation();
+
+            let delta_world = Quat::from_axis_angle(Vec3::Y, bevy_yaw_swing * w_yaw)
+                * Quat::from_axis_angle(avatar_right_world, pitch_swing * w_pitch);
+            let delta_local = parent_world_rot.inverse() * delta_world * parent_world_rot;
+            writes.push((bone, delta_local * bone_local_rot));
+        }
     }
 
     let mut transforms = tx.p0();
-    for (head, rot) in writes {
-        if let Ok(mut t) = transforms.get_mut(head) {
+    for (bone, rot) in writes {
+        if let Ok(mut t) = transforms.get_mut(bone) {
             t.rotation = rot;
         }
     }

--- a/crates/avatar/src/head_ik.rs
+++ b/crates/avatar/src/head_ik.rs
@@ -132,7 +132,7 @@ fn cache_head_ik_rig(
             _ => vec![(head_bone, 1.0, 1.0)],
         };
 
-        info!(
+        debug!(
             "head_ik: cached rig for {:?} (chain: {:?})",
             avatar,
             chain.iter().map(|(e, _, _)| e).collect::<Vec<_>>()

--- a/crates/avatar/src/head_ik.rs
+++ b/crates/avatar/src/head_ik.rs
@@ -1,0 +1,105 @@
+use bevy::prelude::*;
+use common::{
+    sets::PostUpdateSets,
+    structs::{AttachPoints, HeadSync},
+};
+
+use crate::AvatarShape;
+
+pub struct HeadIkPlugin;
+
+impl Plugin for HeadIkPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (cache_head_ik_rig, apply_head_ik)
+                .chain()
+                .in_set(PostUpdateSets::InverseKinematics),
+        );
+    }
+}
+
+#[derive(Component)]
+pub struct HeadIkRig {
+    /// The avatar's head bone, found via the `avatar_head` attach point's
+    /// parent. The attach point is reparented onto the bone during avatar
+    /// build (see `lib.rs::reparent_attach_point`).
+    pub head: Entity,
+}
+
+#[allow(clippy::type_complexity)]
+fn cache_head_ik_rig(
+    mut commands: Commands,
+    needs_rig: Query<(Entity, &AttachPoints), (With<AvatarShape>, Without<HeadIkRig>)>,
+    has_rig: Query<(Entity, &HeadIkRig), With<AvatarShape>>,
+    parents: Query<&ChildOf>,
+    transforms: Query<&Transform>,
+) {
+    // Invalidate stale cache: bone entity got despawned by a wearable swap.
+    for (avatar, rig) in &has_rig {
+        if transforms.get(rig.head).is_err() {
+            commands.entity(avatar).remove::<HeadIkRig>();
+        }
+    }
+
+    for (avatar, ap) in &needs_rig {
+        // The follower entity for the head was reparented onto the head bone, so
+        // the bone is the follower's parent. Skip until the GLB has loaded and
+        // reparenting has happened — until then the head follower is still a
+        // direct child of the avatar entity itself.
+        let Ok(head_bone) = parents.get(ap.head).map(|c| c.parent()) else {
+            continue;
+        };
+        if head_bone == avatar {
+            continue;
+        }
+        info!(
+            "head_ik: cached rig for {:?} (head bone: {:?})",
+            avatar, head_bone
+        );
+        commands
+            .entity(avatar)
+            .try_insert(HeadIkRig { head: head_bone });
+    }
+}
+
+fn apply_head_ik(
+    avatars: Query<(&HeadIkRig, &HeadSync), With<AvatarShape>>,
+    parents: Query<&ChildOf>,
+    mut tx: ParamSet<(Query<&mut Transform>, TransformHelper)>,
+) {
+    let mut writes: Vec<(Entity, Quat)> = Vec::new();
+
+    for (rig, head_sync) in &avatars {
+        if !head_sync.yaw_enabled && !head_sync.pitch_enabled {
+            continue;
+        }
+
+        // Wire format: DCL yaw (N=0, E=90, S=180, W=270) in a left-handed,
+        // +Z-forward frame. To render in bevy's right-handed -Z-forward frame
+        // we mirror the Z-axis (negates the Y-rotation sign) and add 180° so
+        // the head bone's rest-pose forward aligns with the gaze target.
+        let yaw = -head_sync.yaw_deg.to_radians() + std::f32::consts::PI;
+        let pitch = head_sync.pitch_deg.to_radians();
+        let target_world = Quat::from_euler(EulerRot::YXZ, yaw, pitch, 0.0);
+
+        // Convert world target into local space: parent's current world rotation
+        // is the basis the bone's local rotation is composed against.
+        let Ok(head_parent) = parents.get(rig.head).map(|c| c.parent()) else {
+            continue;
+        };
+        let Ok(parent_global) = tx.p1().compute_global_transform(head_parent) else {
+            continue;
+        };
+        let parent_world_rot = parent_global.compute_transform().rotation;
+        let target_local = parent_world_rot.inverse() * target_world;
+        writes.push((rig.head, target_local));
+    }
+
+    let mut transforms = tx.p0();
+    for (head, rot) in writes {
+        if let Ok(mut t) = transforms.get_mut(head) {
+            t.rotation = rot;
+        }
+    }
+}

--- a/crates/avatar/src/head_ik.rs
+++ b/crates/avatar/src/head_ik.rs
@@ -1,18 +1,24 @@
 use bevy::prelude::*;
 use common::{
     sets::PostUpdateSets,
-    structs::{AttachPoints, HeadSync},
+    structs::{AttachPoints, HeadSync, PointAtSync},
 };
+use dcl_component::transform_and_parent::DclTranslation;
 
-use crate::AvatarShape;
+use crate::{point_at_ik::apply_point_at_ik, AvatarShape};
 
 pub struct HeadIkPlugin;
 
 impl Plugin for HeadIkPlugin {
     fn build(&self, app: &mut App) {
+        // `apply_head_ik` runs after `apply_point_at_ik` so it reads the
+        // post-point-at avatar yaw (point_at writes avatar.rotation inline
+        // for the local player). Without this ordering, our per-frame
+        // body-delta compensation reads a yaw that's stale by one
+        // point_at write and the head jitters during a body rotation.
         app.add_systems(
             PostUpdate,
-            (cache_head_ik_rig, apply_head_ik)
+            (cache_head_ik_rig, apply_head_ik.after(apply_point_at_ik))
                 .chain()
                 .in_set(PostUpdateSets::InverseKinematics),
         );
@@ -38,6 +44,12 @@ pub struct HeadIkRig {
     /// having to chase a moving target.
     yaw_offset_deg: f32,
     pitch_deg: f32,
+    /// Body yaw (DCL convention) at the end of the last frame. Used to
+    /// subtract the per-frame body rotation from `yaw_offset_deg` before
+    /// smoothing, so a fast turning body doesn't drag the head world
+    /// direction along with it for a frame or two while the smoother
+    /// catches up.
+    prev_dcl_avatar_yaw: Option<f32>,
 }
 
 /// Exponential-smoothing time constant (seconds) — time for the smoothed
@@ -130,13 +142,14 @@ fn cache_head_ik_rig(
             chain,
             yaw_offset_deg: 0.0,
             pitch_deg: 0.0,
+            prev_dcl_avatar_yaw: None,
         });
     }
 }
 
 fn apply_head_ik(
     time: Res<Time>,
-    mut avatars: Query<(Entity, &mut HeadIkRig, &HeadSync), With<AvatarShape>>,
+    mut avatars: Query<(Entity, &mut HeadIkRig, &HeadSync, &PointAtSync), With<AvatarShape>>,
     parents: Query<&ChildOf>,
     mut tx: ParamSet<(Query<&mut Transform>, TransformHelper)>,
 ) {
@@ -149,7 +162,7 @@ fn apply_head_ik(
 
     let mut writes: Vec<(Entity, Quat)> = Vec::new();
 
-    for (avatar_entity, mut rig, head_sync) in &mut avatars {
+    for (avatar_entity, mut rig, head_sync, point_at) in &mut avatars {
         // Avatar body forward (DCL convention: sign-flipped Y from bevy
         // world). Used as the constraint reference and as the neutral pose
         // we blend back to when the gaze input is off or out of range.
@@ -159,18 +172,64 @@ fn apply_head_ik(
         let bevy_yaw = avatar_global.rotation().to_euler(EulerRot::YXZ).0;
         let dcl_avatar_yaw = -bevy_yaw.to_degrees();
 
-        // Gaze drives the head only while at least one flag is enabled and
-        // the requested yaw stays within the reachable cone; otherwise the
-        // target is the neutral (zero offset, level) pose. Both blend-in
-        // and blend-out flow through the same smoothing path below.
-        let yaw_dev = wrap_180(head_sync.yaw_deg - dcl_avatar_yaw);
-        let active =
-            (head_sync.yaw_enabled || head_sync.pitch_enabled) && yaw_dev.abs() <= YAW_DISABLE_DEG;
-        let (target_yaw_offset, target_pitch) = if active {
+        // Subtract the body's frame-to-frame rotation from the stored
+        // yaw offset before smoothing. The offset is body-relative, so a
+        // body rotation of Δ should appear in the offset as −Δ to keep the
+        // head's world direction unchanged. Without this the smoother lags
+        // by τ behind the body and the head briefly looks past the target
+        // during a fast point-at body rotation.
+        if let Some(prev) = rig.prev_dcl_avatar_yaw {
+            let body_delta = wrap_180(dcl_avatar_yaw - prev);
+            rig.yaw_offset_deg = wrap_180(rig.yaw_offset_deg - body_delta);
+        }
+        rig.prev_dcl_avatar_yaw = Some(dcl_avatar_yaw);
+
+        // Gaze input: while pointing, override the head-sync angles so the
+        // head tracks the point-at target — the wire still carries the raw
+        // head-sync values, this is purely a display-time substitution.
+        // Otherwise fall back to the head-sync angles. Distance is measured
+        // from the head bone position so the gaze converges to the target
+        // even at point-blank range.
+        let (gaze_yaw_deg, gaze_pitch_deg, gaze_active) = if point_at.is_pointing {
+            let target_bevy = DclTranslation([
+                point_at.target_world.x,
+                point_at.target_world.y,
+                point_at.target_world.z,
+            ])
+            .to_bevy_translation();
+            if let Ok(head_global) = tx.p1().compute_global_transform(rig.head) {
+                let delta = target_bevy - head_global.translation();
+                let h_dist = (delta.x * delta.x + delta.z * delta.z).sqrt();
+                // DCL yaw of the bevy delta: DCL +Z = bevy -Z, so atan2(x, -z).
+                // Pitch is sign-flipped to match the head-sync wire convention
+                // (positive pitch_deg = looking down, captured as
+                // `-options.pitch.to_degrees()` on the sender).
+                let yaw_dcl = delta.x.atan2(-delta.z).to_degrees();
+                let pitch_dcl = -delta.y.atan2(h_dist.max(1e-3)).to_degrees();
+                (yaw_dcl, pitch_dcl, true)
+            } else {
+                (
+                    head_sync.yaw_deg,
+                    head_sync.pitch_deg,
+                    head_sync.yaw_enabled || head_sync.pitch_enabled,
+                )
+            }
+        } else {
             (
-                yaw_dev.clamp(-YAW_CLAMP_DEG, YAW_CLAMP_DEG),
+                head_sync.yaw_deg,
                 head_sync.pitch_deg,
+                head_sync.yaw_enabled || head_sync.pitch_enabled,
             )
+        };
+
+        // Gaze drives the head only while engaged and the requested yaw
+        // stays within the reachable cone; otherwise the target is the
+        // neutral (zero offset, level) pose. Both blend-in and blend-out
+        // flow through the same smoothing path below.
+        let yaw_dev = wrap_180(gaze_yaw_deg - dcl_avatar_yaw);
+        let active = gaze_active && yaw_dev.abs() <= YAW_DISABLE_DEG;
+        let (target_yaw_offset, target_pitch) = if active {
+            (yaw_dev.clamp(-YAW_CLAMP_DEG, YAW_CLAMP_DEG), gaze_pitch_deg)
         } else {
             (0.0, 0.0)
         };

--- a/crates/avatar/src/head_ik.rs
+++ b/crates/avatar/src/head_ik.rs
@@ -25,6 +25,46 @@ pub struct HeadIkRig {
     /// parent. The attach point is reparented onto the bone during avatar
     /// build (see `lib.rs::reparent_attach_point`).
     pub head: Entity,
+    /// Smoothed yaw stored as an offset from the avatar's body forward
+    /// (DCL convention). Storing relative — not absolute world yaw — means
+    /// body rotation propagates to the head instantly without the smoother
+    /// having to chase a moving target.
+    yaw_offset_deg: f32,
+    pitch_deg: f32,
+}
+
+/// Exponential-smoothing time constant (seconds) — time for the smoothed
+/// value to cover ~63% of the gap to target. Tuned to absorb 10Hz network
+/// jitter on remotes while still feeling responsive on the local rig.
+const SMOOTH_TAU: f32 = 0.12;
+
+/// Pitch is a vertical look angle, not a wrap-around heading — clamp before
+/// feeding into `from_euler` so values near or past ±90° (gimbal lock) don't
+/// flip the head bone through a full revolution.
+const PITCH_CLAMP_DEG: f32 = 50.0;
+
+/// Maximum yaw deviation from the avatar's body forward — beyond this the
+/// head holds at the limit (waiting for the body to catch up).
+const YAW_CLAMP_DEG: f32 = 70.0;
+
+/// Above this deviation the head IK is disabled entirely (caller is looking
+/// well past anything the neck could plausibly reach).
+const YAW_DISABLE_DEG: f32 = 110.0;
+
+fn wrap_180(deg: f32) -> f32 {
+    let mut d = deg % 360.0;
+    if d > 180.0 {
+        d -= 360.0;
+    } else if d < -180.0 {
+        d += 360.0;
+    }
+    d
+}
+
+/// Exponential approach toward `target`, treating both as degrees on a
+/// circle: takes the short way around the ±180° wrap.
+fn smooth_angle(current: f32, target: f32, alpha: f32) -> f32 {
+    current + wrap_180(target - current) * alpha
 }
 
 #[allow(clippy::type_complexity)]
@@ -57,30 +97,68 @@ fn cache_head_ik_rig(
             "head_ik: cached rig for {:?} (head bone: {:?})",
             avatar, head_bone
         );
-        commands
-            .entity(avatar)
-            .try_insert(HeadIkRig { head: head_bone });
+        commands.entity(avatar).try_insert(HeadIkRig {
+            head: head_bone,
+            yaw_offset_deg: 0.0,
+            pitch_deg: 0.0,
+        });
     }
 }
 
 fn apply_head_ik(
-    avatars: Query<(&HeadIkRig, &HeadSync), With<AvatarShape>>,
+    time: Res<Time>,
+    mut avatars: Query<(Entity, &mut HeadIkRig, &HeadSync), With<AvatarShape>>,
     parents: Query<&ChildOf>,
     mut tx: ParamSet<(Query<&mut Transform>, TransformHelper)>,
 ) {
+    let dt = time.delta_secs();
+    let alpha = if dt > 0.0 {
+        1.0 - (-dt / SMOOTH_TAU).exp()
+    } else {
+        0.0
+    };
+
     let mut writes: Vec<(Entity, Quat)> = Vec::new();
 
-    for (rig, head_sync) in &avatars {
-        if !head_sync.yaw_enabled && !head_sync.pitch_enabled {
+    for (avatar_entity, mut rig, head_sync) in &mut avatars {
+        // Avatar body forward (DCL convention: sign-flipped Y from bevy
+        // world). Used as the constraint reference and as the neutral pose
+        // we blend back to when the gaze input is off or out of range.
+        let Ok(avatar_global) = tx.p1().compute_global_transform(avatar_entity) else {
             continue;
-        }
+        };
+        let bevy_yaw = avatar_global.rotation().to_euler(EulerRot::YXZ).0;
+        let dcl_avatar_yaw = -bevy_yaw.to_degrees();
+
+        // Gaze drives the head only while at least one flag is enabled and
+        // the requested yaw stays within the reachable cone; otherwise the
+        // target is the neutral (zero offset, level) pose. Both blend-in
+        // and blend-out flow through the same smoothing path below.
+        let yaw_dev = wrap_180(head_sync.yaw_deg - dcl_avatar_yaw);
+        let active =
+            (head_sync.yaw_enabled || head_sync.pitch_enabled) && yaw_dev.abs() <= YAW_DISABLE_DEG;
+        let (target_yaw_offset, target_pitch) = if active {
+            (
+                yaw_dev.clamp(-YAW_CLAMP_DEG, YAW_CLAMP_DEG),
+                head_sync.pitch_deg,
+            )
+        } else {
+            (0.0, 0.0)
+        };
+
+        rig.yaw_offset_deg = smooth_angle(rig.yaw_offset_deg, target_yaw_offset, alpha);
+        rig.pitch_deg = smooth_angle(rig.pitch_deg, target_pitch, alpha);
 
         // Wire format: DCL yaw (N=0, E=90, S=180, W=270) in a left-handed,
         // +Z-forward frame. To render in bevy's right-handed -Z-forward frame
         // we mirror the Z-axis (negates the Y-rotation sign) and add 180° so
         // the head bone's rest-pose forward aligns with the gaze target.
-        let yaw = -head_sync.yaw_deg.to_radians() + std::f32::consts::PI;
-        let pitch = head_sync.pitch_deg.to_radians();
+        let world_yaw_dcl = dcl_avatar_yaw + rig.yaw_offset_deg;
+        let yaw = -world_yaw_dcl.to_radians() + std::f32::consts::PI;
+        let pitch = rig
+            .pitch_deg
+            .clamp(-PITCH_CLAMP_DEG, PITCH_CLAMP_DEG)
+            .to_radians();
         let target_world = Quat::from_euler(EulerRot::YXZ, yaw, pitch, 0.0);
 
         // Convert world target into local space: parent's current world rotation

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -33,8 +33,10 @@ pub mod foot_ik;
 pub mod foreign_dynamics;
 pub mod head_ik;
 pub mod mask_material;
+pub mod name_color;
 pub mod npc_dynamics;
 pub mod point_at_ik;
+pub mod point_at_marker;
 mod two_bone_ik;
 
 use common::{
@@ -73,7 +75,7 @@ use world_ui::{spawn_world_ui_view, WorldUi};
 
 use crate::{
     animate::AvatarAnimPlayer, dynamic_nametag::DynamicNametagPlugin, foot_ik::FootIkPlugin,
-    head_ik::HeadIkPlugin, point_at_ik::PointAtIkPlugin,
+    head_ik::HeadIkPlugin, point_at_ik::PointAtIkPlugin, point_at_marker::PointAtMarkerPlugin,
 };
 
 use self::{
@@ -97,6 +99,7 @@ impl Plugin for AvatarPlugin {
         app.add_plugins(FootIkPlugin);
         app.add_plugins(HeadIkPlugin);
         app.add_plugins(PointAtIkPlugin);
+        app.add_plugins(PointAtMarkerPlugin);
         app.add_systems(
             Update,
             (

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -34,6 +34,8 @@ pub mod foreign_dynamics;
 pub mod head_ik;
 pub mod mask_material;
 pub mod npc_dynamics;
+pub mod point_at_ik;
+mod two_bone_ik;
 
 use common::{
     sets::SetupSets,
@@ -71,7 +73,7 @@ use world_ui::{spawn_world_ui_view, WorldUi};
 
 use crate::{
     animate::AvatarAnimPlayer, dynamic_nametag::DynamicNametagPlugin, foot_ik::FootIkPlugin,
-    head_ik::HeadIkPlugin,
+    head_ik::HeadIkPlugin, point_at_ik::PointAtIkPlugin,
 };
 
 use self::{
@@ -94,6 +96,7 @@ impl Plugin for AvatarPlugin {
         app.add_plugins(DynamicNametagPlugin);
         app.add_plugins(FootIkPlugin);
         app.add_plugins(HeadIkPlugin);
+        app.add_plugins(PointAtIkPlugin);
         app.add_systems(
             Update,
             (

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -31,6 +31,7 @@ pub mod colliders;
 mod dynamic_nametag;
 pub mod foot_ik;
 pub mod foreign_dynamics;
+pub mod head_ik;
 pub mod mask_material;
 pub mod npc_dynamics;
 
@@ -70,6 +71,7 @@ use world_ui::{spawn_world_ui_view, WorldUi};
 
 use crate::{
     animate::AvatarAnimPlayer, dynamic_nametag::DynamicNametagPlugin, foot_ik::FootIkPlugin,
+    head_ik::HeadIkPlugin,
 };
 
 use self::{
@@ -91,6 +93,7 @@ impl Plugin for AvatarPlugin {
         app.add_plugins(AvatarTexturePlugin);
         app.add_plugins(DynamicNametagPlugin);
         app.add_plugins(FootIkPlugin);
+        app.add_plugins(HeadIkPlugin);
         app.add_systems(
             Update,
             (

--- a/crates/avatar/src/name_color.rs
+++ b/crates/avatar/src/name_color.rs
@@ -1,0 +1,54 @@
+use bevy::prelude::*;
+use ethers_core::types::Address;
+
+/// Hand-curated palette mirrored from `bevy-ui-scene`'s
+/// `UserNameColors.json`. Keep this in lockstep with the scene so the marker
+/// background matches the in-world nametag tint.
+const PALETTE: [Srgba; 23] = [
+    Srgba::new(0.671_385_05, 0.387_148_47, 0.943_396_2, 1.0),
+    Srgba::new(0.832_455_7, 0.627_358_5, 1.0, 1.0),
+    Srgba::new(0.871_691_4, 0.382_075_5, 1.0, 1.0),
+    Srgba::new(1.0, 0.202_830_2, 0.978_383_7, 1.0),
+    Srgba::new(1.0, 0.353_773_6, 0.923_547_45, 1.0),
+    Srgba::new(1.0, 0.523_584_9, 0.796_823_14, 1.0),
+    Srgba::new(1.0, 0.701_960_8, 0.943_320_4, 1.0),
+    Srgba::new(1.0, 0.287_735_82, 0.309_539_65, 1.0),
+    Srgba::new(1.0, 0.429_245_3, 0.467_913_36, 1.0),
+    Srgba::new(1.0, 0.636_792_4, 0.666_241_65, 1.0),
+    Srgba::new(1.0, 0.505_318_5, 0.080_188_69, 1.0),
+    Srgba::new(1.0, 0.657_052_46, 0.0, 1.0),
+    Srgba::new(1.0, 0.854_872_8, 0.0, 1.0),
+    Srgba::new(1.0, 0.943_192_8, 0.608_490_6, 1.0),
+    Srgba::new(0.515_649_26, 0.867_924_5, 0.0, 1.0),
+    Srgba::new(0.619_413_7, 0.960_784_3, 0.121_568_605, 1.0),
+    Srgba::new(0.858_401, 1.0, 0.561_320_8, 1.0),
+    Srgba::new(0.0, 1.0, 0.728_798_4, 1.0),
+    Srgba::new(0.533_018_8, 1.0, 0.935_397_8, 1.0),
+    Srgba::new(0.607_843_16, 0.839_133_9, 1.0, 1.0),
+    Srgba::new(0.607_843_16, 0.652_744_6, 1.0, 1.0),
+    Srgba::new(0.485_849_08, 0.705_716_6, 1.0, 1.0),
+    Srgba::new(0.278_301_9, 0.782_075_7, 1.0, 1.0),
+];
+
+/// Fallback for unclaimed-name users — `bevy-ui-scene` shows a flat grey for
+/// this case rather than a hashed palette colour. We don't currently know
+/// claimed-name status here, so the caller decides whether to use this.
+pub const UNCLAIMED_NAME_COLOR: Color = Color::srgb(0.6, 0.6, 0.6);
+
+/// 64-bit FNV-1a over the UTF-8 bytes of the lowercase hex address. Matches
+/// `bevy-ui-scene`'s `simpleHash` exactly so palette indices line up with the
+/// nametag scene.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 2166136261;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(16777619);
+    }
+    hash
+}
+
+pub fn name_color(address: Address) -> Color {
+    let s = format!("{address:#x}");
+    let idx = (fnv1a_64(s.as_bytes()) % PALETTE.len() as u64) as usize;
+    Color::Srgba(PALETTE[idx])
+}

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use common::{sets::PostUpdateSets, structs::PointAtSync};
+use common::{
+    sets::PostUpdateSets,
+    structs::{PointAtSync, PrimaryUser},
+};
 use dcl_component::transform_and_parent::DclTranslation;
 
 use crate::{two_bone_ik::solve_two_bone, AvatarShape};
@@ -35,6 +38,10 @@ pub struct PointAtIkRig {
     /// Smoothed IK weight, ramped 0→1 when pointing engages and 1→0 when it
     /// disengages. Lets the animation pose retake the arm without a snap.
     weight: f32,
+    /// Hysteresis flag: once the gaze deviates past the trigger threshold the
+    /// body commits to a full rotation toward the target rather than partial
+    /// catching-up. Cleared once we land within the finish threshold.
+    is_rotating: bool,
 }
 
 /// Time constant for the weight ramp (seconds for ~63% of the gap). Tuned to
@@ -45,6 +52,19 @@ const WEIGHT_TAU: f32 = 0.15;
 /// bends to. Pointing "down" sends the elbow under the shoulder for natural
 /// forward-arm gestures.
 const POLE_DIR_WORLD: Vec3 = Vec3::NEG_Y;
+
+/// Yaw deviation (degrees, body forward → target) past which the body
+/// commits to rotating to face the target. Below this we leave the body
+/// alone — the arm reach is enough.
+const BODY_ROTATE_TRIGGER_DEG: f32 = 45.0;
+
+/// Once rotating, we keep going until we're within this many degrees of
+/// the target — gives a deliberate "turn-and-point" feel rather than a
+/// stuttery catch-up.
+const BODY_ROTATE_FINISH_DEG: f32 = 1.0;
+
+/// Slew rate for body rotation. Matches Unity's PointAt rotation speed.
+const BODY_ROTATE_DEG_PER_SEC: f32 = 250.0;
 
 /// Per-bone curl applied at full IK weight: angle (degrees, positive curls
 /// into a fist, negative straightens) around a per-bone local-space axis.
@@ -113,6 +133,7 @@ fn cache_point_at_rig(
                 hand,
                 curled_fingers,
                 weight: 0.0,
+                is_rotating: false,
             });
         }
     }
@@ -121,7 +142,10 @@ fn cache_point_at_rig(
 #[allow(clippy::type_complexity)]
 fn apply_point_at_ik(
     time: Res<Time>,
-    mut avatars: Query<(&mut PointAtIkRig, &PointAtSync), With<AvatarShape>>,
+    mut avatars: Query<
+        (Entity, &mut PointAtIkRig, &PointAtSync, Has<PrimaryUser>),
+        With<AvatarShape>,
+    >,
     parents: Query<&ChildOf>,
     mut tx: ParamSet<(Query<&mut Transform>, TransformHelper)>,
 ) {
@@ -136,13 +160,65 @@ fn apply_point_at_ik(
     // applied as a post-multiplied curl onto whatever the animation set, so
     // weight=0 leaves the bone alone.
     let mut finger_curls: Vec<(Entity, Vec3, f32)> = Vec::new();
+    // Avatar-entity body-yaw overrides (bevy world yaw, radians). Avatar is
+    // top-level so we just write a pure Y-rotation onto its local Transform.
+    let mut body_yaw_writes: Vec<(Entity, f32)> = Vec::new();
 
-    for (mut rig, point_at) in &mut avatars {
+    for (avatar_entity, mut rig, point_at, is_local) in &mut avatars {
         // Smooth the IK weight toward 1 while pointing, 0 otherwise. This
         // alone provides the blend in/out — the swing math runs every frame,
         // and zero-weight slerp is a no-op.
         let target_weight = if point_at.is_pointing { 1.0 } else { 0.0 };
         rig.weight += (target_weight - rig.weight) * alpha;
+
+        // PointAtSync.target_world is in DCL convention (z mirrored from bevy).
+        let target_world = DclTranslation([
+            point_at.target_world.x,
+            point_at.target_world.y,
+            point_at.target_world.z,
+        ])
+        .to_bevy_translation();
+
+        // Body rotation only for the local player. Foreign players have their
+        // body yaw driven by incoming Movement packets — overriding it here
+        // would fight the network-driven orientation each frame.
+        //
+        // Gated on the raw is_pointing flag (not the smoothed weight): when
+        // the gesture ends we stop steering the body even though the arm
+        // continues to ramp out.
+        if is_local && point_at.is_pointing {
+            if let Ok(avatar_g) = tx.p1().compute_global_transform(avatar_entity) {
+                let avatar_pos = avatar_g.translation();
+                let dx = target_world.x - avatar_pos.x;
+                let dz = target_world.z - avatar_pos.z;
+                if dx * dx + dz * dz > 1e-2 {
+                    // Avatar mesh forward is bevy -Z. Under Y rotation by θ,
+                    // -Z maps to (-sin θ, 0, -cos θ), so the yaw that aims
+                    // the avatar at (dx, _, dz) is atan2(-dx, -dz).
+                    let desired_yaw = (-dx).atan2(-dz);
+                    let cur_yaw = avatar_g.rotation().to_euler(EulerRot::YXZ).0;
+                    let delta_deg = wrap_180_deg((desired_yaw - cur_yaw).to_degrees());
+
+                    if !rig.is_rotating && delta_deg.abs() > BODY_ROTATE_TRIGGER_DEG {
+                        rig.is_rotating = true;
+                    }
+                    if rig.is_rotating {
+                        let max_step = BODY_ROTATE_DEG_PER_SEC * dt;
+                        let step = delta_deg.clamp(-max_step, max_step);
+                        let new_yaw = cur_yaw + step.to_radians();
+                        body_yaw_writes.push((avatar_entity, new_yaw));
+                        if delta_deg.abs() <= BODY_ROTATE_FINISH_DEG {
+                            rig.is_rotating = false;
+                        }
+                    }
+                } else {
+                    rig.is_rotating = false;
+                }
+            }
+        } else {
+            rig.is_rotating = false;
+        }
+
         if rig.weight < 1e-3 {
             continue;
         }
@@ -173,14 +249,6 @@ fn apply_point_at_ik(
         let l_ab = (b - a).length();
         let l_bc = (c - b).length();
 
-        // PointAtSync.target_world is in DCL convention (z mirrored from bevy).
-        let target_world = DclTranslation([
-            point_at.target_world.x,
-            point_at.target_world.y,
-            point_at.target_world.z,
-        ])
-        .to_bevy_translation();
-
         let Some((r_upper, r_lower)) =
             solve_two_bone(a, b, c, target_world, l_ab, l_bc, POLE_DIR_WORLD)
         else {
@@ -208,6 +276,13 @@ fn apply_point_at_ik(
     }
 
     let mut transforms = tx.p0();
+    // Body rotation overrides go first so subsequent reads of avatar Transform
+    // (none here, but a safe ordering) see the new yaw.
+    for (avatar, yaw) in body_yaw_writes {
+        if let Ok(mut t) = transforms.get_mut(avatar) {
+            t.rotation = Quat::from_rotation_y(yaw);
+        }
+    }
     for (bone, rot) in writes {
         if let Ok(mut t) = transforms.get_mut(bone) {
             t.rotation = rot;
@@ -221,6 +296,16 @@ fn apply_point_at_ik(
             t.rotation *= Quat::from_axis_angle(axis, angle);
         }
     }
+}
+
+fn wrap_180_deg(deg: f32) -> f32 {
+    let mut d = deg % 360.0;
+    if d > 180.0 {
+        d -= 360.0;
+    } else if d < -180.0 {
+        d += 360.0;
+    }
+    d
 }
 
 fn find_bone(

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -1,0 +1,245 @@
+use bevy::prelude::*;
+use common::{sets::PostUpdateSets, structs::PointAtSync};
+use dcl_component::transform_and_parent::DclTranslation;
+
+use crate::{two_bone_ik::solve_two_bone, AvatarShape};
+
+pub struct PointAtIkPlugin;
+
+impl Plugin for PointAtIkPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (cache_point_at_rig, apply_point_at_ik)
+                .chain()
+                .in_set(PostUpdateSets::InverseKinematics),
+        );
+    }
+}
+
+#[derive(Component)]
+pub struct PointAtIkRig {
+    /// Upper-arm bone (root of the 2-bone IK chain).
+    pub upper: Entity,
+    /// Forearm bone (mid).
+    pub lower: Entity,
+    /// Hand bone (end-effector).
+    pub hand: Entity,
+    /// Finger bones with the per-bone curl angle (degrees) and local-space
+    /// rotation axis to apply at full IK weight. Negative angles straighten
+    /// — the index finger gets a small back-bend so it doesn't read as a
+    /// relaxed claw. Most fingers curl on local Z but the thumb is laid
+    /// out differently in the rig and needs its own axis. Bones missing
+    /// from the rig drop out silently.
+    curled_fingers: Vec<(Entity, f32, Vec3)>,
+    /// Smoothed IK weight, ramped 0→1 when pointing engages and 1→0 when it
+    /// disengages. Lets the animation pose retake the arm without a snap.
+    weight: f32,
+}
+
+/// Time constant for the weight ramp (seconds for ~63% of the gap). Tuned to
+/// feel responsive without snapping — Unity uses a similar ~0.5s ramp.
+const WEIGHT_TAU: f32 = 0.15;
+
+/// Hint direction in world space for which side of the swing plane the elbow
+/// bends to. Pointing "down" sends the elbow under the shoulder for natural
+/// forward-arm gestures.
+const POLE_DIR_WORLD: Vec3 = Vec3::NEG_Y;
+
+/// Per-bone curl applied at full IK weight: angle (degrees, positive curls
+/// into a fist, negative straightens) around a per-bone local-space axis.
+/// Most segments curl on local Z, but the thumb is laid out differently in
+/// the rig — adjust its axis here without affecting the rest. Mixamo-style
+/// rigs expose these as `avatar_righthand{finger}{1,2,3}`; bones not present
+/// in the rig drop out silently.
+const FINGER_CURLS: &[(&str, f32, Vec3)] = &[
+    ("avatar_righthandthumb1", 0.0, Vec3::Z),
+    ("avatar_righthandthumb2", -60.0, Vec3::X),
+    ("avatar_righthandthumb3", -60.0, Vec3::X),
+    ("avatar_righthandthumb4", -60.0, Vec3::X),
+    ("avatar_righthandindex1", -10.0, Vec3::Z),
+    ("avatar_righthandindex2", -10.0, Vec3::Z),
+    ("avatar_righthandindex3", -10.0, Vec3::Z),
+    ("avatar_righthandmiddle1", 80.0, Vec3::Z),
+    ("avatar_righthandmiddle2", 80.0, Vec3::Z),
+    ("avatar_righthandmiddle3", 80.0, Vec3::Z),
+    ("avatar_righthandring1", 80.0, Vec3::Z),
+    ("avatar_righthandring2", 80.0, Vec3::Z),
+    ("avatar_righthandring3", 80.0, Vec3::Z),
+    ("avatar_righthandpinky1", 80.0, Vec3::Z),
+    ("avatar_righthandpinky2", 80.0, Vec3::Z),
+    ("avatar_righthandpinky3", 80.0, Vec3::Z),
+];
+
+#[allow(clippy::type_complexity)]
+fn cache_point_at_rig(
+    mut commands: Commands,
+    needs_rig: Query<Entity, (With<AvatarShape>, Without<PointAtIkRig>)>,
+    has_rig: Query<(Entity, &PointAtIkRig), With<AvatarShape>>,
+    children_q: Query<&Children>,
+    name_q: Query<&Name>,
+    transforms: Query<&Transform>,
+) {
+    // Invalidate stale cache: bones got despawned by a wearable swap.
+    for (avatar, rig) in &has_rig {
+        let alive = [rig.upper, rig.lower, rig.hand]
+            .iter()
+            .chain(rig.curled_fingers.iter().map(|(e, _, _)| e))
+            .all(|e| transforms.get(*e).is_ok());
+        if !alive {
+            commands.entity(avatar).remove::<PointAtIkRig>();
+        }
+    }
+
+    for avatar in &needs_rig {
+        let upper = find_bone(avatar, "avatar_rightarm", &children_q, &name_q);
+        let lower = find_bone(avatar, "avatar_rightforearm", &children_q, &name_q);
+        let hand = find_bone(avatar, "avatar_righthand", &children_q, &name_q);
+        if let (Some(upper), Some(lower), Some(hand)) = (upper, lower, hand) {
+            let curled_fingers: Vec<(Entity, f32, Vec3)> = FINGER_CURLS
+                .iter()
+                .filter_map(|(name, deg, axis)| {
+                    find_bone(avatar, name, &children_q, &name_q).map(|e| (e, *deg, *axis))
+                })
+                .collect();
+            info!(
+                "point_at_ik: cached rig for {:?} (arm: {:?}, forearm: {:?}, hand: {:?}, fingers: {})",
+                avatar, upper, lower, hand,
+                curled_fingers.len()
+            );
+            commands.entity(avatar).try_insert(PointAtIkRig {
+                upper,
+                lower,
+                hand,
+                curled_fingers,
+                weight: 0.0,
+            });
+        }
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn apply_point_at_ik(
+    time: Res<Time>,
+    mut avatars: Query<(&mut PointAtIkRig, &PointAtSync), With<AvatarShape>>,
+    parents: Query<&ChildOf>,
+    mut tx: ParamSet<(Query<&mut Transform>, TransformHelper)>,
+) {
+    let dt = time.delta_secs();
+    let alpha = if dt > 0.0 {
+        1.0 - (-dt / WEIGHT_TAU).exp()
+    } else {
+        0.0
+    };
+    let mut writes: Vec<(Entity, Quat)> = Vec::new();
+    // (finger_bone, axis, scaled_angle_rad) collected alongside arm writes;
+    // applied as a post-multiplied curl onto whatever the animation set, so
+    // weight=0 leaves the bone alone.
+    let mut finger_curls: Vec<(Entity, Vec3, f32)> = Vec::new();
+
+    for (mut rig, point_at) in &mut avatars {
+        // Smooth the IK weight toward 1 while pointing, 0 otherwise. This
+        // alone provides the blend in/out — the swing math runs every frame,
+        // and zero-weight slerp is a no-op.
+        let target_weight = if point_at.is_pointing { 1.0 } else { 0.0 };
+        rig.weight += (target_weight - rig.weight) * alpha;
+        if rig.weight < 1e-3 {
+            continue;
+        }
+
+        // Read pre-IK globals via TransformHelper. Writes are deferred to a
+        // single pass at the end so the chain math sees a consistent
+        // pre-IK state.
+        let helper = tx.p1();
+        let Ok(upper_g) = helper.compute_global_transform(rig.upper) else {
+            continue;
+        };
+        let Ok(lower_g) = helper.compute_global_transform(rig.lower) else {
+            continue;
+        };
+        let Ok(hand_g) = helper.compute_global_transform(rig.hand) else {
+            continue;
+        };
+        let Ok(upper_parent) = parents.get(rig.upper).map(|c| c.parent()) else {
+            continue;
+        };
+        let Ok(upper_parent_g) = helper.compute_global_transform(upper_parent) else {
+            continue;
+        };
+
+        let a = upper_g.translation();
+        let b = lower_g.translation();
+        let c = hand_g.translation();
+        let l_ab = (b - a).length();
+        let l_bc = (c - b).length();
+
+        // PointAtSync.target_world is in DCL convention (z mirrored from bevy).
+        let target_world = DclTranslation([
+            point_at.target_world.x,
+            point_at.target_world.y,
+            point_at.target_world.z,
+        ])
+        .to_bevy_translation();
+
+        let Some((r_upper, r_lower)) =
+            solve_two_bone(a, b, c, target_world, l_ab, l_bc, POLE_DIR_WORLD)
+        else {
+            continue;
+        };
+
+        let r_upper_w = Quat::IDENTITY.slerp(r_upper, rig.weight);
+        let r_lower_w = Quat::IDENTITY.slerp(r_lower, rig.weight);
+
+        let cur_upper_g_rot = upper_g.compute_transform().rotation;
+        let cur_lower_g_rot = lower_g.compute_transform().rotation;
+        let parent_g_rot = upper_parent_g.compute_transform().rotation;
+
+        let new_upper_g_rot = r_upper_w * cur_upper_g_rot;
+        let new_lower_g_rot = r_lower_w * r_upper_w * cur_lower_g_rot;
+
+        let upper_local = parent_g_rot.inverse() * new_upper_g_rot;
+        let lower_local = new_upper_g_rot.inverse() * new_lower_g_rot;
+
+        writes.push((rig.upper, upper_local));
+        writes.push((rig.lower, lower_local));
+        for &(finger, deg, axis) in &rig.curled_fingers {
+            finger_curls.push((finger, axis, deg.to_radians() * rig.weight));
+        }
+    }
+
+    let mut transforms = tx.p0();
+    for (bone, rot) in writes {
+        if let Ok(mut t) = transforms.get_mut(bone) {
+            t.rotation = rot;
+        }
+    }
+    // Curl post-multiplied onto whatever animation set: identity at angle=0
+    // (weight 0 or zero entry in FINGER_CURLS), per-bone signed degrees and
+    // axis at full weight.
+    for (finger, axis, angle) in finger_curls {
+        if let Ok(mut t) = transforms.get_mut(finger) {
+            t.rotation *= Quat::from_axis_angle(axis, angle);
+        }
+    }
+}
+
+fn find_bone(
+    root: Entity,
+    target_lower: &str,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+) -> Option<Entity> {
+    if let Ok(name) = names.get(root) {
+        if name.as_str().to_lowercase() == target_lower {
+            return Some(root);
+        }
+    }
+    if let Ok(kids) = children.get(root) {
+        for k in kids {
+            if let Some(found) = find_bone(*k, target_lower, children, names) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -271,12 +271,12 @@ pub(crate) fn apply_point_at_ik(
                     // a slightly narrower one, so per-client rounding can't
                     // cause one of us to display while the other doesn't or
                     // one of us to be turning while the other isn't.
-                    let in_display_cone = delta_deg
-                        <= BODY_ROTATE_TRIGGER_LEFT_DEG + CONE_TOLERANCE_DEG
-                        && delta_deg >= -BODY_ROTATE_TRIGGER_RIGHT_DEG - CONE_TOLERANCE_DEG;
-                    let needs_to_rotate = delta_deg
-                        > BODY_ROTATE_TRIGGER_LEFT_DEG - CONE_TOLERANCE_DEG
-                        || delta_deg < -BODY_ROTATE_TRIGGER_RIGHT_DEG + CONE_TOLERANCE_DEG;
+                    let display_cone = (-BODY_ROTATE_TRIGGER_RIGHT_DEG - CONE_TOLERANCE_DEG)
+                        ..=(BODY_ROTATE_TRIGGER_LEFT_DEG + CONE_TOLERANCE_DEG);
+                    let trigger_cone = (-BODY_ROTATE_TRIGGER_RIGHT_DEG + CONE_TOLERANCE_DEG)
+                        ..=(BODY_ROTATE_TRIGGER_LEFT_DEG - CONE_TOLERANCE_DEG);
+                    let in_display_cone = display_cone.contains(&delta_deg);
+                    let needs_to_rotate = !trigger_cone.contains(&delta_deg);
                     body_facing_ok = in_display_cone;
 
                     if is_local {

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -99,6 +99,22 @@ const CONE_TOLERANCE_DEG: f32 = 2.0;
 /// before crossing it. Acts like hysteresis without an explicit flag.
 const ENGAGED_WEIGHT_TARGET: f32 = 3.0;
 
+/// Half-space limits on the upper-arm direction (shoulder→elbow) in the
+/// avatar's body-local frame. Applied after the 2-bone IK solves: if the
+/// solver wants to swing the upper arm such that its direction crosses
+/// these limits, we project the direction onto the boundary plane and
+/// rebuild the shoulder swing rotation. Keeps the right arm out of the
+/// torso when the IK target sits in the rear half-space (smoothing-
+/// through-body during a body rotation) or right under the body center
+/// (click at feet, where target is at the avatar entity origin).
+///
+/// `MIN_X` keeps the upper arm from crossing the body's centerline to the
+/// left; `MAX_Z` keeps it from rotating behind the body. Both are direction
+/// components on a unit vector, in body-local frame (mesh forward = -Z,
+/// mesh right = +X).
+const UPPER_ARM_MIN_X_LOCAL: f32 = 0.1;
+const UPPER_ARM_MAX_Z_LOCAL: f32 = 0.2;
+
 /// Once rotating, we keep going until we're within this many degrees of
 /// the target — gives a deliberate "turn-and-point" feel rather than a
 /// stuttery catch-up.
@@ -374,6 +390,17 @@ pub(crate) fn apply_point_at_ik(
             continue;
         };
 
+        // Clamp the resulting upper-arm direction to a body-local half-space
+        // so the arm doesn't bend through the torso. The clamp runs in the
+        // post-yaw-write body frame (we wrote `avatar.transform.rotation`
+        // above), so as the body rotates the half-space rotates with it.
+        let r_upper = if let Ok(body_g) = tx.p1().compute_global_transform(avatar_entity) {
+            let cur_dir_world = (b - a).normalize_or_zero();
+            constrain_upper_arm(r_upper, cur_dir_world, body_g.rotation())
+        } else {
+            r_upper
+        };
+
         let r_upper_w = Quat::IDENTITY.slerp(r_upper, display_weight);
         let r_lower_w = Quat::IDENTITY.slerp(r_lower, display_weight);
 
@@ -408,6 +435,36 @@ pub(crate) fn apply_point_at_ik(
             t.rotation *= Quat::from_axis_angle(axis, angle);
         }
     }
+}
+
+/// Project the upper-arm swing rotation `r_upper` so the resulting bone
+/// direction stays in the body-local half-space `x >= UPPER_ARM_MIN_X_LOCAL,
+/// z <= UPPER_ARM_MAX_Z_LOCAL`. `cur_dir_world` is the rest-pose
+/// shoulder→elbow direction; the swing rotates that into the new direction
+/// `r_upper * cur_dir_world`. If the new direction violates the constraints
+/// we clamp the offending components in body-local frame, renormalize, and
+/// rebuild `r_upper` as the rotation_arc from rest to the clamped direction.
+fn constrain_upper_arm(r_upper: Quat, cur_dir_world: Vec3, body_rot: Quat) -> Quat {
+    let new_dir_world = r_upper * cur_dir_world;
+    let mut local = body_rot.inverse() * new_dir_world;
+    let mut clamped = false;
+    if local.x < UPPER_ARM_MIN_X_LOCAL {
+        local.x = UPPER_ARM_MIN_X_LOCAL;
+        clamped = true;
+    }
+    if local.z > UPPER_ARM_MAX_Z_LOCAL {
+        local.z = UPPER_ARM_MAX_Z_LOCAL;
+        clamped = true;
+    }
+    if !clamped {
+        return r_upper;
+    }
+    let local = local.normalize_or_zero();
+    if local.length_squared() < 0.5 {
+        return r_upper;
+    }
+    let new_dir_world = body_rot * local;
+    Quat::from_rotation_arc(cur_dir_world, new_dir_world)
 }
 
 fn wrap_180_deg(deg: f32) -> f32 {

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -179,7 +179,7 @@ fn cache_point_at_rig(
                     find_bone(avatar, name, &children_q, &name_q).map(|e| (e, *deg, *axis))
                 })
                 .collect();
-            info!(
+            debug!(
                 "point_at_ik: cached rig for {:?} (arm: {:?}, forearm: {:?}, hand: {:?}, fingers: {})",
                 avatar, upper, lower, hand,
                 curled_fingers.len()

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -183,7 +183,7 @@ fn cache_point_at_rig(
 }
 
 #[allow(clippy::type_complexity)]
-fn apply_point_at_ik(
+pub(crate) fn apply_point_at_ik(
     time: Res<Time>,
     mut avatars: Query<
         (Entity, &mut PointAtIkRig, &PointAtSync, Has<PrimaryUser>),

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -35,28 +35,69 @@ pub struct PointAtIkRig {
     /// out differently in the rig and needs its own axis. Bones missing
     /// from the rig drop out silently.
     curled_fingers: Vec<(Entity, f32, Vec3)>,
-    /// Smoothed IK weight, ramped 0→1 when pointing engages and 1→0 when it
-    /// disengages. Lets the animation pose retake the arm without a snap.
+    /// Smoothed IK weight. Ramps toward `ENGAGED_WEIGHT_TARGET` (>1.0) while
+    /// engaged and 0 otherwise; we clamp to `[0, 1]` for display, so the
+    /// "above 1" reserve acts as a time-based hysteresis dampener — brief
+    /// excursions out of the cone bleed off the reserve before the displayed
+    /// weight starts dropping.
     weight: f32,
+    /// Smoothed gaze target in bevy world space. Lerps toward the latest
+    /// target each frame so that re-aiming during a held drag (or a fresh
+    /// click while the previous gesture is still ramping out) glides the
+    /// hand to the new spot instead of snapping. `None` while idle; init
+    /// to the current target on the first pointing frame, cleared once the
+    /// weight finishes ramping back to zero.
+    smoothed_target: Option<Vec3>,
     /// Hysteresis flag: once the gaze deviates past the trigger threshold the
     /// body commits to a full rotation toward the target rather than partial
     /// catching-up. Cleared once we land within the finish threshold.
     is_rotating: bool,
+    /// Our own copy of the avatar's bevy world yaw (radians). The avatar
+    /// movement system rewrites `Transform.rotation` from a stored
+    /// orientation each frame, and movement-scene round-trips can lag, so
+    /// reading the transform isn't a reliable source for our slew. We hold
+    /// our own state from the first frame of a local pointing gesture and
+    /// override the transform every frame while it's `Some`. Cleared when
+    /// the gesture ends.
+    body_yaw: Option<f32>,
 }
 
-/// Time constant for the weight ramp (seconds for ~63% of the gap). Tuned to
-/// feel responsive without snapping — Unity uses a similar ~0.5s ramp.
-const WEIGHT_TAU: f32 = 0.15;
+/// Time constant for the weight ramp. Combined with `ENGAGED_WEIGHT_TARGET`
+/// = 3.0 this gives ~165ms ramp-in to display=1.0 and ~440ms of "above 1.0"
+/// reserve that has to bleed off after disengagement before the displayed
+/// weight starts dropping.
+const WEIGHT_TAU: f32 = 0.4;
+
+/// Time constant for the gaze-target lerp. Same feel as the weight ramp:
+/// re-aiming visibly slews the hand rather than snapping.
+const TARGET_TAU: f32 = 0.15;
 
 /// Hint direction in world space for which side of the swing plane the elbow
 /// bends to. Pointing "down" sends the elbow under the shoulder for natural
 /// forward-arm gestures.
 const POLE_DIR_WORLD: Vec3 = Vec3::NEG_Y;
 
-/// Yaw deviation (degrees, body forward → target) past which the body
-/// commits to rotating to face the target. Below this we leave the body
-/// alone — the arm reach is enough.
-const BODY_ROTATE_TRIGGER_DEG: f32 = 45.0;
+/// Yaw deviation (degrees, body forward → target, signed) past which the
+/// body commits to rotating to face the target. Asymmetric — values
+/// derived empirically from observing Unity's behavior (~+17° / -53°);
+/// settings asset has presumably moved since the source we read.
+/// Once triggered the body still slews fully to face the target; only the
+/// trigger angle differs per side.
+const BODY_ROTATE_TRIGGER_LEFT_DEG: f32 = 17.5;
+const BODY_ROTATE_TRIGGER_RIGHT_DEG: f32 = 53.0;
+
+/// Slack around the cone edges to absorb rounding-error mismatches between
+/// clients. Display the arm in a slightly wider cone (so we don't go silent
+/// while another client is showing it), and trigger rotation in a slightly
+/// narrower cone (so we don't sit still while another client thinks we
+/// should be turning).
+const CONE_TOLERANCE_DEG: f32 = 2.0;
+
+/// Weight target while engaged. Driving above 1.0 (clamped on display) gives
+/// a time-based dampener: brief excursions out of the display cone don't
+/// pull the displayed weight below 1.0 because we have headroom to burn
+/// before crossing it. Acts like hysteresis without an explicit flag.
+const ENGAGED_WEIGHT_TARGET: f32 = 3.0;
 
 /// Once rotating, we keep going until we're within this many degrees of
 /// the target — gives a deliberate "turn-and-point" feel rather than a
@@ -133,7 +174,9 @@ fn cache_point_at_rig(
                 hand,
                 curled_fingers,
                 weight: 0.0,
+                smoothed_target: None,
                 is_rotating: false,
+                body_yaw: None,
             });
         }
     }
@@ -155,22 +198,18 @@ fn apply_point_at_ik(
     } else {
         0.0
     };
+    let target_alpha = if dt > 0.0 {
+        1.0 - (-dt / TARGET_TAU).exp()
+    } else {
+        0.0
+    };
     let mut writes: Vec<(Entity, Quat)> = Vec::new();
     // (finger_bone, axis, scaled_angle_rad) collected alongside arm writes;
     // applied as a post-multiplied curl onto whatever the animation set, so
     // weight=0 leaves the bone alone.
     let mut finger_curls: Vec<(Entity, Vec3, f32)> = Vec::new();
-    // Avatar-entity body-yaw overrides (bevy world yaw, radians). Avatar is
-    // top-level so we just write a pure Y-rotation onto its local Transform.
-    let mut body_yaw_writes: Vec<(Entity, f32)> = Vec::new();
 
     for (avatar_entity, mut rig, point_at, is_local) in &mut avatars {
-        // Smooth the IK weight toward 1 while pointing, 0 otherwise. This
-        // alone provides the blend in/out — the swing math runs every frame,
-        // and zero-weight slerp is a no-op.
-        let target_weight = if point_at.is_pointing { 1.0 } else { 0.0 };
-        rig.weight += (target_weight - rig.weight) * alpha;
-
         // PointAtSync.target_world is in DCL convention (z mirrored from bevy).
         let target_world = DclTranslation([
             point_at.target_world.x,
@@ -179,14 +218,13 @@ fn apply_point_at_ik(
         ])
         .to_bevy_translation();
 
-        // Body rotation only for the local player. Foreign players have their
-        // body yaw driven by incoming Movement packets — overriding it here
-        // would fight the network-driven orientation each frame.
-        //
-        // Gated on the raw is_pointing flag (not the smoothed weight): when
-        // the gesture ends we stop steering the body even though the arm
-        // continues to ramp out.
-        if is_local && point_at.is_pointing {
+        // Compute the body-forward → target yaw delta (used by both local
+        // body rotation and the arm-IK gate below). For foreign players we
+        // don't drive rotation, but we still measure the delta so the arm
+        // only engages when their network-driven body actually faces the
+        // target.
+        let mut body_facing_ok = false;
+        if point_at.is_pointing {
             if let Ok(avatar_g) = tx.p1().compute_global_transform(avatar_entity) {
                 let avatar_pos = avatar_g.translation();
                 let dx = target_world.x - avatar_pos.x;
@@ -196,30 +234,111 @@ fn apply_point_at_ik(
                     // -Z maps to (-sin θ, 0, -cos θ), so the yaw that aims
                     // the avatar at (dx, _, dz) is atan2(-dx, -dz).
                     let desired_yaw = (-dx).atan2(-dz);
-                    let cur_yaw = avatar_g.rotation().to_euler(EulerRot::YXZ).0;
+                    // For the local player, prefer our own tracked yaw —
+                    // movement-scene round-trips can lag and the transform
+                    // here may be a frame behind. Foreign players fall back
+                    // to the transform since we don't drive their rotation.
+                    let cur_yaw = if is_local {
+                        rig.body_yaw
+                            .unwrap_or_else(|| avatar_g.rotation().to_euler(EulerRot::YXZ).0)
+                    } else {
+                        avatar_g.rotation().to_euler(EulerRot::YXZ).0
+                    };
                     let delta_deg = wrap_180_deg((desired_yaw - cur_yaw).to_degrees());
 
-                    if !rig.is_rotating && delta_deg.abs() > BODY_ROTATE_TRIGGER_DEG {
-                        rig.is_rotating = true;
-                    }
-                    if rig.is_rotating {
-                        let max_step = BODY_ROTATE_DEG_PER_SEC * dt;
-                        let step = delta_deg.clamp(-max_step, max_step);
-                        let new_yaw = cur_yaw + step.to_radians();
-                        body_yaw_writes.push((avatar_entity, new_yaw));
-                        if delta_deg.abs() <= BODY_ROTATE_FINISH_DEG {
-                            rig.is_rotating = false;
+                    // Cone matches Unity's asymmetric extents: 17.5° on the
+                    // anti-clockwise side, 53° on the clockwise side. Net
+                    // effect is the cone center sits ~18° toward the right
+                    // shoulder — pointing slightly right of forward is the
+                    // "comfortable" direction for a right-handed gesture.
+                    // Display in a slightly wider cone, trigger rotation in
+                    // a slightly narrower one, so per-client rounding can't
+                    // cause one of us to display while the other doesn't or
+                    // one of us to be turning while the other isn't.
+                    let in_display_cone = delta_deg
+                        <= BODY_ROTATE_TRIGGER_LEFT_DEG + CONE_TOLERANCE_DEG
+                        && delta_deg >= -BODY_ROTATE_TRIGGER_RIGHT_DEG - CONE_TOLERANCE_DEG;
+                    let needs_to_rotate = delta_deg
+                        > BODY_ROTATE_TRIGGER_LEFT_DEG - CONE_TOLERANCE_DEG
+                        || delta_deg < -BODY_ROTATE_TRIGGER_RIGHT_DEG + CONE_TOLERANCE_DEG;
+                    body_facing_ok = in_display_cone;
+
+                    if is_local {
+                        if !rig.is_rotating && needs_to_rotate {
+                            rig.is_rotating = true;
                         }
+                        let new_yaw = if rig.is_rotating {
+                            let max_step = BODY_ROTATE_DEG_PER_SEC * dt;
+                            let step = delta_deg.clamp(-max_step, max_step);
+                            let stepped = cur_yaw + step.to_radians();
+                            if delta_deg.abs() <= BODY_ROTATE_FINISH_DEG {
+                                rig.is_rotating = false;
+                            }
+                            stepped
+                        } else {
+                            cur_yaw
+                        };
+                        rig.body_yaw = Some(new_yaw);
                     }
                 } else {
+                    // Target overhead/below — body orientation doesn't matter.
+                    body_facing_ok = true;
                     rig.is_rotating = false;
                 }
             }
         } else {
             rig.is_rotating = false;
+            rig.body_yaw = None;
         }
 
-        if rig.weight < 1e-3 {
+        // Arm IK weight target: pointing only counts when the body is also
+        // facing the target. Driven above 1.0 (clamped on display) so
+        // brief excursions out of the cone don't immediately drop the
+        // displayed weight below 1.0 — gives a time-based dampener.
+        let target_weight = if body_facing_ok {
+            ENGAGED_WEIGHT_TARGET
+        } else {
+            0.0
+        };
+        rig.weight += (target_weight - rig.weight) * alpha;
+        let display_weight = rig.weight.clamp(0.0, 1.0);
+
+        // Smooth the IK target so re-aiming or starting a fresh gesture
+        // mid-ramp-out glides the hand instead of snapping. Initialize on
+        // first activation, hold while ramping out, clear once disengaged.
+        let solve_target = if point_at.is_pointing {
+            let new_target = match rig.smoothed_target {
+                Some(prev) => prev + (target_world - prev) * target_alpha,
+                None => target_world,
+            };
+            rig.smoothed_target = Some(new_target);
+            new_target
+        } else {
+            let held = rig.smoothed_target.unwrap_or(target_world);
+            if display_weight < 1e-3 {
+                rig.smoothed_target = None;
+            }
+            held
+        };
+
+        // Write the body-yaw override now (before reading bone globals) so
+        // the IK math sees bones rooted at our intended avatar orientation.
+        // Otherwise the IK would solve for shoulder positions based on the
+        // movement-system yaw, then we'd rotate the avatar at end-of-loop
+        // and the shoulder would shift out from under the hand — visible
+        // arm jitter while the body is mid-turn.
+        if let Some(yaw) = rig.body_yaw {
+            if let Ok(mut t) = tx.p0().get_mut(avatar_entity) {
+                t.rotation = Quat::from_rotation_y(yaw);
+            }
+        }
+
+        if display_weight < 1e-3 {
+            // Once the arm has fully ramped out, drop the body override so
+            // movement reclaims control.
+            if !point_at.is_pointing {
+                rig.body_yaw = None;
+            }
             continue;
         }
 
@@ -250,13 +369,13 @@ fn apply_point_at_ik(
         let l_bc = (c - b).length();
 
         let Some((r_upper, r_lower)) =
-            solve_two_bone(a, b, c, target_world, l_ab, l_bc, POLE_DIR_WORLD)
+            solve_two_bone(a, b, c, solve_target, l_ab, l_bc, POLE_DIR_WORLD)
         else {
             continue;
         };
 
-        let r_upper_w = Quat::IDENTITY.slerp(r_upper, rig.weight);
-        let r_lower_w = Quat::IDENTITY.slerp(r_lower, rig.weight);
+        let r_upper_w = Quat::IDENTITY.slerp(r_upper, display_weight);
+        let r_lower_w = Quat::IDENTITY.slerp(r_lower, display_weight);
 
         let cur_upper_g_rot = upper_g.compute_transform().rotation;
         let cur_lower_g_rot = lower_g.compute_transform().rotation;
@@ -271,18 +390,11 @@ fn apply_point_at_ik(
         writes.push((rig.upper, upper_local));
         writes.push((rig.lower, lower_local));
         for &(finger, deg, axis) in &rig.curled_fingers {
-            finger_curls.push((finger, axis, deg.to_radians() * rig.weight));
+            finger_curls.push((finger, axis, deg.to_radians() * display_weight));
         }
     }
 
     let mut transforms = tx.p0();
-    // Body rotation overrides go first so subsequent reads of avatar Transform
-    // (none here, but a safe ordering) see the new yaw.
-    for (avatar, yaw) in body_yaw_writes {
-        if let Ok(mut t) = transforms.get_mut(avatar) {
-            t.rotation = Quat::from_rotation_y(yaw);
-        }
-    }
     for (bone, rot) in writes {
         if let Ok(mut t) = transforms.get_mut(bone) {
             t.rotation = rot;

--- a/crates/avatar/src/point_at_marker.rs
+++ b/crates/avatar/src/point_at_marker.rs
@@ -1,5 +1,6 @@
-use bevy::{platform::collections::HashMap, prelude::*};
+use bevy::{platform::collections::HashMap, prelude::*, ui::UiSystem};
 use common::{
+    sets::PostUpdateSets,
     structs::{PointAtSync, PrimaryCamera, PrimaryUser, ZOrder},
     util::AsH160,
 };
@@ -18,13 +19,19 @@ impl Plugin for PointAtMarkerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<MarkerOverlay>();
         app.add_systems(Startup, setup_overlay);
+        // Run alongside the IK chain so we read the live (post-CameraUpdate)
+        // camera transform — running in `Update` would see last frame's
+        // camera pose. Also `.before(UiSystem::Layout)` because UI layout
+        // runs in `PostUpdate` before the default `TransformPropagate` and is
+        // otherwise unordered relative to our `InverseKinematics` set —
+        // without the explicit edge, layout could pick up our node writes a
+        // frame late.
         app.add_systems(
-            Update,
-            (
-                sync_markers,
-                update_marker_images,
-                position_markers.after(sync_markers),
-            ),
+            PostUpdate,
+            (sync_markers, update_marker_images, position_markers)
+                .chain()
+                .in_set(PostUpdateSets::InverseKinematics)
+                .before(UiSystem::Layout),
         );
     }
 }
@@ -37,12 +44,11 @@ const MAX_VISIBLE_DISTANCE: f32 = 100.0;
 /// Closer than this and we clamp; further and the marker shrinks linearly.
 const REFERENCE_DISTANCE: f32 = 5.0;
 
-/// Marker base diameter in pixels at `REFERENCE_DISTANCE`.
-const BASE_DIAMETER_PX: f32 = 64.0;
-
-/// Marker minimum and maximum diameters (pixels).
-const MIN_DIAMETER_PX: f32 = 16.0;
-const MAX_DIAMETER_PX: f32 = 96.0;
+/// Marker diameters expressed as a percentage of the viewport's smaller
+/// dimension, so the on-screen size is consistent across aspect ratios.
+const BASE_DIAMETER_PCT: f32 = 6.0;
+const MIN_DIAMETER_PCT: f32 = 1.5;
+const MAX_DIAMETER_PCT: f32 = 9.0;
 
 #[derive(Resource, Default)]
 struct MarkerOverlay {
@@ -124,8 +130,8 @@ fn sync_markers(
                     PointAtMarker { avatar: avatar_ent },
                     Node {
                         position_type: PositionType::Absolute,
-                        width: Val::Px(BASE_DIAMETER_PX),
-                        height: Val::Px(BASE_DIAMETER_PX),
+                        width: Val::Percent(BASE_DIAMETER_PCT),
+                        height: Val::Percent(BASE_DIAMETER_PCT),
                         display: Display::None,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
@@ -186,11 +192,23 @@ fn update_marker_images(
 
 fn position_markers(
     mut commands: Commands,
-    primary_camera: Single<(&Camera, &GlobalTransform), With<PrimaryCamera>>,
+    primary_camera: Single<(Entity, &Camera), With<PrimaryCamera>>,
+    gt_helper: bevy::transform::helper::TransformHelper,
     avatars: Query<&PointAtSync>,
     mut markers: Query<(Entity, &PointAtMarker, &mut Node)>,
 ) {
-    let (camera, camera_transform) = primary_camera.into_inner();
+    let (camera_entity, camera) = primary_camera.into_inner();
+    // The camera moves in `Update` but its `GlobalTransform` is only refreshed
+    // by `TransformPropagate` in `PostUpdate`, so reading the cached
+    // `GlobalTransform` here gives last frame's pose — visible as a one-frame
+    // marker lag during fast camera moves. Recompute on the fly from the live
+    // `Transform` chain instead.
+    let Ok(camera_transform) = gt_helper.compute_global_transform(camera_entity) else {
+        return;
+    };
+    let Some(viewport_size) = camera.logical_viewport_size() else {
+        return;
+    };
 
     for (marker_ent, marker, mut node) in markers.iter_mut() {
         let Ok(sync) = avatars.get(marker.avatar) else {
@@ -213,23 +231,35 @@ fn position_markers(
             continue;
         }
 
-        let Ok(viewport) = camera.world_to_viewport_with_depth(camera_transform, target_bevy)
+        let Ok(projected) = camera.world_to_viewport_with_depth(&camera_transform, target_bevy)
         else {
             node.display = Display::None;
             continue;
         };
-        if viewport.z <= 0.0 {
+        if projected.z <= 0.0 {
             node.display = Display::None;
             continue;
         }
 
+        // Diameter is a percentage of the viewport's smaller dimension —
+        // `Val::Percent` on width/height resolves against the matching parent
+        // axis, so we keep things isotropic by referencing the same axis for
+        // both, and we offset left/top in the matching dimension's percent.
         let scale = REFERENCE_DISTANCE / distance.max(REFERENCE_DISTANCE * 0.5);
-        let diameter = (BASE_DIAMETER_PX * scale).clamp(MIN_DIAMETER_PX, MAX_DIAMETER_PX);
+        let diameter_pct = (BASE_DIAMETER_PCT * scale).clamp(MIN_DIAMETER_PCT, MAX_DIAMETER_PCT);
+        let short_side = viewport_size.x.min(viewport_size.y);
+        let diameter_px = diameter_pct * 0.01 * short_side;
+        let half_w_pct = (diameter_px * 0.5 / viewport_size.x) * 100.0;
+        let half_h_pct = (diameter_px * 0.5 / viewport_size.y) * 100.0;
+        let left_pct = (projected.x / viewport_size.x) * 100.0 - half_w_pct;
+        let top_pct = (projected.y / viewport_size.y) * 100.0 - half_h_pct;
+        let width_pct = diameter_pct * short_side / viewport_size.x;
+        let height_pct = diameter_pct * short_side / viewport_size.y;
 
         node.display = Display::Flex;
-        node.width = Val::Px(diameter);
-        node.height = Val::Px(diameter);
-        node.left = Val::Px(viewport.x - diameter * 0.5);
-        node.top = Val::Px(viewport.y - diameter * 0.5);
+        node.width = Val::Percent(width_pct);
+        node.height = Val::Percent(height_pct);
+        node.left = Val::Percent(left_pct);
+        node.top = Val::Percent(top_pct);
     }
 }

--- a/crates/avatar/src/point_at_marker.rs
+++ b/crates/avatar/src/point_at_marker.rs
@@ -50,6 +50,14 @@ const BASE_DIAMETER_PCT: f32 = 6.0;
 const MIN_DIAMETER_PCT: f32 = 1.5;
 const MAX_DIAMETER_PCT: f32 = 9.0;
 
+/// Exponential-smoothing time constant (seconds) for the marker's fade.
+/// Matches Unity's ~0.3s fade duration when applied as a τ for an
+/// exponential ramp toward 1.0/0.0.
+const FADE_TAU: f32 = 0.12;
+
+/// Below this fade level a fading-out marker is despawned entirely.
+const FADE_DESPAWN_THRESHOLD: f32 = 0.01;
+
 #[derive(Resource, Default)]
 struct MarkerOverlay {
     root: Option<Entity>,
@@ -61,6 +69,11 @@ struct PointAtMarkerOverlay;
 #[derive(Component)]
 struct PointAtMarker {
     avatar: Entity,
+    bg: Color,
+    /// Smoothed [0, 1] visibility. Ramps toward 1 while the source avatar is
+    /// pointing and toward 0 once it stops; the marker is despawned once it
+    /// reaches `FADE_DESPAWN_THRESHOLD` so the ramp-out plays through.
+    fade: f32,
 }
 
 #[derive(Component)]
@@ -108,11 +121,10 @@ fn sync_markers(
         return;
     };
 
-    let mut existing: HashMap<Entity, Entity> =
-        markers.iter().map(|(m, p)| (p.avatar, m)).collect();
+    let existing: HashMap<Entity, Entity> = markers.iter().map(|(m, p)| (p.avatar, m)).collect();
 
     for (avatar_ent, sync, foreign, profile) in &avatars {
-        if !sync.is_pointing {
+        if !sync.is_pointing || existing.contains_key(&avatar_ent) {
             continue;
         }
         let Some(address) = foreign
@@ -122,15 +134,15 @@ fn sync_markers(
             continue;
         };
 
-        if existing.remove(&avatar_ent).is_some() {
-            continue;
-        }
-
         let bg = name_color(address);
         commands.entity(root).with_children(|parent| {
             parent
                 .spawn((
-                    PointAtMarker { avatar: avatar_ent },
+                    PointAtMarker {
+                        avatar: avatar_ent,
+                        bg,
+                        fade: 0.0,
+                    },
                     Node {
                         position_type: PositionType::Absolute,
                         width: Val::Percent(BASE_DIAMETER_PCT),
@@ -140,7 +152,7 @@ fn sync_markers(
                         justify_content: JustifyContent::Center,
                         ..Default::default()
                     },
-                    BackgroundColor(bg),
+                    BackgroundColor(bg.with_alpha(0.0)),
                     BorderRadius::MAX,
                     PendingMarkerImage(address),
                     Pickable::IGNORE,
@@ -158,10 +170,6 @@ fn sync_markers(
                     ));
                 });
         });
-    }
-
-    for marker_ent in existing.values().copied() {
-        commands.entity(marker_ent).despawn();
     }
 }
 
@@ -195,10 +203,18 @@ fn update_marker_images(
 
 fn position_markers(
     mut commands: Commands,
+    time: Res<Time>,
     primary_camera: Single<(Entity, &Camera), With<PrimaryCamera>>,
     gt_helper: bevy::transform::helper::TransformHelper,
     avatars: Query<&PointAtSync>,
-    mut markers: Query<(Entity, &PointAtMarker, &mut Node)>,
+    mut markers: Query<(
+        Entity,
+        &mut PointAtMarker,
+        &mut Node,
+        &mut BackgroundColor,
+        &Children,
+    )>,
+    mut images: Query<&mut ImageNode, With<MarkerImageNode>>,
 ) {
     let (camera_entity, camera) = primary_camera.into_inner();
     // The camera moves in `Update` but its `GlobalTransform` is only refreshed
@@ -213,20 +229,55 @@ fn position_markers(
         return;
     };
 
-    for (marker_ent, marker, mut node) in markers.iter_mut() {
-        let Ok(sync) = avatars.get(marker.avatar) else {
+    let dt = time.delta_secs();
+    let alpha_step = if dt > 0.0 {
+        1.0 - (-dt / FADE_TAU).exp()
+    } else {
+        0.0
+    };
+
+    for (marker_ent, mut marker, mut node, mut bg, children) in markers.iter_mut() {
+        // Resolve target fade from the source avatar's pointing state. A
+        // missing avatar (despawned/wearable swap) ramps out the same way as
+        // a normal release.
+        let target_fade = match avatars.get(marker.avatar) {
+            Ok(sync) if sync.is_pointing => 1.0,
+            _ => 0.0,
+        };
+        marker.fade += (target_fade - marker.fade) * alpha_step;
+
+        // Despawn once we've ramped down past the despawn threshold. Mid-fade
+        // we keep the marker alive and visible, modulating only its alpha.
+        if target_fade <= 0.0 && marker.fade < FADE_DESPAWN_THRESHOLD {
             commands.entity(marker_ent).despawn();
             continue;
-        };
-        if !sync.is_pointing {
-            continue;
         }
-        let target_bevy = DclTranslation([
-            sync.target_world.x,
-            sync.target_world.y,
-            sync.target_world.z,
-        ])
-        .to_bevy_translation();
+
+        let alpha = marker.fade.clamp(0.0, 1.0);
+        bg.0 = marker.bg.with_alpha(alpha);
+        for child in children.iter() {
+            if let Ok(mut image) = images.get_mut(child) {
+                image.color = Color::WHITE.with_alpha(alpha);
+            }
+        }
+
+        // Pull the latest target from the avatar (if still pointing) for
+        // positioning; otherwise hold position while we ramp out.
+        let Some(target_bevy) = avatars
+            .get(marker.avatar)
+            .ok()
+            .filter(|s| s.is_pointing)
+            .map(|sync| {
+                DclTranslation([
+                    sync.target_world.x,
+                    sync.target_world.y,
+                    sync.target_world.z,
+                ])
+                .to_bevy_translation()
+            })
+        else {
+            continue;
+        };
 
         let distance = (target_bevy - camera_transform.translation()).length();
         if distance > MAX_VISIBLE_DISTANCE {

--- a/crates/avatar/src/point_at_marker.rs
+++ b/crates/avatar/src/point_at_marker.rs
@@ -97,7 +97,10 @@ fn sync_markers(
             Option<&ForeignPlayer>,
             Option<&UserProfile>,
         ),
-        (With<AvatarShape>, Or<(With<PrimaryUser>, With<ForeignPlayer>)>),
+        (
+            With<AvatarShape>,
+            Or<(With<PrimaryUser>, With<ForeignPlayer>)>,
+        ),
     >,
     markers: Query<(Entity, &PointAtMarker)>,
 ) {

--- a/crates/avatar/src/point_at_marker.rs
+++ b/crates/avatar/src/point_at_marker.rs
@@ -1,0 +1,235 @@
+use bevy::{platform::collections::HashMap, prelude::*};
+use common::{
+    structs::{PointAtSync, PrimaryCamera, PrimaryUser, ZOrder},
+    util::AsH160,
+};
+use comms::{
+    global_crdt::ForeignPlayer,
+    profile::{ProfileManager, UserProfile},
+};
+use dcl_component::transform_and_parent::DclTranslation;
+use ethers_core::types::Address;
+
+use crate::{name_color::name_color, AvatarShape};
+
+pub struct PointAtMarkerPlugin;
+
+impl Plugin for PointAtMarkerPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<MarkerOverlay>();
+        app.add_systems(Startup, setup_overlay);
+        app.add_systems(
+            Update,
+            (
+                sync_markers,
+                update_marker_images,
+                position_markers.after(sync_markers),
+            ),
+        );
+    }
+}
+
+/// Marker visibility cutoff (metres from camera) — beyond this we hide rather
+/// than letting the marker shrink into a dot.
+const MAX_VISIBLE_DISTANCE: f32 = 100.0;
+
+/// Reference distance (metres) at which the marker is drawn at base size.
+/// Closer than this and we clamp; further and the marker shrinks linearly.
+const REFERENCE_DISTANCE: f32 = 5.0;
+
+/// Marker base diameter in pixels at `REFERENCE_DISTANCE`.
+const BASE_DIAMETER_PX: f32 = 64.0;
+
+/// Marker minimum and maximum diameters (pixels).
+const MIN_DIAMETER_PX: f32 = 16.0;
+const MAX_DIAMETER_PX: f32 = 96.0;
+
+#[derive(Resource, Default)]
+struct MarkerOverlay {
+    root: Option<Entity>,
+}
+
+#[derive(Component)]
+struct PointAtMarkerOverlay;
+
+#[derive(Component)]
+struct PointAtMarker {
+    avatar: Entity,
+}
+
+#[derive(Component)]
+struct MarkerImageNode;
+
+#[derive(Component)]
+struct PendingMarkerImage(Address);
+
+fn setup_overlay(mut commands: Commands, mut overlay: ResMut<MarkerOverlay>) {
+    let root = commands
+        .spawn((
+            PointAtMarkerOverlay,
+            Node {
+                position_type: PositionType::Absolute,
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..Default::default()
+            },
+            Pickable::IGNORE,
+            ZOrder::PointAtMarker.default(),
+        ))
+        .id();
+    overlay.root = Some(root);
+}
+
+#[allow(clippy::type_complexity)]
+fn sync_markers(
+    mut commands: Commands,
+    overlay: Res<MarkerOverlay>,
+    avatars: Query<
+        (
+            Entity,
+            &PointAtSync,
+            Option<&ForeignPlayer>,
+            Option<&UserProfile>,
+        ),
+        (With<AvatarShape>, Or<(With<PrimaryUser>, With<ForeignPlayer>)>),
+    >,
+    markers: Query<(Entity, &PointAtMarker)>,
+) {
+    let Some(root) = overlay.root else {
+        return;
+    };
+
+    let mut existing: HashMap<Entity, Entity> =
+        markers.iter().map(|(m, p)| (p.avatar, m)).collect();
+
+    for (avatar_ent, sync, foreign, profile) in &avatars {
+        if !sync.is_pointing {
+            continue;
+        }
+        let Some(address) = foreign
+            .map(|f| f.address)
+            .or_else(|| profile.and_then(|p| p.content.eth_address.as_h160()))
+        else {
+            continue;
+        };
+
+        if existing.remove(&avatar_ent).is_some() {
+            continue;
+        }
+
+        let bg = name_color(address);
+        commands.entity(root).with_children(|parent| {
+            parent
+                .spawn((
+                    PointAtMarker { avatar: avatar_ent },
+                    Node {
+                        position_type: PositionType::Absolute,
+                        width: Val::Px(BASE_DIAMETER_PX),
+                        height: Val::Px(BASE_DIAMETER_PX),
+                        display: Display::None,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        ..Default::default()
+                    },
+                    BackgroundColor(bg),
+                    BorderRadius::MAX,
+                    PendingMarkerImage(address),
+                    Pickable::IGNORE,
+                ))
+                .with_children(|inner| {
+                    inner.spawn((
+                        MarkerImageNode,
+                        Node {
+                            width: Val::Percent(85.0),
+                            height: Val::Percent(85.0),
+                            ..Default::default()
+                        },
+                        BorderRadius::MAX,
+                        Pickable::IGNORE,
+                    ));
+                });
+        });
+    }
+
+    for marker_ent in existing.values().copied() {
+        commands.entity(marker_ent).despawn();
+    }
+}
+
+fn update_marker_images(
+    mut commands: Commands,
+    mut profiles: ProfileManager,
+    pending: Query<(Entity, &PendingMarkerImage, &Children)>,
+    mut images: Query<&mut ImageNode, With<MarkerImageNode>>,
+    image_owners: Query<Entity, With<MarkerImageNode>>,
+) {
+    for (marker_ent, pending_image, children) in &pending {
+        match profiles.get_image(pending_image.0) {
+            Err(_) => {
+                commands.entity(marker_ent).remove::<PendingMarkerImage>();
+            }
+            Ok(Some(handle)) => {
+                let image_child = children.iter().find(|c| image_owners.get(*c).is_ok());
+                if let Some(image_ent) = image_child {
+                    if let Ok(mut image_node) = images.get_mut(image_ent) {
+                        image_node.image = handle;
+                    } else {
+                        commands.entity(image_ent).insert(ImageNode::new(handle));
+                    }
+                    commands.entity(marker_ent).remove::<PendingMarkerImage>();
+                }
+            }
+            Ok(None) => (),
+        }
+    }
+}
+
+fn position_markers(
+    mut commands: Commands,
+    primary_camera: Single<(&Camera, &GlobalTransform), With<PrimaryCamera>>,
+    avatars: Query<&PointAtSync>,
+    mut markers: Query<(Entity, &PointAtMarker, &mut Node)>,
+) {
+    let (camera, camera_transform) = primary_camera.into_inner();
+
+    for (marker_ent, marker, mut node) in markers.iter_mut() {
+        let Ok(sync) = avatars.get(marker.avatar) else {
+            commands.entity(marker_ent).despawn();
+            continue;
+        };
+        if !sync.is_pointing {
+            continue;
+        }
+        let target_bevy = DclTranslation([
+            sync.target_world.x,
+            sync.target_world.y,
+            sync.target_world.z,
+        ])
+        .to_bevy_translation();
+
+        let distance = (target_bevy - camera_transform.translation()).length();
+        if distance > MAX_VISIBLE_DISTANCE {
+            node.display = Display::None;
+            continue;
+        }
+
+        let Ok(viewport) = camera.world_to_viewport_with_depth(camera_transform, target_bevy)
+        else {
+            node.display = Display::None;
+            continue;
+        };
+        if viewport.z <= 0.0 {
+            node.display = Display::None;
+            continue;
+        }
+
+        let scale = REFERENCE_DISTANCE / distance.max(REFERENCE_DISTANCE * 0.5);
+        let diameter = (BASE_DIAMETER_PX * scale).clamp(MIN_DIAMETER_PX, MAX_DIAMETER_PX);
+
+        node.display = Display::Flex;
+        node.width = Val::Px(diameter);
+        node.height = Val::Px(diameter);
+        node.left = Val::Px(viewport.x - diameter * 0.5);
+        node.top = Val::Px(viewport.y - diameter * 0.5);
+    }
+}

--- a/crates/avatar/src/two_bone_ik.rs
+++ b/crates/avatar/src/two_bone_ik.rs
@@ -1,0 +1,66 @@
+use bevy::prelude::*;
+
+/// World-space delta rotations for the root and mid bone of a 3-link chain
+/// (root → mid → end), such that after applying them in order the end bone
+/// reaches `target`. Returns `None` if the chain has degenerate lengths or
+/// the geometry is otherwise unsolvable.
+///
+/// `pole_dir` selects which side of the swing plane the mid bone bends to —
+/// for legs this is the body's forward direction, for arms a downward bias
+/// keeps the elbow under the shoulder.
+///
+/// The returned rotations are *swings* relative to the current pose, not
+/// absolute orientations. Call sites typically slerp them from `IDENTITY` by
+/// an IK weight before composing onto the bone's current global rotation.
+pub fn solve_two_bone(
+    root: Vec3,
+    mid: Vec3,
+    end: Vec3,
+    target: Vec3,
+    l_root_mid: f32,
+    l_mid_end: f32,
+    pole_dir: Vec3,
+) -> Option<(Quat, Quat)> {
+    let at = target - root;
+    let l_at_raw = at.length();
+    if l_at_raw < 1e-4 {
+        return None;
+    }
+    let l_at = l_at_raw.clamp(1e-4, l_root_mid + l_mid_end - 1e-4);
+    let dir_at = at / l_at_raw;
+
+    // Project the pole hint onto the plane perpendicular to the chain
+    // direction so it picks a bend side without affecting the chain length.
+    // Fall back to a Y-cross axis (and finally world X) if the hint collapses.
+    let pole_perp = pole_dir - dir_at * dir_at.dot(pole_dir);
+    let pole_perp = pole_perp.normalize_or_zero();
+    let pole_perp = if pole_perp.length_squared() < 0.5 {
+        let alt = Vec3::Y.cross(dir_at).normalize_or_zero();
+        if alt.length_squared() < 0.5 {
+            Vec3::X
+        } else {
+            alt
+        }
+    } else {
+        pole_perp
+    };
+
+    // Law of cosines at the root to find the mid-bone position that puts
+    // both segments on the swing plane and the end at `target`.
+    let cos_a = ((l_root_mid * l_root_mid + l_at * l_at - l_mid_end * l_mid_end)
+        / (2.0 * l_root_mid * l_at))
+        .clamp(-1.0, 1.0);
+    let sin_a = (1.0 - cos_a * cos_a).max(0.0).sqrt();
+    let new_mid = root + dir_at * (l_root_mid * cos_a) + pole_perp * (l_root_mid * sin_a);
+
+    let cur_dir_root_mid = (mid - root).normalize_or_zero();
+    let new_dir_root_mid = (new_mid - root).normalize_or_zero();
+    let r_root = Quat::from_rotation_arc(cur_dir_root_mid, new_dir_root_mid);
+
+    let cur_dir_mid_end = (end - mid).normalize_or_zero();
+    let dir_mid_end_after_root = r_root * cur_dir_mid_end;
+    let new_dir_mid_end = (target - new_mid).normalize_or_zero();
+    let r_mid = Quat::from_rotation_arc(dir_mid_end_after_root, new_dir_mid_end);
+
+    Some((r_root, r_mid))
+}

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -19,6 +19,7 @@ futures-lite = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_repr = "0.1"
 uuid = { workspace = true }
 reqwest = { workspace = true }
 async-compat = { workspace = true }

--- a/crates/common/src/inputs.rs
+++ b/crates/common/src/inputs.rs
@@ -42,6 +42,7 @@ pub enum SystemAction {
     QuickEmote8,
     QuickEmote9,
     QuickEmote0,
+    PointAt,
 }
 
 impl From<SystemAction> for Action {
@@ -410,14 +411,18 @@ impl Default for InputMap {
                 ),
                 (
                     Action::System(SystemAction::RollLeft),
-                    vec![
-                        InputIdentifier::Key(KeyCode::KeyT),
-                        InputIdentifier::Mouse(MouseButton::Middle),
-                    ],
+                    vec![InputIdentifier::Key(KeyCode::KeyT)],
                 ),
                 (
                     Action::System(SystemAction::RollRight),
                     vec![InputIdentifier::Key(KeyCode::KeyG)],
+                ),
+                (
+                    Action::System(SystemAction::PointAt),
+                    vec![
+                        InputIdentifier::Mouse(MouseButton::Middle),
+                        InputIdentifier::Key(KeyCode::KeyQ),
+                    ],
                 ),
                 (
                     Action::System(SystemAction::Microphone),

--- a/crates/common/src/sets.rs
+++ b/crates/common/src/sets.rs
@@ -41,12 +41,13 @@ pub enum PostUpdateSets {
     ColliderUpdate,
     PlayerUpdate,
     CameraUpdate,
-    /// Foot-IK chain: pelvis-drop / leg rotations + a transform-propagate
-    /// for the avatar subtree. Producers run `.in_set(FootIk)`; consumers
-    /// that need post-IK bone globals (e.g. nametag) run `.after(FootIk)`.
-    FootIk,
+    /// IK chain: foot-IK (pelvis drop / leg rotations) and head-IK (head
+    /// bone gaze) plus a transform-propagate for the avatar subtree. Producers
+    /// run `.in_set(InverseKinematics)`; consumers that need post-IK bone
+    /// globals (e.g. nametag) run `.after(InverseKinematics)`.
+    InverseKinematics,
     /// Per-frame nametag positioning. Reads post-IK head/position globals,
-    /// so it sits after `FootIk` in the chain.
+    /// so it sits after `InverseKinematics` in the chain.
     Nametag,
     AttachSync,
     Billboard,

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1210,7 +1210,8 @@ pub enum ZOrder {
     Crosshair = -65536,
     // PortableScene -> -65535 <= value <= -1
     // default 0 => appear in world, under scene ui
-    OutOfWorldBackdrop = 1,
+    PointAtMarker = 1,
+    OutOfWorldBackdrop,
     SceneUi,
     SceneUiOverlay,
     SystemSceneUi,

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -358,6 +358,19 @@ pub struct PrimaryPlayerRes(pub Entity);
 #[derive(Resource)]
 pub struct PrimaryCameraRes(pub Entity);
 
+/// World-space head gaze angles, in degrees. On the local player, written each frame
+/// from the real camera (and zeroed/disabled when a scene-driven camera is active). On
+/// remote players, written from the incoming rfc4::Movement head-sync fields. The
+/// `*_enabled` flags drive the receive-side IK weight crossfade and gate the broadcast
+/// of valid angles for the local player.
+#[derive(Component, Default, Clone, Copy)]
+pub struct HeadSync {
+    pub yaw_deg: f32,
+    pub pitch_deg: f32,
+    pub yaw_enabled: bool,
+    pub pitch_enabled: bool,
+}
+
 // marker for the root ui component (full screen, used for checking pointer/mouse button events are not intercepted by any other ui component)
 #[derive(Component)]
 pub struct UiRoot;

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -371,6 +371,41 @@ pub struct HeadSync {
     pub pitch_enabled: bool,
 }
 
+/// Classifier for pointer-target hits — distinguishes scene world geometry,
+/// scene UI overlays, and avatars. Lives here (not in system_bridge) because
+/// the engine's pointer pipeline produces it before any scene API surface is
+/// involved; system_bridge re-exports the same value into its HoverEvent.
+#[derive(
+    Hash,
+    Clone,
+    Copy,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    Debug,
+    PartialEq,
+    Eq,
+    Default,
+)]
+#[repr(u32)]
+pub enum PointerTargetType {
+    #[default]
+    World = 0,
+    Ui = 1,
+    Avatar = 2,
+}
+
+/// World-space point-at state. On the local player, populated when the PointAt
+/// action fires and `WorldPointerTarget` has a hit; cleared when the latch
+/// expires. On remote players, populated from the incoming rfc4::Movement
+/// `point_at_*` / `is_pointing_at` fields. Coordinates are stored in DCL
+/// convention (Z mirrored from bevy world) so the same value flows over the
+/// wire and into the IK apply step without a per-site flip.
+#[derive(Component, Default, Clone, Copy)]
+pub struct PointAtSync {
+    pub target_world: Vec3,
+    pub is_pointing: bool,
+}
+
 // marker for the root ui component (full screen, used for checking pointer/mouse button events are not intercepted by any other ui component)
 #[derive(Component)]
 pub struct UiRoot;

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -2,7 +2,9 @@ use std::f32::consts::TAU;
 
 use bevy::prelude::*;
 
-use common::structs::{AvatarDynamicState, HeadSync, MoveKind, PrimaryUser, SceneDrivenAnim};
+use common::structs::{
+    AvatarDynamicState, HeadSync, MoveKind, PointAtSync, PrimaryUser, SceneDrivenAnim,
+};
 use dcl_component::{
     proto_components::kernel::comms::rfc4,
     transform_and_parent::{DclQuat, DclTranslation},
@@ -61,12 +63,14 @@ fn broadcast_position(
             &AvatarDynamicState,
             Option<&SceneDrivenAnim>,
             Option<&HeadSync>,
+            Option<&PointAtSync>,
         ),
         With<PrimaryUser>,
     >,
     transports: Query<&Transport>,
     mut last_position: Local<(Vec3, Quat, Vec3)>,
     mut last_head_sync: Local<HeadSync>,
+    mut last_point_at: Local<PointAtSync>,
     mut last_sent: Local<f64>,
     mut last_index: Local<u32>,
     mut last_anim: Local<LastAnim>,
@@ -74,10 +78,11 @@ fn broadcast_position(
     global_crdt: Res<GlobalCrdtState>,
     wallet: Res<Wallet>,
 ) {
-    let Ok((player, dynamics, scene_anim, head_sync)) = player.single() else {
+    let Ok((player, dynamics, scene_anim, head_sync, point_at)) = player.single() else {
         return;
     };
     let head_sync = head_sync.copied().unwrap_or_default();
+    let point_at = point_at.copied().unwrap_or_default();
     let time = time.elapsed_secs_f64();
 
     // Latch any single-frame seek from the scene so we still send it even if the
@@ -126,6 +131,12 @@ fn broadcast_position(
         || head_sync.pitch_enabled != last_head_sync.pitch_enabled
         || (head_sync.yaw_deg - last_head_sync.yaw_deg).abs() > HEAD_SYNC_EPSILON_DEG
         || (head_sync.pitch_deg - last_head_sync.pitch_deg).abs() > HEAD_SYNC_EPSILON_DEG;
+    // Point-at toggling or any non-trivial coord change breaks the keepalive.
+    // No degree-style threshold: target coords can move continuously when the
+    // user drags, and the receiver visually integrates whatever it gets.
+    let point_at_changed = point_at.is_pointing != last_point_at.is_pointing
+        || (point_at.is_pointing
+            && (point_at.target_world - last_point_at.target_world).length_squared() > 0.01);
     if elapsed < STATIC_FREQ
         && (translation - last_position.0).length_squared() < 0.01
         && rotation == last_position.1
@@ -133,6 +144,7 @@ fn broadcast_position(
         && last_anim.pending_seek.is_none()
         && !anim_changed
         && !head_changed
+        && !point_at_changed
     {
         return;
     }
@@ -300,10 +312,10 @@ fn broadcast_position(
         head_ik_pitch_enabled: head_sync.pitch_enabled,
         head_yaw: head_sync.yaw_deg,
         head_pitch: head_sync.pitch_deg,
-        point_at_x: 0.0,
-        point_at_y: 0.0,
-        point_at_z: 0.0,
-        is_pointing_at: false,
+        point_at_x: point_at.target_world.x,
+        point_at_y: point_at.target_world.y,
+        point_at_z: point_at.target_world.z,
+        is_pointing_at: point_at.is_pointing,
         scene_driven_animation,
     };
 
@@ -341,6 +353,7 @@ fn broadcast_position(
 
     *last_position = (translation, rotation, dynamics.velocity);
     *last_head_sync = head_sync;
+    *last_point_at = point_at;
     *last_index += 1;
     *last_sent = time;
 }

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -2,7 +2,7 @@ use std::f32::consts::TAU;
 
 use bevy::prelude::*;
 
-use common::structs::{AvatarDynamicState, MoveKind, PrimaryUser, SceneDrivenAnim};
+use common::structs::{AvatarDynamicState, HeadSync, MoveKind, PrimaryUser, SceneDrivenAnim};
 use dcl_component::{
     proto_components::kernel::comms::rfc4,
     transform_and_parent::{DclQuat, DclTranslation},
@@ -29,6 +29,10 @@ const STATIC_FREQ: f64 = 1.0;
 const DYNAMIC_FREQ: f64 = 0.1;
 // Re-send the anim hash pair at least this often so late joiners pick up the active clip.
 const ANIM_URN_KEEPALIVE: f64 = 1.0;
+// A head-yaw or head-pitch change beyond this threshold (in degrees) breaks the
+// STATIC_FREQ idle keepalive and gets the next packet sent at the DYNAMIC_FREQ tick.
+// Smaller deltas are coarsely sampled at 1Hz, which is fine for sub-threshold drift.
+const HEAD_SYNC_EPSILON_DEG: f32 = 10.0;
 
 #[derive(Default)]
 struct LastAnim {
@@ -49,18 +53,20 @@ struct LastAnim {
     last_seen_sounds: Vec<String>,
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn broadcast_position(
     player: Query<
         (
             &GlobalTransform,
             &AvatarDynamicState,
             Option<&SceneDrivenAnim>,
+            Option<&HeadSync>,
         ),
         With<PrimaryUser>,
     >,
     transports: Query<&Transport>,
     mut last_position: Local<(Vec3, Quat, Vec3)>,
+    mut last_head_sync: Local<HeadSync>,
     mut last_sent: Local<f64>,
     mut last_index: Local<u32>,
     mut last_anim: Local<LastAnim>,
@@ -68,9 +74,10 @@ fn broadcast_position(
     global_crdt: Res<GlobalCrdtState>,
     wallet: Res<Wallet>,
 ) {
-    let Ok((player, dynamics, scene_anim)) = player.single() else {
+    let Ok((player, dynamics, scene_anim, head_sync)) = player.single() else {
         return;
     };
+    let head_sync = head_sync.copied().unwrap_or_default();
     let time = time.elapsed_secs_f64();
 
     // Latch any single-frame seek from the scene so we still send it even if the
@@ -112,12 +119,20 @@ fn broadcast_position(
         .and_then(|s| s.active.as_ref())
         .map(|a| (a.scene_hash.clone(), a.content_hash.clone()));
     let anim_changed = current_hashes != last_anim.hashes;
+    // Toggling either enabled flag, or a yaw/pitch delta past the threshold, also
+    // breaks the keepalive — same shape as anim_changed. Sub-threshold drift just
+    // rides the 1Hz keepalive.
+    let head_changed = head_sync.yaw_enabled != last_head_sync.yaw_enabled
+        || head_sync.pitch_enabled != last_head_sync.pitch_enabled
+        || (head_sync.yaw_deg - last_head_sync.yaw_deg).abs() > HEAD_SYNC_EPSILON_DEG
+        || (head_sync.pitch_deg - last_head_sync.pitch_deg).abs() > HEAD_SYNC_EPSILON_DEG;
     if elapsed < STATIC_FREQ
         && (translation - last_position.0).length_squared() < 0.01
         && rotation == last_position.1
         && (dynamics.velocity - last_position.2).length_squared() < 0.01
         && last_anim.pending_seek.is_none()
         && !anim_changed
+        && !head_changed
     {
         return;
     }
@@ -281,6 +296,14 @@ fn broadcast_position(
         is_emoting: dynamics.move_kind == MoveKind::Emote,
         jump_count,
         glide_state,
+        head_ik_yaw_enabled: head_sync.yaw_enabled,
+        head_ik_pitch_enabled: head_sync.pitch_enabled,
+        head_yaw: head_sync.yaw_deg,
+        head_pitch: head_sync.pitch_deg,
+        point_at_x: 0.0,
+        point_at_y: 0.0,
+        point_at_z: 0.0,
+        is_pointing_at: false,
         scene_driven_animation,
     };
 
@@ -317,6 +340,7 @@ fn broadcast_position(
     }
 
     *last_position = (translation, rotation, dynamics.velocity);
+    *last_head_sync = head_sync;
     *last_index += 1;
     *last_sent = time;
 }

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -572,6 +572,12 @@ pub fn process_transport_updates(
                     PlayerMessage::PlayerData(Message::Voice(_)) => (),
                     PlayerMessage::PlayerData(Message::Movement(m)) => {
                         debug!("movement data: {m:?}");
+                        commands.entity(entity).try_insert(HeadSync {
+                            yaw_deg: m.head_yaw,
+                            pitch_deg: m.head_pitch,
+                            yaw_enabled: m.head_ik_yaw_enabled,
+                            pitch_enabled: m.head_ik_pitch_enabled,
+                        });
                         let pos = Vec3::new(m.position_x, m.position_y, -m.position_z);
                         let vel = Vec3::new(m.velocity_x, m.velocity_y, -m.velocity_z);
                         let rot = Quat::from_rotation_y(-m.rotation_y / 360.0 * TAU);

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -10,7 +10,7 @@ use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender, RpcStreamSender},
     structs::{
-        AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, HeadSync, MoveKind,
+        AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, HeadSync, MoveKind, PointAtSync,
         SceneDrivenAnimationRequest,
     },
 };
@@ -438,6 +438,7 @@ pub fn process_transport_updates(
                                 current_transport: None,
                             },
                             HeadSync::default(),
+                            PointAtSync::default(),
                             Propagate(RenderLayers::default()),
                         ))
                         .id();
@@ -572,12 +573,18 @@ pub fn process_transport_updates(
                     PlayerMessage::PlayerData(Message::Voice(_)) => (),
                     PlayerMessage::PlayerData(Message::Movement(m)) => {
                         debug!("movement data: {m:?}");
-                        commands.entity(entity).try_insert(HeadSync {
-                            yaw_deg: m.head_yaw,
-                            pitch_deg: m.head_pitch,
-                            yaw_enabled: m.head_ik_yaw_enabled,
-                            pitch_enabled: m.head_ik_pitch_enabled,
-                        });
+                        commands.entity(entity).try_insert((
+                            HeadSync {
+                                yaw_deg: m.head_yaw,
+                                pitch_deg: m.head_pitch,
+                                yaw_enabled: m.head_ik_yaw_enabled,
+                                pitch_enabled: m.head_ik_pitch_enabled,
+                            },
+                            PointAtSync {
+                                target_world: Vec3::new(m.point_at_x, m.point_at_y, m.point_at_z),
+                                is_pointing: m.is_pointing_at,
+                            },
+                        ));
                         let pos = Vec3::new(m.position_x, m.position_y, -m.position_z);
                         let vel = Vec3::new(m.velocity_x, m.velocity_y, -m.velocity_z);
                         let rot = Quat::from_rotation_y(-m.rotation_y / 360.0 * TAU);

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -10,7 +10,7 @@ use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender, RpcStreamSender},
     structs::{
-        AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, MoveKind,
+        AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, HeadSync, MoveKind,
         SceneDrivenAnimationRequest,
     },
 };
@@ -437,6 +437,7 @@ pub fn process_transport_updates(
                                 available_transports: Default::default(),
                                 current_transport: None,
                             },
+                            HeadSync::default(),
                             Propagate(RenderLayers::default()),
                         ))
                         .id();

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -77,6 +77,19 @@ message Movement {
     CLOSING_PROP = 3;
   }
 
+  // point-at (world-space target the avatar is pointing its arm at)
+  float point_at_x = 25;
+  float point_at_y = 26;
+  float point_at_z = 27;
+  bool is_pointing_at = 28;
+
+  // head-sync (enabled flags + world-space yaw and pitch angles, in degrees,
+  // derived from the camera forward direction on the sender)
+  bool head_ik_yaw_enabled = 19;
+  bool head_ik_pitch_enabled = 20;
+  float head_yaw = 21;
+  float head_pitch = 22;
+
   // Scene-driven movement animation (bevy-explorer local extension). Wrapped in a nested
   // message at a high private tag so that other clients (Unity, web) can't accidentally
   // populate these fields by reusing the same tag numbers at the Movement level — an
@@ -118,6 +131,8 @@ message SceneDrivenAnimation {
 message MovementCompressed {
   int32 temporal_data = 1; // bit-compressed: timestamp + animations
   int64 movement_data = 2; // bit-compressed: position + velocity
+  int32 head_sync_data = 3; // bit-compressed: enabled flags + yaw + pitch
+  int32 point_at_data = 4; // bit-compressed: flag + point coordinates
 
   // Mirror of Movement.scene_driven_animation — see that field for semantics and the
   // collision-avoidance rationale behind the high nested tag.

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -11,7 +11,7 @@ use bevy::{
 use bevy_console::ConsoleCommand;
 use comms::global_crdt::ForeignPlayer;
 use console::DoAddConsoleCommand;
-use system_bridge::{HoverAction, HoverEvent, PointerTargetType, SystemApi};
+use system_bridge::{HoverAction, HoverEvent, SystemApi};
 
 use crate::{
     gltf_resolver::GltfMeshResolver,
@@ -29,7 +29,7 @@ use common::{
     dynamics::PLAYER_COLLIDER_RADIUS,
     inputs::{Action, CommonInputAction, POINTER_SET},
     rpc::RpcStreamSender,
-    structs::{CursorLocks, DebugInfo, MonotonicTimestamp, PrimaryCamera},
+    structs::{CursorLocks, DebugInfo, MonotonicTimestamp, PointerTargetType, PrimaryCamera},
     util::DespawnWith,
 };
 use dcl::interface::CrdtType;
@@ -191,7 +191,7 @@ pub struct AvatarColliders {
 }
 
 #[derive(Default, Debug, Resource, Clone, PartialEq)]
-pub struct WorldPointerTarget(Option<PointerTargetInfo>);
+pub struct WorldPointerTarget(pub Option<PointerTargetInfo>);
 
 #[derive(Resource, Default)]
 pub struct PointerRay(pub Option<Ray3d>);

--- a/crates/scene_runner/src/update_world/transform_and_parent.rs
+++ b/crates/scene_runner/src/update_world/transform_and_parent.rs
@@ -37,7 +37,7 @@ impl Plugin for TransformAndParentPlugin {
                 PostUpdateSets::ColliderUpdate,
                 PostUpdateSets::PlayerUpdate,
                 PostUpdateSets::CameraUpdate,
-                PostUpdateSets::FootIk,
+                PostUpdateSets::InverseKinematics,
                 PostUpdateSets::Nametag,
                 PostUpdateSets::AttachSync,
                 PostUpdateSets::Billboard,

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -16,6 +16,7 @@ use common::{
     rpc::{RpcResultSender, RpcStreamSender},
     structs::{
         AppConfig, MicState, PermissionLevel, PermissionType, PermissionUsed, PermissionValue,
+        PointerTargetType,
     },
 };
 use dcl_component::proto_components::{
@@ -23,7 +24,6 @@ use dcl_component::proto_components::{
     sdk::components::{pb_pointer_events, PbAvatarBase, PbAvatarEquippedData},
 };
 use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
 use settings::SettingBridgePlugin;
 
 use crate::settings::SettingInfo;
@@ -96,14 +96,6 @@ pub struct VoiceMessage {
     pub sender_address: String,
     pub channel: String,
     pub active: bool,
-}
-
-#[derive(Hash, Clone, Copy, Serialize_repr, Deserialize_repr, Debug, PartialEq, Eq)]
-#[repr(u32)]
-pub enum PointerTargetType {
-    World = 0,
-    Ui = 1,
-    Avatar = 2,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -206,6 +206,13 @@ pub fn update_camera_position(
     head_sync.yaw_enabled = head_active && !first_person;
     head_sync.pitch_enabled = head_active;
     if head_active {
+        // DCL world is left-handed (Z+ forward) while bevy is right-handed
+        // (-Z forward). The Y-up rotation handedness flips going across, so
+        // a yaw of θ in bevy maps to -θ on the wire. With this, looking N is
+        // 0°, E is 90°, S is 180°, W is 270° — matching unity senders.
+        // Pitch is also handedness-flipped on the wire (looking up positive
+        // in DCL = negative bevy pitch). HeadSync holds the wire value, and
+        // the IK reader applies the same negation to render back in bevy.
         head_sync.yaw_deg = -options.yaw.to_degrees();
         head_sync.pitch_deg = -options.pitch.to_degrees();
     }

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -8,7 +8,10 @@ use bevy::{
 
 use common::{
     inputs::{Action, SystemAction, CAMERA_SET, CAMERA_ZOOM, POINTER_SET},
-    structs::{AvatarDynamicState, CameraOverride, CursorLocks, PrimaryCamera, PrimaryUser},
+    structs::{
+        AvatarDynamicState, CameraOverride, CursorLocks, HeadSync, MoveKind, PrimaryCamera,
+        PrimaryUser,
+    },
     util::ModifyComponentExt,
 };
 use dcl_component::proto_components::sdk::components::common::camera_transition::TransitionMode;
@@ -169,8 +172,13 @@ pub fn update_camera_position(
         &mut Projection,
         Option<&mut SystemTween>,
     )>,
-    player: Query<
-        (&Transform, &AvatarDynamicState, Has<OutOfWorld>),
+    mut player: Query<
+        (
+            &Transform,
+            &AvatarDynamicState,
+            Has<OutOfWorld>,
+            &mut HeadSync,
+        ),
         (With<PrimaryUser>, Without<PrimaryCamera>),
     >,
     mut prev_override: Local<Option<CameraOverride>>,
@@ -178,12 +186,29 @@ pub fn update_camera_position(
     gt_helper: TransformHelper,
 ) {
     let (
-        Ok((player_transform, dynamic_state, is_oow)),
+        Ok((player_transform, dynamic_state, is_oow, mut head_sync)),
         Ok((camera_ent, camera_transform, options, mut projection, maybe_tween)),
-    ) = (player.single(), camera.single_mut())
+    ) = (player.single_mut(), camera.single_mut())
     else {
         return;
     };
+
+    // Capture head-sync angles only when the real camera drives rotation (not OOW, not
+    // a scene-driven cinematic). We additionally gate on the avatar being idle so head
+    // gaze doesn't broadcast through movement/jump/emote — matches unity's HeadIK gate.
+    // In first-person the head is rigidly attached to the camera, so additional yaw IK
+    // would over-rotate the neck — pitch is still meaningful (head tilts up/down).
+    let real_camera =
+        !is_oow && !matches!(options.scene_override, Some(CameraOverride::Cinematic(_)));
+    let idle = dynamic_state.move_kind == MoveKind::Idle;
+    let head_active = real_camera && idle;
+    let first_person = options.distance < 0.05;
+    head_sync.yaw_enabled = head_active && !first_person;
+    head_sync.pitch_enabled = head_active;
+    if head_active {
+        head_sync.yaw_deg = -options.yaw.to_degrees();
+        head_sync.pitch_deg = -options.pitch.to_degrees();
+    }
 
     let mut target_transform = *camera_transform;
     let mut target_transition = TransitionMode::Time(TRANSITION_TIME);

--- a/crates/user_input/src/lib.rs
+++ b/crates/user_input/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod avatar_movement;
 pub mod camera;
+pub mod point_at;
 
 use bevy::{app::Propagate, ecs::query::Has, prelude::*, render::view::RenderLayers};
 
@@ -16,6 +17,7 @@ use console::DoAddConsoleCommand;
 use scene_runner::{update_scene::pointer_lock::update_pointer_lock, OutOfWorld};
 
 use crate::avatar_movement::AvatarMovementPlugin;
+use crate::point_at::PointAtPlugin;
 
 use self::camera::{update_camera, update_camera_position};
 
@@ -26,7 +28,7 @@ pub struct UserInputPlugin;
 
 impl Plugin for UserInputPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(AvatarMovementPlugin);
+        app.add_plugins((AvatarMovementPlugin, PointAtPlugin));
         app.add_systems(
             Update,
             update_camera

--- a/crates/user_input/src/point_at.rs
+++ b/crates/user_input/src/point_at.rs
@@ -24,6 +24,11 @@ const NO_HIT_DISTANCE: f32 = 200.0;
 /// duration.
 const DRAG_CANCEL_DEG: f32 = 2.0;
 
+/// Pointing at another player's avatar from within this radius is rejected
+/// — the arm would have to bend around them and reads weirdly. Matches
+/// unity's `HandPointAtSystem.cs:150-154`.
+const MIN_AVATAR_TARGET_DISTANCE: f32 = 2.0;
+
 pub struct PointAtPlugin;
 
 impl Plugin for PointAtPlugin {
@@ -37,11 +42,11 @@ fn capture_point_at(
     world_target: Res<WorldPointerTarget>,
     pointer_ray: Res<PointerRay>,
     time: Res<Time>,
-    mut player: Query<(&mut PointAtSync, &AvatarDynamicState), With<PrimaryUser>>,
+    mut player: Query<(&mut PointAtSync, &AvatarDynamicState, &GlobalTransform), With<PrimaryUser>>,
     mut latch_until: Local<f32>,
     mut press_origin_dir: Local<Option<Vec3>>,
 ) {
-    let Ok((mut sync, dynamics)) = player.single_mut() else {
+    let Ok((mut sync, dynamics, player_global)) = player.single_mut() else {
         return;
     };
     let now = time.elapsed_secs();
@@ -89,6 +94,17 @@ fn capture_point_at(
         if let Some(target) = world_target.0.as_ref() {
             if target.ty == PointerTargetType::Ui {
                 return;
+            }
+            // Pointing at a player avatar from up close looks bad — the arm
+            // has to bend around them. Bail rather than produce that.
+            if target.ty == PointerTargetType::Avatar {
+                if let Some(target_pos) = target.position {
+                    if (target_pos - player_global.translation()).length()
+                        < MIN_AVATAR_TARGET_DISTANCE
+                    {
+                        return;
+                    }
+                }
             }
         }
 

--- a/crates/user_input/src/point_at.rs
+++ b/crates/user_input/src/point_at.rs
@@ -1,0 +1,127 @@
+use bevy::prelude::*;
+use common::{
+    inputs::SystemAction,
+    sets::SceneSets,
+    structs::{AvatarDynamicState, MoveKind, PointAtSync, PointerTargetType, PrimaryUser},
+};
+use dcl_component::transform_and_parent::DclTranslation;
+use input_manager::{InputManager, InputPriority};
+use scene_runner::update_scene::pointer_results::{PointerRay, WorldPointerTarget};
+
+/// Once latched, pointing persists for this many seconds (matches unity's
+/// `CharacterControllerSettings.PointAtDuration`). Cancelled early by leaving
+/// the idle move-state.
+const POINT_AT_DURATION: f32 = 10.0;
+
+/// Fallback distance when the cursor ray doesn't hit anything. Pushed past
+/// unity's 100m marker-visibility threshold so receivers don't draw a billboard
+/// for "pointing into the sky".
+const NO_HIT_DISTANCE: f32 = 200.0;
+
+/// On release, if the cursor ray has swung more than this many degrees from
+/// where it was at press, treat the gesture as a drag (cursor manipulation)
+/// rather than a click — drop the latch instead of holding for the full
+/// duration.
+const DRAG_CANCEL_DEG: f32 = 2.0;
+
+pub struct PointAtPlugin;
+
+impl Plugin for PointAtPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, capture_point_at.in_set(SceneSets::Input));
+    }
+}
+
+fn capture_point_at(
+    input_manager: InputManager,
+    world_target: Res<WorldPointerTarget>,
+    pointer_ray: Res<PointerRay>,
+    time: Res<Time>,
+    mut player: Query<(&mut PointAtSync, &AvatarDynamicState), With<PrimaryUser>>,
+    mut latch_until: Local<f32>,
+    mut press_origin_dir: Local<Option<Vec3>>,
+) {
+    let Ok((mut sync, dynamics)) = player.single_mut() else {
+        return;
+    };
+    let now = time.elapsed_secs();
+    let idle = dynamics.move_kind == MoveKind::Idle;
+
+    // Drop the latch the moment we leave idle — pointing while running looks
+    // wrong and unity gates the same way.
+    if !idle {
+        *latch_until = 0.0;
+        *press_origin_dir = None;
+        sync.is_pointing = false;
+        return;
+    }
+
+    let action = SystemAction::PointAt;
+
+    // Stash the ray direction at press so we can decide on release whether
+    // this was a click or a drag.
+    if input_manager.just_down(action, InputPriority::None) {
+        *press_origin_dir = pointer_ray.0.as_ref().map(|r| *r.direction);
+    }
+
+    // On release, compare the ray direction now to where it was at press.
+    // If the cursor swung past the threshold, drop the latch — the user was
+    // manipulating the camera/cursor, not pointing.
+    if input_manager.just_up(action) {
+        if let (Some(origin_dir), Some(ray)) = (*press_origin_dir, pointer_ray.0.as_ref()) {
+            let dot = origin_dir.dot(*ray.direction).clamp(-1.0, 1.0);
+            if dot.acos().to_degrees() > DRAG_CANCEL_DEG {
+                *latch_until = 0.0;
+                *press_origin_dir = None;
+                sync.is_pointing = false;
+                return;
+            }
+        }
+        *press_origin_dir = None;
+    }
+
+    // While the button is held, keep re-sampling the target so the user can
+    // re-aim by dragging. On release the latch counts down with `target_world`
+    // frozen at the last sample — point and walk away rather than tracking.
+    if input_manager.is_down(action, InputPriority::None) {
+        // If the cursor is over UI, the click belongs to that UI — don't
+        // hijack it for a point-at gesture.
+        if let Some(target) = world_target.0.as_ref() {
+            if target.ty == PointerTargetType::Ui {
+                return;
+            }
+        }
+
+        // Prefer a real hit (scene/avatar collider). If the cursor is over
+        // empty space, project the ray to the fallback distance — but if the
+        // ray would dip below the ground plane before then, clamp to y=0 so
+        // we point at a sensible piece of ground rather than under the world.
+        let target_bevy = world_target
+            .0
+            .as_ref()
+            .and_then(|t| t.position)
+            .or_else(|| {
+                pointer_ray.0.map(|r| {
+                    let mut t = NO_HIT_DISTANCE;
+                    if r.direction.y < 0.0 {
+                        let to_ground = -r.origin.y / r.direction.y;
+                        if to_ground > 0.0 && to_ground < t {
+                            t = to_ground;
+                        }
+                    }
+                    r.origin + *r.direction * t
+                })
+            });
+        if let Some(target_bevy) = target_bevy {
+            let dcl = DclTranslation::from_bevy_translation(target_bevy);
+            sync.target_world = Vec3::new(dcl.0[0], dcl.0[1], dcl.0[2]);
+            sync.is_pointing = true;
+            *latch_until = now + POINT_AT_DURATION;
+            return;
+        }
+    }
+
+    if now >= *latch_until {
+        sync.is_pointing = false;
+    }
+}

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -27,9 +27,9 @@ use common::{
     sets::SetupSets,
     structs::{
         AppConfig, AppError, AvatarDynamicState, CurrentRealm, CursorLocks, GraphicsSettings,
-        HeadSync, IVec2Arg, PermissionUsed, PreviewMode, PrimaryCamera, PrimaryCameraRes,
-        PrimaryPlayerRes, SceneGlobalLight, SceneImposterBake, SceneLoadDistance, SystemAudio,
-        TimeOfDay, ToolTips,
+        HeadSync, IVec2Arg, PermissionUsed, PointAtSync, PreviewMode, PrimaryCamera,
+        PrimaryCameraRes, PrimaryPlayerRes, SceneGlobalLight, SceneImposterBake, SceneLoadDistance,
+        SystemAudio, TimeOfDay, ToolTips,
     },
     util::UtilsPlugin,
 };
@@ -364,6 +364,7 @@ fn setup(
             OutOfWorld,
             AvatarDynamicState::default(),
             HeadSync::default(),
+            PointAtSync::default(),
             GroundCollider::default(),
         ))
         .id();

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -27,8 +27,9 @@ use common::{
     sets::SetupSets,
     structs::{
         AppConfig, AppError, AvatarDynamicState, CurrentRealm, CursorLocks, GraphicsSettings,
-        IVec2Arg, PermissionUsed, PreviewMode, PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes,
-        SceneGlobalLight, SceneImposterBake, SceneLoadDistance, SystemAudio, TimeOfDay, ToolTips,
+        HeadSync, IVec2Arg, PermissionUsed, PreviewMode, PrimaryCamera, PrimaryCameraRes,
+        PrimaryPlayerRes, SceneGlobalLight, SceneImposterBake, SceneLoadDistance, SystemAudio,
+        TimeOfDay, ToolTips,
     },
     util::UtilsPlugin,
 };
@@ -362,6 +363,7 @@ fn setup(
             config.player_settings.clone(),
             OutOfWorld,
             AvatarDynamicState::default(),
+            HeadSync::default(),
             GroundCollider::default(),
         ))
         .id();

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -26,9 +26,9 @@ use common::{
     rpc::RpcResultSender,
     sets::SetupSets,
     structs::{
-        AppConfig, AvatarDynamicState, CurrentRealm, IVec2Arg, PreviewMode, PrimaryCamera,
-        PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser, SceneLoadDistance, StartupScene,
-        StartupScenes, Version, GROUND_RENDERLAYER,
+        AppConfig, AvatarDynamicState, CurrentRealm, HeadSync, IVec2Arg, PreviewMode,
+        PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser, SceneLoadDistance,
+        StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
     },
     util::UtilsPlugin,
 };
@@ -383,6 +383,7 @@ fn setup(
             config.player_settings.clone(),
             OutOfWorld,
             AvatarDynamicState::default(),
+            HeadSync::default(),
             GroundCollider::default(),
             Propagate(RenderLayers::default()),
         ))

--- a/src/lib/actual_web.rs
+++ b/src/lib/actual_web.rs
@@ -26,7 +26,7 @@ use common::{
     rpc::RpcResultSender,
     sets::SetupSets,
     structs::{
-        AppConfig, AvatarDynamicState, CurrentRealm, HeadSync, IVec2Arg, PreviewMode,
+        AppConfig, AvatarDynamicState, CurrentRealm, HeadSync, IVec2Arg, PointAtSync, PreviewMode,
         PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser, SceneLoadDistance,
         StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
     },
@@ -384,6 +384,7 @@ fn setup(
             OutOfWorld,
             AvatarDynamicState::default(),
             HeadSync::default(),
+            PointAtSync::default(),
             GroundCollider::default(),
             Propagate(RenderLayers::default()),
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,10 @@ use common::{
     inputs::InputMap,
     sets::SetupSets,
     structs::{
-        AppConfig, AvatarDynamicState, GraphicsSettings, HeadSync, IVec2Arg, PreviewMode,
-        PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser, SceneImposterBake,
-        SceneLoadDistance, StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
+        AppConfig, AvatarDynamicState, GraphicsSettings, HeadSync, IVec2Arg, PointAtSync,
+        PreviewMode, PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser,
+        SceneImposterBake, SceneLoadDistance, StartupScene, StartupScenes, Version,
+        GROUND_RENDERLAYER,
     },
     util::UtilsPlugin,
 };
@@ -588,6 +589,7 @@ fn setup(
             OutOfWorld,
             AvatarDynamicState::default(),
             HeadSync::default(),
+            PointAtSync::default(),
             GroundCollider::default(),
             Propagate(RenderLayers::default()),
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,9 @@ use common::{
     inputs::InputMap,
     sets::SetupSets,
     structs::{
-        AppConfig, AvatarDynamicState, GraphicsSettings, IVec2Arg, PreviewMode, PrimaryCamera,
-        PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser, SceneImposterBake, SceneLoadDistance,
-        StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
+        AppConfig, AvatarDynamicState, GraphicsSettings, HeadSync, IVec2Arg, PreviewMode,
+        PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser, SceneImposterBake,
+        SceneLoadDistance, StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
     },
     util::UtilsPlugin,
 };
@@ -587,6 +587,7 @@ fn setup(
             config.player_settings.clone(),
             OutOfWorld,
             AvatarDynamicState::default(),
+            HeadSync::default(),
             GroundCollider::default(),
             Propagate(RenderLayers::default()),
         ))


### PR DESCRIPTION
## Summary

Implements the head **look-at** and arm **point-at** avatar gestures as a Rust port of Unity's `HeadIKSystem` / `HandPointAtSystem`, plus a world-space target marker.

### Head IK (look-at)
- Per-frame yaw/pitch broadcast on `rfc4::Movement` from the local camera (gated to idle, real camera, not first-person)
- Receive-side IK on local + remote avatars: yaw/pitch swing distributed across upper-chest, neck, and head bones with weighted contributions; smoothed via exponential τ ≈ 0.12s, clamped to ±70° yaw / ±50° pitch, disabled past ±110°
- Body-delta compensation: stored offset is body-relative so a turning body doesn't drag the head along while the smoother chases

### Point-at IK
- New `SystemAction::PointAt` (`MMB` + `Q`); 10s latch, 2° drag-cancel, 200m no-hit fallback, 2m near-avatar reject, UI-pickup gate
- Two-bone arm IK (shared kernel with foot IK), pointing-finger pose, body rotation toward target with asymmetric ±17.5°/±53° cone matching Unity
- Upper-arm direction half-space constraint in body-local frame so the arm doesn't pass through the body when reaching for awkward targets
- Time-based hysteresis via above-1 weight target so brief excursions don't flicker the IK weight

### Marker
- Circular UI overlay positioned via world-to-viewport projection, scaled by viewport-percent of the smaller dimension and clamped per distance
- Background colour ported from `bevy-ui-scene`'s 23-entry palette via FNV-1a-of-address so marker tint matches the in-world nametag
- Profile thumbnail loaded via `ProfileManager::get_image` with the existing pending-retry pattern
- Exponential fade in/out (τ ≈ 0.12s) so the marker doesn't pop on press/release
- New `ZOrder::PointAtMarker = 1` slot — above the world, below scene/system UI

### Notable schedule fix
Marker systems run in `PostUpdate`'s `InverseKinematics` set with explicit `.before(UiSystem::Layout)`. Without that edge UI layout is unordered relative to the IK chain (both run before `TransformPropagate`) and our node writes get picked up a frame late.

## Follow-ups (out of scope)
- Marker visibility setting (friends-only / all / none) — Unity has this in `PointAtMarkerVisibilitySettings`. To open as a separate issue.
- Audio cue when a remote starts pointing
- Claimed-name vs unclaimed: Unity's nametag scene shows flat grey for unclaimed users, we always palette-pick

🤖 Generated with [Claude Code](https://claude.com/claude-code)