### PR TITLE
Allow /new_entity to instantiate at caller-specified ids

### DIFF
--- a/crates/dcl/src/interface/crdt_context.rs
+++ b/crates/dcl/src/interface/crdt_context.rs
@@ -120,6 +120,22 @@ impl CrdtContext {
         self.entity_entry(entity.id).0 > entity.generation
     }
 
+    // Queue an entity for creation at a caller-specified id (instead of a fresh allocation) — used to
+    // recreate entities at their original ids on a freshly-reloaded scene. Returns false if the id is
+    // already alive at that generation (a collision) or has aged past it (dead). Advances the
+    // fresh-allocation cursor past the id so a later `new_in_range` won't hand the same number out
+    // before the next census marks it alive.
+    pub fn alloc_explicit(&mut self, entity: SceneEntityId) -> bool {
+        if self.is_born(entity) {
+            return false; // already alive at this generation — collision
+        }
+        if !self.init(entity) {
+            return false; // dead/aged at this generation
+        }
+        self.last_new = entity.id;
+        true
+    }
+
     pub fn new_in_range(&mut self, range: &RangeInclusive<u16>) -> Option<SceneEntityId> {
         let mut next_new = self.last_new.wrapping_add(1);
         if !range.contains(&self.last_new) {

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -15,7 +15,7 @@ use crate::{
         AllocatorContext, CommunicatedWithRenderer, FilteredCrdtStore, RendererStore,
         SceneResponseSender, ShuttingDown,
     },
-    CrdtComponentInterfaces, CrdtStore, RendererResponse, RpcCalls, SceneElapsedTime,
+    AllocError, CrdtComponentInterfaces, CrdtStore, RendererResponse, RpcCalls, SceneElapsedTime,
     SceneLogMessage, SceneResponse,
 };
 
@@ -160,11 +160,17 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
                 component_id,
                 data,
                 count,
+                explicit_ids,
             }) => {
-                // Allocate fresh ids from the authoritative allocator (collision-free, correctly
+                // Allocate ids from the authoritative allocator (collision-free, correctly
                 // generationed) and reply immediately. Buffer the instantiating put_components so
                 // they're delivered with the next Ok tick rather than ticking the scene here — the
                 // scene's @dcl/ecs then adopts the entities on receive, before its update() runs.
+                //
+                // With `explicit_ids`, instantiate those exact ids instead of allocating fresh —
+                // used to recreate entities at their original ids on a freshly-reloaded scene. A
+                // requested id that's already alive (a collision) yields an `Err` in its slot, so
+                // the caller can surface it. Without it, `count` fresh ids.
                 //
                 // IMPORTANT: `component_id` MUST be a non-engine-recognized (custom) component.
                 // Engine-recognized components flow renderer→scene one-way (the scene never echoes
@@ -176,14 +182,37 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
                 let mut allocator = op_state.borrow_mut().take::<AllocatorContext>();
                 let mut filtered_store = op_state.borrow_mut().take::<FilteredCrdtStore>();
                 let scene_id = allocator.0.scene_id;
-                let mut ids = Vec::with_capacity(count);
-                for _ in 0..count {
-                    // authored entities live above the reserved-static range (512); avoid the
-                    // u16::MAX wrap sentinel used by new_in_range's `last_new`.
-                    let Some(id) = allocator.0.new_in_range(&(512..=u16::MAX - 1)) else {
-                        warn!("AllocateEntity: no free entity id");
-                        break;
+                // One result per requested slot, in order: a caller-specified id (validated below)
+                // or a freshly-allocated one, else the reason it couldn't be allocated. authored
+                // entities live above the reserved-static range (512); avoid the u16::MAX wrap
+                // sentinel used by new_in_range's `last_new`.
+                let results: Vec<Result<dcl_component::SceneEntityId, AllocError>> =
+                    match &explicit_ids {
+                        Some(protos) => protos
+                            .iter()
+                            .map(|p| {
+                                let entity = dcl_component::SceneEntityId::from_proto_u32(*p);
+                                if allocator.0.alloc_explicit(entity) {
+                                    Ok(entity)
+                                } else {
+                                    warn!("AllocateEntity: id {entity:?} already live (collision)");
+                                    Err(AllocError::Collision(entity))
+                                }
+                            })
+                            .collect(),
+                        None => (0..count)
+                            .map(|_| {
+                                allocator
+                                    .0
+                                    .new_in_range(&(512..=u16::MAX - 1))
+                                    .ok_or_else(|| {
+                                        warn!("AllocateEntity: no free entity id");
+                                        AllocError::NoFreeId
+                                    })
+                            })
+                            .collect(),
                     };
+                for id in results.iter().filter_map(|r| r.as_ref().ok()).copied() {
                     // Also record the instantiation in the sidecar so /crdt_snapshot reflects it —
                     // the scene never echoes the injected (renderer→scene) component back, so without
                     // this the editor's view of the component would vanish on the next reload.
@@ -200,15 +229,14 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
                         &SceneCrdtTimestamp(1),
                         Some(&data),
                     ));
-                    ids.push(id);
                 }
                 op_state.borrow_mut().put(allocator);
                 op_state.borrow_mut().put(filtered_store);
-                debug!("AllocateEntity: allocated {ids:?}");
+                debug!("AllocateEntity: {results:?}");
                 let _ = op_state
                     .borrow_mut()
                     .borrow_mut::<SceneResponseSender>()
-                    .try_send(SceneResponse::EntityAllocated(scene_id, ids));
+                    .try_send(SceneResponse::EntityAllocated(scene_id, results));
                 continue;
             }
             other => break other,

