### PR TITLE
Console commands: per-invocation response channel + concurrent dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
 [[package]]
 name = "bevy_console"
 version = "0.14.0"
-source = "git+https://github.com/robtfm/bevy-console?branch=0.16#8e8681ce2fbc62fee81e25a6222b64d79452450f"
+source = "git+https://github.com/robtfm/bevy-console?branch=0.16#636e66e2c032ad32a7f21ec7ea5389b00ae42b90"
 dependencies = [
  "ansi-parser",
  "bevy",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "bevy_console_derive"
 version = "0.5.0"
-source = "git+https://github.com/robtfm/bevy-console?branch=0.16#8e8681ce2fbc62fee81e25a6222b64d79452450f"
+source = "git+https://github.com/robtfm/bevy-console?branch=0.16#636e66e2c032ad32a7f21ec7ea5389b00ae42b90"
 dependencies = [
  "better-bae",
  "proc-macro2",

--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -1,7 +1,7 @@
 use bevy::{ecs::system::ScheduleSystem, prelude::*, scene::scene_spawner_system};
 use bevy_console::{
-    Command, ConsoleCommand, ConsoleCommandEntered, ConsoleConfiguration, ConsoleSet,
-    PrintConsoleLine,
+    Command, ConsoleCommand, ConsoleCommandEntered, ConsoleConfiguration, ConsoleResponder,
+    ConsoleSet, PrintConsoleLine,
 };
 use clap::Parser;
 use common::{rpc::RpcResultReceiver, sets::SceneSets};
@@ -180,55 +180,81 @@ pub fn send_pending(
         sender.write(ConsoleCommandEntered {
             command_name,
             args: Default::default(),
+            responder: None,
         });
     }
 }
 
 type ConsoleResponseFn = Box<dyn Fn() -> Option<Result<String, String>> + Send + Sync>;
 
+struct PendingResponse {
+    poll: ConsoleResponseFn,
+    /// If set, the result is delivered to this responder; otherwise it is written to
+    /// the console as reply lines followed by `[ok]` / `[failed]`.
+    responder: Option<ConsoleResponder>,
+}
+
 /// Stores pending async console command responses. Register a receiver with
-/// [`push_receiver`](PendingConsoleResponses::push_receiver) and a mapping function;
-/// the polling system will print `[ok]` or `[failed]` once the receiver resolves.
+/// [`push_receiver`](PendingConsoleResponses::push_receiver) and a mapping function.
+/// When the receiver resolves, the result is delivered to the command's
+/// [`ConsoleResponder`] if one was supplied (programmatic invocation), or printed to
+/// the console as reply lines followed by `[ok]` / `[failed]` (console invocation).
 #[derive(Resource, Default)]
-pub struct PendingConsoleResponses(Vec<ConsoleResponseFn>);
+pub struct PendingConsoleResponses(Vec<PendingResponse>);
 
 impl PendingConsoleResponses {
     /// Register an [`RpcResultReceiver`] to be polled each frame. When it resolves,
-    /// `map` converts the value to `Ok(message)` or `Err(message)`, and the
-    /// appropriate console line is printed followed by `[ok]` or `[failed]`.
-    pub fn push_receiver<T, F>(&mut self, receiver: RpcResultReceiver<T>, map: F)
-    where
+    /// `map` converts the value to `Ok(message)` or `Err(message)`, which is then
+    /// delivered to `responder` (or printed to the console if `responder` is `None`).
+    ///
+    /// `responder` is typically obtained from [`ConsoleCommand::take_responder`].
+    pub fn push_receiver<T, F>(
+        &mut self,
+        receiver: RpcResultReceiver<T>,
+        map: F,
+        responder: Option<ConsoleResponder>,
+    ) where
         T: Send + 'static,
         F: Fn(T) -> Result<String, String> + Send + Sync + 'static,
     {
         let receiver = Mutex::new(receiver);
-        self.0.push(Box::new(move || {
-            let mut guard = receiver.lock().unwrap();
-            match guard.poll_once() {
-                Ok(Some(val)) => Some(map(val)),
-                Ok(None) => None,
-                Err(()) => Some(Err("cancelled".to_string())),
-            }
-        }));
+        self.0.push(PendingResponse {
+            poll: Box::new(move || {
+                let mut guard = receiver.lock().unwrap();
+                match guard.poll_once() {
+                    Ok(Some(val)) => Some(map(val)),
+                    Ok(None) => None,
+                    Err(()) => Some(Err("cancelled".to_string())),
+                }
+            }),
+            responder,
+        });
     }
 
     /// Register a raw tokio oneshot receiver to be polled each frame.
-    pub fn push_oneshot<T, F>(&mut self, receiver: tokio::sync::oneshot::Receiver<T>, map: F)
-    where
+    pub fn push_oneshot<T, F>(
+        &mut self,
+        receiver: tokio::sync::oneshot::Receiver<T>,
+        map: F,
+        responder: Option<ConsoleResponder>,
+    ) where
         T: Send + 'static,
         F: Fn(T) -> Result<String, String> + Send + Sync + 'static,
     {
         let receiver = Mutex::new(receiver);
-        self.0.push(Box::new(move || {
-            let mut guard = receiver.lock().unwrap();
-            match guard.try_recv() {
-                Ok(val) => Some(map(val)),
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
-                Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
-                    Some(Err("cancelled".to_string()))
+        self.0.push(PendingResponse {
+            poll: Box::new(move || {
+                let mut guard = receiver.lock().unwrap();
+                match guard.try_recv() {
+                    Ok(val) => Some(map(val)),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
+                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                        Some(Err("cancelled".to_string()))
+                    }
                 }
-            }
-        }));
+            }),
+            responder,
+        });
     }
 }
 
