### PR TITLE
Redirect bare subpath URLs to trailing-slash form (#807)

### DIFF
--- a/deploy/web/index.html
+++ b/deploy/web/index.html
@@ -2,12 +2,20 @@
 <html lang="en">
 <head>
     <script>
-        // Set base href so relative paths work when deployed under a subpath (e.g. /bevy-web)
+        // Issue #807: when loaded without a trailing slash (e.g. /bevy-web?position=88,88)
+        // the page is outside the service worker scope (/bevy-web/), so the worker's
+        // COEP `credentialless` rewrite never runs and cross-origin scene assets are
+        // blocked by `require-corp`. Redirect to the trailing-slash URL (preserving the
+        // query and hash) so the service worker controls the page. Runs first, before
+        // anything else parses, to minimise wasted work.
         (function() {
-            var base = document.createElement('base');
             var path = window.location.pathname;
-            base.href = path.endsWith('/') ? path : path + '/';
-            document.head.appendChild(base);
+            var lastSegment = path.substring(path.lastIndexOf('/') + 1);
+            // Only redirect "directory" paths missing a trailing slash; skip anything
+            // that looks like a file (has an extension) to avoid redirect loops.
+            if (!path.endsWith('/') && lastSegment.indexOf('.') === -1) {
+                window.location.replace(path + '/' + window.location.search + window.location.hash);
+            }
         })();
     </script>
     <script>


### PR DESCRIPTION
## Problem

The web client fails to load scenes when accessed without a trailing slash:
- ❌ `https://decentraland.zone/bevy-web?position=88,88` → scenes don't load
- ✅ `https://decentraland.zone/bevy-web/?position=88,88` → works

The service worker registers at `/bevy-web/service_worker.js`, so its default scope is `/bevy-web/`. The no-slash URL is outside that scope and isn't controlled by the worker, so the worker's `Cross-Origin-Embedder-Policy: credentialless` rewrite never runs. Scene assets from cross-origin content servers (which lack CORP headers) then get blocked by the static `require-corp` policy. The engine boots fine (same-origin WASM), but scene asset fetches fail with `ERR_BLOCKED_BY_RESPONSE` / CORP errors.

Fixes #807.

## Fix

Add an inline redirect as the first thing in `<head>`: if the path is a directory-style path missing a trailing slash, `location.replace()` to the slash form (preserving query and hash) before anything else parses. The page is then always within service-worker scope.

This is the in-page equivalent of a hosting-layer 308 redirect, requiring no CDN/hosting access. The explicit-scope alternative (`register(..., { scope: '/bevy-web' })`) can't be done from code alone — the worker lives at `/bevy-web/`, so widening scope to `/bevy-web` would require a `Service-Worker-Allowed` response header.

### Also removes the `<base href>` shim

The old inline `<base href>` script existed to normalize relative-path resolution on the no-slash page. With the redirect guaranteeing a trailing slash, default document-relative resolution already loads `main.js`/`ui.js`/favicons/`logo.svg` correctly on every committed URL. The element's only remaining effect would be on a bare no-slash path — which is broken at the SW-scope level regardless — so it's dead code now. The worker/module loading in `engine.js`/`main.js` never used `<base>` (it derives paths from `location.pathname`) and is unaffected.