--- a/crates/dcl/src/lib.rs
+++ b/crates/dcl/src/lib.rs
@@ -43,10 +43,16 @@ pub enum RendererResponse {
     /// generationed) and instantiate each scene-side by injecting `put_component(id, component_id,
     /// data)` into the receive results — the only way to make the scene's `@dcl/ecs` adopt the
     /// entity. Replies with [`SceneResponse::EntityAllocated`].
+    ///
+    /// When `explicit_ids` is `Some`, those exact ids (proto-u32 form) are instantiated instead of
+    /// freshly allocated — used to recreate entities at their original ids on a freshly-reloaded
+    /// scene (where the id sits at its original generation and is free). `count` is ignored in that
+    /// case. A requested id that is currently alive is a collision and fails the request.
     AllocateEntity {
         component_id: SceneComponentId,
         data: Vec<u8>,
         count: usize,
+        explicit_ids: Option<Vec<u32>>,
     },
 }
 
@@ -70,8 +76,19 @@ pub enum SceneResponse {
     CompareSnapshot(CompareSnapshot),
     /// Response to [`RendererResponse::GetCrdtSnapshot`]: the full scene-side CRDT state.
     CrdtSnapshot(SceneId, CrdtStore),
-    /// Response to [`RendererResponse::AllocateEntity`]: the freshly-allocated entity ids.
-    EntityAllocated(SceneId, Vec<SceneEntityId>),
+    /// Response to [`RendererResponse::AllocateEntity`]: one result per requested slot, in order —
+    /// `Ok(id)` for an instantiated entity, `Err` for a slot that couldn't be allocated (an explicit
+    /// id that was already live, or no free id for a fresh allocation).
+    EntityAllocated(SceneId, Vec<Result<SceneEntityId, AllocError>>),
+}
+
+/// Why an [`RendererResponse::AllocateEntity`] slot couldn't be allocated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AllocError {
+    /// The requested explicit id was already live (a collision).
+    Collision(SceneEntityId),
+    /// No free id was available for a fresh allocation.
+    NoFreeId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]

--- a/crates/scene_inspector/src/active_scene.rs
+++ b/crates/scene_inspector/src/active_scene.rs
@@ -88,10 +88,11 @@ impl SceneResolver<'_, '_> {
         component_id: SceneComponentId,
         data: Vec<u8>,
         count: usize,
+        explicit_ids: Option<Vec<u32>>,
         callback: F,
     ) -> Result<(), String>
     where
-        F: FnOnce(&[SceneEntityId]) + Send + Sync + 'static,
+        F: FnOnce(&[Result<SceneEntityId, dcl::AllocError>]) + Send + Sync + 'static,
     {
         let entity = self.resolve_entity()?;
         let handle = self
@@ -104,6 +105,7 @@ impl SceneResolver<'_, '_> {
                 component_id,
                 data,
                 count,
+                explicit_ids,
             })
             .map_err(|_| "failed to send allocate request to scene".to_string())?;
         pending.push(entity, Box::new(callback) as AllocCallback);