@@ -236,20 +262,22 @@ fn poll_console_responses(
     mut pending: ResMut<PendingConsoleResponses>,
     mut console: EventWriter<PrintConsoleLine>,
 ) {
-    pending.0.retain(|f| match f() {
+    pending.0.retain(|entry| match (entry.poll)() {
         None => true,
-        Some(Ok(msg)) => {
-            if !msg.is_empty() {
-                console.write(PrintConsoleLine::new(msg));
+        Some(result) => {
+            match &entry.responder {
+                Some(responder) => responder(result),
+                None => {
+                    let (msg, sentinel) = match result {
+                        Ok(msg) => (msg, "[ok]"),
+                        Err(msg) => (msg, "[failed]"),
+                    };
+                    if !msg.is_empty() {
+                        console.write(PrintConsoleLine::new(msg));
+                    }
+                    console.write(PrintConsoleLine::new(sentinel.into()));
+                }
             }
-            console.write(PrintConsoleLine::new("[ok]".into()));
-            false
-        }
-        Some(Err(msg)) => {
-            if !msg.is_empty() {
-                console.write(PrintConsoleLine::new(msg));
-            }
-            console.write(PrintConsoleLine::new("[failed]".into()));
             false
         }
     });

--- a/crates/restricted_actions/src/agent_commands.rs
+++ b/crates/restricted_actions/src/agent_commands.rs
@@ -56,17 +56,22 @@ fn move_player_to_cmd(
         });
         let (x, y, z) = (command.x, command.y, command.z);
         let has_duration = command.duration.is_some();
-        pending.push_receiver(rx, move |success| {
-            if success {
-                Ok(if has_duration {
-                    format!("arrived at ({x}, {y}, {z})")
+        let responder = input.take_responder();
+        pending.push_receiver(
+            rx,
+            move |success| {
+                if success {
+                    Ok(if has_duration {
+                        format!("arrived at ({x}, {y}, {z})")
+                    } else {
+                        format!("moved to ({x}, {y}, {z})")
+                    })
                 } else {
-                    format!("moved to ({x}, {y}, {z})")
-                })
-            } else {
-                Err("move cancelled".to_string())
-            }
-        });
+                    Err("move cancelled".to_string())
+                }
+            },
+            responder,
+        );
     }
 }
 
@@ -104,13 +109,18 @@ fn walk_player_to_cmd(
             response,
         });
         let (x, y, z) = (command.x, command.y, command.z);
-        pending.push_receiver(rx, move |success| {
-            if success {
-                Ok(format!("arrived at ({x}, {y}, {z})"))
-            } else {
-                Err("walk failed or timed out".to_string())
-            }
-        });
+        let responder = input.take_responder();
+        pending.push_receiver(
+            rx,
+            move |success| {
+                if success {
+                    Ok(format!("arrived at ({x}, {y}, {z})"))
+                } else {
+                    Err("walk failed or timed out".to_string())
+                }
+            },
+            responder,
+        );
     }
 }
 
