### PR TITLE
Fix scrollbar mispositioned on recreate (stale GlobalTransform)

### DIFF
--- a/crates/ui_core/src/scrollable.rs
+++ b/crates/ui_core/src/scrollable.rs
@@ -24,7 +24,8 @@ impl Plugin for ScrollablePlugin {
         app.add_systems(Startup, setup)
             .add_systems(
                 PostUpdate,
-                update_scrollables.after(TransformSystem::TransformPropagate),
+                (update_scrollables, resync_scrollbar_transforms)
+                    .after(TransformSystem::TransformPropagate),
             )
             .add_event::<ScrollTargetEvent>();
     }
@@ -35,6 +36,33 @@ fn setup(mut dui: ResMut<DuiRegistry>) {
     dui.register_template("vscroll", VerticalScrollTemplate);
     dui.register_template("hscroll", HorizontalScrollTemplate);
     dui.register_template("scroll", TwoWayScrollTemplate);
+}
+
+// Scrollbars/sliders are spawned and positioned in `update_scrollables`, which runs after
+// `TransformSystem::TransformPropagate`. Under the multithreaded executor, bevy 0.16's dirty-tree
+// transform propagation intermittently fails to refresh such a freshly-added child, leaving its
+// `GlobalTransform` stale (parent * identity) even once the local `Transform` is correct.
+//
+// Detect the mismatch (`GlobalTransform` != parent * local) and re-dirty the local `Transform` so
+// propagation retries next frame. Unlike an unconditional re-dirty, this stops once the transform
+// is correct, so it converges to a stable fixed point instead of perpetually re-exposing the bar
+// to the propagation race.
+#[allow(clippy::type_complexity)]
+fn resync_scrollbar_transforms(
+    mut bars: Query<
+        (&ChildOf, &GlobalTransform, &mut Transform),
+        Or<(With<ScrollBar>, With<Slider>)>,
+    >,
+    globals: Query<&GlobalTransform>,
+) {
+    for (child_of, global, mut transform) in bars.iter_mut() {
+        let Ok(parent_global) = globals.get(child_of.parent()) else {
+            continue;
+        };
+        if *global != parent_global.mul_transform(*transform) {
+            transform.set_changed();
+        }
+    }
 }
 
 pub trait SpawnScrollable {


### PR DESCRIPTION
## Problem

Scrollbars (and their sliders) sometimes render at the centre of their container instead of along the edge, on the second/subsequent creation of a scrollable UI element. Reproducible on native, never on wasm.

## Root cause

`update_scrollables` spawns and positions the bar/slider entities, and it runs *after* `TransformSystem::TransformPropagate` (it needs post-layout `ComputedNode` sizes). So a bar is a child added to an already-existing parent and only gets propagated the following frame.

Under the multithreaded executor, bevy 0.16's dirty-tree transform propagation intermittently fails to refresh such a freshly-added child: the bar's local `Transform` is correct, but its `GlobalTransform` is left stale at `parent * identity`, so it renders at the parent's centre. The static-subtree skip only recalculates a child when the child's own `TransformTreeChanged` is dirty or the parent's `GlobalTransform` *value* changed — and the static parent's never does, while the UI layout walk stops re-dirtying the bar's `Transform` once it settles. Net: no path back from the stale value. wasm runs the same propagation single-threaded, so it never hits the race.

## Fix

`resync_scrollbar_transforms` (PostUpdate, after `TransformPropagate`): for each bar/slider, if `GlobalTransform != parent_global * local`, re-dirty the local `Transform` so propagation retries next frame. It mirrors exactly what propagation computes, so it goes quiet the moment the value is correct — converging to a stable fixed point rather than re-exposing the node to the race every frame. Worst case is ~1 frame of wrong position before it self-corrects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)