### PR TITLE
feat: cap scene dt and surface a scene "not responding" timeout

### DIFF
--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -297,13 +297,19 @@ pub(crate) fn scene_thread(
         return;
     }
 
+    // Scenes aren't driven on a fixed timestep, so a slow frame (asset load, GC, a stalled
+    // renderer round-trip) yields a huge dt. Cap it so dt-scaled scene logic (timers, animations)
+    // is never handed a multi-second step. Mirrored by MAX_SCENE_DT_SECONDS in
+    // deploy/web/sandbox_worker.js for the wasm runtime.
+    const MAX_SCENE_DT: std::time::Duration = std::time::Duration::from_secs(1);
+
     let start_time = std::time::Instant::now();
     let mut prev_time = start_time;
     let mut elapsed;
     let mut reported_errors = 0;
     loop {
         let now = std::time::Instant::now();
-        let dt = now.saturating_duration_since(prev_time);
+        let dt = now.saturating_duration_since(prev_time).min(MAX_SCENE_DT);
         elapsed = now.saturating_duration_since(start_time);
         prev_time = now;
 

--- a/crates/restricted_actions/src/teleport.rs
+++ b/crates/restricted_actions/src/teleport.rs
@@ -11,7 +11,7 @@ use scene_runner::{
         LiveScenes, PointerResult, SceneHash, SceneLoading, ScenePointers, PARCEL_SIZE,
     },
     permissions::Permission,
-    renderer_context::{RendererSceneContext, FROZEN_BLOCK},
+    renderer_context::{RendererSceneContext, FROZEN_BLOCK, SCENE_NOT_RESPONDING_TIMEOUT},
     update_world::mesh_collider::SceneColliderData,
     OutOfWorld,
 };