@@ -149,17 +159,22 @@ fn list_portables_cmd(
     if let Some(Ok(_)) = input.take() {
         let (response, rx) = RpcResultSender::<Vec<SpawnResponse>>::channel();
         events.write(RpcCall::ListPortables { response });
-        pending.push_receiver(rx, |portables| {
-            if portables.is_empty() {
-                Ok("no portables running".to_string())
-            } else {
-                Ok(portables
-                    .iter()
-                    .map(|p| format!("{} ({})", p.ens.as_deref().unwrap_or(&p.name), p.pid))
-                    .collect::<Vec<_>>()
-                    .join(", "))
-            }
-        });
+        let responder = input.take_responder();
+        pending.push_receiver(
+            rx,
+            |portables| {
+                if portables.is_empty() {
+                    Ok("no portables running".to_string())
+                } else {
+                    Ok(portables
+                        .iter()
+                        .map(|p| format!("{} ({})", p.ens.as_deref().unwrap_or(&p.name), p.pid))
+                        .collect::<Vec<_>>()
+                        .join(", "))
+                }
+            },
+            responder,
+        );
     }
 }
 
@@ -177,13 +192,18 @@ fn connected_players_cmd(
     if let Some(Ok(_)) = input.take() {
         let (response, rx) = RpcResultSender::<Vec<String>>::channel();
         events.write(RpcCall::GetConnectedPlayers { response });
-        pending.push_receiver(rx, |players| {
-            if players.is_empty() {
-                Ok("no other players connected".to_string())
-            } else {
-                Ok(players.join(", "))
-            }
-        });
+        let responder = input.take_responder();
+        pending.push_receiver(
+            rx,
+            |players| {
+                if players.is_empty() {
+                    Ok("no other players connected".to_string())
+                } else {
+                    Ok(players.join(", "))
+                }
+            },
+            responder,
+        );
     }
 }
 
@@ -242,15 +262,20 @@ fn get_user_data_cmd(
             response,
         });
         let label = command.address.unwrap_or_else(|| "self".to_string());
-        pending.push_receiver(rx, move |result| match result {
-            Ok(profile) => Ok(format!(
-                "{} ({}): v{}, web3={}",
-                profile.name,
-                profile.eth_address,
-                profile.version,
-                profile.has_connected_web3.unwrap_or(false),
-            )),
-            Err(()) => Err(format!("profile not found for {label}")),
-        });
+        let responder = input.take_responder();
+        pending.push_receiver(
+            rx,
+            move |result| match result {
+                Ok(profile) => Ok(format!(
+                    "{} ({}): v{}, web3={}",
+                    profile.name,
+                    profile.eth_address,
+                    profile.version,
+                    profile.has_connected_web3.unwrap_or(false),
+                )),
+                Err(()) => Err(format!("profile not found for {label}")),
+            },
+            responder,
+        );
     }
 }

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -14,7 +14,7 @@ use bevy::{
     prelude::*,
     tasks::{IoTaskPool, Task},
 };
