### PR TITLE
Fix #768: proximity panic and missing dispatch

### DIFF
--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -380,7 +380,7 @@ fn update_pointer_target(
     if let Some(avatar_hit) = maybe_nearest_avatar {
         let nearest_point = avatar_colliders
             .collider_data
-            .closest_point(player_translation, |cid| cid == &avatar_hit.id)
+            .closest_point_to(player_translation, &avatar_hit.id)
             .unwrap_or(player_translation);
         let distance = (nearest_point - player_translation).length();
 
@@ -398,11 +398,11 @@ fn update_pointer_target(
             ty: PointerTargetType::Avatar,
         });
     } else if let Some((scene_entity, hit)) = maybe_nearest_hit {
-        let (_, context, mut collider_data) = scenes.get_mut(scene_entity).unwrap();
+        let (_, context, collider_data) = scenes.get_mut(scene_entity).unwrap();
 
         // get player distance
         let nearest_point = collider_data
-            .closest_point(player_translation, |cid| cid == &hit.id)
+            .closest_point_to(player_translation, &hit.id)
             .unwrap_or(player_translation);
         let distance = (nearest_point - player_translation).length();
 
@@ -645,10 +645,10 @@ fn collect_proximity_candidates(
         // GltfContainer with one pointer-aware mesh and several physics-only
         // hitboxes) should only fire proximity events relative to its
         // pointer-aware geometry.
-        let Some((nearest_point, hit_collider_id)) = collider_data.closest_point_with_id(
+        let Some((nearest_point, hit_collider_id)) = collider_data.closest_point_to_entity(
             player_center,
+            entity_id,
             ColliderLayer::ClPointer as u32,
-            |cid| cid.entity == entity_id,
         ) else {
             continue;
         };
@@ -1420,11 +1420,17 @@ fn send_proximity_events(
             let Ok((mut context, scene_transform)) = scenes.get_mut(scene_entity.root) else {
                 continue;
             };
+            // The SDK's per-entity dispatch expands `IA_ANY` to a list of real
+            // input actions and matches `command.button` strictly — `IA_ANY`
+            // itself is not in that list, so a result with `button=IA_ANY` never
+            // dispatches. Default to `IaPointer` when the entry didn't specify
+            // a button; honour an explicit one if it did.
             let button = entry
                 .event_info
                 .as_ref()
                 .and_then(|i| i.button.map(|_| i.button()))
-                .unwrap_or(InputAction::IaAny);
+                .filter(|&b| b != InputAction::IaAny)
+                .unwrap_or(InputAction::IaPointer);
             let info = PointerTargetInfo {
                 container: entity,
                 mesh_name: None,

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -796,45 +796,49 @@ impl SceneColliderData {
         (constraint_min, constraint_max)
     }
 
-    pub fn closest_point<F: Fn(&ColliderId) -> bool>(
-        &mut self,
-        origin: Vec3,
-        filter: F,
-    ) -> Option<Vec3> {
-        self.closest_point_with_id(origin, u32::MAX, filter)
-            .map(|(point, _)| point)
+    /// Project `origin` onto a specific collider's shape and return the
+    /// world-space nearest point, or `None` if the collider isn't registered.
+    pub fn closest_point_to(&self, origin: Vec3, id: &ColliderId) -> Option<Vec3> {
+        let collider = self.get_collider(id)?;
+        let proj =
+            collider
+                .shape()
+                .project_point(collider.position(), &origin.as_dvec3().into(), true);
+        Some(DVec3::from(proj.point).as_vec3())
     }
 
-    /// Like `closest_point` but also returns the id of the collider that
-    /// produced the projected point, and restricts the query to colliders
-    /// whose interaction groups intersect `collision_mask`. Useful when the
-    /// caller wants to identify which of several colliders attached to the
-    /// same scene entity (e.g. multi-collider GltfContainers) was the
-    /// closest, or limit the search to a specific layer (e.g. only
-    /// `CL_POINTER` colliders for proximity events).
-    pub fn closest_point_with_id<F: Fn(&ColliderId) -> bool>(
-        &mut self,
+    /// Like [`closest_point_to`] but operates across all colliders attached to
+    /// `entity` whose collision groups intersect `collision_mask`, and returns
+    /// the specific [`ColliderId`] that produced the nearest point.
+    pub fn closest_point_to_entity(
+        &self,
         origin: Vec3,
+        entity: SceneEntityId,
         collision_mask: u32,
-        filter: F,
     ) -> Option<(Vec3, ColliderId)> {
-        self.update_bvh();
-
-        let predicate = |h, _: &Collider| self.get_id(h).is_some_and(&filter);
-        let q = QueryFilter::new()
-            .groups(InteractionGroups::new(
-                Group::from_bits_truncate(collision_mask),
-                Group::from_bits_truncate(collision_mask),
-                InteractionTestMode::And,
-            ))
-            .predicate(&predicate);
-
-        self.query_pipeline(q)
-            .project_point(&origin.as_dvec3().into(), f64::MAX, true)
-            .and_then(|(handle, projection)| {
-                let id = self.get_id(handle).cloned()?;
-                Some((DVec3::from(projection.point).as_vec3(), id))
-            })
+        let mask = Group::from_bits_truncate(collision_mask);
+        let groups = InteractionGroups::new(mask, mask, InteractionTestMode::And);
+        let origin_pt = origin.as_dvec3().into();
+        let mut best: Option<(f64, Vec3, ColliderId)> = None;
+        for (cid, handle) in self.scaled_collider.iter() {
+            if cid.entity != entity {
+                continue;
+            }
+            let Some(collider) = self.collider_set.get(*handle) else {
+                continue;
+            };
+            if !collider.collision_groups().test(groups) {
+                continue;
+            }
+            let proj = collider
+                .shape()
+                .project_point(collider.position(), &origin_pt, true);
+            let d2 = (proj.point - origin_pt).norm_squared();
+            if best.as_ref().is_none_or(|(prev_d2, _, _)| d2 < *prev_d2) {
+                best = Some((d2, DVec3::from(proj.point).as_vec3(), cid.clone()));
+            }
+        }
+        best.map(|(_, p, id)| (p, id))
     }
 
     /// Centre of a collider's axis-aligned bounding box in world space.


### PR DESCRIPTION
## Summary

- Fixes the parry panic at `point_composite_shape.rs:79` (`Option::unwrap()` on `None`) reported in #768.
- Also fixes proximity event callbacks not firing on the SDK side, even when the bevy code path runs cleanly.

## What was happening

`closest_point_with_id` routed through rapier's `QueryPipeline::project_point`, which dispatches to parry's `CompositeShapeRef::project_local_point`. That method does `bvh.find_best(...).unwrap()` and panics whenever every BVH leaf is rejected by the `QueryFilter`.

`collect_proximity_candidates` runs in `PreUpdate`, but `update_colliders` runs in `Update::SceneSets::Init`. So a freshly-spawned entity (e.g. one of the user's CL_POINTER bricks created via CRDT) has its `PointerEvents` component visible but its collider not yet in the scene's `BroadPhaseBvh`. The per-entity filter (`cid.entity == entity_id`) rejects every leaf, parry hits `find_best → None`, unwraps, and crashes the compute task pool. Diagnostic output confirmed: `leaf_count=110, leaves_visited=110, leaves_accepted=0`.

## Fix 1 — bypass the panicking composite-shape path

All three callers of the old API pin to a specific collider (`pointer_results.rs:383, 405`) or to all colliders attached to one `SceneEntityId` (`pointer_results.rs:648`). The generic predicate-filter API didn't pull its weight, so it's gone. Replaced with two methods on `SceneColliderData`:

- `closest_point_to(origin, &ColliderId)` — exact-collider variant
- `closest_point_to_entity(origin, SceneEntityId, mask)` — per-entity variant

Both iterate the relevant colliders directly via `scaled_collider` and call `Shape::project_point` per shape. No `QueryPipeline`, no `CompositeShapeRef`, no panic. With `max_dist=Real::MAX` the BVH was visiting every leaf anyway, so we lose nothing in complexity.

## Fix 2 — make the SDK actually dispatch the result

After the panic was gone, proximity callbacks still didn't fire. The SDK's per-entity dispatch (`@dcl/ecs/dist/engine/input.js:128-138`) expands `IA_ANY` to iterating the real `InputCommands` `[IaPointer=0, IaPrimary=1, IaSecondary=2, IaForward=4, …]` and matches `command.button` strictly — `IA_ANY=3` is not in that list. So a result written with `button=IA_ANY` (the default when the user didn't pass `button` to `pointerEventsSystem.onProximityEnter`) never dispatches.

Unity-explorer has the same bug; its proximity-interactions test scene only works because it sets `button: IA_POINTER` explicitly (`scenes/3,2-proximity-interactions/src/index.ts:159`).

`send_hover_event` already mirrors this convention — it hardcodes `IaPointer` regardless of the entry's `button`. `send_proximity_events::emit` now does the same when the entry didn't specify a button (or specified `IaAny`); an explicit user-supplied button is still honoured.

## Notes

- The SDK could fix this in one line by adding `|| inputAction === IA_ANY` to `findLastAction` (mirroring commit `091fce46`'s global-state fix). Worth doing upstream, but the bevy-side fix means we don't need to wait.
- Diagnostic instrumentation in parry was reverted; `Cargo.toml` parry source restored to the git fork.

Closes #768.