@@ -75,9 +75,10 @@ pub fn teleport_player(
     }
 }
 
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn handle_out_of_world(
     mut commands: Commands,
+    time: Res<Time>,
     mut scenes: Query<
         (
             Option<&RendererSceneContext>,
@@ -135,9 +136,20 @@ pub fn handle_out_of_world(
         // tick or clears `blocked` to become "ready" on its own. FROZEN_BLOCK is only ever set by the
         // inspector's /freeze_scene + /tick_scene, so this only affects inspector-paused scenes.
         let frozen = context.blocked.contains(FROZEN_BLOCK);
-        if !context.broken && !frozen && (context.tick_number <= 5 || !context.blocked.is_empty()) {
+        // A scene whose tick has been in-flight past the not-responding timeout is hung; stop
+        // holding the player behind the loading screen and let them into the world.
+        let not_responding = context.in_flight
+            && time.elapsed_secs() - context.last_sent > SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32();
+        if !not_responding
+            && !context.broken
+            && !frozen
+            && (context.tick_number <= 5 || !context.blocked.is_empty())
+        {
             debug!("scene not ready");
         } else {
+            if not_responding {
+                debug!("scene not responding, returning to world");
+            }
             debug!(
                 "ready, returning to world (set spawn here) tick: {}",
                 context.tick_number

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -115,6 +115,16 @@ pub const FROZEN_BLOCK: &str = "frozen";
 
 pub const SCENE_LOG_BUFFER_SIZE: usize = 100;
 
+// A scene tick that has been in-flight (sent to the scene, no response yet) for longer than this
+// is treated as "not responding": handle_out_of_world stops holding the player behind the loading
+// screen, and the loading UI surfaces a countdown to this timeout.
+pub const SCENE_NOT_RESPONDING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+// Don't surface the "not responding" message until a tick has been in-flight at least this long,
+// so a normal slow frame doesn't flicker the warning.
+pub const SCENE_NOT_RESPONDING_DISPLAY_AFTER: std::time::Duration =
+    std::time::Duration::from_secs(2);
+
 impl RendererSceneContext {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/crates/system_ui/src/oow.rs
+++ b/crates/system_ui/src/oow.rs
@@ -8,7 +8,10 @@ use common::{
     util::TryPushChildrenEx,
 };
 use scene_runner::{
-    renderer_context::RendererSceneContext, update_world::gltf_container::GltfLoadingCount,
+    renderer_context::{
+        RendererSceneContext, SCENE_NOT_RESPONDING_DISPLAY_AFTER, SCENE_NOT_RESPONDING_TIMEOUT,
+    },
+    update_world::gltf_container::GltfLoadingCount,
     ContainingScene, OutOfWorld,
 };
 use system_bridge::{NativeUi, SceneLoadingUi, SystemApi};
@@ -20,6 +23,7 @@ use crate::change_realm::ChangeRealmDialog;
 /// Extracts scene loading info: (title, pending_assets_count)
 fn get_scene_loading_info(
     player: Entity,
+    now: f32,
     containing_scene: &ContainingScene,
     scenes: &Query<(&RendererSceneContext, Option<&GltfLoadingCount>)>,
 ) -> (String, Option<u32>) {
@@ -27,11 +31,28 @@ fn get_scene_loading_info(
         .get_parcel_oow(player)
         .and_then(|scene| scenes.get(scene).ok());
 
-    let title = scene
+    let mut title = scene
         .map(|(context, _)| context.title.clone())
         .unwrap_or_else(|| "Scene".to_owned());
 
     let pending_assets = scene.and_then(|(_, gltf_count)| gltf_count.map(|c| c.0 as u32));
+
+    // Assets are loaded (nothing pending) but a tick has been in-flight for a while: the scene
+    // script is stalling. Surface a countdown to the not-responding timeout, after which
+    // handle_out_of_world lets the player into the world.
+    if let Some((context, _)) = scene {
+        let in_flight_for = now - context.last_sent;
+        if pending_assets.unwrap_or(0) == 0
+            && context.in_flight
+            && in_flight_for >= SCENE_NOT_RESPONDING_DISPLAY_AFTER.as_secs_f32()
+        {
+            let remaining = (SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32() - in_flight_for).max(0.0);
+            title = format!(
+                "{title} (not responding... timeout in {} seconds)",
+                remaining.ceil() as u32
+            );
+        }
+    }
 
     (title, pending_assets)
 }
@@ -52,6 +73,7 @@ impl Plugin for OowUiPlugin {
 #[allow(clippy::too_many_arguments)]
 fn update_loading_scene_dialog(
     mut commands: Commands,
+    time: Res<Time>,
     wallet: Res<Wallet>,
     oow: Query<&OutOfWorld>,
     mut last_count: Local<usize>,
@@ -75,7 +97,8 @@ fn update_loading_scene_dialog(
         return;
     };
 
-    let (title_text, pending_assets) = get_scene_loading_info(player, &containing_scene, &scenes);
+    let (title_text, pending_assets) =
+        get_scene_loading_info(player, time.elapsed_secs(), &containing_scene, &scenes);
     let state_text = pending_assets
         .map(|count| format!("{} assets", count))
         .unwrap_or_else(|| "assets".to_owned());
@@ -210,6 +233,7 @@ fn update_loading_backdrop(
 #[allow(clippy::too_many_arguments)]
 fn pipe_scene_loading_ui_stream(
     mut requests: EventReader<SystemApi>,
+    time: Res<Time>,
     wallet: Res<Wallet>,
     oow: Query<&OutOfWorld>,
     player: Query<Entity, With<PrimaryUser>>,
@@ -239,7 +263,8 @@ fn pipe_scene_loading_ui_stream(
     let visible = wallet.address().is_some() && !oow.is_empty();
 
     let current_state = if let (true, Ok(player)) = (visible, player.single()) {
-        let (title, pending_assets) = get_scene_loading_info(player, &containing_scene, &scenes);
+        let (title, pending_assets) =
+            get_scene_loading_info(player, time.elapsed_secs(), &containing_scene, &scenes);
         SceneLoadingUi {
             visible: true,
             title,

--- a/deploy/web/sandbox_worker.js
+++ b/deploy/web/sandbox_worker.js
@@ -335,8 +335,12 @@ self.onmessage = async (event) => {
       var count = 0;
       var reportedErrors = 0;
       var consecutiveErrorsWithoutInteraction = 0;
+      // Cap the per-frame dt handed to the scene: a slow frame must not feed dt-scaled scene
+      // logic (timers, animations) a multi-second step. Mirrors MAX_SCENE_DT in
+      // crates/dcl_deno/src/js/mod.rs.
+      const MAX_SCENE_DT_SECONDS = 1;
       while (ops.op_continue_running()) {
-        const dt = (elapsed - prevElapsed) / 1000;
+        const dt = Math.min((elapsed - prevElapsed) / 1000, MAX_SCENE_DT_SECONDS);
         ops.op_set_elapsed(elapsed / 1000);
         try {
           await module.onUpdate(dt);


### PR DESCRIPTION
Closes #829.

## Problem

Scenes aren't driven on a fixed timestep, so a slow frame — a big asset load, a GC pause, or a stalled renderer round-trip — can hand the scene script a multi-second `dt`. dt-scaled scene logic (timers, animations) then takes a huge step in one tick; in the worst case (e.g. a re-arming `setTimeout` in the SDK timer helper) it can spin and the scene stops responding entirely.

Separately, when a scene's tick hangs *after* its assets have loaded, the player is held behind the out-of-world loading screen indefinitely. This is the "asset count stuck at 0" symptom in #829: with assets finished (count 0) the spinner sits at 0 with no way to tell whether the client is still loading or wedged.

## Changes

- **Cap scene `dt` at 1s on all platforms** — `.min(MAX_SCENE_DT)` on the native (`dcl_deno`) loop and `Math.min(..., MAX_SCENE_DT_SECONDS)` on the wasm (`sandbox_worker.js`) loop. These are the only two `onUpdate` dt sites.
- **Loading UI "not responding" countdown** — `get_scene_loading_info` (shared by the RPC loading stream and the native loading dialog) appends `" (not responding... timeout in N seconds)"` to the scene title when the scene has no pending assets, its tick is in-flight, and it has been in-flight for at least `SCENE_NOT_RESPONDING_DISPLAY_AFTER` (2s). `N` counts down to the timeout, so a stalled-at-0 spinner now tells the user what's happening.
- **Return to world on timeout** — `handle_out_of_world` treats an in-flight tick older than `SCENE_NOT_RESPONDING_TIMEOUT` (10s) as a ready/exit condition, so a hung scene no longer traps the player on the loading screen.

Cap and timeouts are named constants (`MAX_SCENE_DT` in `dcl_deno`; `SCENE_NOT_RESPONDING_TIMEOUT` / `SCENE_NOT_RESPONDING_DISPLAY_AFTER` in `scene_runner::renderer_context`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