-use bevy_console::{ConsoleCommand, PrintConsoleLine};
+use bevy_console::{ConsoleCommand, ConsoleResponder, PrintConsoleLine};
 use bevy_dui::{DuiEntityCommandsExt, DuiProps, DuiRegistry};
 use common::{
     profile::SerializedProfile,
@@ -1742,6 +1742,7 @@ struct PendingPortableCommands(
     Vec<(
         Task<Result<(String, PortableSource), String>>,
         PortableAction,
+        Option<ConsoleResponder>,
     )>,
 );
 
@@ -1759,6 +1760,7 @@ fn spawn_portable_command(
     ipfas: IpfsAssetServer,
 ) {
     if let Some(Ok(command)) = input.take() {
+        let responder = input.take_responder();
         pending.0.push((
             IoTaskPool::get().spawn_compat(lookup_ens(
                 None,
@@ -1767,6 +1769,7 @@ fn spawn_portable_command(
                 ipfas.ipfs().clone(),
             )),
             PortableAction::Spawn,
+            responder,
         ));
     }
 }
@@ -1784,6 +1787,7 @@ fn kill_portable_command(
     ipfas: IpfsAssetServer,
 ) {
     if let Some(Ok(command)) = input.take() {
+        let responder = input.take_responder();
         pending.0.push((
             IoTaskPool::get().spawn_compat(lookup_ens(
                 None,
@@ -1792,6 +1796,7 @@ fn kill_portable_command(
                 ipfas.ipfs().clone(),
             )),
             PortableAction::Kill,
+            responder,
         ));
     }
 }
@@ -1801,26 +1806,36 @@ fn handle_spawned_command(
     mut portables: ResMut<PortableScenes>,
     mut reply: EventWriter<PrintConsoleLine>,
 ) {
-    pending.0.retain_mut(|(task, action)| {
+    pending.0.retain_mut(|(task, action, responder)| {
         if let Some(result) = task.complete() {
-            match result {
+            let outcome: Result<String, String> = match result {
                 Ok((hash, source)) => match action {
                     PortableAction::Spawn => {
                         portables.insert(hash.clone(), source);
-                        reply.write(PrintConsoleLine::new("[ok]".into()));
+                        Ok(String::new())
                     }
                     PortableAction::Kill => {
                         if portables.remove(&hash).is_some() {
-                            reply.write(PrintConsoleLine::new("[ok]".into()));
+                            Ok(String::new())
                         } else {
-                            reply.write(PrintConsoleLine::new("portable not running".into()));
-                            reply.write(PrintConsoleLine::new("[failed]".into()));
+                            Err("portable not running".to_string())
                         }
                     }
                 },
-                Err(e) => {
-                    reply.write(PrintConsoleLine::new(format!("failed to lookup ens: {e}")));
-                    reply.write(PrintConsoleLine::new("[failed]".into()));
+                Err(e) => Err(format!("failed to lookup ens: {e}")),
+            };
+
+            match responder.take() {
+                Some(responder) => responder(outcome),
+                None => {
+                    let (msg, sentinel) = match outcome {
+                        Ok(msg) => (msg, "[ok]"),
+                        Err(msg) => (msg, "[failed]"),
+                    };
+                    if !msg.is_empty() {
+                        reply.write(PrintConsoleLine::new(msg));
+                    }
+                    reply.write(PrintConsoleLine::new(sentinel.into()));
                 }
             }
             false

--- a/crates/scene_inspector/src/read_commands.rs
+++ b/crates/scene_inspector/src/read_commands.rs
@@ -197,7 +197,7 @@ fn scene_entities_cmd(
             };
             let _ = tx.send(result);
         }) {
-            Ok(()) => console_responses.push_oneshot(rx, |r| r),
+            Ok(()) => console_responses.push_oneshot(rx, |r| r, input.take_responder()),
             Err(e) => input.reply_failed(e),
         }
     }
@@ -259,7 +259,7 @@ fn entity_components_cmd(
             };
             let _ = tx.send(result);
         }) {
-            Ok(()) => console_responses.push_oneshot(rx, |r| r),
+            Ok(()) => console_responses.push_oneshot(rx, |r| r, input.take_responder()),
             Err(e) => input.reply_failed(e),
         }
     }
@@ -333,7 +333,7 @@ fn inspect_component_cmd(
                 "entity {entity_str} has no component '{component_str}'"
             )));
         }) {
-            Ok(()) => console_responses.push_oneshot(rx, |r| r),
+            Ok(()) => console_responses.push_oneshot(rx, |r| r, input.take_responder()),
             Err(e) => input.reply_failed(e),
         }
     }
@@ -469,7 +469,7 @@ fn scene_tree_cmd(
             };
             let _ = tx.send(result);
         }) {
-            Ok(()) => console_responses.push_oneshot(rx, |r| r),
+            Ok(()) => console_responses.push_oneshot(rx, |r| r, input.take_responder()),
             Err(e) => input.reply_failed(e),
         }
     }
@@ -563,7 +563,7 @@ fn crdt_snapshot_cmd(
             let result = serde_json::to_string(&entity_map).unwrap_or_default();
             let _ = tx.send(Ok(result));
         }) {
-            Ok(()) => console_responses.push_oneshot(rx, |r| r),
+            Ok(()) => console_responses.push_oneshot(rx, |r| r, input.take_responder()),
             Err(e) => input.reply_failed(e),
         }
     }

