### PR TITLE
Disable colliders by scaled AABB extent, not raw scale factor

### DIFF
--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -328,8 +328,13 @@ impl SceneColliderData {
 
                     let mut new_scale = *init_scale;
                     if (req_scale - *init_scale).length_squared() > SCALE_EPSILON {
-                        if req_scale.abs().min_element() < 0.001 {
-                            // disable 0-sized colliders
+                        // check the final world-space size rather than the raw scale factor,
+                        // so large meshes with small scales aren't disabled.
+                        let extents = base_collider.shape().compute_local_aabb().extents();
+                        let scaled_max = (extents.x as f32 * req_scale.x.abs())
+                            .max(extents.y as f32 * req_scale.y.abs())
+                            .max(extents.z as f32 * req_scale.z.abs());
+                        if scaled_max < 0.001 {
                             collider.set_enabled(false);
                         } else {
                             collider.set_enabled(true);

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -226,7 +226,10 @@ pub struct SceneColliderData {
     disabled: HashSet<ColliderHandle>,
 }
 
-const SCALE_EPSILON: f32 = 0.001;
+// max world-space size change (metres) before we rebuild the scaled shape
+const COLLIDER_RESCALE_SIZE: f32 = 0.01;
+// disable colliders whose largest scaled extent falls below this (metres)
+const COLLIDER_DISABLE_SIZE: f32 = 0.001;
 const RAYCAST_EPSILON: f64 = 0.0001;
 
 pub trait ScaleShapeExt {
@@ -327,21 +330,21 @@ impl SceneColliderData {
                     };
 
                     let mut new_scale = *init_scale;
-                    if (req_scale - *init_scale).length_squared() > SCALE_EPSILON {
-                        // check the final world-space size rather than the raw scale factor,
-                        // so large meshes with small scales aren't disabled.
+                    if req_scale != *init_scale {
+                        // gate both rescale-tolerance and disable on the final world-space
+                        // size, not the raw scale factor — so large meshes with small
+                        // scales (and vice versa) are handled correctly.
                         let extents = base_collider.shape().compute_local_aabb().extents();
-                        let scaled_max = (extents.x as f32 * req_scale.x.abs())
-                            .max(extents.y as f32 * req_scale.y.abs())
-                            .max(extents.z as f32 * req_scale.z.abs());
-                        if scaled_max < 0.001 {
-                            collider.set_enabled(false);
-                        } else {
-                            collider.set_enabled(true);
+                        let extents =
+                            Vec3::new(extents.x as f32, extents.y as f32, extents.z as f32);
+                        let size_change = (extents * (req_scale - *init_scale).abs()).max_element();
+                        if size_change > COLLIDER_RESCALE_SIZE {
+                            let scaled_max = (extents * req_scale.abs()).max_element();
+                            collider.set_enabled(scaled_max >= COLLIDER_DISABLE_SIZE);
+                            new_scale = req_scale;
+                            // colliders don't have a scale, we have to modify the shape directly when scale changes (significantly)
+                            collider.set_shape(base_collider.shape().scale_ext(req_scale));
                         }
-                        new_scale = req_scale;
-                        // colliders don't have a scale, we have to modify the shape directly when scale changes (significantly)
-                        collider.set_shape(base_collider.shape().scale_ext(req_scale));
                     }
 
                     let state_mut = self.collider_state.get_mut(id).unwrap();


### PR DESCRIPTION
## Summary

Replaces two scale-factor-based thresholds in `update_collider_transform` with world-space size thresholds, computed from the shape's local AABB extents × the requested scale.

- **Disable threshold** (was `req_scale.abs().min_element() < 0.001` on raw scale): now disables when the max scaled extent is below `COLLIDER_DISABLE_SIZE = 0.001` m. Previously a 100m GLB at scale 0.0001 (→ 1cm) was incorrectly disabled because the scale factor was < 0.001; now the final size is what matters. The scale-to-zero hide trick still triggers (max scaled extent = 0).
- **Rescale tolerance** (was `(req_scale - init_scale).length_squared() > SCALE_EPSILON`): now rebuilds the scaled shape only when the max world-space size change exceeds `COLLIDER_RESCALE_SIZE = 0.01` m. Previously a 100m mesh and a 1cm mesh hit the rebuild threshold at the same scale delta; now tolerance scales with the actual collider.

`max_element` is used for the disable check so flat trimeshes (one axis ≈ 0) stay enabled. The AABB is only computed when the scale actually changed (the common transform update changes only translation/rotation), and `compute_local_aabb` is O(1) for all shape types we construct (TriMesh reads the BVH root AABB, Compound returns a cached field, primitives are arithmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)