### PR TITLE
Switch npm publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
       - name: Set package.json version
         uses: decentraland/oddish-action@master
         with:
@@ -261,5 +262,3 @@ jobs:
           access: public
           gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
           gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump Node to 24 in the `build-deploy-web` job — its bundled npm is ≥ 11.5.1, the floor for OIDC trusted publisher auto-detection
- Move `registry-url` onto `setup-node` so the OIDC flow knows the target registry
- Drop `NODE_AUTH_TOKEN: NPM_TOKEN` from the publish step — with OIDC, npm mints a short-lived token from the GitHub-issued ID token, and a static token would override that

Requires a one-time setup on npmjs.com: in the package settings, add a Trusted Publisher pointing at `decentraland/bevy-explorer`, workflow filename `ci.yml`, no environment.

`permissions.id-token: write` is already set on the job.

## What could break
- If `decentraland/oddish-action` strips the OIDC env vars (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) or injects its own auth token, publish will fail with 401/403. Fallback: replace the action with a plain `npm publish ./deploy/web --access public --provenance` step.
- If the Trusted Publisher isn't configured on npmjs.com before this merges, the first release after merge will fail to publish.
- Node 24 instead of 22 for the web publish job — the WASM build itself isn't affected (that's Rust/wasm-pack), but if any postinstall scripts in deploy/web are pinned to Node 22, watch for incompatibilities.
- GitLab CDN deploy is unchanged and still uses its own secret.

## How to test
- [ ] Configure the Trusted Publisher on npmjs.com (org decentraland, repo bevy-explorer, workflow ci.yml)
- [ ] Merge to main and watch the next Build and Deploy Web run — confirm publish step succeeds without NPM_TOKEN
- [ ] Verify the new version appears on npmjs.com (bonus: provenance badge)