### PR TITLE
Fix ContainingScene::get_ray hang at large Y positions

### DIFF
--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -641,11 +641,6 @@ impl ContainingScene<'_, '_> {
             ray = ray.normalize() * 1000.0;
         }
 
-        // Parcels are a 2D x/z grid with no height bound, so only x/z
-        // matter for grid traversal. The previous version walked y=16k
-        // planes instead of z=16k planes and could hang when adding the
-        // fixed `0.01` nudge to large y positions where it gets lost to
-        // f32 precision.
         let offset: Vec3 = Vec3::new(ray.x.signum() * 0.01, 0.0, ray.z.signum() * 0.01);
 
         loop {

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -641,7 +641,12 @@ impl ContainingScene<'_, '_> {
             ray = ray.normalize() * 1000.0;
         }
 
-        let offset: Vec3 = Vec3::new(ray.x.signum() * 0.01, ray.y.signum() * 0.01, 0.0);
+        // Parcels are a 2D x/z grid with no height bound, so only x/z
+        // matter for grid traversal. The previous version walked y=16k
+        // planes instead of z=16k planes and could hang when adding the
+        // fixed `0.01` nudge to large y positions where it gets lost to
+        // f32 precision.
+        let offset: Vec3 = Vec3::new(ray.x.signum() * 0.01, 0.0, ray.z.signum() * 0.01);
 
         loop {
             let adj_position = position + offset;
@@ -658,15 +663,15 @@ impl ContainingScene<'_, '_> {
             } else {
                 999.0
             };
-            let y_dist = if ray.y < 0.0 {
-                (((adj_position.y / 16.0).floor() * 16.0) - position.y) / ray.y
-            } else if ray.y > 0.0 {
-                (((adj_position.y / 16.0).ceil() * 16.0) - position.y) / ray.y
+            let z_dist = if ray.z < 0.0 {
+                (((adj_position.z / 16.0).floor() * 16.0) - position.z) / ray.z
+            } else if ray.z > 0.0 {
+                (((adj_position.z / 16.0).ceil() * 16.0) - position.z) / ray.z
             } else {
                 999.0
             };
 
-            let step_fraction = x_dist.min(y_dist);
+            let step_fraction = x_dist.min(z_dist);
             if step_fraction > 1.0 {
                 return results;
             }


### PR DESCRIPTION
## Summary
- `get_ray` was stepping along world-Y 16m planes instead of world-Z 16m planes. Parcels are a 2D x/z grid with no height bound, so the second axis should be Z.
- At large Y positions the fixed `0.01` f32 nudge in `offset` is lost to precision (past ~40k, ULP at that magnitude exceeds 0.01), so `y_dist` computed to 0, `step_fraction` was 0, the loop made no progress and never returned — observable by parking the player at y ≈ 1e6 and firing any scene raycast that targets the player.
- Switch the second-axis math to `position.z` / `ray.z` and drop the y component of the nudge. The ray's Y component still rides through `position += step` so the returned distance remains a true 3D ray length; it just no longer drives grid traversal.

Closes #784.