### PR TITLE
imposters: cancel in-flight downloads on handle drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "async-broadcast",
  "async-channel 2.5.0",
@@ -962,6 +962,7 @@ dependencies = [
  "either",
  "futures-io",
  "futures-lite",
+ "gloo-timers 0.3.0",
  "js-sys",
  "notify-debouncer-full",
  "parking_lot",
@@ -980,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1013,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1054,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1083,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1093,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1120,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1148,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1205,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1214,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1230,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1254,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1265,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1300,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1328,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1346,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1361,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1418,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1449,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1461,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1480,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1504,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1512,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1545,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1569,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1586,12 +1587,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1617,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1629,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1651,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1705,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1716,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1747,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1774,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1789,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1800,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1821,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1850,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1864,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1881,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1915,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1924,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1943,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4dfb0a19220f8797cede5045f98cdb1b854771d6"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#ede652c2afff2c1ff9d8f59907493e6b487c362f"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -6051,6 +6052,8 @@ dependencies = [
  "scene_runner",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-util",
  "tween",
  "urlencoding",
  "web-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ serde_json = { version = "1.0.92", features = ["raw_value"] }
 
 itertools = "0.12"
 tokio = { version = "1.44", features = ["sync", "macros", "rt"] }
+tokio-util = "*"
 anyhow = "1.0.70"
 http = "1.1"
 urn = "0.7.0"
@@ -305,22 +306,22 @@ bevy_time = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl
 bevy_winit = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }
 bevy_window = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }
 bevy_platform = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }
-# bevy = { path="../bevy" }
-# bevy_a11y = { path="../bevy/crates/bevy_a11y" }
-# bevy_asset = { path="../bevy/crates/bevy_asset" }
-# bevy_app = { path="../bevy/crates/bevy_app" }
-# bevy_derive = { path="../bevy/crates/bevy_derive" }
-# bevy_ecs = { path="../bevy/crates/bevy_ecs" }
-# bevy_image = { path="../bevy/crates/bevy_image" }
-# bevy_input = { path="../bevy/crates/bevy_input" }
-# bevy_log = { path="../bevy/crates/bevy_log" }
-# bevy_math = { path="../bevy/crates/bevy_math" }
-# bevy_reflect = { path="../bevy/crates/bevy_reflect" }
-# bevy_render = { path="../bevy/crates/bevy_render" }
-# bevy_time = { path="../bevy/crates/bevy_time" }
-# bevy_winit = { path="../bevy/crates/bevy_winit" }
-# bevy_window = { path="../bevy/crates/bevy_window" }
-# bevy_platform = { path="../bevy/crates/bevy_platform" }
+# bevy = { path = "../bevy-fork" }
+# bevy_a11y = { path = "../bevy-fork/crates/bevy_a11y" }
+# bevy_asset = { path = "../bevy-fork/crates/bevy_asset" }
+# bevy_app = { path = "../bevy-fork/crates/bevy_app" }
+# bevy_derive = { path = "../bevy-fork/crates/bevy_derive" }
+# bevy_ecs = { path = "../bevy-fork/crates/bevy_ecs" }
+# bevy_image = { path = "../bevy-fork/crates/bevy_image" }
+# bevy_input = { path = "../bevy-fork/crates/bevy_input" }
+# bevy_log = { path = "../bevy-fork/crates/bevy_log" }
+# bevy_math = { path = "../bevy-fork/crates/bevy_math" }
+# bevy_reflect = { path = "../bevy-fork/crates/bevy_reflect" }
+# bevy_render = { path = "../bevy-fork/crates/bevy_render" }
+# bevy_time = { path = "../bevy-fork/crates/bevy_time" }
+# bevy_winit = { path = "../bevy-fork/crates/bevy_winit" }
+# bevy_window = { path = "../bevy-fork/crates/bevy_window" }
+# bevy_platform = { path = "../bevy-fork/crates/bevy_platform" }
 
 ffmpeg-next = { git = "https://github.com/robtfm/rust-ffmpeg", branch = "audio-linesize-0-6.1" }
 parry3d-f64 = { git = "https://github.com/robtfm/parry", branch = "fix-bvh-negative-scale-0.25" }
