### PR TITLE
Proximity events, interaction_type, and priority resolution

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1165,6 +1165,12 @@ impl TimeOfDay {
     }
 }
 
+/// Vertical FOV of the active player camera, in radians. Pushed to scene
+/// workers via the GlobalCrdtState channel — defaulted on the worker side and
+/// updated when the renderer's camera projection changes.
+#[derive(Resource, Default, Clone, Copy, Debug)]
+pub struct CameraFov(pub f32);
+
 /// Fixed time defined on `scene.json` `skyboxConfig`
 #[derive(Component)]
 #[component(immutable)]
@@ -1268,6 +1274,9 @@ pub struct DebugInfo {
 pub enum GlobalCrdtStateUpdate {
     Crdt(Vec<u8>, dcl_component::Localizer),
     Time(f32),
+    /// Vertical FOV of the active camera, in radians. Pushed when the value
+    /// changes (camera zoom etc.).
+    CameraFov(f32),
 }
 
 // used for responses to scenes which require strict monotonic timestamps

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -244,6 +244,15 @@ impl GlobalCrdtState {
             error!("failed to send time update to scenes: {e}");
         }
     }
+
+    pub fn update_camera_fov(&mut self, fov_y: f32) {
+        if let Err(e) = self
+            .int_sender
+            .send(GlobalCrdtStateUpdate::CameraFov(fov_y))
+        {
+            error!("failed to send camera fov update to scenes: {e}");
+        }
+    }
 }
 
 #[derive(Component, Debug)]

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 use bevy::log::{debug, info, warn};
 #[cfg(feature = "span_scene_loop")]
 use bevy::log::{info_span, tracing::span::EnteredSpan};
-use common::structs::{GlobalCrdtStateUpdate, TimeOfDay};
+use common::structs::{CameraFov, GlobalCrdtStateUpdate, TimeOfDay};
 use dcl_component::{DclReader, Localizer, SceneOrigin};
 use tokio::sync::{broadcast::error::TryRecvError, Mutex};
 
@@ -212,6 +212,10 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
                 GlobalCrdtStateUpdate::Time(time) => {
                     let time_of_day = op_state.borrow_mut::<TimeOfDay>();
                     time_of_day.time = time;
+                }
+                GlobalCrdtStateUpdate::CameraFov(fov_y) => {
+                    let camera_fov = op_state.borrow_mut::<CameraFov>();
+                    camera_fov.0 = fov_y;
                 }
             },
             Err(TryRecvError::Empty) => break,

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use anyhow::anyhow;
 use bevy::log::debug;
