### PR TITLE
fix(ui_input): preserve cursor position on submit when clearOnSubmit=false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 [[package]]
 name = "bevy_simple_text_input"
 version = "0.11.1"
-source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#b4602cd531de4047d1c7f7ceb88acf45b20519a1"
+source = "git+https://github.com/robtfm/bevy_simple_text_input?branch=0.16#1f4e184cc4e6535dee7a953457a62d2945e21332"
 dependencies = [
  "bevy",
  "copypwasmta",


### PR DESCRIPTION
## Summary

Follow-up to #774. When `clearOnSubmit: false`, pressing Enter was moving the cursor to the start of the input field. Bumps `bevy_simple_text_input` to pick up [robtfm/bevy_simple_text_input@1f4e184](https://github.com/robtfm/bevy_simple_text_input/commit/1f4e184cc4e6535dee7a953457a62d2945e21332), which leaves the cursor where it was on submit when `retain_on_submit` is set.