--- a/crates/scene_inspector/src/snapshot.rs
+++ b/crates/scene_inspector/src/snapshot.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use dcl::interface::CrdtStore;
+use dcl::{interface::CrdtStore, AllocError};
 use dcl_component::SceneEntityId;
 use scene_runner::{
     renderer_context::RendererSceneContext, CrdtSnapshotEvent, EntityAllocatedEvent,
@@ -7,7 +7,7 @@ use scene_runner::{
 use std::collections::HashMap;
 
 pub type SnapshotCallback = Box<dyn FnOnce(&CrdtStore) + Send + Sync>;
-pub type AllocCallback = Box<dyn FnOnce(&[SceneEntityId]) + Send + Sync>;
+pub type AllocCallback = Box<dyn FnOnce(&[Result<SceneEntityId, AllocError>]) + Send + Sync>;
 
 /// Callbacks waiting for a CRDT snapshot from their scene thread.
 /// Requests are dispatched immediately via [`SceneResolver::request_snapshot`];
@@ -57,11 +57,17 @@ pub fn handle_entity_allocated_events(
 ) {
     for event in events.read() {
         if let Ok(mut ctx) = scenes.get_mut(event.scene_entity) {
-            ctx.nascent.extend(event.ids.iter().copied());
+            ctx.nascent.extend(
+                event
+                    .results
+                    .iter()
+                    .filter_map(|r| r.as_ref().ok())
+                    .copied(),
+            );
         }
         if let Some(callbacks) = pending.0.remove(&event.scene_entity) {
             for cb in callbacks {
-                cb(&event.ids);
+                cb(&event.results);
             }
         }
     }

--- a/crates/scene_inspector/src/write_commands.rs
+++ b/crates/scene_inspector/src/write_commands.rs
@@ -188,8 +188,13 @@ struct NewEntityCommand {
     component: u32,
     /// base64-encoded component value bytes
     data: String,
-    /// number of entities to allocate
+    /// number of entities to allocate (ignored when --ids is given)
     count: usize,
+    /// instantiate these exact ids (proto-u32, comma-separated) instead of allocating fresh — to
+    /// recreate entities at their original ids on a freshly-reloaded scene. A colliding id is
+    /// skipped and absent from the reply.
+    #[arg(long, value_delimiter = ',')]
+    ids: Vec<u32>,
 }
 
 fn new_entity_cmd(
@@ -219,16 +224,32 @@ fn new_entity_cmd(
                 return;
             }
         };
+        let explicit_ids = if cmd.ids.is_empty() {
+            None
+        } else {
+            Some(cmd.ids)
+        };
         let (tx, rx) = tokio::sync::oneshot::channel();
         match resolver.request_allocate_entity(
             &mut pending,
             SceneComponentId(cmd.component),
             data,
             cmd.count,
-            move |ids| {
+            explicit_ids,
+            move |results| {
+                // The worker reports a result per requested slot. Fail the command if any slot
+                // couldn't be allocated (e.g. an explicit id already live), rather than returning a
+                // partial set — the caller can then handle the miss.
+                let failed: Vec<_> = results.iter().filter_map(|r| r.as_ref().err()).collect();
+                if !failed.is_empty() {
+                    let _ = tx.send(Err(format!("could not allocate: {failed:?}")));
+                    return;
+                }
                 let json = format!(
                     "[{}]",
-                    ids.iter()
+                    results
+                        .iter()
+                        .filter_map(|r| r.as_ref().ok())
                         .map(|id| id.as_proto_u32().unwrap_or(id.id as u32).to_string())
                         .collect::<Vec<_>>()
                         .join(",")

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -117,12 +117,12 @@ pub struct CrdtSnapshotEvent {
     pub crdt: dcl::interface::CrdtStore,
 }
 
-/// Carries the response to a [`RendererResponse::AllocateEntity`] request: the freshly-allocated
-/// scene entity ids.
+/// Carries the response to a [`RendererResponse::AllocateEntity`] request: one result per requested
+/// slot (`Ok(id)` instantiated, `Err` couldn't be allocated).
 #[derive(Event)]
 pub struct EntityAllocatedEvent {
     pub scene_entity: Entity,
-    pub ids: Vec<dcl_component::SceneEntityId>,
+    pub results: Vec<Result<dcl_component::SceneEntityId, dcl::AllocError>>,
 }
 
 // event which can be sent from anywhere to trigger replacing the current scene with the one specified
@@ -920,9 +920,12 @@ fn receive_scene_updates(
                     }
                     None
                 }
-                SceneResponse::EntityAllocated(scene_id, ids) => {
+                SceneResponse::EntityAllocated(scene_id, results) => {
                     if let Some(&scene_entity) = updates.scene_ids.get(&scene_id) {
-                        entity_allocated_events.write(EntityAllocatedEvent { scene_entity, ids });
+                        entity_allocated_events.write(EntityAllocatedEvent {
+                            scene_entity,
+                            results,
+                        });
                     }
                     None
                 }


### PR DESCRIPTION
Adds an explicit-id path to the scene entity allocator so the editor can recreate entities at their **original** ids on a freshly-reloaded scene, instead of only ever receiving fresh allocations. Recreation at the original id means recorded component values that reference it (parent/self) resolve as-is, with no remap — which makes the editor's reload-reapply lossless and unblocks general undo/redo.

## What changed

- `RendererResponse::AllocateEntity` gains `explicit_ids: Option<Vec<u32>>`. The shared worker handler (`engine.rs`, used by both the Deno-IPC and wasm scene-worker paths) instantiates those exact ids via a new `CrdtContext::alloc_explicit` — which rejects an id that's already live, queues `nascent`, and advances the fresh-allocation cursor — instead of `new_in_range`. No generation override: recreation only ever runs on a reloaded scene, where the id sits at its original generation and `init()` succeeds cleanly.
- `/new_entity` takes an optional `--ids` (proto-u32, comma-separated). Without it, behaviour is unchanged (`count` fresh ids).
- The worker reports a result **per requested slot**: `EntityAllocated` now carries `Vec<Result<SceneEntityId, AllocError>>` (`AllocError = Collision(id) | NoFreeId`), threaded through `EntityAllocatedEvent` and the alloc callback, so the `/new_entity` command relays the outcome directly rather than re-deriving it by diffing requested vs returned. A collision fails the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)