-use common::structs::{GlobalCrdtStateUpdate, TimeOfDay};
+use common::structs::{CameraFov, GlobalCrdtStateUpdate, TimeOfDay};
 use dcl_component::{
     proto_components::sdk::components::PbPlayerIdentityData, DclReader, FromDclReader,
     SceneComponentId, SceneEntityId,
@@ -151,6 +151,7 @@ pub fn init_state(
     state.put(Vec::<SceneLogMessage>::default());
     state.put(SceneElapsedTime(0.0));
     state.put(TimeOfDay { time: 0. });
+    state.put(CameraFov::default());
     state.put(dcl_component::SceneOrigin(scene_origin));
     if let Some(super_user) = super_user {
         state.put(SuperUserScene(super_user));

--- a/crates/dcl/src/js/modules/Runtime.js
+++ b/crates/dcl/src/js/modules/Runtime.js
@@ -9,6 +9,12 @@ module.exports.getWorldTime = async function (body) {
     return res;
 }
 
+// Vertical FOV of the active camera, in radians. Use with the player camera's
+// transform to project world points to screen space.
+module.exports.getCameraFov = async function () {
+    return await Deno.core.ops.op_camera_fov();
+}
+
 module.exports.readFile = async function (body) {
     const res = await Deno.core.ops.op_read_file(body.fileName)
     return {

--- a/crates/dcl/src/js/modules/SystemApi.js
+++ b/crates/dcl/src/js/modules/SystemApi.js
@@ -368,6 +368,27 @@ module.exports.getHoverStream = async function() {
   return streamGenerator();
 }
 
+// get proximity events as a stream
+// type ProximityEvent = {
+//   entered: bool,
+//   entity: number,            // session-stable opaque id; matches enter/leave
+//   entityPosition: Vector3,   // entity transform origin in world space (stable anchor)
+//   actions: HoverAction[],
+// }
+module.exports.getProximityStream = async function() {
+  const rid = await Deno.core.ops.op_get_proximity_stream();
+
+  async function* streamGenerator() {
+    while (true) {
+      const next = await Deno.core.ops.op_read_proximity_stream(rid);
+      if (next === null) break;
+      yield next;
+    }
+  }
+
+  return streamGenerator();
+}
+
 // Social / Friends
 
 module.exports.social = {

--- a/crates/dcl/src/js/runtime.rs
+++ b/crates/dcl/src/js/runtime.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use bevy::{log::debug, math::f32};
 use common::{
     rpc::{ReadFileResponse, RpcCall, RpcResultSender},
-    structs::TimeOfDay,
+    structs::{CameraFov, TimeOfDay},
 };
 use dcl_component::{
     proto_components::sdk::components::PbRealmInfo, DclReader, FromDclReader, SceneComponentId,
@@ -131,6 +131,12 @@ pub async fn op_world_time(op_state: Rc<RefCell<impl State>>) -> Result<WorldTim
     let state = op_state.borrow();
     let TimeOfDay { time } = state.borrow::<TimeOfDay>();
     Ok(WorldTime { seconds: *time })
+}
+
+pub async fn op_camera_fov(op_state: Rc<RefCell<impl State>>) -> Result<f32, anyhow::Error> {
+    debug!("op_camera_fov");
+    let state = op_state.borrow();
+    Ok(state.borrow::<CameraFov>().0)
 }
 
 pub fn get_platform() -> &'static str {

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -20,8 +20,8 @@ use system_bridge::{
     settings::SettingInfo, AvatarModifierState, BlockedUserData, ChatMessage,
     FriendConnectivityEvent, FriendData, FriendRequestData, FriendStatusData,
     FriendshipEventUpdate, HomeScene, HoverEvent, LiveSceneInfo, PermanentPermissionItem,
-    PermissionRequest, SceneLoadingUi, SetAvatarData, SetPermanentPermission, SetSinglePermission,
-    SystemApi, VoiceMessage,
+    PermissionRequest, ProximityEvent, SceneLoadingUi, SetAvatarData, SetPermanentPermission,
+    SetSinglePermission, SystemApi, VoiceMessage,
 };
 
 use crate::{interface::crdt_context::CrdtContext, js::player_identity, RpcCalls};
@@ -712,6 +712,40 @@ pub async fn op_read_hover_stream(
     let Some(mut receiver) = state
         .borrow_mut()
         .try_take::<RpcStreamReceiver<HoverEvent>>()
+    else {
+        return Ok(None);
+    };
+
+    let res = match receiver.recv().await {
+        Some(data) => Ok(Some(data)),
+        None => Ok(None),
+    };
+
+    state.borrow_mut().put(receiver);
+
+    res
+}
+
+pub async fn op_get_proximity_stream(state: Rc<RefCell<impl State>>) -> u32 {
+    let (sx, rx) = RpcStreamSender::channel();
+    state.borrow_mut().put(rx);
+
+    state
+        .borrow_mut()
+        .borrow_mut::<SuperUserScene>()
+        .send(SystemApi::GetProximityStream(sx))
+        .unwrap();
+
+    5
+}
+
+pub async fn op_read_proximity_stream(
+    state: Rc<RefCell<impl State>>,
+    _rid: u32,
+) -> Result<Option<ProximityEvent>, anyhow::Error> {
+    let Some(mut receiver) = state
+        .borrow_mut()
+        .try_take::<RpcStreamReceiver<ProximityEvent>>()
     else {
         return Ok(None);
     };

--- a/crates/dcl_deno/src/js/op_wrappers/runtime.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/runtime.rs
@@ -11,6 +11,7 @@ pub fn ops() -> Vec<OpDecl> {
         op_scene_information(),
         op_realm_information(),
         op_world_time(),
+        op_camera_fov(),
         op_get_platform(),
     ]
 }
@@ -42,6 +43,11 @@ async fn op_realm_information(op_state: Rc<RefCell<OpState>>) -> Result<PbRealmI
 #[serde]
 async fn op_world_time(op_state: Rc<RefCell<OpState>>) -> Result<WorldTime, AnyError> {
     dcl::js::runtime::op_world_time(op_state).await
+}
+
+#[op2(async)]
+async fn op_camera_fov(op_state: Rc<RefCell<OpState>>) -> Result<f32, AnyError> {
+    dcl::js::runtime::op_camera_fov(op_state).await
 }
 
 #[op2]

--- a/crates/dcl_deno/src/js/op_wrappers/system_api.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/system_api.rs
@@ -14,7 +14,7 @@ use system_bridge::{
     settings::SettingInfo, AvatarModifierState, BlockedUserData, ChatMessage,
     FriendConnectivityEvent, FriendData, FriendRequestData, FriendStatusData,
     FriendshipEventUpdate, HomeScene, HoverEvent, LiveSceneInfo, PermanentPermissionItem,
-    PermissionRequest, SceneLoadingUi, VoiceMessage,
+    PermissionRequest, ProximityEvent, SceneLoadingUi, VoiceMessage,
 };
 
 // list of op declarations
@@ -64,6 +64,8 @@ pub fn ops(super_user: bool) -> Vec<OpDecl> {
             op_read_voice_stream(),
             op_get_hover_stream(),
             op_read_hover_stream(),
+            op_get_proximity_stream(),
+            op_read_proximity_stream(),
             op_get_scene_loading_ui_stream(),
             op_read_scene_loading_ui_stream(),
             op_get_avatar_modifiers(),
@@ -402,6 +404,20 @@ pub async fn op_read_hover_stream(
     rid: u32,
 ) -> Result<Option<HoverEvent>, deno_core::anyhow::Error> {
     dcl::js::system_api::op_read_hover_stream(state, rid).await
+}
+
+#[op2(async)]
+pub async fn op_get_proximity_stream(state: Rc<RefCell<OpState>>) -> u32 {
+    dcl::js::system_api::op_get_proximity_stream(state).await
+}
+
+#[op2(async)]
+#[serde]
+pub async fn op_read_proximity_stream(
+    state: Rc<RefCell<OpState>>,
+    rid: u32,
+) -> Result<Option<ProximityEvent>, deno_core::anyhow::Error> {
+    dcl::js::system_api::op_read_proximity_stream(state, rid).await
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/runtime.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/runtime.rs
@@ -25,6 +25,13 @@ pub async fn op_world_time(op_state: &WorkerContext) -> Result<JsValue, WasmErro
 }
 
 #[wasm_bindgen]
+pub async fn op_camera_fov(op_state: &WorkerContext) -> Result<f32, WasmError> {
+    dcl::js::runtime::op_camera_fov(op_state.rc())
+        .await
+        .map_err(WasmError::from)
+}
+
+#[wasm_bindgen]
 pub fn op_get_platform(_op_state: &WorkerContext) -> String {
     dcl::js::runtime::get_platform().to_string()
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
@@ -340,6 +340,25 @@ pub async fn op_read_hover_stream(state: &WorkerContext, rid: u32) -> Result<JsV
 }
 
 #[wasm_bindgen]
+pub async fn op_get_proximity_stream(state: &WorkerContext) -> u32 {
+    dcl::js::system_api::op_get_proximity_stream(state.rc()).await
+}
+
+#[wasm_bindgen]
+pub async fn op_read_proximity_stream(
+    state: &WorkerContext,
+    rid: u32,
+) -> Result<JsValue, WasmError> {
+    let proximity_event = dcl::js::system_api::op_read_proximity_stream(state.rc(), rid).await;
+    proximity_event
+        .map(|v| {
+            v.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+                .unwrap()
+        })
+        .map_err(WasmError::from)
+}
+
+#[wasm_bindgen]
 pub async fn op_get_scene_loading_ui_stream(state: &WorkerContext) -> u32 {
     dcl::js::system_api::op_get_scene_loading_ui_stream(state.rc()).await
 }

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -325,6 +325,7 @@ impl Plugin for SceneRunnerPlugin {
                 .in_set(SceneSets::Input)
                 .run_if(on_real_timer(Duration::from_secs(1))),
         );
+        app.add_systems(Update, push_camera_fov_to_crdt.in_set(SceneSets::Input));
     }
 }
 
@@ -1129,4 +1130,27 @@ fn set_ui_constraints(
 
 fn push_time_to_crdt(time_of_day: Res<TimeOfDay>, mut global_crdt_state: ResMut<GlobalCrdtState>) {
     global_crdt_state.update_time(time_of_day.time);
+}
+
+/// Push the active camera's vertical FOV to scene workers via GlobalCrdtState.
+/// Sends immediately when the value changes, and at least every two seconds so
+/// that scenes loaded after a change still see the latest value.
+fn push_camera_fov_to_crdt(
+    camera: Query<&Projection, With<PrimaryCamera>>,
+    mut global_crdt_state: ResMut<GlobalCrdtState>,
+    time: Res<Time>,
+    mut last_pushed: Local<Option<(f32, f32)>>,
+) {
+    let Ok(Projection::Perspective(p)) = camera.single() else {
+        return;
+    };
+    let now = time.elapsed_secs();
+    let should_push = match *last_pushed {
+        None => true,
+        Some((last_fov, last_time)) => last_fov != p.fov || now - last_time >= 2.0,
+    };
+    if should_push {
+        global_crdt_state.update_camera_fov(p.fov);
+        *last_pushed = Some((p.fov, now));
+    }
 }

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -185,6 +185,16 @@ pub fn passes_distance_check(
 /// per-entry fallback rather than a hard global cap.
 pub const PROXIMITY_DEFAULT_MAX_DISTANCE: f32 = 3.0;
 
+/// Full FOV angle of the horizontal proximity cone, in degrees. Matches
+/// unity-explorer (`PROXIMITY_FOV_ANGLE_DEGREES`). Entities whose collider
+/// nearest-point is outside this cone (in the horizontal plane, relative to the
+/// player's body forward direction) are excluded from proximity candidates.
+pub const PROXIMITY_FOV_ANGLE_DEGREES: f32 = 120.0;
+
+/// Squared cosine of the proximity cone's half-angle. cos(60°) = 0.5; squared = 0.25.
+/// Used in the per-entity FOV gate so we can compare without a sqrt.
+const PROXIMITY_FOV_HALF_ANGLE_COS_SQR: f32 = 0.25;
+
 /// Resolve the effective player-distance threshold for a PROXIMITY entry.
 ///
 /// `None` → fallback to `PROXIMITY_DEFAULT_MAX_DISTANCE`.
@@ -582,6 +592,7 @@ fn update_manual_cursor(
 /// enter/leave dispatch.
 fn collect_proximity_candidates(
     player: Query<(Entity, &GlobalTransform), With<PrimaryUser>>,
+    camera: Query<&GlobalTransform, With<PrimaryCamera>>,
     mut scenes: Query<&mut SceneColliderData>,
     pointer_events: Query<(Entity, &SceneEntity, &PointerEvents, &GlobalTransform)>,
     containing_scenes: ContainingScene,
@@ -592,6 +603,16 @@ fn collect_proximity_candidates(
         return;
     };
     let player_center = player_transform.translation() + Vec3::Y * (PLAYER_COLLIDER_HEIGHT * 0.5);
+    let player_forward = *player_transform.forward();
+    let player_flat_forward =
+        Vec3::new(player_forward.x, 0.0, player_forward.z).normalize_or_zero();
+    // Camera forward is optional — if no PrimaryCamera, fall back to a body-only
+    // cone test. When present, a target also qualifies if it's in front of the
+    // body (within 180°) AND within the camera's 120° cone.
+    let camera_flat_forward = camera.single().ok().map(|gt| {
+        let f = *gt.forward();
+        Vec3::new(f.x, 0.0, f.z).normalize_or_zero()
+    });
     let nearby_scenes = containing_scenes.get_area(player, PARCEL_SIZE);
 
     for (entity, scene_entity, pe, entity_transform) in pointer_events.iter() {
@@ -624,14 +645,49 @@ fn collect_proximity_candidates(
             continue;
         };
         let distance = (nearest_point - player_center).length();
-        if distance <= max_threshold {
-            candidates.0.push(ProximityCandidate {
-                entity,
-                distance,
-                nearest_point,
-                entity_position: entity_transform.translation(),
-            });
+        if distance > max_threshold {
+            continue;
         }
+
+        // Horizontal FOV gate: matches unity's closest-point cone test.
+        // Accept if the entity's nearest collider point falls within the body
+        // forward 120° cone, OR (in front of the body within 180° AND within
+        // the camera forward 120° cone). Vertical is unconstrained.
+        let to_target = nearest_point - player_center;
+        let flat_to_target = Vec3::new(to_target.x, 0.0, to_target.z);
+        let flat_sqr_mag = flat_to_target.length_squared();
+        if flat_sqr_mag < 1e-6 {
+            // Player on top of entity — skip (matches unity).
+            continue;
+        }
+        let body_dot = player_flat_forward.dot(flat_to_target);
+        if body_dot <= 0.0 {
+            // Behind player body.
+            continue;
+        }
+        let in_body_cone =
+            body_dot * body_dot >= flat_sqr_mag * PROXIMITY_FOV_HALF_ANGLE_COS_SQR;
+        if !in_body_cone {
+            // Outside body cone — accept only if camera is present and target
+            // is also within the camera cone (still in front of the body, since
+            // body_dot > 0).
+            let in_camera_cone = camera_flat_forward
+                .map(|c| {
+                    let dot = c.dot(flat_to_target);
+                    dot > 0.0 && dot * dot >= flat_sqr_mag * PROXIMITY_FOV_HALF_ANGLE_COS_SQR
+                })
+                .unwrap_or(false);
+            if !in_camera_cone {
+                continue;
+            }
+        }
+
+        candidates.0.push(ProximityCandidate {
+            entity,
+            distance,
+            nearest_point,
+            entity_position: entity_transform.translation(),
+        });
     }
 }
 

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -258,7 +258,10 @@ pub struct PointerRay(pub Option<Ray3d>);
 /// Entities currently within `max_player_distance` of the avatar that carry at
 /// least one PROXIMITY pointer-event entry. Distance is the closest-point distance
 /// from the avatar's center (transform + half player collider height) to the
-/// entity's collider geometry. Recomputed each frame in `PreUpdate`.
+/// entity's collider geometry. `nearest_point` is that closest point in world
+/// space; downstream emitters use it for `RaycastHit.position` since the entity
+/// transform is something a scene already knows. Recomputed each frame in
+/// `PreUpdate`.
 #[derive(Resource, Default, Debug, Clone)]
 pub struct ProximityCandidates(pub Vec<ProximityCandidate>);
 
@@ -266,6 +269,7 @@ pub struct ProximityCandidates(pub Vec<ProximityCandidate>);
 pub struct ProximityCandidate {
     pub entity: Entity,
     pub distance: f32,
+    pub nearest_point: Vec3,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -611,14 +615,18 @@ fn collect_proximity_candidates(
             continue;
         };
         let entity_id = scene_entity.id;
-        let Some(closest) =
+        let Some(nearest_point) =
             collider_data.closest_point(player_center, |cid| cid.entity == entity_id)
         else {
             continue;
         };
-        let distance = (closest - player_center).length();
+        let distance = (nearest_point - player_center).length();
         if distance <= max_threshold {
-            candidates.0.push(ProximityCandidate { entity, distance });
+            candidates.0.push(ProximityCandidate {
+                entity,
+                distance,
+                nearest_point,
+            });
         }
     }
 }
@@ -1212,7 +1220,9 @@ pub fn resolve_action_winner(
             distance: FloatOrd(cand.distance),
             camera_distance: FloatOrd(0.0),
             in_scene: true,
-            position: None,
+            // Proximity-emitted CRDTs report the closest point on the entity's
+            // collider to the avatar in `RaycastHit.position`.
+            position: Some(cand.nearest_point),
             normal: None,
             face: None,
             ty: PointerTargetType::World,
@@ -1251,16 +1261,14 @@ fn send_proximity_events(
     timestamp: Res<MonotonicTimestamp<PbPointerEventsResult>>,
     mut prev_in_range: Local<HashSet<Entity>>,
 ) {
-    let dist_by_entity: HashMap<Entity, f32> = candidates
-        .0
-        .iter()
-        .map(|c| (c.entity, c.distance))
-        .collect();
-    let new_in_range: HashSet<Entity> = dist_by_entity.keys().copied().collect();
+    let candidate_by_entity: HashMap<Entity, &ProximityCandidate> =
+        candidates.0.iter().map(|c| (c.entity, c)).collect();
+    let new_in_range: HashSet<Entity> = candidate_by_entity.keys().copied().collect();
 
     let emit = |entity: Entity,
                 pet: PointerEventType,
                 dist: f32,
+                position: Option<Vec3>,
                 scenes: &mut Query<(&mut RendererSceneContext, &GlobalTransform)>|
      -> Option<()> {
         let (scene_entity, pe) = pointer_events.get(entity).ok()?;
@@ -1291,7 +1299,7 @@ fn send_proximity_events(
                 distance: FloatOrd(dist),
                 camera_distance: FloatOrd(0.0),
                 in_scene: true,
-                position: None,
+                position,
                 normal: None,
                 face: None,
                 ty: PointerTargetType::World,
@@ -1311,19 +1319,25 @@ fn send_proximity_events(
     };
 
     for &entity in new_in_range.difference(&prev_in_range) {
-        let dist = dist_by_entity.get(&entity).copied().unwrap_or(0.0);
+        let cand = candidate_by_entity.get(&entity);
+        let dist = cand.map(|c| c.distance).unwrap_or(0.0);
+        let position = cand.map(|c| c.nearest_point);
         emit(
             entity,
             PointerEventType::PetProximityEnter,
             dist,
+            position,
             &mut scenes,
         );
     }
+    // LEAVE events fire after the entity has dropped out of every per-entry
+    // gate, so we have no current `nearest_point`; emit `position: None`.
     for &entity in prev_in_range.difference(&new_in_range) {
         emit(
             entity,
             PointerEventType::PetProximityLeave,
             0.0,
+            None,
             &mut scenes,
         );
     }

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -26,7 +26,7 @@ use crate::{
     PARCEL_SIZE,
 };
 use common::{
-    dynamics::PLAYER_COLLIDER_RADIUS,
+    dynamics::{PLAYER_COLLIDER_HEIGHT, PLAYER_COLLIDER_RADIUS},
     inputs::{Action, CommonInputAction, POINTER_SET},
     rpc::RpcStreamSender,
     structs::{CursorLocks, DebugInfo, MonotonicTimestamp, PointerTargetType, PrimaryCamera},
@@ -37,7 +37,7 @@ use dcl_component::{
     proto_components::{
         common::Vector3,
         sdk::components::{
-            common::{InputAction, PointerEventType, RaycastHit},
+            common::{InputAction, InteractionType, PointerEventType, RaycastHit},
             pb_pointer_events::Entry,
             ColliderLayer, PbPointerEventsResult,
         },
@@ -109,11 +109,16 @@ impl Plugin for PointerResultPlugin {
             .init_resource::<WorldPointerTarget>()
             .init_resource::<DebugPointers>()
             .init_resource::<AvatarColliders>()
+            .init_resource::<ProximityCandidates>()
             .init_resource::<MonotonicTimestamp<PbPointerEventsResult>>();
 
         app.add_systems(
             PreUpdate,
-            (update_pointer_target, update_manual_cursor)
+            (
+                update_pointer_target,
+                update_manual_cursor,
+                collect_proximity_candidates,
+            )
                 .chain()
                 .after(InputSystem)
                 .before(UiSystem::Focus),
@@ -123,6 +128,7 @@ impl Plugin for PointerResultPlugin {
             (
                 resolve_pointer_target,
                 send_hover_events,
+                send_proximity_events,
                 send_action_events,
                 debug_pointer,
                 handle_hover_stream,
@@ -173,12 +179,38 @@ pub fn passes_distance_check(
     }
 }
 
+/// Default `max_player_distance` applied to PROXIMITY entries that leave the field
+/// unset. Roughly mirrors unity-explorer's broad-phase cap, but applied here as a
+/// per-entry fallback rather than a hard global cap.
+pub const PROXIMITY_DEFAULT_MAX_DISTANCE: f32 = 3.0;
+
+/// Resolve the effective player-distance threshold for a PROXIMITY entry.
+///
+/// `None` → fallback to `PROXIMITY_DEFAULT_MAX_DISTANCE`.
+/// `Some(0)` → never qualifies (an explicit disable, since real distances are > 0).
+/// `Some(x)` → use x.
+pub fn proximity_threshold(
+    info: Option<&dcl_component::proto_components::sdk::components::pb_pointer_events::Info>,
+) -> f32 {
+    info.and_then(|i| i.max_player_distance)
+        .unwrap_or(PROXIMITY_DEFAULT_MAX_DISTANCE)
+}
+
+/// Returns true if a PROXIMITY entry's player-distance check passes.
+pub fn passes_proximity_distance_check(
+    info: Option<&dcl_component::proto_components::sdk::components::pb_pointer_events::Info>,
+    player_distance: f32,
+) -> bool {
+    let threshold = proximity_threshold(info);
+    threshold > 0.0 && player_distance <= threshold
+}
+
 #[derive(Default, Debug, Resource, Clone, PartialEq)]
 pub struct PointerTarget(pub Option<PointerTargetInfo>);
 
 #[derive(Default, Debug, Resource, Clone, PartialEq)]
 pub struct PointerDragTarget {
-    entities: HashMap<InputAction, (PointerTargetInfo, bool)>,
+    entities: HashMap<InputAction, (PointerTargetInfo, ActionCandidateMode, bool)>,
 }
 
 #[derive(Default, Debug, Resource, Clone, PartialEq, Eq)]
@@ -222,6 +254,19 @@ pub struct WorldPointerTarget(pub Option<PointerTargetInfo>);
 
 #[derive(Resource, Default)]
 pub struct PointerRay(pub Option<Ray3d>);
+
+/// Entities currently within `max_player_distance` of the avatar that carry at
+/// least one PROXIMITY pointer-event entry. Distance is the closest-point distance
+/// from the avatar's center (transform + half player collider height) to the
+/// entity's collider geometry. Recomputed each frame in `PreUpdate`.
+#[derive(Resource, Default, Debug, Clone)]
+pub struct ProximityCandidates(pub Vec<ProximityCandidate>);
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProximityCandidate {
+    pub entity: Entity,
+    pub distance: f32,
+}
 
 #[allow(clippy::too_many_arguments)]
 fn update_pointer_target(
@@ -523,6 +568,61 @@ fn update_manual_cursor(
     cursor.0 = Some(uv * resolve.texture_size);
 }
 
+/// Walks all entities carrying `PointerEvents` with at least one PROXIMITY entry
+/// and computes the closest-point distance from each entity's collider geometry
+/// to the avatar's center. Entities whose loosest entry threshold is satisfied
+/// are pushed into `ProximityCandidates` for downstream priority resolution and
+/// enter/leave dispatch.
+fn collect_proximity_candidates(
+    player: Query<(Entity, &GlobalTransform), With<PrimaryUser>>,
+    mut scenes: Query<&mut SceneColliderData>,
+    pointer_events: Query<(Entity, &SceneEntity, &PointerEvents)>,
+    containing_scenes: ContainingScene,
+    mut candidates: ResMut<ProximityCandidates>,
+) {
+    candidates.0.clear();
+    let Ok((player, player_transform)) = player.single() else {
+        return;
+    };
+    let player_center = player_transform.translation() + Vec3::Y * (PLAYER_COLLIDER_HEIGHT * 0.5);
+    let nearby_scenes = containing_scenes.get_area(player, PARCEL_SIZE);
+
+    for (entity, scene_entity, pe) in pointer_events.iter() {
+        if !nearby_scenes.contains(&scene_entity.root) {
+            continue;
+        }
+        // Loosest player-distance threshold across this entity's PROXIMITY entries.
+        // Used as a per-entity broad-phase gate; per-entry checks happen downstream.
+        let mut max_threshold: f32 = 0.0;
+        for entry in pe.iter() {
+            if entry.interaction_type != Some(InteractionType::Proximity as i32) {
+                continue;
+            }
+            let t = proximity_threshold(entry.event_info.as_ref());
+            if t > max_threshold {
+                max_threshold = t;
+            }
+        }
+        if max_threshold <= 0.0 {
+            continue;
+        }
+
+        let Ok(mut collider_data) = scenes.get_mut(scene_entity.root) else {
+            continue;
+        };
+        let entity_id = scene_entity.id;
+        let Some(closest) =
+            collider_data.closest_point(player_center, |cid| cid.entity == entity_id)
+        else {
+            continue;
+        };
+        let distance = (closest - player_center).length();
+        if distance <= max_threshold {
+            candidates.0.push(ProximityCandidate { entity, distance });
+        }
+    }
+}
+
 fn barycentric_coords(posns: &[Vec3; 3], target: Vec3) -> Option<Vec3> {
     let v0 = posns[1] - posns[0];
     let v1 = posns[2] - posns[0];
@@ -775,9 +875,44 @@ fn send_hover_events(
     *previously_entered = new_entities;
 }
 
+/// Source of an action-event candidate, controlling which distance gate applies
+/// and which `interaction_type` entries are eligible.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionCandidateMode {
+    Cursor,
+    Proximity,
+}
+
+impl ActionCandidateMode {
+    pub fn matches_entry(self, entry: &Entry) -> bool {
+        let entry_proximity = entry.interaction_type == Some(InteractionType::Proximity as i32);
+        match self {
+            ActionCandidateMode::Cursor => !entry_proximity,
+            ActionCandidateMode::Proximity => entry_proximity,
+        }
+    }
+
+    pub fn passes_distance(
+        self,
+        info: Option<&dcl_component::proto_components::sdk::components::pb_pointer_events::Info>,
+        camera_distance: f32,
+        player_distance: f32,
+    ) -> bool {
+        match self {
+            ActionCandidateMode::Cursor => {
+                passes_distance_check(info, camera_distance, player_distance)
+            }
+            ActionCandidateMode::Proximity => {
+                passes_proximity_distance_check(info, player_distance)
+            }
+        }
+    }
+}
+
 fn filtered_events<'a>(
     pointer_requests: &'a Query<(Option<&SceneEntity>, Option<&ForeignPlayer>, &PointerEvents)>,
     info: &PointerTargetInfo,
+    mode: ActionCandidateMode,
     ev_type: PointerEventType,
     action: InputAction,
 ) -> impl Iterator<Item = (Entity, &'a Entry)> {
@@ -791,13 +926,18 @@ fn filtered_events<'a>(
         .flatten();
 
     pe.filter(move |(_, f)| {
+        if f.event_type != ev_type as i32 {
+            return false;
+        }
+        if !mode.matches_entry(f) {
+            return false;
+        }
         let event_button = f
             .event_info
             .as_ref()
             .and_then(|info| info.button)
             .unwrap_or(InputAction::IaAny as i32);
-        f.event_type == ev_type as i32
-            && (event_button == InputAction::IaAny as i32 || event_button == action as i32)
+        event_button == InputAction::IaAny as i32 || event_button == action as i32
     })
 }
 
@@ -869,6 +1009,10 @@ fn send_hover_event(
         if !info.in_scene {
             continue;
         }
+        // Hover is cursor-domain — skip entries flagged as proximity.
+        if !ActionCandidateMode::Cursor.matches_entry(ev) {
+            continue;
+        }
         if !passes_distance_check(
             ev.event_info.as_ref(),
             info.camera_distance.0,
@@ -906,9 +1050,10 @@ fn send_hover_event(
     action
 }
 
-/// Iterates entries pre-filtered by `(event_type, action)` and emits a CRDT for
-/// each whose distance check passes. Returns the last-written scene as the
-/// "consuming" scene, which the caller uses to skip duplicate root-entity events.
+/// Iterates entries pre-filtered by `(event_type, action)` and `mode`-appropriate
+/// `interaction_type`, emitting a CRDT for each whose distance check passes.
+/// Returns the last-written scene as the "consuming" scene, which the caller uses
+/// to skip duplicate root-entity events.
 #[allow(clippy::too_many_arguments)]
 fn send_action_event(
     pointer_requests: &Query<(Option<&SceneEntity>, Option<&ForeignPlayer>, &PointerEvents)>,
@@ -916,6 +1061,7 @@ fn send_action_event(
     timestamp: &MonotonicTimestamp<PbPointerEventsResult>,
     time: &Time,
     info: &PointerTargetInfo,
+    mode: ActionCandidateMode,
     ev_type: PointerEventType,
     action: InputAction,
     direction: Option<Vec2>,
@@ -925,7 +1071,8 @@ fn send_action_event(
         return None;
     };
 
-    let mut potential_entries = filtered_events(pointer_requests, info, ev_type, action).peekable();
+    let mut potential_entries =
+        filtered_events(pointer_requests, info, mode, ev_type, action).peekable();
     potential_entries.peek()?;
 
     let mut consumer = None;
@@ -934,7 +1081,7 @@ fn send_action_event(
         if !info.in_scene {
             continue;
         }
-        if !passes_distance_check(
+        if !mode.passes_distance(
             ev.event_info.as_ref(),
             info.camera_distance.0,
             info.distance.0,
@@ -962,8 +1109,212 @@ fn send_action_event(
     consumer
 }
 
+/// Maximum `priority` across this candidate's entries that match `(ev_type,
+/// action)` after distance and interaction-type filtering. `None` means no entry
+/// is eligible — the candidate doesn't compete in this bucket.
+fn bucket_max_priority(
+    pe: &PointerEvents,
+    info: &PointerTargetInfo,
+    mode: ActionCandidateMode,
+    ev_type: PointerEventType,
+    action: InputAction,
+) -> Option<u32> {
+    if !info.in_scene {
+        return None;
+    }
+    pe.iter()
+        .filter(|e| {
+            if e.event_type != ev_type as i32 {
+                return false;
+            }
+            if !mode.matches_entry(e) {
+                return false;
+            }
+            let event_button = e
+                .event_info
+                .as_ref()
+                .and_then(|i| i.button)
+                .unwrap_or(InputAction::IaAny as i32);
+            if event_button != InputAction::IaAny as i32 && event_button != action as i32 {
+                return false;
+            }
+            mode.passes_distance(
+                e.event_info.as_ref(),
+                info.camera_distance.0,
+                info.distance.0,
+            )
+        })
+        .map(|e| e.event_info.as_ref().and_then(|i| i.priority).unwrap_or(0))
+        .max()
+}
+
+/// Picks the winning `(info, mode)` for an action bucket across the cursor target
+/// and the proximity candidate set. Highest priority wins; ties broken by entity
+/// id (lower wins). Returns `None` if no candidate has an eligible entry.
+pub fn resolve_action_winner(
+    target: Option<&PointerTargetInfo>,
+    proximity: &ProximityCandidates,
+    pointer_requests: &Query<(Option<&SceneEntity>, Option<&ForeignPlayer>, &PointerEvents)>,
+    ev_type: PointerEventType,
+    action: InputAction,
+) -> Option<(PointerTargetInfo, ActionCandidateMode)> {
+    let mut best: Option<(u32, Entity, PointerTargetInfo, ActionCandidateMode)> = None;
+
+    let mut consider =
+        |entity: Entity, info: PointerTargetInfo, mode: ActionCandidateMode, prio: u32| {
+            let beats = match best {
+                None => true,
+                Some((bp, be, _, _)) => prio > bp || (prio == bp && entity < be),
+            };
+            if beats {
+                best = Some((prio, entity, info, mode));
+            }
+        };
+
+    if let Some(info) = target {
+        if let Ok((_, _, pe)) = pointer_requests.get(info.container) {
+            if let Some(prio) =
+                bucket_max_priority(pe, info, ActionCandidateMode::Cursor, ev_type, action)
+            {
+                consider(
+                    info.container,
+                    info.clone(),
+                    ActionCandidateMode::Cursor,
+                    prio,
+                );
+            }
+        }
+    }
+
+    for cand in &proximity.0 {
+        let synthetic = PointerTargetInfo {
+            container: cand.entity,
+            mesh_name: None,
+            distance: FloatOrd(cand.distance),
+            camera_distance: FloatOrd(0.0),
+            in_scene: true,
+            position: None,
+            normal: None,
+            face: None,
+            ty: PointerTargetType::World,
+        };
+        if let Ok((_, _, pe)) = pointer_requests.get(cand.entity) {
+            if let Some(prio) = bucket_max_priority(
+                pe,
+                &synthetic,
+                ActionCandidateMode::Proximity,
+                ev_type,
+                action,
+            ) {
+                consider(cand.entity, synthetic, ActionCandidateMode::Proximity, prio);
+            }
+        }
+    }
+
+    best.map(|(_, _, info, mode)| (info, mode))
+}
+
+/// Tracks per-entity proximity range state across frames and emits
+/// `PetProximityEnter` / `PetProximityLeave` CRDTs on transitions. Tier-1 (state)
+/// events: not gated by priority or button. An entity is "in range" iff it
+/// appears in `ProximityCandidates` (the collection system gates entry by the
+/// entity's loosest configured threshold). On enter, every PROXIMITY entry of
+/// type `PetProximityEnter` whose own per-entry gate currently passes fires its
+/// CRDT. On leave, every `PetProximityLeave` entry fires unconditionally (we are,
+/// by definition, outside all per-entry gates).
+///
+/// Per-entity granularity (rather than per-entry-index) matches `send_hover_events`
+/// and is robust to scenes mutating their entry list.
+fn send_proximity_events(
+    candidates: Res<ProximityCandidates>,
+    pointer_events: Query<(&SceneEntity, &PointerEvents)>,
+    mut scenes: Query<(&mut RendererSceneContext, &GlobalTransform)>,
+    timestamp: Res<MonotonicTimestamp<PbPointerEventsResult>>,
+    mut prev_in_range: Local<HashSet<Entity>>,
+) {
+    let dist_by_entity: HashMap<Entity, f32> = candidates
+        .0
+        .iter()
+        .map(|c| (c.entity, c.distance))
+        .collect();
+    let new_in_range: HashSet<Entity> = dist_by_entity.keys().copied().collect();
+
+    let emit = |entity: Entity,
+                pet: PointerEventType,
+                dist: f32,
+                scenes: &mut Query<(&mut RendererSceneContext, &GlobalTransform)>|
+     -> Option<()> {
+        let (scene_entity, pe) = pointer_events.get(entity).ok()?;
+        let pb_pe = pe.msg.get(&None)?;
+        for entry in pb_pe.pointer_events.iter() {
+            if entry.event_type != pet as i32 {
+                continue;
+            }
+            if entry.interaction_type != Some(InteractionType::Proximity as i32) {
+                continue;
+            }
+            if pet == PointerEventType::PetProximityEnter
+                && !passes_proximity_distance_check(entry.event_info.as_ref(), dist)
+            {
+                continue;
+            }
+            let Ok((mut context, scene_transform)) = scenes.get_mut(scene_entity.root) else {
+                continue;
+            };
+            let button = entry
+                .event_info
+                .as_ref()
+                .and_then(|i| i.button.map(|_| i.button()))
+                .unwrap_or(InputAction::IaAny);
+            let info = PointerTargetInfo {
+                container: entity,
+                mesh_name: None,
+                distance: FloatOrd(dist),
+                camera_distance: FloatOrd(0.0),
+                in_scene: true,
+                position: None,
+                normal: None,
+                face: None,
+                ty: PointerTargetType::World,
+            };
+            write_pointer_result(
+                &mut context,
+                scene_transform,
+                &info,
+                scene_entity.id,
+                button,
+                pet,
+                None,
+                &timestamp,
+            );
+        }
+        Some(())
+    };
+
+    for &entity in new_in_range.difference(&prev_in_range) {
+        let dist = dist_by_entity.get(&entity).copied().unwrap_or(0.0);
+        emit(
+            entity,
+            PointerEventType::PetProximityEnter,
+            dist,
+            &mut scenes,
+        );
+    }
+    for &entity in prev_in_range.difference(&new_in_range) {
+        emit(
+            entity,
+            PointerEventType::PetProximityLeave,
+            0.0,
+            &mut scenes,
+        );
+    }
+
+    *prev_in_range = new_in_range;
+}
+
 fn send_action_events(
     target: Res<PointerTarget>,
+    proximity: Res<ProximityCandidates>,
     pointer_requests: Query<(Option<&SceneEntity>, Option<&ForeignPlayer>, &PointerEvents)>,
     mut scenes: Query<(Entity, &mut RendererSceneContext, &GlobalTransform)>,
     input_mgr: InputManager,
@@ -974,33 +1325,50 @@ fn send_action_events(
     player: Query<Entity, With<PrimaryUser>>,
     containing_scenes: ContainingScene,
 ) {
-    // send event to action target
     let mut events_and_consumers = Vec::default(); // (event type, button, option<consuming scene>)
-    if let Some(info) = target.0.as_ref() {
-        let down_events = input_mgr
-            .iter_scene_just_down()
-            .map(IaToDcl::to_dcl)
-            .map(|down| {
-                let consumed_by = send_action_event(
+
+    for down in input_mgr.iter_scene_just_down().map(IaToDcl::to_dcl) {
+        let consumed_by = match resolve_action_winner(
+            target.0.as_ref(),
+            &proximity,
+            &pointer_requests,
+            PointerEventType::PetDown,
+            down,
+        ) {
+            Some((info, mode)) => {
+                let consumed = send_action_event(
                     &pointer_requests,
                     &mut scenes,
                     &timestamp,
                     &time,
-                    info,
+                    &info,
+                    mode,
                     PointerEventType::PetDown,
                     down,
                     None,
                 );
-                if filtered_events(&pointer_requests, info, PointerEventType::PetDrag, down)
-                    .next()
-                    .is_some()
+                // Capture the winning candidate's info+mode for the lifetime of
+                // the drag (so subsequent PetDrag/Locked CRDTs fire on the same
+                // entity even if cursor / proximity state changes).
+                if filtered_events(
+                    &pointer_requests,
+                    &info,
+                    mode,
+                    PointerEventType::PetDrag,
+                    down,
+                )
+                .next()
+                .is_some()
                 {
                     debug!("added drag");
-                    drag_target.entities.insert(down, (info.clone(), false));
+                    drag_target
+                        .entities
+                        .insert(down, (info.clone(), mode, false));
                 }
                 if filtered_events(
                     &pointer_requests,
-                    info,
+                    &info,
+                    mode,
                     PointerEventType::PetDragLocked,
                     down,
                 )
@@ -1008,53 +1376,46 @@ fn send_action_events(
                 .is_some()
                 {
                     debug!("added drag lock");
-                    drag_target.entities.insert(down, (info.clone(), true));
+                    drag_target
+                        .entities
+                        .insert(down, (info.clone(), mode, true));
                 }
+                consumed
+            }
+            None => None,
+        };
+        events_and_consumers.push((PointerEventType::PetDown, down, consumed_by));
+    }
 
-                (PointerEventType::PetDown, down, consumed_by)
-            });
-        events_and_consumers.extend(down_events);
-
-        let up_events = input_mgr
-            .iter_scene_just_up()
-            .map(IaToDcl::to_dcl)
-            .map(|up| {
-                (
-                    PointerEventType::PetUp,
-                    up,
-                    send_action_event(
-                        &pointer_requests,
-                        &mut scenes,
-                        &timestamp,
-                        &time,
-                        info,
-                        PointerEventType::PetUp,
-                        up,
-                        None,
-                    ),
-                )
-            });
-        events_and_consumers.extend(up_events);
-    } else {
-        events_and_consumers.extend(
-            input_mgr
-                .iter_scene_just_down()
-                .map(IaToDcl::to_dcl)
-                .map(|b| (PointerEventType::PetDown, b, None)),
-        );
-        events_and_consumers.extend(
-            input_mgr
-                .iter_scene_just_up()
-                .map(IaToDcl::to_dcl)
-                .map(|b| (PointerEventType::PetUp, b, None)),
-        );
+    for up in input_mgr.iter_scene_just_up().map(IaToDcl::to_dcl) {
+        let consumed_by = match resolve_action_winner(
+            target.0.as_ref(),
+            &proximity,
+            &pointer_requests,
+            PointerEventType::PetUp,
+            up,
+        ) {
+            Some((info, mode)) => send_action_event(
+                &pointer_requests,
+                &mut scenes,
+                &timestamp,
+                &time,
+                &info,
+                mode,
+                PointerEventType::PetUp,
+                up,
+                None,
+            ),
+            None => None,
+        };
+        events_and_consumers.push((PointerEventType::PetUp, up, consumed_by));
     }
 
     // send any drags
     let frame_delta = input_mgr.get_analog(POINTER_SET, InputPriority::Scene);
 
     let mut any_drag_lock = false;
-    for (input, (info, lock)) in drag_target.entities.iter() {
+    for (input, (info, mode, lock)) in drag_target.entities.iter() {
         if frame_delta != Vec2::ZERO {
             send_action_event(
                 &pointer_requests,
@@ -1062,6 +1423,7 @@ fn send_action_events(
                 &timestamp,
                 &time,
                 info,
+                *mode,
                 if *lock {
                     PointerEventType::PetDragLocked
                 } else {
@@ -1077,13 +1439,14 @@ fn send_action_events(
     // send drag ends
     for up in input_mgr.iter_scene_just_up() {
         let up = up.to_dcl();
-        if let Some((info, _)) = drag_target.entities.remove(&up) {
+        if let Some((info, mode, _)) = drag_target.entities.remove(&up) {
             send_action_event(
                 &pointer_requests,
                 &mut scenes,
                 &timestamp,
                 &time,
                 &info,
+                mode,
                 PointerEventType::PetDragEnd,
                 up,
                 None,

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -1165,8 +1165,9 @@ fn bucket_max_priority(
 }
 
 /// Picks the winning `(info, mode)` for an action bucket across the cursor target
-/// and the proximity candidate set. Highest priority wins; ties broken by entity
-/// id (lower wins). Returns `None` if no candidate has an eligible entry.
+/// and the proximity candidate set. Highest priority wins; on tie, cursor wins
+/// over proximity, then nearest player distance wins. Returns `None` if no
+/// candidate has an eligible entry.
 pub fn resolve_action_winner(
     target: Option<&PointerTargetInfo>,
     proximity: &ProximityCandidates,
@@ -1174,30 +1175,32 @@ pub fn resolve_action_winner(
     ev_type: PointerEventType,
     action: InputAction,
 ) -> Option<(PointerTargetInfo, ActionCandidateMode)> {
-    let mut best: Option<(u32, Entity, PointerTargetInfo, ActionCandidateMode)> = None;
+    let mut best: Option<(u32, PointerTargetInfo, ActionCandidateMode)> = None;
 
-    let mut consider =
-        |entity: Entity, info: PointerTargetInfo, mode: ActionCandidateMode, prio: u32| {
-            let beats = match best {
-                None => true,
-                Some((bp, be, _, _)) => prio > bp || (prio == bp && entity < be),
-            };
-            if beats {
-                best = Some((prio, entity, info, mode));
-            }
+    let mut consider = |info: PointerTargetInfo, mode: ActionCandidateMode, prio: u32| {
+        let beats = match &best {
+            None => true,
+            Some((bp, b_info, b_mode)) => match prio.cmp(bp) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                std::cmp::Ordering::Equal => match (mode, *b_mode) {
+                    (ActionCandidateMode::Cursor, ActionCandidateMode::Proximity) => true,
+                    (ActionCandidateMode::Proximity, ActionCandidateMode::Cursor) => false,
+                    _ => info.distance.0 < b_info.distance.0,
+                },
+            },
         };
+        if beats {
+            best = Some((prio, info, mode));
+        }
+    };
 
     if let Some(info) = target {
         if let Ok((_, _, pe)) = pointer_requests.get(info.container) {
             if let Some(prio) =
                 bucket_max_priority(pe, info, ActionCandidateMode::Cursor, ev_type, action)
             {
-                consider(
-                    info.container,
-                    info.clone(),
-                    ActionCandidateMode::Cursor,
-                    prio,
-                );
+                consider(info.clone(), ActionCandidateMode::Cursor, prio);
             }
         }
     }
@@ -1222,12 +1225,12 @@ pub fn resolve_action_winner(
                 ev_type,
                 action,
             ) {
-                consider(cand.entity, synthetic, ActionCandidateMode::Proximity, prio);
+                consider(synthetic, ActionCandidateMode::Proximity, prio);
             }
         }
     }
 
-    best.map(|(_, _, info, mode)| (info, mode))
+    best.map(|(_, info, mode)| (info, mode))
 }
 
 /// Tracks per-entity proximity range state across frames and emits

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -907,6 +907,17 @@ impl ActionCandidateMode {
             }
         }
     }
+
+    /// Default `priority` for entries that leave the field unset. Cursor
+    /// defaults to `u32::MAX` so cursor interactions win by default — a scene
+    /// must explicitly set a cursor entry's priority to demote it below a
+    /// competing proximity entry. Proximity defaults to 0 per the proto.
+    pub fn default_priority(self) -> u32 {
+        match self {
+            ActionCandidateMode::Cursor => u32::MAX,
+            ActionCandidateMode::Proximity => 0,
+        }
+    }
 }
 
 fn filtered_events<'a>(
@@ -1144,7 +1155,12 @@ fn bucket_max_priority(
                 info.distance.0,
             )
         })
-        .map(|e| e.event_info.as_ref().and_then(|i| i.priority).unwrap_or(0))
+        .map(|e| {
+            e.event_info
+                .as_ref()
+                .and_then(|i| i.priority)
+                .unwrap_or_else(|| mode.default_priority())
+        })
         .max()
 }
 

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -260,9 +260,10 @@ pub struct PointerRay(pub Option<Ray3d>);
 /// least one PROXIMITY pointer-event entry. Distance is the closest-point distance
 /// from the avatar's center (transform + half player collider height) to the
 /// entity's collider geometry. `nearest_point` is that closest point in world
-/// space; downstream emitters use it for `RaycastHit.position` since the entity
-/// transform is something a scene already knows. Recomputed each frame in
-/// `PreUpdate`.
+/// space (used for `RaycastHit.position` on emitted CRDTs). `entity_position` is
+/// the entity's transform origin in world space, used as a stable anchor for
+/// tooltip UI (which jitters if it follows `nearest_point` as the player moves).
+/// Recomputed each frame in `PreUpdate`.
 #[derive(Resource, Default, Debug, Clone)]
 pub struct ProximityCandidates(pub Vec<ProximityCandidate>);
 
@@ -271,6 +272,7 @@ pub struct ProximityCandidate {
     pub entity: Entity,
     pub distance: f32,
     pub nearest_point: Vec3,
+    pub entity_position: Vec3,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -581,7 +583,7 @@ fn update_manual_cursor(
 fn collect_proximity_candidates(
     player: Query<(Entity, &GlobalTransform), With<PrimaryUser>>,
     mut scenes: Query<&mut SceneColliderData>,
-    pointer_events: Query<(Entity, &SceneEntity, &PointerEvents)>,
+    pointer_events: Query<(Entity, &SceneEntity, &PointerEvents, &GlobalTransform)>,
     containing_scenes: ContainingScene,
     mut candidates: ResMut<ProximityCandidates>,
 ) {
@@ -592,7 +594,7 @@ fn collect_proximity_candidates(
     let player_center = player_transform.translation() + Vec3::Y * (PLAYER_COLLIDER_HEIGHT * 0.5);
     let nearby_scenes = containing_scenes.get_area(player, PARCEL_SIZE);
 
-    for (entity, scene_entity, pe) in pointer_events.iter() {
+    for (entity, scene_entity, pe, entity_transform) in pointer_events.iter() {
         if !nearby_scenes.contains(&scene_entity.root) {
             continue;
         }
@@ -627,6 +629,7 @@ fn collect_proximity_candidates(
                 entity,
                 distance,
                 nearest_point,
+                entity_position: entity_transform.translation(),
             });
         }
     }
@@ -1654,7 +1657,7 @@ fn handle_proximity_stream(
             ProximityEvent {
                 entered: true,
                 entity: cand.entity.to_bits(),
-                nearest_point: Vector3::world_vec_from_vec3(&cand.nearest_point),
+                entity_position: Vector3::world_vec_from_vec3(&cand.entity_position),
                 actions,
             },
         );

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -11,7 +11,7 @@ use bevy::{
 use bevy_console::ConsoleCommand;
 use comms::global_crdt::ForeignPlayer;
 use console::DoAddConsoleCommand;
-use system_bridge::{HoverAction, HoverEvent, SystemApi};
+use system_bridge::{HoverAction, HoverEvent, ProximityEvent, SystemApi};
 
 use crate::{
     gltf_resolver::GltfMeshResolver,
@@ -132,6 +132,7 @@ impl Plugin for PointerResultPlugin {
                 send_action_events,
                 debug_pointer,
                 handle_hover_stream,
+                handle_proximity_stream,
             )
                 .chain()
                 .in_set(SceneSets::Input),
@@ -1597,4 +1598,98 @@ fn handle_hover_stream(
 
         prev_state.0 = event;
     }
+}
+
+/// Mirrors `handle_hover_stream` but for proximity. Sends a `ProximityEvent` to
+/// subscribers when an entity enters/leaves the candidate set, or when the
+/// `enabled` flag on any of its actions flips (per-entry distance gate crossing).
+/// Distance and `nearest_point` are sampled at send-time, not streamed
+/// per-frame — the system scene is expected to anchor UI rather than smoothly
+/// follow it.
+fn handle_proximity_stream(
+    mut events: EventReader<SystemApi>,
+    mut senders: Local<Vec<RpcStreamSender<ProximityEvent>>>,
+    candidates: Res<ProximityCandidates>,
+    pointer_events: Query<&PointerEvents>,
+    mut prev_state: Local<HashMap<Entity, ProximityEvent>>,
+) {
+    let new_senders = events
+        .read()
+        .filter_map(|ev| {
+            if let SystemApi::GetProximityStream(s) = ev {
+                Some(s.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    senders.extend(new_senders);
+    senders.retain(|s| !s.is_closed());
+
+    if senders.is_empty() {
+        prev_state.clear();
+        return;
+    }
+
+    // Build current state: one entered=true ProximityEvent per in-range entity
+    // that has at least one PROXIMITY entry.
+    let mut current: HashMap<Entity, ProximityEvent> = HashMap::new();
+    for cand in &candidates.0 {
+        let Ok(pe) = pointer_events.get(cand.entity) else {
+            continue;
+        };
+        let actions = pe
+            .iter()
+            .filter(|e| e.interaction_type == Some(InteractionType::Proximity as i32))
+            .map(|e| HoverAction {
+                event: e.clone(),
+                enabled: passes_proximity_distance_check(e.event_info.as_ref(), cand.distance),
+            })
+            .collect::<Vec<_>>();
+        if actions.is_empty() {
+            continue;
+        }
+        current.insert(
+            cand.entity,
+            ProximityEvent {
+                entered: true,
+                entity: cand.entity.to_bits(),
+                nearest_point: Vector3::world_vec_from_vec3(&cand.nearest_point),
+                actions,
+            },
+        );
+    }
+
+    let actions_match = |a: &[HoverAction], b: &[HoverAction]| -> bool {
+        a.len() == b.len()
+            && a.iter()
+                .zip(b)
+                .all(|(x, y)| x.event == y.event && x.enabled == y.enabled)
+    };
+
+    // Emit leaves for entities that dropped out of the candidate set.
+    for (entity, prev_ev) in prev_state.iter() {
+        if !current.contains_key(entity) {
+            let mut leave = prev_ev.clone();
+            leave.entered = false;
+            for s in &senders {
+                let _ = s.send(leave.clone());
+            }
+        }
+    }
+
+    // Emit enters / refreshes for new candidates and any whose actions flipped.
+    for (entity, curr_ev) in &current {
+        let send = match prev_state.get(entity) {
+            None => true,
+            Some(prev_ev) => !actions_match(&prev_ev.actions, &curr_ev.actions),
+        };
+        if send {
+            for s in &senders {
+                let _ = s.send(curr_ev.clone());
+            }
+        }
+    }
+
+    *prev_state = current;
 }

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -641,9 +641,15 @@ fn collect_proximity_candidates(
             continue;
         };
         let entity_id = scene_entity.id;
-        let Some((nearest_point, hit_collider_id)) =
-            collider_data.closest_point_with_id(player_center, |cid| cid.entity == entity_id)
-        else {
+        // Restrict to CL_POINTER colliders. A multi-collider entity (e.g. a
+        // GltfContainer with one pointer-aware mesh and several physics-only
+        // hitboxes) should only fire proximity events relative to its
+        // pointer-aware geometry.
+        let Some((nearest_point, hit_collider_id)) = collider_data.closest_point_with_id(
+            player_center,
+            ColliderLayer::ClPointer as u32,
+            |cid| cid.entity == entity_id,
+        ) else {
             continue;
         };
         let distance = (nearest_point - player_center).length();
@@ -690,12 +696,52 @@ fn collect_proximity_candidates(
             }
         }
 
+        // Occlusion gate: accept if a ray from the player's centre to the
+        // nearest collider point OR to the AABB centre of the hit collider
+        // reaches the entity unobstructed by another scene entity. Either
+        // succeeding is enough; this trades a tighter "you can definitely
+        // touch it" guarantee for the more useful "you can probably reach
+        // it" one (e.g. a recessed door whose nearest point hides behind the
+        // wall is still interactable via its AABB centre, which the player
+        // can see through the doorway).
+        if !ray_reaches_target(&mut collider_data, player_center, nearest_point, entity_id)
+            && !ray_reaches_target(&mut collider_data, player_center, entity_position, entity_id)
+        {
+            continue;
+        }
+
         candidates.0.push(ProximityCandidate {
             entity,
             distance,
             nearest_point,
             entity_position,
         });
+    }
+}
+
+/// Returns true if a ray from `origin` toward `target` reaches an entity with
+/// id `target_entity` without first hitting a collider that belongs to a
+/// different scene entity. Multi-collider entities (e.g. GltfContainers) are
+/// treated as a single target — hitting any of their colliders counts.
+fn ray_reaches_target(
+    collider_data: &mut SceneColliderData,
+    origin: Vec3,
+    target: Vec3,
+    target_entity: SceneEntityId,
+) -> bool {
+    let to_target = target - origin;
+    let distance = to_target.length();
+    if distance < 1e-4 {
+        return true;
+    }
+    let direction = to_target / distance;
+    // Physics + pointer mask, mirroring unity's PLAYER_PROXIMITY_MASK. Physics
+    // catches walls / floors; pointer catches another interactable entity
+    // sitting in front of the target — both intuitively occlude.
+    let mask = ColliderLayer::ClPointer as u32 | ColliderLayer::ClPhysics as u32;
+    match collider_data.cast_ray_nearest(origin, direction, distance, mask, true, false, None) {
+        None => true,
+        Some(hit) => hit.id.entity == target_entity,
     }
 }
 

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -270,10 +270,12 @@ pub struct PointerRay(pub Option<Ray3d>);
 /// least one PROXIMITY pointer-event entry. Distance is the closest-point distance
 /// from the avatar's center (transform + half player collider height) to the
 /// entity's collider geometry. `nearest_point` is that closest point in world
-/// space (used for `RaycastHit.position` on emitted CRDTs). `entity_position` is
-/// the entity's transform origin in world space, used as a stable anchor for
-/// tooltip UI (which jitters if it follows `nearest_point` as the player moves).
-/// Recomputed each frame in `PreUpdate`.
+/// space (used for `RaycastHit.position` on emitted CRDTs). `entity_position`
+/// is the AABB centre of the *specific* collider that produced the closest
+/// point — for multi-collider entities (e.g. GltfContainers with several
+/// hitboxes) this anchors a tooltip on the part of the entity the player is
+/// actually nearest, rather than the entity's transform origin which can sit
+/// far from any visible geometry. Recomputed each frame in `PreUpdate`.
 #[derive(Resource, Default, Debug, Clone)]
 pub struct ProximityCandidates(pub Vec<ProximityCandidate>);
 
@@ -594,7 +596,7 @@ fn collect_proximity_candidates(
     player: Query<(Entity, &GlobalTransform), With<PrimaryUser>>,
     camera: Query<&GlobalTransform, With<PrimaryCamera>>,
     mut scenes: Query<&mut SceneColliderData>,
-    pointer_events: Query<(Entity, &SceneEntity, &PointerEvents, &GlobalTransform)>,
+    pointer_events: Query<(Entity, &SceneEntity, &PointerEvents)>,
     containing_scenes: ContainingScene,
     mut candidates: ResMut<ProximityCandidates>,
 ) {
@@ -615,7 +617,7 @@ fn collect_proximity_candidates(
     });
     let nearby_scenes = containing_scenes.get_area(player, PARCEL_SIZE);
 
-    for (entity, scene_entity, pe, entity_transform) in pointer_events.iter() {
+    for (entity, scene_entity, pe) in pointer_events.iter() {
         if !nearby_scenes.contains(&scene_entity.root) {
             continue;
         }
@@ -639,8 +641,8 @@ fn collect_proximity_candidates(
             continue;
         };
         let entity_id = scene_entity.id;
-        let Some(nearest_point) =
-            collider_data.closest_point(player_center, |cid| cid.entity == entity_id)
+        let Some((nearest_point, hit_collider_id)) =
+            collider_data.closest_point_with_id(player_center, |cid| cid.entity == entity_id)
         else {
             continue;
         };
@@ -648,6 +650,12 @@ fn collect_proximity_candidates(
         if distance > max_threshold {
             continue;
         }
+        // Anchor on the AABB centre of the specific collider that produced the
+        // hit, rather than the entity transform — for a multi-collider entity
+        // each part has its own anchor.
+        let Some(entity_position) = collider_data.collider_aabb_center(&hit_collider_id) else {
+            continue;
+        };
 
         // Horizontal FOV gate: matches unity's closest-point cone test.
         // Accept if the entity's nearest collider point falls within the body
@@ -686,7 +694,7 @@ fn collect_proximity_candidates(
             entity,
             distance,
             nearest_point,
-            entity_position: entity_transform.translation(),
+            entity_position,
         });
     }
 }

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -988,6 +988,20 @@ impl ActionCandidateMode {
     }
 }
 
+/// Tier-2 (button-driven action) event types that participate in per-bucket
+/// priority resolution. Returns the typed enum form when the i32 is one of
+/// those, else `None` (e.g. for hover/proximity enter/leave or unknown values).
+pub fn action_event_type(event_type: i32) -> Option<PointerEventType> {
+    match event_type {
+        x if x == PointerEventType::PetDown as i32 => Some(PointerEventType::PetDown),
+        x if x == PointerEventType::PetUp as i32 => Some(PointerEventType::PetUp),
+        x if x == PointerEventType::PetDrag as i32 => Some(PointerEventType::PetDrag),
+        x if x == PointerEventType::PetDragLocked as i32 => Some(PointerEventType::PetDragLocked),
+        x if x == PointerEventType::PetDragEnd as i32 => Some(PointerEventType::PetDragEnd),
+        _ => None,
+    }
+}
+
 fn filtered_events<'a>(
     pointer_requests: &'a Query<(Option<&SceneEntity>, Option<&ForeignPlayer>, &PointerEvents)>,
     info: &PointerTargetInfo,
@@ -1626,7 +1640,12 @@ fn handle_hover_stream(
         actions: actions
             .get(t.container)
             .map(|pe| {
+                // The hover stream is the cursor pipeline; proximity entries
+                // surface separately on GetProximityStream. Filter so the same
+                // entity's proximity tooltips don't double-fire on the cursor
+                // stream when the player happens to be aiming at it.
                 pe.iter()
+                    .filter(|event| ActionCandidateMode::Cursor.matches_entry(event))
                     .map(|event| HoverAction {
                         event: event.clone(),
                         enabled: t.in_scene
@@ -1668,8 +1687,9 @@ fn handle_hover_stream(
 fn handle_proximity_stream(
     mut events: EventReader<SystemApi>,
     mut senders: Local<Vec<RpcStreamSender<ProximityEvent>>>,
+    target: Res<PointerTarget>,
     candidates: Res<ProximityCandidates>,
-    pointer_events: Query<&PointerEvents>,
+    pointer_requests: Query<(Option<&SceneEntity>, Option<&ForeignPlayer>, &PointerEvents)>,
     mut prev_state: Local<HashMap<Entity, ProximityEvent>>,
 ) {
     let new_senders = events
@@ -1690,21 +1710,52 @@ fn handle_proximity_stream(
         return;
     }
 
-    // Build current state: one entered=true ProximityEvent per in-range entity
-    // that has at least one PROXIMITY entry.
+    // Per-frame cache of `(event_type, button) → winning entity` so we resolve
+    // each bucket once even when several candidates share an event type.
+    let mut winner_cache: HashMap<(i32, i32), Option<Entity>> = HashMap::new();
+
+    // Build current state: one ProximityEvent per in-range entity that wins at
+    // least one action bucket. Tier-2 (PetUp/Down/Drag*) entries are filtered
+    // to the priority winner; non-action proximity entries (PetProximityEnter
+    // /Leave) are dropped from the tooltip stream — they're informational and
+    // would otherwise fight for screen space with the actionable tooltip.
     let mut current: HashMap<Entity, ProximityEvent> = HashMap::new();
     for cand in &candidates.0 {
-        let Ok(pe) = pointer_events.get(cand.entity) else {
+        let Ok((_, _, pe)) = pointer_requests.get(cand.entity) else {
             continue;
         };
-        let actions = pe
-            .iter()
-            .filter(|e| e.interaction_type == Some(InteractionType::Proximity as i32))
-            .map(|e| HoverAction {
-                event: e.clone(),
-                enabled: passes_proximity_distance_check(e.event_info.as_ref(), cand.distance),
-            })
-            .collect::<Vec<_>>();
+        let mut actions: Vec<HoverAction> = Vec::new();
+        for entry in pe.iter() {
+            if entry.interaction_type != Some(InteractionType::Proximity as i32) {
+                continue;
+            }
+            let Some(action_event) = action_event_type(entry.event_type) else {
+                continue;
+            };
+            let button = entry
+                .event_info
+                .as_ref()
+                .and_then(|i| i.button.map(|_| i.button()))
+                .unwrap_or(InputAction::IaAny);
+            let key = (action_event as i32, button as i32);
+            let winner = *winner_cache.entry(key).or_insert_with(|| {
+                resolve_action_winner(
+                    target.0.as_ref(),
+                    &candidates,
+                    &pointer_requests,
+                    action_event,
+                    button,
+                )
+                .map(|(info, _)| info.container)
+            });
+            if winner != Some(cand.entity) {
+                continue;
+            }
+            actions.push(HoverAction {
+                event: entry.clone(),
+                enabled: passes_proximity_distance_check(entry.event_info.as_ref(), cand.distance),
+            });
+        }
         if actions.is_empty() {
             continue;
         }

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -679,8 +679,7 @@ fn collect_proximity_candidates(
             // Behind player body.
             continue;
         }
-        let in_body_cone =
-            body_dot * body_dot >= flat_sqr_mag * PROXIMITY_FOV_HALF_ANGLE_COS_SQR;
+        let in_body_cone = body_dot * body_dot >= flat_sqr_mag * PROXIMITY_FOV_HALF_ANGLE_COS_SQR;
         if !in_body_cone {
             // Outside body cone — accept only if camera is present and target
             // is also within the camera cone (still in front of the body, since
@@ -705,7 +704,12 @@ fn collect_proximity_candidates(
         // wall is still interactable via its AABB centre, which the player
         // can see through the doorway).
         if !ray_reaches_target(&mut collider_data, player_center, nearest_point, entity_id)
-            && !ray_reaches_target(&mut collider_data, player_center, entity_position, entity_id)
+            && !ray_reaches_target(
+                &mut collider_data,
+                player_center,
+                entity_position,
+                entity_id,
+            )
         {
             continue;
         }

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -801,23 +801,33 @@ impl SceneColliderData {
         origin: Vec3,
         filter: F,
     ) -> Option<Vec3> {
-        self.closest_point_with_id(origin, filter)
+        self.closest_point_with_id(origin, u32::MAX, filter)
             .map(|(point, _)| point)
     }
 
     /// Like `closest_point` but also returns the id of the collider that
-    /// produced the projected point. Useful when the caller needs to identify
-    /// which of several colliders attached to the same scene entity (e.g.
-    /// multi-collider GltfContainers) was the closest.
+    /// produced the projected point, and restricts the query to colliders
+    /// whose interaction groups intersect `collision_mask`. Useful when the
+    /// caller wants to identify which of several colliders attached to the
+    /// same scene entity (e.g. multi-collider GltfContainers) was the
+    /// closest, or limit the search to a specific layer (e.g. only
+    /// `CL_POINTER` colliders for proximity events).
     pub fn closest_point_with_id<F: Fn(&ColliderId) -> bool>(
         &mut self,
         origin: Vec3,
+        collision_mask: u32,
         filter: F,
     ) -> Option<(Vec3, ColliderId)> {
         self.update_bvh();
 
         let predicate = |h, _: &Collider| self.get_id(h).is_some_and(&filter);
-        let q = QueryFilter::new().predicate(&predicate);
+        let q = QueryFilter::new()
+            .groups(InteractionGroups::new(
+                Group::from_bits_truncate(collision_mask),
+                Group::from_bits_truncate(collision_mask),
+                InteractionTestMode::And,
+            ))
+            .predicate(&predicate);
 
         self.query_pipeline(q)
             .project_point(&origin.as_dvec3().into(), f64::MAX, true)

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -801,6 +801,19 @@ impl SceneColliderData {
         origin: Vec3,
         filter: F,
     ) -> Option<Vec3> {
+        self.closest_point_with_id(origin, filter)
+            .map(|(point, _)| point)
+    }
+
+    /// Like `closest_point` but also returns the id of the collider that
+    /// produced the projected point. Useful when the caller needs to identify
+    /// which of several colliders attached to the same scene entity (e.g.
+    /// multi-collider GltfContainers) was the closest.
+    pub fn closest_point_with_id<F: Fn(&ColliderId) -> bool>(
+        &mut self,
+        origin: Vec3,
+        filter: F,
+    ) -> Option<(Vec3, ColliderId)> {
         self.update_bvh();
 
         let predicate = |h, _: &Collider| self.get_id(h).is_some_and(&filter);
@@ -808,7 +821,18 @@ impl SceneColliderData {
 
         self.query_pipeline(q)
             .project_point(&origin.as_dvec3().into(), f64::MAX, true)
-            .map(|(_, point)| DVec3::from(point.point).as_vec3())
+            .and_then(|(handle, projection)| {
+                let id = self.get_id(handle).cloned()?;
+                Some((DVec3::from(projection.point).as_vec3(), id))
+            })
+    }
+
+    /// Centre of a collider's axis-aligned bounding box in world space.
+    pub fn collider_aabb_center(&self, id: &ColliderId) -> Option<Vec3> {
+        let collider = self.get_collider(id)?;
+        let aabb = collider.compute_aabb();
+        let c = aabb.center();
+        Some(Vec3::new(c.x as f32, c.y as f32, c.z as f32))
     }
 
     pub fn remove_collider(&mut self, id: &ColliderId) {

--- a/crates/scene_runner/src/update_world/pointer_events.rs
+++ b/crates/scene_runner/src/update_world/pointer_events.rs
@@ -1,24 +1,28 @@
 use bevy::{
+    math::FloatOrd,
     platform::collections::{HashMap, HashSet},
     prelude::*,
 };
 use common::{
     inputs::InputMap,
-    structs::{ToolTips, TooltipSource},
+    structs::{PointerTargetType, ToolTips, TooltipSource},
 };
 use comms::global_crdt::ForeignPlayer;
 
 use crate::{
     renderer_context::RendererSceneContext,
     update_scene::pointer_results::{
-        passes_distance_check, IaToCommon, PointerTarget, PointerTargetInfo,
+        resolve_action_winner, ActionCandidateMode, IaToCommon, PointerTarget, PointerTargetInfo,
+        ProximityCandidates,
     },
     SceneEntity,
 };
 use dcl::interface::ComponentPosition;
 use dcl_component::{
     proto_components::sdk::components::{
-        common::InputAction, pb_pointer_events::Entry, PbPointerEvents,
+        common::{InputAction, PointerEventType},
+        pb_pointer_events::{Entry, Info},
+        PbPointerEvents,
     },
     SceneComponentId,
 };
@@ -122,70 +126,150 @@ pub fn propagate_avatar_events(
 #[derive(Component)]
 pub struct HoverText;
 
+/// Tier-2 (button-driven action) event types whose tooltips are restricted to
+/// the priority winner of the corresponding `(event_type, button)` bucket.
+fn action_event_type(event_type: i32) -> Option<PointerEventType> {
+    match event_type {
+        x if x == PointerEventType::PetDown as i32 => Some(PointerEventType::PetDown),
+        x if x == PointerEventType::PetUp as i32 => Some(PointerEventType::PetUp),
+        x if x == PointerEventType::PetDrag as i32 => Some(PointerEventType::PetDrag),
+        x if x == PointerEventType::PetDragLocked as i32 => Some(PointerEventType::PetDragLocked),
+        x if x == PointerEventType::PetDragEnd as i32 => Some(PointerEventType::PetDragEnd),
+        _ => None,
+    }
+}
+
+fn format_button_label(input_map: &InputMap, info: &Info) -> String {
+    input_map
+        .get_input(info.button().to_common())
+        .map(|b| {
+            let button_str = serde_json::to_string(&b).unwrap();
+            let button_str = button_str.strip_prefix("\"").unwrap_or(&button_str);
+            button_str
+                .strip_suffix("\"")
+                .unwrap_or(button_str)
+                .to_owned()
+        })
+        .unwrap_or_else(|| {
+            if info.button() == InputAction::IaAny {
+                "(ANY)"
+            } else {
+                "(No binding)"
+            }
+            .to_owned()
+        })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn hover_text(
-    pointer_events: Query<&PointerEvents>,
+    pointer_events: Query<(Option<&SceneEntity>, Option<&ForeignPlayer>, &PointerEvents)>,
     hover_target: Res<PointerTarget>,
+    proximity: Res<ProximityCandidates>,
     input_map: Res<InputMap>,
     mut tooltip: ResMut<ToolTips>,
 ) {
-    let mut texts = Vec::default();
+    let mut texts = Vec::<(String, bool)>::default();
 
-    if let Some(PointerTargetInfo {
-        container,
-        distance,
-        camera_distance,
-        ..
-    }) = hover_target.0
-    {
-        if let Ok(pes) = pointer_events.get(container) {
-            texts = pes
-                .iter()
-                .flat_map(|pe| {
-                    if let Some(info) = pe.event_info.as_ref() {
-                        if info.show_feedback.unwrap_or(true) {
-                            if let Some(text) = info.hover_text.as_ref() {
-                                let button = input_map
-                                    .get_input(info.button().to_common())
-                                    .map(|b| {
-                                        let button_str = serde_json::to_string(&b).unwrap();
-                                        let button_str =
-                                            button_str.strip_prefix("\"").unwrap_or(&button_str);
-                                        button_str
-                                            .strip_suffix("\"")
-                                            .unwrap_or(button_str)
-                                            .to_owned()
-                                    })
-                                    .unwrap_or_else(|| {
-                                        if info.button() == InputAction::IaAny {
-                                            "(ANY)"
-                                        } else {
-                                            "(No binding)"
-                                        }
-                                        .to_owned()
-                                    });
-                                return Some((
-                                    format!("{button} : {text}"),
-                                    passes_distance_check(
-                                        Some(info),
-                                        camera_distance.0,
-                                        distance.0,
-                                    ),
-                                ));
-                            }
-                        }
-                    }
-                    None
-                })
-                .collect::<Vec<_>>();
-            // make unique
-            texts = texts
-                .into_iter()
-                .collect::<HashSet<_>>()
-                .into_iter()
-                .collect();
+    // Collect every `(action-event-type, button)` bucket present across the
+    // candidate set and pre-resolve the priority winner for each. Tier-2
+    // tooltips only surface on the winning entity.
+    let mut buckets: HashSet<(PointerEventType, InputAction)> = HashSet::new();
+    let mut collect_buckets = |entity: Entity| {
+        if let Ok((_, _, pe)) = pointer_events.get(entity) {
+            for entry in pe.iter() {
+                let Some(et) = action_event_type(entry.event_type) else {
+                    continue;
+                };
+                let button = entry
+                    .event_info
+                    .as_ref()
+                    .and_then(|i| i.button.map(|_| i.button()))
+                    .unwrap_or(InputAction::IaAny);
+                buckets.insert((et, button));
+            }
         }
+    };
+    if let Some(info) = hover_target.0.as_ref() {
+        collect_buckets(info.container);
     }
+    for cand in &proximity.0 {
+        collect_buckets(cand.entity);
+    }
+
+    let mut winners: HashMap<(i32, i32), Option<Entity>> = HashMap::new();
+    for &(et, button) in &buckets {
+        let winner = resolve_action_winner(
+            hover_target.0.as_ref(),
+            &proximity,
+            &pointer_events,
+            et,
+            button,
+        )
+        .map(|(info, _)| info.container);
+        winners.insert((et as i32, button as i32), winner);
+    }
+
+    let mut process = |entity: Entity, mode: ActionCandidateMode, info: &PointerTargetInfo| {
+        let Ok((_, _, pe)) = pointer_events.get(entity) else {
+            return;
+        };
+        for entry in pe.iter().filter(|e| mode.matches_entry(e)) {
+            let Some(event_info) = entry.event_info.as_ref() else {
+                continue;
+            };
+            if !event_info.show_feedback.unwrap_or(true) {
+                continue;
+            }
+            let Some(text) = event_info.hover_text.as_ref() else {
+                continue;
+            };
+
+            // Tier-2 entries only show on the winning entity for their bucket.
+            if let Some(action_et) = action_event_type(entry.event_type) {
+                let button = event_info
+                    .button
+                    .map(|_| event_info.button())
+                    .unwrap_or(InputAction::IaAny);
+                let winner = winners
+                    .get(&(action_et as i32, button as i32))
+                    .copied()
+                    .flatten();
+                if winner != Some(entity) {
+                    continue;
+                }
+            }
+
+            let button_label = format_button_label(&input_map, event_info);
+            let in_range =
+                mode.passes_distance(Some(event_info), info.camera_distance.0, info.distance.0);
+            texts.push((format!("{button_label} : {text}"), in_range));
+        }
+    };
+
+    if let Some(info) = hover_target.0.as_ref() {
+        process(info.container, ActionCandidateMode::Cursor, info);
+    }
+    for cand in &proximity.0 {
+        let synthetic = PointerTargetInfo {
+            container: cand.entity,
+            mesh_name: None,
+            distance: FloatOrd(cand.distance),
+            camera_distance: FloatOrd(0.0),
+            in_scene: true,
+            position: None,
+            normal: None,
+            face: None,
+            ty: PointerTargetType::World,
+        };
+        process(cand.entity, ActionCandidateMode::Proximity, &synthetic);
+    }
+
+    // make unique
+    texts = texts
+        .into_iter()
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
 
     tooltip
         .0

--- a/crates/scene_runner/src/update_world/pointer_events.rs
+++ b/crates/scene_runner/src/update_world/pointer_events.rs
@@ -12,8 +12,8 @@ use comms::global_crdt::ForeignPlayer;
 use crate::{
     renderer_context::RendererSceneContext,
     update_scene::pointer_results::{
-        resolve_action_winner, ActionCandidateMode, IaToCommon, PointerTarget, PointerTargetInfo,
-        ProximityCandidates,
+        action_event_type, resolve_action_winner, ActionCandidateMode, IaToCommon, PointerTarget,
+        PointerTargetInfo, ProximityCandidates,
     },
     SceneEntity,
 };
@@ -125,19 +125,6 @@ pub fn propagate_avatar_events(
 
 #[derive(Component)]
 pub struct HoverText;
-
-/// Tier-2 (button-driven action) event types whose tooltips are restricted to
-/// the priority winner of the corresponding `(event_type, button)` bucket.
-fn action_event_type(event_type: i32) -> Option<PointerEventType> {
-    match event_type {
-        x if x == PointerEventType::PetDown as i32 => Some(PointerEventType::PetDown),
-        x if x == PointerEventType::PetUp as i32 => Some(PointerEventType::PetUp),
-        x if x == PointerEventType::PetDrag as i32 => Some(PointerEventType::PetDrag),
-        x if x == PointerEventType::PetDragLocked as i32 => Some(PointerEventType::PetDragLocked),
-        x if x == PointerEventType::PetDragEnd as i32 => Some(PointerEventType::PetDragEnd),
-        _ => None,
-    }
-}
 
 fn format_button_label(input_map: &InputMap, info: &Info) -> String {
     input_map

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -118,15 +118,15 @@ pub struct HoverEvent {
 /// entries enters or leaves the avatar's interaction range, or when one of its
 /// per-entry distance gates flips (so the `enabled` flag on an action changes).
 /// `entity` is an opaque session-stable identifier so the scene can match
-/// enter/leave pairs. `nearest_point` is the closest point on the entity's
-/// collider to the avatar at the moment of send (in world space) — refreshed on
-/// state-change, not every frame.
+/// enter/leave pairs. `entity_position` is the entity's transform origin in
+/// world space — used as a stable anchor for tooltip UI (matches unity, which
+/// projects the collider AABB centre to the screen for proximity tooltips).
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ProximityEvent {
     pub entered: bool,
     pub entity: u64,
-    pub nearest_point: Vector3,
+    pub entity_position: Vector3,
     pub actions: Vec<HoverAction>,
 }
 

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -20,7 +20,7 @@ use common::{
     },
 };
 use dcl_component::proto_components::{
-    common::Vector2,
+    common::{Vector2, Vector3},
     sdk::components::{pb_pointer_events, PbAvatarBase, PbAvatarEquippedData},
 };
 use serde::{Deserialize, Serialize};
@@ -114,6 +114,22 @@ pub struct HoverEvent {
     pub actions: Vec<HoverAction>,
 }
 
+/// Streamed to the system scene whenever an entity carrying PROXIMITY pointer
+/// entries enters or leaves the avatar's interaction range, or when one of its
+/// per-entry distance gates flips (so the `enabled` flag on an action changes).
+/// `entity` is an opaque session-stable identifier so the scene can match
+/// enter/leave pairs. `nearest_point` is the closest point on the entity's
+/// collider to the avatar at the moment of send (in world space) — refreshed on
+/// state-change, not every frame.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProximityEvent {
+    pub entered: bool,
+    pub entity: u64,
+    pub nearest_point: Vector3,
+    pub actions: Vec<HoverAction>,
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SceneLoadingUi {
@@ -149,6 +165,7 @@ pub enum SystemApi {
     GetChatStream(RpcStreamSender<ChatMessage>),
     GetVoiceStream(RpcStreamSender<VoiceMessage>),
     GetHoverStream(RpcStreamSender<HoverEvent>),
+    GetProximityStream(RpcStreamSender<ProximityEvent>),
     GetSceneLoadingUiStream(RpcStreamSender<SceneLoadingUi>),
     SendChat(String, String),
     Quit,

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -118,10 +118,12 @@ pub struct HoverEvent {
 /// entries enters or leaves the avatar's interaction range, or when one of its
 /// per-entry distance gates flips (so the `enabled` flag on an action changes).
 /// `entity` is an opaque session-stable identifier so the scene can match
-/// enter/leave pairs. `entity_position` is the entity's transform origin in
-/// world space; the scene is responsible for projecting it to screen space
-/// per frame using its own helper (the bevy camera's FOV is exposed via
-/// `GetCameraStream`).
+/// enter/leave pairs. `entity_position` is the world-space AABB centre of the
+/// specific collider on the entity that produced the closest-point hit — for
+/// multi-collider entities (e.g. GltfContainers) this anchors UI on the part
+/// of the entity the player is actually nearest. The scene is responsible for
+/// projecting it to screen space per frame; the active camera's vertical FOV
+/// is available via `Runtime.getCameraFov`.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ProximityEvent {
@@ -129,17 +131,6 @@ pub struct ProximityEvent {
     pub entity: u64,
     pub entity_position: Vector3,
     pub actions: Vec<HoverAction>,
-}
-
-/// Streamed to the system scene whenever the active camera's vertical FOV
-/// changes. Combined with `Transform.get(engine.CameraEntity)` (which the SDK
-/// already exposes per-frame) and `UiCanvasInformation` (for aspect), this is
-/// everything a scene needs to do its own world→screen projection. `fov_y` is
-/// in radians.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct CameraInfoEvent {
-    pub fov_y: f32,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -119,8 +119,9 @@ pub struct HoverEvent {
 /// per-entry distance gates flips (so the `enabled` flag on an action changes).
 /// `entity` is an opaque session-stable identifier so the scene can match
 /// enter/leave pairs. `entity_position` is the entity's transform origin in
-/// world space — used as a stable anchor for tooltip UI (matches unity, which
-/// projects the collider AABB centre to the screen for proximity tooltips).
+/// world space; the scene is responsible for projecting it to screen space
+/// per frame using its own helper (the bevy camera's FOV is exposed via
+/// `GetCameraStream`).
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ProximityEvent {
@@ -128,6 +129,17 @@ pub struct ProximityEvent {
     pub entity: u64,
     pub entity_position: Vector3,
     pub actions: Vec<HoverAction>,
+}
+
+/// Streamed to the system scene whenever the active camera's vertical FOV
+/// changes. Combined with `Transform.get(engine.CameraEntity)` (which the SDK
+/// already exposes per-frame) and `UiCanvasInformation` (for aspect), this is
+/// everything a scene needs to do its own world→screen projection. `fov_y` is
+/// in radians.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CameraInfoEvent {
+    pub fov_y: f32,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
## Summary

Implements the protocol additions that landed alongside `max_player_distance` (closes #759):

- **Proximity events** — `PetProximityEnter` / `PetProximityLeave` fire as entities cross their `max_player_distance` boundary. Per-entity in-range tracking matches `send_hover_events`. Default range is 3m if unset (`Some(0)` explicitly disables), `None` distinguishes from explicit zero per proto3 optional semantics.
- **`interaction_type` routing** — cursor pipeline only sees Cursor entries, proximity pipeline only sees Proximity entries. Cursor target hover stream now also filters out proximity entries so they don't double-fire.
- **Per-bucket priority resolution** — for each `(event_type, button)` action bucket, highest-priority entry wins across cursor + proximity candidates. Cursor entries default to `u32::MAX` so cursor wins unless a scene explicitly demotes them. Tiebreak: mode (Cursor > Proximity) then nearest player distance. `IA_ANY` competes in every button bucket.
- **Tooltip restriction** — bevy-side `hover_text` and the system-scene proximity stream both filter tier-2 entries to bucket winners only.

Proximity-specific refinements (matching unity, with a couple of improvements):

- Closest-point distance via rapier `project_point` from avatar centre (`transform + Y * PLAYER_COLLIDER_HEIGHT/2`).
- 120° FOV cone (body forward; or camera forward as long as the entity is also within 180° of body).
- Two-ray occlusion check: closest collider point **or** collider AABB centre — accepting either forgives the recessed-door case unity's single-ray test misses.
- Proximity candidates restricted to `CL_POINTER` colliders so a multi-collider GltfContainer doesn't fire against its physics-only hitboxes.
- `RaycastHit.position` on proximity-emitted CRDTs reports the closest collider point (informational and novel — scenes already know transform).
- Tooltip anchor uses the AABB centre of the *specific* hit collider, so multi-part entities anchor tooltips on the part the player is nearest.

System-scene plumbing:

- New `GetProximityStream` RPC carrying enter/leave + winning `actions` per in-range entity.
- New `Runtime.getCameraFov` op (mirrors `getWorldTime`'s pattern via `GlobalCrdtState`), pushed on change and at least every two seconds so scenes loaded after a change still see the latest value. Combined with `Transform.get(engine.CameraEntity)` and `UiCanvasInformation`, the system scene has everything it needs to do its own world→screen projection per frame.

## Cross-dependency

The system-scene consumer of the new stream lives in companion PR [dcl-regenesislabs/bevy-ui-scene#63](https://github.com/dcl-regenesislabs/bevy-ui-scene/pull/63). That PR adds the proximity tooltip rendering (re-projects `entityPosition` per render, falls back to a viewport-edge "compass" indicator when off-screen, clamps to `interactableArea`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)