### PR TITLE
Treat an inspector-paused scene as ready

### DIFF
--- a/crates/restricted_actions/src/teleport.rs
+++ b/crates/restricted_actions/src/teleport.rs
@@ -11,7 +11,7 @@ use scene_runner::{
         LiveScenes, PointerResult, SceneHash, SceneLoading, ScenePointers, PARCEL_SIZE,
     },
     permissions::Permission,
-    renderer_context::RendererSceneContext,
+    renderer_context::{RendererSceneContext, FROZEN_BLOCK},
     update_world::mesh_collider::SceneColliderData,
     OutOfWorld,
 };
@@ -130,7 +130,12 @@ pub fn handle_out_of_world(
     let (maybe_context, maybe_loadstate, maybe_collider_data) = scenes.get_mut(*scene).unwrap();
 
     if let Some(context) = maybe_context {
-        if !context.broken && (context.tick_number <= 5 || !context.blocked.is_empty()) {
+        // A scene the inspector has paused is as loaded as it's going to get — keeping the player
+        // out-of-world (behind the loading screen) is wrong, and a frozen scene never advances its
+        // tick or clears `blocked` to become "ready" on its own. FROZEN_BLOCK is only ever set by the
+        // inspector's /freeze_scene + /tick_scene, so this only affects inspector-paused scenes.
+        let frozen = context.blocked.contains(FROZEN_BLOCK);
+        if !context.broken && !frozen && (context.tick_number <= 5 || !context.blocked.is_empty()) {
             debug!("scene not ready");
         } else {
             debug!(

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -44,7 +44,7 @@ use super::{update_world::CrdtExtractors, LoadSceneEvent, PrimaryUser, SceneSets
 use crate::{
     bounds_calc::scene_regions,
     parcel_to_vec3,
-    renderer_context::RendererSceneContext,
+    renderer_context::{RendererSceneContext, FROZEN_BLOCK},
     update_world::{visibility::VisibilityComponent, ComponentTracker},
     vec3_to_parcel, ContainerEntity, DeletedSceneEntities, OutOfWorld, SceneEntity,
     SceneThreadHandle,
@@ -1723,7 +1723,11 @@ fn animate_ready_scene(
             continue;
         }
 
-        if transform.translation.y < 0.0 && (ctx.tick_number >= 5 || ctx.broken) {
+        // A scene parked below the world (y = -1000) is raised once it's ready: past tick 5, broken,
+        // or paused by the inspector. Without the frozen case, a scene frozen before tick 5 has its
+        // (already-spawned) main.crdt content stuck underground and looks empty until unfrozen.
+        let frozen = ctx.blocked.contains(FROZEN_BLOCK);
+        if transform.translation.y < 0.0 && (ctx.tick_number >= 5 || ctx.broken || frozen) {
             if transform.translation.y == -1000.0 {
                 for child in children.map(|c| c.iter()).unwrap_or_default() {
                     if loading_quads.get(child).is_ok() {


### PR DESCRIPTION
Two related fixes so a scene paused by the inspector (`/freeze_scene`) behaves as "ready" rather than perpetually mid-load. Both are scoped to inspector-paused scenes — `FROZEN_BLOCK` is set only by `/freeze_scene` + `/tick_scene`.

## 1. Don't keep the player out-of-world

`handle_out_of_world` holds the player out-of-world (behind the loading blocker) until the scene under them is ready: not broken, past tick 5, empty `blocked`. `/freeze_scene` inserts `FROZEN_BLOCK` into `blocked` and a frozen scene never advances its tick, so pausing before tick 6 stranded the player behind the loading screen.

Fix: treat a frozen scene as ready in the readiness check, clearing `OutOfWorld`.

## 2. Raise an inspector-paused scene from below the world

A freshly-spawned scene is parked at `y = -1000` and only raised to `y = 0` once ready — `animate_ready_scene` gated that on `tick_number >= 5` (or broken). So a scene frozen before tick 5 has its already-spawned main.crdt content stuck underground and looks **empty**, until unfrozen and ticked to 5. (The entities are spawned at spawn-time independent of ticking; only the raise was gated.)

Fix: treat a frozen scene as ready here too, so its content surfaces immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)