### PR TITLE
feat(ui_input): honor clear_on_submit flag

### DIFF
--- a/crates/dcl_component/src/proto/decentraland/sdk/components/ui_input.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/ui_input.proto
@@ -18,4 +18,5 @@ message PBUiInput {
   optional int32 font_size = 12; // default=10
   optional string value = 13;
   optional bool multi_line = 14; // default=false; when true, the input accepts newlines and behaves as a textarea
+  optional bool clear_on_submit = 15; // default=true; when false, the input value is preserved after pressing Enter
 }

--- a/crates/scene_runner/src/update_world/scene_ui/ui_input.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_input.rs
@@ -57,6 +57,7 @@ pub fn set_ui_input(
         };
         let font_size = input.0.font_size.unwrap_or(10).max(1) as f32;
         let multiline = input.0.multi_line.unwrap_or(false);
+        let clear_on_submit = input.0.clear_on_submit.unwrap_or(true);
 
         let ui_entity = link.ui_entity;
         let root = scene_ent.root;
@@ -118,7 +119,7 @@ pub fn set_ui_input(
                     .map(Color4DclToBevy::convert_srgba),
                 enabled: !input.0.disabled,
                 content: input.0.value.clone().unwrap_or_default(),
-                accept_line: true,
+                accept_line: clear_on_submit,
                 multiline: if multiline { 2 } else { 1 },
                 text_style: Some((
                     TextFont {


### PR DESCRIPTION
## Summary

Adds support for the new `PBUiInput.clear_on_submit` proto field. When a scene sets `clearOnSubmit: false`, the input value is preserved after pressing Enter; the default (`true`) keeps the current clear-on-submit behavior.

Maps the proto field onto `TextEntry.accept_line`, which already drives `bevy_simple_text_input`'s `retain_on_submit` setting.

Closes #773
Depends on decentraland/protocol#404