### PR TITLE
Fix concurrent entity allocation: dedup ids, drain per frame, unbounded response channel

### DIFF
--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -129,7 +129,7 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
     let response = loop {
         let receiver = op_state
             .borrow_mut()
-            .borrow_mut::<Arc<Mutex<tokio::sync::mpsc::Receiver<RendererResponse>>>>()
+            .borrow_mut::<Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<RendererResponse>>>>()
             .clone();
         let response = receiver.lock().await.recv().await;
 

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -9,7 +9,7 @@ use dcl_component::{
 };
 use ipfs::SceneJsFile;
 use system_bridge::SystemApi;
-use tokio::sync::{mpsc::Receiver, Mutex};
+use tokio::sync::{mpsc::UnboundedReceiver, Mutex};
 
 use crate::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtType},
@@ -144,7 +144,7 @@ pub fn init_state(
     scene_js: SceneJsFile,
     crdt_component_interfaces: CrdtComponentInterfaces,
     thread_sx: SceneResponseSender,
-    thread_rx: Receiver<RendererResponse>,
+    thread_rx: UnboundedReceiver<RendererResponse>,
     global_update_receiver: tokio::sync::broadcast::Receiver<GlobalCrdtStateUpdate>,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
     scene_origin: bevy::prelude::Vec3,

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -21,7 +21,7 @@ use deno_core::{
 use multihash_codetable::MultihashDigest;
 use platform::project_directories;
 use system_bridge::SystemApi;
-use tokio::{sync::mpsc::Receiver, time::timeout};
+use tokio::{sync::mpsc::UnboundedReceiver, time::timeout};
 
 use ipfs::SceneJsFile;
 
@@ -190,7 +190,7 @@ pub(crate) fn scene_thread(
     scene_js: SceneJsFile,
     crdt_component_interfaces: CrdtComponentInterfaces,
     thread_sx: SceneResponseSender,
-    thread_rx: Receiver<RendererResponse>,
+    thread_rx: UnboundedReceiver<RendererResponse>,
     global_update_receiver: tokio::sync::broadcast::Receiver<GlobalCrdtStateUpdate>,
     inspect: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,

--- a/crates/dcl_deno/src/lib.rs
+++ b/crates/dcl_deno/src/lib.rs
@@ -10,7 +10,7 @@ use common::structs::GlobalCrdtStateUpdate;
 use deno_core::v8::IsolateHandle;
 use once_cell::sync::Lazy;
 use system_bridge::SystemApi;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 
 use ipfs::SceneJsFile;
 
@@ -42,9 +42,9 @@ pub fn spawn_scene(
     inspect: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
     scene_origin: bevy::prelude::Vec3,
-) -> Sender<RendererResponse> {
+) -> UnboundedSender<RendererResponse> {
     let id = scene_context.scene_id;
-    let (main_sx, thread_rx) = tokio::sync::mpsc::channel::<RendererResponse>(1);
+    let (main_sx, thread_rx) = tokio::sync::mpsc::unbounded_channel::<RendererResponse>();
 
     std::thread::Builder::new()
         .name(format!("scene thread {:?}", id.0))

--- a/crates/dcl_deno_ipc/src/lib.rs
+++ b/crates/dcl_deno_ipc/src/lib.rs
@@ -61,7 +61,7 @@ thread_local! {
 pub struct NewSceneCommand {
     id: u64,
     info: NewSceneInfo,
-    renderer_channel: tokio::sync::mpsc::Receiver<RendererResponse>,
+    renderer_channel: tokio::sync::mpsc::UnboundedReceiver<RendererResponse>,
     global_channel: tokio::sync::broadcast::Receiver<GlobalCrdtStateUpdate>,
     response_channel: SceneResponseSender,
     system_api_sender: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
@@ -278,11 +278,11 @@ pub fn spawn_scene(
     inspect: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
     scene_origin: bevy::prelude::Vec3,
-) -> tokio::sync::mpsc::Sender<RendererResponse> {
+) -> tokio::sync::mpsc::UnboundedSender<RendererResponse> {
     let is_super = super_user.is_some();
     let id = scene_context.scene_id;
 
-    let (main_sx, thread_rx) = tokio::sync::mpsc::channel::<RendererResponse>(1);
+    let (main_sx, thread_rx) = tokio::sync::mpsc::unbounded_channel::<RendererResponse>();
 
     let ipc_out = NEW_SCENE_SENDER.read().unwrap();
     let ipc_out = ipc_out.as_ref().unwrap();

--- a/crates/dcl_deno_ipc/src/main.rs
+++ b/crates/dcl_deno_ipc/src/main.rs
@@ -146,7 +146,7 @@ async fn scene_ipc_in(
                     continue;
                 };
 
-                let _ = sender.send(renderer_response).await;
+                let _ = sender.send(renderer_response);
             }
             EngineToScene::GlobalUpdate(data) => {
                 let _ = global_sx.send(data);

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -16,14 +16,14 @@ use ipfs::SceneJsFile;
 use once_cell::sync::OnceCell;
 use system_bridge::SystemApi;
 use tokio::sync::{
-    mpsc::{channel, Receiver, Sender},
+    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     Mutex,
 };
 
 pub struct SceneInitializationData {
     pub initial_crdt_store: CrdtStore,
     pub scene_context: CrdtContext,
-    pub thread_rx: Receiver<RendererResponse>,
+    pub thread_rx: UnboundedReceiver<RendererResponse>,
     pub scene_js: SceneJsFile,
     pub crdt_component_interfaces: CrdtComponentInterfaces,
     pub renderer_sender: SceneResponseSender,
@@ -53,9 +53,9 @@ pub fn spawn_scene(
     _inspect: bool,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
     scene_origin: bevy::prelude::Vec3,
-) -> Sender<RendererResponse> {
+) -> UnboundedSender<RendererResponse> {
     // create engine channel
-    let (thread_sx, thread_rx) = channel(1);
+    let (thread_sx, thread_rx) = unbounded_channel();
 
     IoTaskPool::get()
         .spawn(async move {

--- a/crates/scene_inspector/src/active_scene.rs
+++ b/crates/scene_inspector/src/active_scene.rs
@@ -74,7 +74,7 @@ impl SceneResolver<'_, '_> {
             .map_err(|_| "scene has no thread handle".to_string())?;
         handle
             .sender
-            .try_send(dcl::RendererResponse::GetCrdtSnapshot)
+            .send(dcl::RendererResponse::GetCrdtSnapshot)
             .map_err(|_| "failed to send snapshot request to scene".to_string())?;
         pending.push(entity, Box::new(callback) as SnapshotCallback);
         Ok(())
@@ -101,7 +101,7 @@ impl SceneResolver<'_, '_> {
             .map_err(|_| "scene has no thread handle".to_string())?;
         handle
             .sender
-            .try_send(dcl::RendererResponse::AllocateEntity {
+            .send(dcl::RendererResponse::AllocateEntity {
                 component_id,
                 data,
                 count,

--- a/crates/scene_inspector/src/snapshot.rs
+++ b/crates/scene_inspector/src/snapshot.rs
@@ -65,10 +65,23 @@ pub fn handle_entity_allocated_events(
                     .copied(),
             );
         }
-        if let Some(callbacks) = pending.0.remove(&event.scene_entity) {
-            for cb in callbacks {
+        // One EntityAllocated event corresponds to one AllocateEntity request, so fire exactly one
+        // callback (FIFO) — not all queued callbacks. The worker processes requests in order and the
+        // response channel is ordered, so request order == event order. Firing every callback would
+        // deliver this event's ids to all pending requests, cross-wiring concurrent allocations: a
+        // later request gets an earlier one's id (a duplicate), and its own event then finds no
+        // callback and is dropped.
+        let drained = if let Some(callbacks) = pending.0.get_mut(&event.scene_entity) {
+            if !callbacks.is_empty() {
+                let cb = callbacks.remove(0);
                 cb(&event.results);
             }
+            callbacks.is_empty()
+        } else {
+            false
+        };
+        if drained {
+            pending.0.remove(&event.scene_entity);
         }
     }
 }

--- a/crates/scene_inspector/src/write_commands.rs
+++ b/crates/scene_inspector/src/write_commands.rs
@@ -204,7 +204,9 @@ fn new_entity_cmd(
     mut pending: ResMut<PendingEntityAllocations>,
     mut console_responses: ResMut<PendingConsoleResponses>,
 ) {
-    if let Some(Ok(cmd)) = input.take() {
+    // Drain every queued invocation this frame (concurrent allocations all dispatch now); the
+    // per-request callbacks are matched to their EntityAllocated events FIFO downstream.
+    while let Some(Ok(cmd)) = input.take() {
         // The instantiation must use a custom component — an engine-recognized one flows
         // renderer→scene one-way (never echoed back) and would be lost.
         if crdt_interfaces
@@ -215,13 +217,13 @@ fn new_entity_cmd(
                 "component {} is engine-recognized; instantiate with a custom component",
                 cmd.component
             ));
-            return;
+            continue;
         }
         let data = match BASE64_STANDARD.decode(cmd.data.as_bytes()) {
             Ok(d) => d,
             Err(e) => {
                 input.reply_failed(format!("invalid base64: {e}"));
-                return;
+                continue;
             }
         };
         let explicit_ids = if cmd.ids.is_empty() {

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -106,7 +106,7 @@ impl SceneUpdates {
 
 #[derive(Component)]
 pub struct SceneThreadHandle {
-    pub sender: tokio::sync::mpsc::Sender<RendererResponse>,
+    pub sender: tokio::sync::mpsc::UnboundedSender<RendererResponse>,
 }
 
 /// Emitted by [`receive_scene_updates`] when the scene thread responds to a
@@ -879,7 +879,7 @@ fn send_scene_updates(
         died: std::mem::take(&mut context.outbound_died),
     };
 
-    if let Err(e) = handle.sender.blocking_send(RendererResponse::Ok(
+    if let Err(e) = handle.sender.send(RendererResponse::Ok(
         context.crdt_store.take_updates(),
         census,
     )) {


### PR DESCRIPTION
Concurrent `/new_entity` allocations (e.g. the scene inspector creating many entities at once) could return **duplicate** entity ids and silently **drop** allocations. Three issues, fixed in order:

### 1. Cross-wired ids (`handle_entity_allocated_events`)
`PendingEntityAllocations` holds a `Vec<AllocCallback>` per scene, and on each `EntityAllocated` event the handler removed and fired **every** queued callback with that one event's results. With more than one allocation in flight, a later request's callback fired with an earlier request's id — a duplicate — and the later event then found no callback and was dropped. Now one event is matched to one callback, FIFO (the worker processes `AllocateEntity` requests in order and the response channel is ordered, so request order == event order).

### 2. One allocation per frame (`new_entity_cmd`)
`new_entity_cmd` used `if let` to take a single invocation per frame, serialising concurrent allocations to one per tick. Switched to `while let` (as the other write commands already do) so a burst dispatches in one frame; the parse-error paths use `continue` so one bad invocation doesn't abort the drain.

### 3. Bounded(1) renderer→scene channel
The `RendererResponse` channel was bounded at capacity 1. Per-scene `Ok` traffic is already serialised by the `in_flight` gate, so the bound was redundant for flow control — but out-of-band allocation sends bypass that gate, so a burst either dropped on a full `try_send`, or made the main scene loop's `blocking_send` block on a full channel, which **panics on wasm**. Switched to an unbounded channel: `send` is non-blocking and only fails when the scene is gone, removing both the dropped allocations and the latent wasm panic.

Verified on wasm and native (deno-IPC): 100 concurrent allocations → 100 distinct entities, no duplicates, no drops.