### PR TITLE
fix first pointer event result

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1298,7 +1298,7 @@ impl<T> Default for MonotonicTimestamp<T> {
 
 impl<T> MonotonicTimestamp<T> {
     pub fn next_timestamp(&self) -> u32 {
-        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1
     }
 }
 


### PR DESCRIPTION
the very first pointer event result (with timestamp 0) is discarded by the sdk's InputSystem, so the first hover, or click, of the whole app doesn't register. 

start timestamps from 1 to mitigate