### PR TITLE
Make movePlayerTo facing authoritative over scene-driven orientation

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1093,6 +1093,12 @@ pub struct EngineMovementControl {
     pub suppress_clipping: HashSet<&'static str>,
     /// Non-empty means avatar physics movement systems are suppressed (e.g. "move_player_to" during interpolation)
     pub suppress_avatar_physics: HashSet<&'static str>,
+    /// Scene-driven `AvatarMovement` is ignored (physics suppressed) until a tick
+    /// initiated strictly after this time (engine dispatch clock, `last_sent` secs)
+    /// is received. Set by `movePlayerTo` when it imposes a facing, so the imposed
+    /// orientation survives until the controller scene reads the new transform and
+    /// echoes it back, rather than being clobbered by an in-flight stale tick.
+    pub accept_movement_after: f32,
 }
 
 #[derive(Default, Clone, Copy, PartialEq, Eq)]

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -205,7 +205,12 @@ pub fn handle_player_move_requests(
     mut perms: Permission<PendingPlayerMove>,
     mut movement_control: ResMut<EngineMovementControl>,
     mut movement_info: ResMut<AvatarMovementInfo>,
+    time: Res<Time>,
 ) {
+    // Engine dispatch clock, matching RendererSceneContext::last_sent. Constant
+    // within a frame, so a same-frame scene dispatch compares equal (and is treated
+    // as stale by the strict `>` acceptance test in apply_movement).
+    let now = time.elapsed_secs();
     let Ok((player_entity, _, _, _)) = player.single() else {
         return;
     };
@@ -257,6 +262,7 @@ pub fn handle_player_move_requests(
                     &mut player,
                     &mut movement_control,
                     &mut movement_info,
+                    now,
                 );
             }
             Some(scene_ent) => {
@@ -311,6 +317,7 @@ pub fn handle_player_move_requests(
             &mut player,
             &mut movement_control,
             &mut movement_info,
+            now,
         );
     }
 
@@ -320,6 +327,7 @@ pub fn handle_player_move_requests(
 }
 
 #[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments)]
 fn apply_player_move(
     commands: &mut Commands,
     player_entity: Entity,
@@ -336,6 +344,7 @@ fn apply_player_move(
     >,
     movement_control: &mut EngineMovementControl,
     movement_info: &mut AvatarMovementInfo,
+    now: f32,
 ) {
     let (_, mut player_transform, mut dynamics, maybe_active) = player.single_mut().unwrap();
     if let Some(active) = maybe_active {
@@ -384,6 +393,12 @@ fn apply_player_move(
                 dynamics.velocity =
                     rotation * player_transform.rotation.inverse() * dynamics.velocity;
                 player_transform.rotation = rotation;
+                // Hold this imposed facing against the scene-driven orientation pipeline:
+                // ignore any AvatarMovement initiated up to now, giving the controller
+                // scene time to read the new transform and echo the facing back. Without
+                // this, the next apply_movement re-applies the scene's stale orientation
+                // and the avatar snaps back (e.g. a keeper placed facing the kicker).
+                movement_control.accept_movement_after = now;
             }
         }
 

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -278,6 +278,10 @@ pub struct ActivePlayerComponent<C: Component> {
     scene_last_update: u32,
     scene_start_tick: u32,
     scene_is_portable: bool,
+    /// Engine dispatch time (`RendererSceneContext::last_sent`) of the scene tick
+    /// that produced `component`. Used to reject AvatarMovement that was initiated
+    /// before a `movePlayerTo`-imposed facing (and so read a stale transform).
+    initiated_at: f32,
     pub component: C,
 }
 
@@ -295,6 +299,7 @@ impl<C: Component + FromConfig> FromConfig for ActivePlayerComponent<C> {
             scene_last_update: 0,
             scene_start_tick: 0,
             scene_is_portable: true,
+            initiated_at: 0.0,
             component: C::from_config(config),
         }
     }
@@ -392,6 +397,7 @@ impl<C: Component + Clone + FromConfig> ActivePlayerComponent<C> {
                 scene_last_update: ctx.last_update_frame,
                 scene_start_tick: ctx.start_tick,
                 scene_is_portable: ctx.is_portable,
+                initiated_at: ctx.last_sent,
                 component: update.clone(),
             };
 
@@ -453,6 +459,7 @@ impl<C: Component + Clone + FromConfig> ActivePlayerComponent<C> {
                 scene_last_update: ctx.last_update_frame,
                 scene_start_tick: ctx.start_tick,
                 scene_is_portable: ctx.is_portable,
+                initiated_at: ctx.last_sent,
                 component: update.clone(),
             };
 
@@ -515,7 +522,14 @@ pub fn apply_movement(
 
     info.0.step_time = time_res.delta_secs();
 
-    let suppress = !movement_control.suppress_avatar_physics.is_empty();
+    // Suppress while an explicit suppression is held (e.g. movePlayerTo interpolation),
+    // OR while the active AvatarMovement was initiated before the most recent
+    // movePlayerTo-imposed facing — such a tick read a pre-teleport transform, so
+    // applying its orientation would clobber the imposed facing. Strict `>` (here as
+    // `<=` to suppress) treats a same-frame dispatch as stale, since `last_sent` is
+    // captured before this restricted-action runs and shares the frame's timestamp.
+    let suppress = !movement_control.suppress_avatar_physics.is_empty()
+        || movement.initiated_at <= movement_control.accept_movement_after;
     if !suppress {
         transform.rotation = Quat::from_rotation_y(movement.component.orientation / 360.0 * TAU);
     }


### PR DESCRIPTION
## Problem

An instant `movePlayerTo({ newRelativePosition, cameraTarget })` set the avatar's facing only once. Under scene-driven movement, `apply_movement` overwrites `transform.rotation` every frame from the controller scene's `AvatarMovement.orientation`, so the imposed facing was clobbered the same frame. Symptom: in goal-legends-arena the local player faced backwards when placed as the keeper (the keeper must face opposite the kicker, so it's the case that visibly breaks).

The one-shot facing was only protected for *interpolated* moves (`suppress_avatar_physics`), never for instant ones.

## Fix

A monotonic watermark, `EngineMovementControl::accept_movement_after`:

- `movePlayerTo` with a facing records the current dispatch time (`time.elapsed_secs()`, the same clock as `RendererSceneContext::last_sent`).
- `ActivePlayerComponent` gains `initiated_at`, captured from `ctx.last_sent` in both pickers, so the producing scene tick's dispatch time travels with the value.
- `apply_movement` suppresses **all** physics (including the orientation write) for any active `AvatarMovement` whose `initiated_at` is **not strictly after** the watermark.

This holds the imposed facing until the controller scene reads the new transform and echoes it back, and — crucially — rejects in-flight ticks that *started* before the request even if they *complete* after it. Because the test is per-value, multiple scene sources at different delays are each filtered correctly. Strict `>` treats a same-frame dispatch as stale, since `last_sent` is captured before this restricted action runs and `elapsed_secs()` is frame-constant (also dodges web timer granularity).

Requires the companion movement-scene change (robtfm/movement-scene#9) so the controller re-bases orientation on the live transform when locked; the two together make the first accepted value equal the imposed facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)