--- a/crates/scene_inspector/src/write_commands.rs
+++ b/crates/scene_inspector/src/write_commands.rs
@@ -41,12 +41,20 @@ fn set_component_cmd(
     crdt_interfaces: Res<CrdtExtractors>,
     mut commands: Commands,
 ) {
-    if let Some(Ok(cmd)) = input.take() {
+    // Stage the immediate Bevy-side updates so a batch of invocations in one frame is
+    // delivered as a single `CrdtStateComponent` per component, rather than each
+    // overwriting the previous on the scene root (`process_crdt_lww_updates` only sees the
+    // last insert).
+    let mut bevy_updates = CrdtStore::default();
+    let mut touched: Vec<SceneComponentId> = Vec::new();
+    let mut scene_root = None;
+
+    while let Some(Ok(cmd)) = input.take() {
         let eid = match parse_entity_id(&cmd.entity) {
             Ok(e) => e,
             Err(e) => {
                 input.reply_failed(e);
-                return;
+                continue;
             }
         };
 
@@ -54,7 +62,7 @@ fn set_component_cmd(
             Some(e) => e,
             None => {
                 input.reply_failed(format!("unknown component '{}'", cmd.component));
-                return;
+                continue;
             }
         };
 
@@ -62,7 +70,7 @@ fn set_component_cmd(
             Some(f) => f.clone(),
             None => {
                 input.reply_failed(format!("'{}' is read-only", cmd.component));
-                return;
+                continue;
             }
         };
 
@@ -74,7 +82,7 @@ fn set_component_cmd(
             Ok(b) => b,
             Err(e) => {
                 input.reply_failed(format!("invalid JSON: {e}"));
-                return;
+                continue;
             }
         };
 
@@ -88,25 +96,36 @@ fn set_component_cmd(
                     Some(&mut DclReader::new(&bytes)),
                 );
 
-                // Also apply immediately to the Bevy entity so the renderer reflects the change
-                // without waiting for the scene to echo it back. Pure scene-side components have
-                // no entry in CrdtExtractors and will be applied when the scene echoes the write.
-                if let Some(interface) = crdt_interfaces.0.get(&component_id) {
-                    let mut mini_crdt = CrdtStore::default();
-                    mini_crdt.force_update(
+                // Stage the write for immediate application to the Bevy entity so the
+                // renderer reflects the change without waiting for the scene to echo it
+                // back. Pure scene-side components have no entry in CrdtExtractors and are
+                // applied when the scene echoes the write. Staged updates are flushed once,
+                // after the loop, so concurrent invocations don't clobber one another.
+                if crdt_interfaces.0.contains_key(&component_id) {
+                    bevy_updates.force_update(
                         component_id,
                         crdt_type,
                         eid,
                         Some(&mut DclReader::new(&bytes)),
                     );
-                    interface.updates_to_entity(
-                        component_id,
-                        &mut mini_crdt,
-                        &mut commands.entity(scene_entity),
-                    );
+                    if !touched.contains(&component_id) {
+                        touched.push(component_id);
+                    }
+                    scene_root = Some(scene_entity);
                 }
 
                 input.reply_ok(format!("set {}.{} = {json}", cmd.entity, cmd.component));
+            }
+        }
+    }
+
+    // Flush staged updates: one `CrdtStateComponent` per component, carrying every entity
+    // touched this run, so a batch applies in full rather than only the last invocation.
+    if let Some(scene_entity) = scene_root {
+        let mut entity_commands = commands.entity(scene_entity);
+        for component_id in touched {
+            if let Some(interface) = crdt_interfaces.0.get(&component_id) {
+                interface.updates_to_entity(component_id, &mut bevy_updates, &mut entity_commands);
             }
         }
     }
@@ -156,12 +175,12 @@ fn collect_descendants(crdt_store: &CrdtStore, root_eid: SceneEntityId) -> HashS
 }
 
 fn delete_entity_cmd(mut input: ConsoleCommand<DeleteEntityCommand>, mut resolver: SceneResolver) {
-    if let Some(Ok(cmd)) = input.take() {
+    while let Some(Ok(cmd)) = input.take() {
         let eid = match parse_entity_id(&cmd.entity) {
             Ok(e) => e,
             Err(e) => {
                 input.reply_failed(e);
-                return;
+                continue;
             }
         };
 
@@ -170,7 +189,7 @@ fn delete_entity_cmd(mut input: ConsoleCommand<DeleteEntityCommand>, mut resolve
             Ok((_scene_entity, mut ctx)) => {
                 if ctx.bevy_entity(eid).is_none() {
                     input.reply_failed(format!("entity {} does not exist", cmd.entity));
-                    return;
+                    continue;
                 }
 
                 let to_delete = if cmd.recursive {

--- a/crates/system_bridge/src/agent_commands.rs
+++ b/crates/system_bridge/src/agent_commands.rs
@@ -48,10 +48,15 @@ fn login_previous_cmd(
     if let Some(Ok(_)) = input.take() {
         let (sx, rx) = common::rpc::RpcResultSender::<Result<(), String>>::channel();
         events.write(SystemApi::LoginPrevious(sx));
-        pending.push_receiver(rx, |result| match result {
-            Ok(()) => Ok("logged in with previous credentials".to_string()),
-            Err(e) => Err(e),
-        });
+        let responder = input.take_responder();
+        pending.push_receiver(
+            rx,
+            |result| match result {
+                Ok(()) => Ok("logged in with previous credentials".to_string()),
+                Err(e) => Err(e),
+            },
+            responder,
+        );
     }
 }
 
@@ -82,25 +87,30 @@ fn live_scenes_cmd(
     if let Some(Ok(_)) = input.take() {
         let (response, rx) = common::rpc::RpcResultSender::<Vec<LiveSceneInfo>>::channel();
         events.write(SystemApi::LiveSceneInfo(response));
-        pending.push_receiver(rx, |scenes| {
-            if scenes.is_empty() {
-                Ok("no scenes loaded".to_string())
-            } else {
-                Ok(scenes
-                    .iter()
-                    .map(|s| {
-                        format!(
-                            "{} [{}{}{}]",
-                            s.title,
-                            s.hash,
-                            if s.is_portable { ", portable" } else { "" },
-                            if s.is_broken { ", broken" } else { "" },
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n"))
-            }
-        });
+        let responder = input.take_responder();
+        pending.push_receiver(
+            rx,
+            |scenes| {
+                if scenes.is_empty() {
+                    Ok("no scenes loaded".to_string())
+                } else {
+                    Ok(scenes
+                        .iter()
+                        .map(|s| {
+                            format!(
+                                "{} [{}{}{}]",
+                                s.title,
+                                s.hash,
+                                if s.is_portable { ", portable" } else { "" },
+                                if s.is_broken { ", broken" } else { "" },
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n"))
+                }
+            },
+            responder,
+        );
     }
 }
 

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -1,16 +1,17 @@
 pub mod agent_commands;
 pub mod settings;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use bevy::{
     app::{AppExit, Plugin, Update},
-    ecs::{event::EventReader, system::Local},
+    ecs::event::EventReader,
     log::debug,
     math::Vec4,
     prelude::{Event, EventWriter, Res, ResMut, Resource},
 };
-use bevy_console::{ConsoleCommandEntered, ConsoleConfiguration, PrintConsoleLine};
+use bevy_console::{ConsoleCommandEntered, ConsoleConfiguration, ConsoleResponder};
 use common::{
     inputs::{BindingsData, InputIdentifier, SystemActionEvent},
     rpc::{RpcResultSender, RpcStreamSender},
@@ -380,53 +381,28 @@ pub fn post_events(
     mut bridge: ResMut<SystemBridge>,
     mut writer: EventWriter<SystemApi>,
     mut console: EventWriter<ConsoleCommandEntered>,
-    mut console_response: Local<Option<RpcResultSender<Result<String, String>>>>,
-    mut replies: EventReader<PrintConsoleLine>,
-    mut pending: Local<VecDeque<(String, Vec<String>, RpcResultSender<Result<String, String>>)>>,
     console_config: Res<ConsoleConfiguration>,
 ) {
     while let Ok(ev) = bridge.receiver.try_recv() {
-        if let SystemApi::ConsoleCommand(cmd, args, sender) = ev {
-            debug!("system bridge (cc): {cmd} {args:?}");
-            pending.push_back((cmd, args, sender));
-        } else {
+        let SystemApi::ConsoleCommand(cmd, args, sender) = ev else {
             debug!("system bridge: {ev:?}");
             writer.write(ev);
-        }
-    }
+            continue;
+        };
 
-    if let Some(response) = console_response.take() {
-        let mut reply = replies.read().collect::<Vec<_>>();
-        match reply.pop() {
-            Some(PrintConsoleLine { line }) if line.as_str() == "[ok]" => {
-                response.send(Ok(reply
-                    .into_iter()
-                    .map(|l| l.line.clone())
-                    .collect::<Vec<_>>()
-                    .join("\n")));
-            }
-            Some(PrintConsoleLine { line }) if line.as_str() == "[failed]" => {
-                response.send(Err(reply
-                    .into_iter()
-                    .map(|l| l.line.clone())
-                    .collect::<Vec<_>>()
-                    .join("\n")));
-            }
-            Some(PrintConsoleLine { line }) => {
-                debug!("got {line}");
-                *console_response = Some(response);
-            }
-            _ => {
-                *console_response = Some(response);
-            }
-        }
-    } else if let Some((cmd, args, sender)) = pending.pop_front() {
+        debug!("system bridge (cc): {cmd} {args:?}");
+
+        // Dispatch as a `ConsoleCommandEntered` carrying its own responder, so the result
+        // flows back through the channel rather than being scraped from shared console
+        // output. `bevy_console` queues concurrent invocations and refires any it can't
+        // process this frame, so there is no need to serialize dispatch here.
         if console_config.commands.contains_key(cmd.as_str()) {
+            let responder: ConsoleResponder = Arc::new(move |result| sender.send(result));
             console.write(ConsoleCommandEntered {
                 command_name: cmd,
                 args,
+                responder: Some(responder),
             });
-            *console_response = Some(sender);
         } else {
             sender.send(Err(format!(
                 "Command not recognized: `{cmd}`. Recognized commands: {:?}",
@@ -434,8 +410,6 @@ pub fn post_events(
             )));
         }
     }
-
-    replies.clear();
 }
 
 fn handle_home_scene(mut ev: EventReader<SystemApi>, mut config: ResMut<AppConfig>) {

--- a/crates/system_ui/src/chat/mod.rs
+++ b/crates/system_ui/src/chat/mod.rs
@@ -549,7 +549,11 @@ fn emit_user_chat(
                 let command = console_config.commands.get(command_name.as_str());
 
                 if command.is_some() {
-                    command_entered.write(ConsoleCommandEntered { command_name, args });
+                    command_entered.write(ConsoleCommandEntered {
+                        command_name,
+                        args,
+                        responder: None,
+                    });
                 } else {
                     debug!(
                         "Command not recognized, recognized commands: `{:?}`",
@@ -738,7 +742,11 @@ fn pipe_chats_from_scene(
             let command = console_config.commands.get(command_name.as_str());
 
             if command.is_some() {
-                command_entered.write(ConsoleCommandEntered { command_name, args });
+                command_entered.write(ConsoleCommandEntered {
+                    command_name,
+                    args,
+                    responder: None,
+                });
             } else {
                 sender.write(ChatEvent {
                     timestamp: time.elapsed_secs_f64(),


### PR DESCRIPTION
## Problem

Agent/console commands (defined with clap, replying via `reply_ok`/`reply_failed`) are invoked through three channels: the browser console (`engine.command()`), super-user scenes (`op_console_command`), and in-game `/command` chat. The two programmatic channels build an `RpcResultSender` but then throw it away — `post_events` reconstructed the result by **scraping the shared `PrintConsoleLine` stream** for `[ok]`/`[failed]` sentinels. Because that stream is global, parallel commands interleaved and got misattributed, so dispatch had to be serialized one-at-a-time.

## Approach

Thread a per-invocation response channel from dispatch all the way to the handler's reply, so the result flows back over the channel instead of via console output. In-game chat keeps its existing behavior (no responder → writes `PrintConsoleLine` as before).

- **bevy_console** (`robtfm/bevy-console@0.16`, bumped here): `ConsoleCommandEntered` carries an optional `ConsoleResponder`; `ConsoleCommand`'s reply methods resolve it when present, else write to the console. `take()` now drains a per-frame queue of all matching invocations — single-exec handlers take one and the rest are re-emitted via `SystemParam::apply` to be retried next frame; a handler can `while let Some(Ok(c)) = cmd.take()` to process every concurrent invocation in one frame.
- **`post_events`** dispatches every pending command at once (no throttle, no scraping); each carries its own responder.
- **`PendingConsoleResponses`** and the portable `/spawn`–`/kill` queue thread the responder through for deferred (async) results.
- **`/set_component`** and **`/delete_entity`** opt into same-frame batched execution. `/set_component` additionally stages its immediate Bevy-side apply and flushes once after the loop, so a batch updates every entity rather than only the last (the per-invocation `CrdtStateComponent` insert on the scene root otherwise clobbers all but the last).

The browser and super-user-scene entry points are unchanged — they already awaited an `RpcResultSender`; they now receive the real result instead of a scraped string.

Depends on robtfm/bevy-console@0.16 `636e66e` (pinned in `Cargo.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)