@@ -352,7 +353,7 @@ wgpu-types = { git = "https://github.com/robtfm/wgpu", branch = "24.0.5-dcl" }
 naga = { git = "https://github.com/robtfm/wgpu", branch = "24.0.5-dcl" }
 
 # [patch."https://github.com/robtfm/bevy"]
-# bevy = { path = "../bevy" }
+# bevy = { path = "../bevy-fork" }
 
 # [patch."https://github.com/robtfm/bevy_dui"]
 # bevy_dui = { path = "../bevy_dui" }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -30,5 +30,5 @@ bevy_kira_audio = { workspace = true }
 hex = "0.4.3"
 smallvec = "1.11"
 rmp-serde = "1.3"
-tokio-util = "*"
+tokio-util = { workspace = true }
 pin-project = "1"

--- a/crates/imposters/Cargo.toml
+++ b/crates/imposters/Cargo.toml
@@ -26,6 +26,8 @@ crc = { workspace = true }
 reqwest = { workspace = true }
 
 zip = { version = "2", default-features = false }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-fs = { workspace = true }

--- a/crates/imposters/src/imposter_spec.rs
+++ b/crates/imposters/src/imposter_spec.rs
@@ -169,8 +169,7 @@ pub async fn load_imposter(
     }
 
     if download {
-        if let Err(e) =
-            load_imposter_remote(&ipfs, &id, parcel, level, required_crc, cancel).await
+        if let Err(e) = load_imposter_remote(&ipfs, &id, parcel, level, required_crc, cancel).await
         {
             warn!("{e}");
             return None;

--- a/crates/imposters/src/imposter_spec.rs
+++ b/crates/imposters/src/imposter_spec.rs
@@ -13,6 +13,7 @@ use bevy::{
 use common::structs::IVec2Arg;
 use ipfs::{ipfs_path::IpfsPath, IpfsIo};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tokio_util::sync::CancellationToken;
 use zip::ZipArchive;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -156,6 +157,7 @@ pub async fn load_imposter(
     level: usize,
     required_crc: Option<u32>,
     download: bool,
+    cancel: CancellationToken,
 ) -> Option<BakedScene> {
     if required_crc.is_some_and(|crc| crc == 0) {
         return None;
@@ -167,7 +169,9 @@ pub async fn load_imposter(
     }
 
     if download {
-        if let Err(e) = load_imposter_remote(&ipfs, &id, parcel, level, required_crc).await {
+        if let Err(e) =
+            load_imposter_remote(&ipfs, &id, parcel, level, required_crc, cancel).await
+        {
             warn!("{e}");
             return None;
         }
@@ -183,6 +187,7 @@ pub async fn load_imposter_remote(
     parcel: IVec2,
     level: usize,
     crc: Option<u32>,
+    cancel: CancellationToken,
 ) -> Result<(), anyhow::Error> {
     let client = ipfs.client();
     let zip_file = zip_path(None, id, parcel, level, crc)
@@ -195,11 +200,27 @@ pub async fn load_imposter_remote(
     debug!("zip_url {zip_url}");
 
     let request = client.get(&zip_url).build()?;
-    let response = ipfs.async_request(request, client).await?;
-    if response.status() != reqwest::StatusCode::OK {
-        return Ok(());
-    }
-    let bytes = response.bytes().await?;
+    // Race the network fetch + body read against the cancel token. If the
+    // owning `ImposterLoadTask` Component is dropped (entity despawn / out of
+    // range), this future is dropped together with the `select!`, releasing
+    // the IPFS semaphore permit and (on wasm) firing reqwest's `AbortGuard`
+    // to abort the in-flight browser fetch.
+    let bytes = tokio::select! {
+        fetched = async {
+            let response = ipfs.async_request(request, client).await?;
+            if response.status() != reqwest::StatusCode::OK {
+                return Ok(None);
+            }
+            Ok::<_, anyhow::Error>(Some(response.bytes().await?))
+        } => match fetched? {
+            Some(bytes) => bytes,
+            None => return Ok(()),
+        },
+        _ = cancel.cancelled() => {
+            debug!("imposter load cancelled: id={id} parcel={parcel} level={level} url={zip_url}");
+            return Ok(());
+        }
+    };
     let mut zip = ZipArchive::new(Cursor::new(bytes))?;
     let root = file_root(ipfs.cache_path(), false, id, level);
     platform_fs::create_dir_all(&root).await?;

--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -30,6 +30,8 @@ use scene_runner::{
     renderer_context::RendererSceneContext,
 };
 
+use tokio_util::sync::CancellationToken;
+
 use crate::{
     bake_scene::IMPOSTERCEPTION_LAYER,
     floor_imposter::{FloorImposter, FloorImposterLoader},
@@ -122,18 +124,32 @@ pub struct SceneImposter {
 }
 
 #[derive(Component)]
-pub struct ImposterLoadTask(Task<Option<BakedScene>>);
+pub struct ImposterLoadTask(Task<Option<BakedScene>>, CancellationToken);
+
+impl Drop for ImposterLoadTask {
+    fn drop(&mut self) {
+        // On native, `Task::drop` already cancels the future. On wasm,
+        // `bevy_tasks::Task` is uncancellable (it wraps a `wasm_bindgen_futures::spawn_local`
+        // task with no abort handle), so we use this explicit signal — the task body
+        // races against `cancel.cancelled()` and drops its work future (and thereby
+        // the IPFS permit and the in-flight reqwest fetch) when this fires.
+        self.1.cancel();
+    }
+}
 
 impl ImposterLoadTask {
     pub fn new_scene(ipfas: &IpfsAssetServer, scene_hash: &str, download: bool) -> Self {
-        Self(IoTaskPool::get().spawn_compat(load_imposter(
+        let cancel = CancellationToken::new();
+        let task = IoTaskPool::get().spawn_compat(load_imposter(
             ipfas.ipfs().clone(),
             scene_hash.to_string(),
             IVec2::MAX,
             0,
             None, // don't need to check since we load by id,
             download,
-        )))
+            cancel.clone(),
+        ));
+        Self(task, cancel)
     }
 
     pub fn new_mip(
@@ -144,14 +160,17 @@ impl ImposterLoadTask {
         crc: u32,
         download: bool,
     ) -> Self {
-        Self(IoTaskPool::get().spawn_compat(load_imposter(
+        let cancel = CancellationToken::new();
+        let task = IoTaskPool::get().spawn_compat(load_imposter(
             ipfas.ipfs().clone(),
             address.to_string(),
             parcel,
             level,
             Some(crc),
             download,
-        )))
+            cancel.clone(),
+        ));
+        Self(task, cancel)
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds handle-drop cancellation to imposter ZIP downloads on wasm. `ImposterLoadTask` carries a `tokio_util::sync::CancellationToken`; its `Drop` calls `cancel.cancel()`, and `load_imposter_remote` races the fetch + body read against `cancel.cancelled()`. When the owning Component is dropped (entity despawn, out of range, realm change), the work future is dropped together with the `tokio::select!`, releasing the IPFS semaphore permit and — on wasm, where `bevy_tasks::Task` is uncancellable since it wraps an opaque `wasm_bindgen_futures::spawn_local` — firing reqwest's `AbortGuard` to abort the in-flight browser fetch.
- Bumps the bevy fork to `ede652c2` to pick up the matching cancellation for the wasm asset thread loader: the worker handler now polls `AssetInfos::path_to_id` every 2 s and drops the load when no strong handles remain.
- Hoists `tokio-util` into `[workspace.dependencies]` and converts `crates/common`'s inline use to `{ workspace = true }`.

## Why

Pre-fix, scene change or realm switch on wasm left in-flight imposter and asset loads running to natural completion, holding IPFS semaphore permits the whole time (up to ~95 s × 3 attempts per stuck remote). This starved the new scene's loads behind zombies of the old one. With the fix, both the asset thread loader and imposter downloads abort within ≤2 s of handle drop and release their permits.