### PR TITLE
Defer imposter loading while a high-priority scene loads

### DIFF
--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -25,7 +25,8 @@ use ipfs::IpfsAssetServer;
 
 use scene_runner::{
     initialize_scene::{
-        CurrentImposterScene, LiveScenes, PointerResult, SceneLoading, ScenePointers, PARCEL_SIZE,
+        CurrentImposterScene, CurrentSceneLoading, LiveScenes, PointerResult, SceneLoading,
+        ScenePointers, PARCEL_SIZE,
     },
     renderer_context::RendererSceneContext,
 };
@@ -222,6 +223,7 @@ pub fn spawn_imposters(
     live_scenes: Res<LiveScenes>,
     scenes: Query<&RendererSceneContext, Without<SceneLoading>>,
     current_imposter_scene: Res<CurrentImposterScene>,
+    current_scene_loading: Res<CurrentSceneLoading>,
     mut manager: ImposterSpecManager,
 ) {
     if current_realm.is_changed() || config.scene_imposter_distances.is_empty() {
@@ -239,6 +241,14 @@ pub fn spawn_imposters(
 
     // skip if no realm
     if manager.pointers.min() == IVec2::MAX {
+        return;
+    }
+
+    // defer imposter loading while the scene the player is in is still loading,
+    // so we don't contend with the active scene's asset loads (the scene
+    // lifecycle defers all other scenes under the same condition). Realm-change
+    // teardown above still runs; we only hold off requiring/loading new tiles.
+    if current_scene_loading.0 {
         return;
     }
 
@@ -497,6 +507,7 @@ pub struct ImposterSpecManager<'w, 's> {
     ipfas: IpfsAssetServer<'w, 's>,
     focus: Res<'w, ImposterFocus>,
     plugin: Res<'w, DclImposterPlugin>,
+    current_scene_loading: Res<'w, CurrentSceneLoading>,
 }
 
 const MAX_ASSET_LOADS: usize = 20;
@@ -842,6 +853,12 @@ impl<'w, 's> ImposterSpecManager<'w, 's> {
     }
 
     fn end_tick(&mut self) {
+        // while the scene the player is in is still loading, hold off starting
+        // new imposter downloads/loads so they don't contend with the active
+        // scene's asset fetches. In-flight tasks finish and the pending queue
+        // stays intact, resuming once the current scene is ready.
+        let defer = self.current_scene_loading.0;
+
         let ImposterManagerData {
             loading_mips,
             just_removed,
@@ -887,7 +904,11 @@ impl<'w, 's> ImposterSpecManager<'w, 's> {
         new_loading_handles.extend(
             requests
                 .into_iter()
-                .take(MAX_ASSET_LOADS - new_loading_handles.len())
+                .take(if defer {
+                    0
+                } else {
+                    MAX_ASSET_LOADS - new_loading_handles.len()
+                })
                 .take_while(|(_, req)| req.benefit > 0.0)
                 .map(|(imposter, req)| {
                     let imposter_handle = req.spec.imposter_data.map(|(_, path)| {
@@ -922,6 +943,13 @@ impl<'w, 's> ImposterSpecManager<'w, 's> {
         let count2 = new_loading_handles.len();
         *loading_handles = std::mem::take(&mut new_loading_handles);
         debug!("loading {} / {}", count, count2);
+
+        if defer {
+            // current scene still loading: leave loading_mips untouched so the
+            // pending-remote queue (and any in-flight fetches) survives intact,
+            // and start no new downloads this tick.
+            return;
+        }
 
         if self.plugin.download {
             // count current downloads

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -85,6 +85,7 @@ pub struct SceneLifecyclePlugin;
 impl Plugin for SceneLifecyclePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CurrentImposterScene>();
+        app.init_resource::<CurrentSceneLoading>();
         app.init_resource::<LiveScenes>();
         app.init_resource::<ScenePointers>();
         app.init_resource::<PortableScenes>();
@@ -1466,6 +1467,14 @@ fn load_active_entities(
 #[derive(Resource, Default)]
 pub struct CurrentImposterScene(pub Option<(PointerResult, bool)>);
 
+// true while a high-priority scene is still loading (not yet spawned, or within
+// its first few ticks): either the scene the player is standing in, or a system
+// (super-user) scene such as the UI. Imposter loading defers while this is set
+// so it doesn't contend with those scenes' asset loads. The current-scene part
+// mirrors the lifecycle's own deferral of all other scenes.
+#[derive(Resource, Default)]
+pub struct CurrentSceneLoading(pub bool);
+
 #[expect(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn process_scene_lifecycle(
     mut commands: Commands,
@@ -1473,7 +1482,12 @@ pub fn process_scene_lifecycle(
     portables: Res<PortableScenes>,
     focus: Query<&GlobalTransform, With<PrimaryUser>>,
     scene_entities: Query<
-        (Entity, &SceneHash, Option<&RendererSceneContext>),
+        (
+            Entity,
+            &SceneHash,
+            Option<&RendererSceneContext>,
+            Has<SuperUserScene>,
+        ),
         Or<(With<SceneLoading>, With<RendererSceneContext>)>,
     >,
     range: Res<SceneLoadDistance>,
@@ -1482,6 +1496,7 @@ pub fn process_scene_lifecycle(
     pointers: Res<ScenePointers>,
     imposter_scene: Res<CurrentImposterScene>,
     preview_mode: Res<PreviewMode>,
+    mut current_scene_loading_res: ResMut<CurrentSceneLoading>,
 ) {
     let mut required_scene_ids: HashMap<(String, Option<String>), bool> = HashMap::new();
 
@@ -1566,7 +1581,8 @@ pub fn process_scene_lifecycle(
 
     // despawn any no-longer required entities
     let mut current_scene_loading = false;
-    for (entity, scene_hash, maybe_ctx) in &scene_entities {
+    let mut system_scene_loading = false;
+    for (entity, scene_hash, maybe_ctx, is_super) in &scene_entities {
         match keep_entities.get(&entity) {
             Some((hash, _)) => {
                 existing_ids.insert(<&String>::clone(hash));
@@ -1580,13 +1596,20 @@ pub fn process_scene_lifecycle(
             }
         }
 
+        let still_loading = maybe_ctx.is_none_or(|ctx| ctx.tick_number <= 6 && !ctx.broken);
+
         // check if the current scene is still loading
         if let Some((current_hash, _)) = current_scene.as_ref() {
-            if &scene_hash.0 == current_hash
-                && maybe_ctx.is_none_or(|ctx| ctx.tick_number <= 6 && !ctx.broken)
-            {
+            if &scene_hash.0 == current_hash && still_loading {
                 current_scene_loading = true;
             }
+        }
+
+        // system/super-user scenes (e.g. the UI scene) are highest priority and
+        // exempt from the deferral below; track their load so imposters wait on
+        // them too, otherwise nothing blocks while the system scene loads.
+        if is_super && still_loading {
+            system_scene_loading = true;
         }
     }
     drop(keep_entities);
@@ -1595,14 +1618,20 @@ pub fn process_scene_lifecycle(
         live_scenes.scenes.remove(removed_hash);
     }
 
+    let mut defer_to_current_scene = false;
     if let Some(current_scene) = current_scene {
         if required_scene_ids.contains_key(&current_scene)
             && (!existing_ids.contains(&current_scene.0) || current_scene_loading)
         {
+            defer_to_current_scene = true;
             // if the current scene is not even spawned, spawn only that scene
             required_scene_ids.retain(|scene, super_user| *super_user || (scene == &current_scene));
         }
     }
+    // publish for imposter loading: defer while the current scene is loading
+    // (same condition the lifecycle uses above) or while a system scene is
+    // still loading (it's exempt from the deferral but still highest priority)
+    current_scene_loading_res.0 = defer_to_current_scene || system_scene_loading;
 
     if live_scenes.block_new_scenes {
         return;


### PR DESCRIPTION
## Problem

Imposter downloads and asset loads share the IPFS asset pipeline with active scenes. A large queue of pending imposters can contend with — and delay — the scene the player actually needs to load, both at startup and when walking into a not-yet-loaded scene.

`OutOfWorld` (`oow`) is **not** the right signal here: it's effectively startup-only, so walking into an unloaded scene leaves it false while the active scene is loading.

## Approach

Publish a `CurrentSceneLoading` resource from `process_scene_lifecycle`, set true while a **high-priority** scene is still loading:

- the player's **current-parcel scene** — the same condition the lifecycle already uses to defer all *other* scenes to the current one, and
- a **system/super-user scene** such as the UI — exempt from that scene deferral (always spawned, highest priority) but its own load must still hold back imposters, otherwise nothing gates them while it loads. Detected via the existing `SuperUserScene` marker.

"Loading" means *not yet spawned*, or `tick_number <= 6 && !broken` — so this only gates briefly at startup / scene entry and can never permanently block imposters.

## Gating

Imposters defer on the signal in two places:

- **`spawn_imposters`** early-returns (after realm-change teardown) so no new tiles are required.
- **`ImposterSpecManager::end_tick`** — the actual download/load throttle choke point — starts no new asset loads and skips the remote-download dispatch, **leaving the pending-remote queue and in-flight fetches intact** so they resume once the scene is ready. This is what holds back an existing backlog; the spawn gate alone would not, because `load_imposters` re-requests every pending imposter each tick.

The scene-spawning logic is unchanged — `system_scene_loading` is only OR'd into the *published* signal for imposters, not into the lifecycle's own `retain`/spawn deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)