### PR TITLE
Fix Worlds scenes surviving realm change

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1378,6 +1378,26 @@ pub struct CurrentRealm {
     pub public_url: String,
 }
 
+impl CurrentRealm {
+    /// Identity used to tag scene pointers and detect staleness on realm
+    /// change. Realms with an explicit scene list (Worlds) are uniquely
+    /// identified by `about_url`; realms backed by parcel-based
+    /// ActiveEntities queries share a catalog scoped by `address` (the
+    /// content/services URL).
+    pub fn pointer_realm(&self) -> &str {
+        if self
+            .config
+            .scenes_urn
+            .as_ref()
+            .is_some_and(|s| !s.is_empty())
+        {
+            &self.about_url
+        } else {
+            &self.address
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CommsConfig {

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -1208,7 +1208,7 @@ fn load_active_entities(
             .into_iter()
             .filter_map(|(parcel, distance)| match pointers.get(parcel) {
                 Some(PointerResult::Exists { realm, .. }) => {
-                    (realm != &current_realm.address).then_some((distance, parcel))
+                    (realm != current_realm.pointer_realm()).then_some((distance, parcel))
                 }
                 Some(PointerResult::Nothing) => None,
                 _ => Some((distance, parcel)),
@@ -1254,7 +1254,7 @@ fn load_active_entities(
                 .flat_map(|(parcel, ptr)| match ptr {
                     PointerResult::Nothing => None,
                     PointerResult::Exists { realm, hash, .. } => {
-                        if realm == &current_realm.address {
+                        if realm == current_realm.pointer_realm() {
                             Some((hash, *parcel))
                         } else {
                             None
@@ -1411,7 +1411,7 @@ fn load_active_entities(
                 if let Some(new_bounds) = pointers.insert(
                     parcel,
                     PointerResult::Exists {
-                        realm: current_realm.address.clone(),
+                        realm: current_realm.pointer_realm().to_owned(),
                         hash: active_entity.id.clone(),
                         urn: urn.clone(),
                     },
@@ -1510,7 +1510,7 @@ pub fn process_scene_lifecycle(
                 .get(parcel)
                 // immediately unload scenes from other realms, even if they might match
                 // we don't check them until they are in range, so better to just nuke them
-                .filter(|pr| pr.realm() == Some(&current_realm.address))
+                .filter(|pr| pr.realm() == Some(current_realm.pointer_realm()))
                 .and_then(PointerResult::hash_and_urn)
         } else {
             None

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -122,9 +122,7 @@ impl Plugin for SceneLifecyclePlugin {
 #[derive(Component, Debug)]
 pub enum SceneLoading {
     SceneSpawned,
-    SceneEntity {
-        realm: String,
-    },
+    SceneEntity,
     MainCrdt {
         crdt: Option<Handle<SerializedCrdtStore>>,
     },
@@ -176,9 +174,7 @@ pub(crate) fn load_scene_entity(
         };
 
         commands.try_insert((
-            SceneLoading::SceneEntity {
-                realm: event.realm.clone(),
-            },
+            SceneLoading::SceneEntity,
             SceneEntityDefinitionHandle(h_scene),
         ));
 
@@ -196,7 +192,7 @@ pub(crate) fn load_scene_json(
 ) {
     for (entity, mut state, h_scene) in loading_scenes
         .iter_mut()
-        .filter(|(_, state, _)| matches!(**state, SceneLoading::SceneEntity { .. }))
+        .filter(|(_, state, _)| matches!(**state, SceneLoading::SceneEntity))
     {
         let mut fail = |msg: &str| {
             warn!("{entity:?} failed to initialize scene: {msg}");
@@ -1595,7 +1591,6 @@ pub fn process_scene_lifecycle(
             .scenes
             .insert(required_scene_hash.clone(), entity);
         spawn.write(LoadSceneEvent {
-            realm: current_realm.address.clone(),
             entity: Some(entity),
             location: match maybe_urn {
                 Some(urn) => SceneIpfsLocation::Urn(urn.to_owned()),

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -120,7 +120,6 @@ pub struct CrdtSnapshotEvent {
 // event which can be sent from anywhere to trigger replacing the current scene with the one specified
 #[derive(Event)]
 pub struct LoadSceneEvent {
-    pub realm: String,
     pub entity: Option<Entity>,
     pub location: SceneIpfsLocation,
     pub super_user: bool,


### PR DESCRIPTION
## Summary

Players reported that after teleporting away from `pepino.dcl.eth` (and other Worlds), the world's buildings and farm plots stayed visible overlaid on the destination realm. Reproduces across bevy/unity/godot, occasional, persistent.

Root cause: `ScenePointer` entries are tagged with the realm they were fetched from so we can detect stale pointers on realm change and re-query. The discriminator was `current_realm.address` — which is actually the catalyst content/services URL, not a per-realm identity. Every World plus Genesis share `https://peer.decentraland.org/content` for `address`, so the "different realm" check always returned false on World→World and World→Genesis jumps. None of the source world's pointers were ever flagged for re-query, none were overwritten, and `process_scene_lifecycle` kept the scene entity alive indefinitely.

`about_url` is unique per realm and is what other identity-sensitive code (permissions, `RendererSceneContext::storage_root`) already uses — but it's only the right discriminator when the realm publishes an explicit scene list. Realms backed by parcel-based `ActiveEntities` queries share their catalog by content URL across realm names, so for those `address` is actually the correct identity.

`CurrentRealm::pointer_realm()` returns `about_url` when `config.scenes_urn` is non-empty, otherwise `address`. The four pointer-staleness sites in `initialize_scene.rs` route through it.

Also drops `LoadSceneEvent.realm` and `SceneLoading::SceneEntity.realm` — both were assigned but never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)