### PR TITLE
Expose BroadcastChannel to the super-user scene sandbox

### DIFF
--- a/deploy/web/sandbox_worker.js
+++ b/deploy/web/sandbox_worker.js
@@ -71,6 +71,10 @@ var jsProxy = undefined;
 var jsPreamble = undefined;
 function createJsContext(wasmApi, context) {
   const isSuper = wasmApi.is_super(context);
+  // BroadcastChannel is a same-origin, serverless side channel — exposed ONLY to the trusted
+  // super-user (--ui) scene, so an embedded host page can drive it; ordinary scenes never see it
+  // (it would otherwise let an untrusted scene coordinate with the page / other scenes off-network).
+  const allowList = isSuper ? [...allowListES2020, "BroadcastChannel"] : allowListES2020;
   const sceneLabel = context.get_scene_title();
   const sceneStartTime = performance.now();
   function scenePrefix() {
@@ -175,7 +179,7 @@ function createJsContext(wasmApi, context) {
       if (propKey === "global") return jsProxy;
       if (propKey === "undefined") return undefined;
       if (jsContext[propKey] !== undefined) return jsContext[propKey];
-      if (allowListES2020.includes(propKey)) {
+      if (allowList.includes(propKey)) {
         return globalThis[propKey];
       }
       return undefined;
@@ -183,7 +187,7 @@ function createJsContext(wasmApi, context) {
   });
 
   const contextKeys = Object.getOwnPropertyNames(jsContext);
-  const allGlobals = [...new Set([...allowListES2020, ...contextKeys])];
+  const allGlobals = [...new Set([...allowList, ...contextKeys])];
   jsPreamble = allGlobals
     .map((key) => `const ${key} = globalThis.${key};`)
     .join("\n");


### PR DESCRIPTION
The scene sandbox (`deploy/web/sandbox_worker.js`) forwards only an allowlist of globals into each scene's JS context. This adds `BroadcastChannel` — gated to the **super-user (`--ui`) scene** via the existing `is_super(context)` check, not the shared static allowlist.

### Why
A same-origin host page embedding the engine can then drive the super-user editor scene **in-browser over a `BroadcastChannel`** — no WebSocket server, no external process. Ordinary scenes never gain a serverless same-origin side channel (which they could otherwise use to coordinate with the host page or other scenes off-network), so the capability stays scoped to the scene already trusted with the full `SystemApi`/console surface.

### Change
Builds a per-context `allowList = isSuper ? [...allowListES2020, "BroadcastChannel"] : allowListES2020`, used at both the proxy `get` trap and the preamble. Non-super scenes are byte-for-byte unchanged.

Verified live: with a super-user inspector scene, a `new BroadcastChannel('dcl-inspector-agent')` opened from the page console round-trips action frames to/from the scene; a non-super scene still sees `BroadcastChannel` as `undefined`.