### PR TITLE
chore: pin 1466587594/get-current-time to commit SHA

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,13 +16,13 @@ jobs:
             uses: actions/checkout@v3
 
           - name: Get current time with underscores
-            uses: 1466587594/get-current-time@v2.1.1
+            uses: 1466587594/get-current-time@5979d2f4455ed5df566aa6df67cedd77d17afaa9 # v2.1.1, pinned for supply-chain safety
             id: current_time_underscores
             with:
                 format: YYYY-MM-DD-HH-mm-ss
 
           - name: Get current time with dashes
-            uses: 1466587594/get-current-time@v2.1.1
+            uses: 1466587594/get-current-time@5979d2f4455ed5df566aa6df67cedd77d17afaa9 # v2.1.1, pinned for supply-chain safety
             id: current_time_dashes
             with:
                 format: YYYY-MM-DD-HH-mm-ss


### PR DESCRIPTION
- Pins 1466587594/get-current-time from the mutable tag @v2.1.1 to its immutable commit SHA (5979d2f)

Part of the wider effort to pin third-party GitHub Actions to fixed versions and avoid pulling compromised upstream code on the fly. Behavior unchanged — no version bump.