### PR TITLE
Render-only avatar tilt (glide banking) + movement-anim pipeline fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "async-broadcast",
  "async-channel 2.5.0",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1121,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1255,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1362,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1587,12 +1587,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#4c108e72ece792f3d134454dcd047e1031e70054"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -607,6 +607,14 @@ struct SpawnedExtras {
     scene_initialized: bool,
     audio: Option<(Entity, f32)>,
     clip: Option<(AnimationNodeIndex, Handle<AnimationGraph>)>,
+    // Intended clip-start wall-time (`elapsed_secs - playtime`) captured when a seek was
+    // requested on the frame the prop scene was spawned. Spawning a prop defers the
+    // emote's play (we `continue` until the instance is ready), so a one-shot
+    // `playback_time` from the scene would otherwise be gone before it's applied. Storing
+    // the *start* time (rather than the raw seek) lets the deferred play resume at
+    // `elapsed_secs - start` — i.e. advanced by however long the prop took to load — so a
+    // slow load doesn't resume stale. Cleared when the avatar + prop finally play.
+    deferred_start: Option<f32>,
 }
 
 impl SpawnedExtras {
@@ -617,6 +625,7 @@ impl SpawnedExtras {
             scene_initialized: false,
             audio: None,
             clip: None,
+            deferred_start: None,
         }
     }
 }
@@ -644,11 +653,20 @@ fn play_current_emote(
     mut playing: Local<HashMap<Entity, EmoteUrn>>,
     ipfas: IpfsAssetServer,
     mut cached_gltf_handles: Local<HashSet<Handle<Gltf>>>,
-    mut spawned_extras: Local<HashMap<Entity, SpawnedExtras>>,
+    // spawned_extras: prop/audio for the current clip. retiring_extras: prop kept alive
+    // across a clip change until its replacement is visible (or the new clip has no
+    // prop), so a prop carried by both clips (e.g. an embedded glider) doesn't blink out
+    // while the new scene loads — (wrapper entity, scene instance) keyed by avatar.
+    // Grouped as a tuple to stay within Bevy's per-system param limit.
+    (mut spawned_extras, mut retiring_extras): (
+        Local<HashMap<Entity, SpawnedExtras>>,
+        Local<HashMap<Entity, (Entity, InstanceId)>>,
+    ),
     mut scene_spawner: ResMut<SceneSpawner>,
-    (sounds, anim_clips): (
+    (sounds, anim_clips, time): (
         Res<Assets<bevy_kira_audio::AudioSource>>,
         Res<Assets<AnimationClip>>,
+        Res<Time>,
     ),
     mut emitters: Query<&mut AudioEmitter>,
     prop_details: Query<(Option<&Name>, &Transform, &ChildOf)>,
@@ -670,10 +688,18 @@ fn play_current_emote(
         // clean up old extras
         if let Some(extras) = prev_spawned_extras.remove(&entity) {
             if extras.urn != active_emote.urn {
+                // Defer despawning the old prop scene until its replacement is visible
+                // (or we learn the new clip has no prop) to avoid a one-frame gap while
+                // the new scene loads. Despawn any already-retiring prop first, so a
+                // rapid run of switches can't accumulate more than one.
                 if let Some((wrapper, scene)) = extras.scene {
-                    scene_spawner.despawn_instance(scene);
-                    if let Ok(mut commands) = commands.get_entity(wrapper) {
-                        commands.despawn();
+                    if let Some((old_wrapper, old_scene)) =
+                        retiring_extras.insert(entity, (wrapper, scene))
+                    {
+                        scene_spawner.despawn_instance(old_scene);
+                        if let Ok(mut commands) = commands.get_entity(old_wrapper) {
+                            commands.despawn();
+                        }
                     }
                 }
 
@@ -888,6 +914,16 @@ fn play_current_emote(
                     }
                     commands.entity(wrapper).try_insert(Visibility::Inherited);
                     extras.scene_initialized = true;
+                    // Replacement is up — and posed this same frame thanks to the
+                    // thread_animation_graphs ordering fix in the engine — so drop the
+                    // prop we kept alive across the switch. The overlap covers the new
+                    // prop's load time; the engine fix covers the would-be bind-pose frame.
+                    if let Some((old_wrapper, old_scene)) = retiring_extras.remove(&entity) {
+                        scene_spawner.despawn_instance(old_scene);
+                        if let Ok(mut commands) = commands.get_entity(old_wrapper) {
+                            commands.despawn();
+                        }
+                    }
                 }
 
                 if let Ok(Some(prop_clip)) = emote.prop_anim(&gltfs) {
@@ -920,11 +956,30 @@ fn play_current_emote(
                     .spawn((Transform::default(), Visibility::Hidden, ChildOf(entity)))
                     .id();
                 let scene = scene_spawner.spawn_as_child(props, wrapper);
-                spawned_extras
+                let extras = spawned_extras
                     .entry(entity)
-                    .or_insert_with(|| SpawnedExtras::new(active_emote.urn.clone()))
-                    .scene = Some((wrapper, scene));
+                    .or_insert_with(|| SpawnedExtras::new(active_emote.urn.clone()));
+                extras.scene = Some((wrapper, scene));
+                // Carry any seek requested this frame across the deferred play (below), so
+                // a one-shot scene `playback_time` isn't lost while the prop loads. Stash
+                // the intended clip-start time so the deferred play resumes advanced by
+                // the load duration rather than at the (now-stale) requested value.
+                extras.deferred_start = active_emote
+                    .pending_seek
+                    .map(|seek| time.elapsed_secs() - seek);
                 continue;
+            }
+        }
+
+        // New clip definitively has no prop — drop any prop kept alive across the switch
+        // (e.g. glide ended). `Err(Loading)` is left pending so we keep showing the old
+        // prop until we know.
+        if matches!(emote.prop_scene(&gltfs), Ok(None)) {
+            if let Some((old_wrapper, old_scene)) = retiring_extras.remove(&entity) {
+                scene_spawner.despawn_instance(old_scene);
+                if let Ok(mut commands) = commands.get_entity(old_wrapper) {
+                    commands.despawn();
+                }
             }
         }
 
@@ -1064,7 +1119,15 @@ fn play_current_emote(
                 (graph.add_clip(clip, 1.0, graph.root), 0.0)
             });
 
-        let pending_seek = active_emote.pending_seek.take();
+        // Prefer a seek requested this frame; otherwise apply one stashed when the prop
+        // was spawned (deferred a frame), advanced by the load duration via the stashed
+        // start time, so the avatar + prop pick up in phase regardless of load time.
+        let pending_seek = active_emote.pending_seek.take().or_else(|| {
+            spawned_extras
+                .get_mut(&entity)
+                .and_then(|extras| extras.deferred_start.take())
+                .map(|start| time.elapsed_secs() - start)
+        });
         let elapsed = play(
             transitions,
             &mut player,

--- a/crates/avatar/src/point_at_ik.rs
+++ b/crates/avatar/src/point_at_ik.rs
@@ -345,7 +345,11 @@ pub(crate) fn apply_point_at_ik(
         // arm jitter while the body is mid-turn.
         if let Some(yaw) = rig.body_yaw {
             if let Ok(mut t) = tx.p0().get_mut(avatar_entity) {
-                t.rotation = Quat::from_rotation_y(yaw);
+                // Override the body yaw for the point-at frame but keep any render-only
+                // tilt (pitch/roll) the movement system applied this frame, so leaning
+                // survives pointing.
+                let (_, pitch, roll) = t.rotation.to_euler(EulerRot::YXZ);
+                t.rotation = Quat::from_euler(EulerRot::YXZ, yaw, pitch, roll);
             }
         }
 

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -240,6 +240,19 @@ pub struct SceneDrivenAnim {
     pub active: Option<SceneDrivenAnimationRequest>,
 }
 
+/// Build the render-only avatar tilt (lean) quaternion from pitch/roll in degrees.
+/// Composed as `Y * X * Z`, so `Quat::from_rotation_y(yaw) * avatar_tilt_quat(p, r)`
+/// equals `Quat::from_euler(EulerRot::YXZ, yaw, p_rad, r_rad)` — letting consumers recover
+/// the authoritative yaw with `to_euler(EulerRot::YXZ).0` even when tilt is present.
+pub fn avatar_tilt_quat(pitch_deg: f32, roll_deg: f32) -> bevy::math::Quat {
+    bevy::math::Quat::from_euler(
+        bevy::math::EulerRot::YXZ,
+        0.0,
+        pitch_deg.to_radians(),
+        roll_deg.to_radians(),
+    )
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct SceneDrivenAnimationRequest {
     // scene-relative path (e.g. "assets/walk.glb") — used for feedback to the controlling
@@ -258,6 +271,10 @@ pub struct SceneDrivenAnimationRequest {
     pub idle: bool,
     pub transition_seconds: f32,
     pub seek: Option<f32>,
+    // Render-only avatar lean (degrees), mirrored from `PBAvatarMovement.tilt_pitch` /
+    // `tilt_roll` for the local sender and carried to remotes on the wire. 0 = upright.
+    pub tilt_pitch: f32,
+    pub tilt_roll: f32,
     // Scene-requested avatar-bus sound clips to play this update. Each entry is the
     // content_hash of a file hosted in the same scene as the animation. The consumer
     // dedups per-avatar so leaving identical entries across consecutive updates doesn't

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -271,10 +271,6 @@ pub struct SceneDrivenAnimationRequest {
     pub idle: bool,
     pub transition_seconds: f32,
     pub seek: Option<f32>,
-    // Render-only avatar lean (degrees), mirrored from `PBAvatarMovement.tilt_pitch` /
-    // `tilt_roll` for the local sender and carried to remotes on the wire. 0 = upright.
-    pub tilt_pitch: f32,
-    pub tilt_roll: f32,
     // Scene-requested avatar-bus sound clips to play this update. Each entry is the
     // content_hash of a file hosted in the same scene as the animation. The consumer
     // dedups per-avatar so leaving identical entries across consecutive updates doesn't

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -237,6 +237,10 @@ fn broadcast_position(
     let transition_seconds = active_anim.map(|a| a.transition_seconds);
     let r#loop = active_anim.map(|a| a.r#loop);
     let idle = active_anim.map(|a| a.idle);
+    // Render-only lean, carried so remotes can bank a tilted avatar. Rides along with an
+    // active anim, like speed/loop; receivers compose it on top of the yaw in rotation_y.
+    let tilt_pitch = active_anim.map(|a| a.tilt_pitch);
+    let tilt_roll = active_anim.map(|a| a.tilt_roll);
     // The latch above already mirrors the freshest `seek` seen since the last
     // broadcast. Only send if there's an active anim to apply it to.
     let playback_time = active_anim.and(last_anim.pending_seek.take());
@@ -265,6 +269,8 @@ fn broadcast_position(
                 sound_content_hashes,
                 origin_address: wallet.address().map(|a| format!("{a:#x}")),
                 idle,
+                tilt_pitch,
+                tilt_roll,
             },
         )
     } else {

--- a/crates/comms/src/broadcast_position.rs
+++ b/crates/comms/src/broadcast_position.rs
@@ -239,8 +239,15 @@ fn broadcast_position(
     let idle = active_anim.map(|a| a.idle);
     // Render-only lean, carried so remotes can bank a tilted avatar. Rides along with an
     // active anim, like speed/loop; receivers compose it on top of the yaw in rotation_y.
-    let tilt_pitch = active_anim.map(|a| a.tilt_pitch);
-    let tilt_roll = active_anim.map(|a| a.tilt_roll);
+    // Derived from the same composed rotation we extract yaw from above — `apply_rotation`
+    // baked the lean in as `from_euler(YXZ, yaw, pitch, roll)`, so `.1`/`.2` recover it.
+    let (tilt_pitch, tilt_roll) = match active_anim {
+        Some(_) => {
+            let (_, pitch, roll) = rotation.to_euler(bevy::math::EulerRot::YXZ);
+            (Some(pitch.to_degrees()), Some(roll.to_degrees()))
+        }
+        None => (None, None),
+    };
     // The latch above already mirrors the freshest `seek` seen since the last
     // broadcast. Only send if there's an active anim to apply it to.
     let playback_time = active_anim.and(last_anim.pending_seek.take());

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -10,8 +10,8 @@ use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender, RpcStreamSender},
     structs::{
-        AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, HeadSync, MoveKind, PointAtSync,
-        SceneDrivenAnimationRequest,
+        avatar_tilt_quat, AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, HeadSync,
+        MoveKind, PointAtSync, SceneDrivenAnimationRequest,
     },
 };
 use ethers_core::types::Address;
@@ -622,7 +622,13 @@ pub fn process_transport_updates(
                         ));
                         let pos = Vec3::new(m.position_x, m.position_y, -m.position_z);
                         let vel = Vec3::new(m.velocity_x, m.velocity_y, -m.velocity_z);
-                        let rot = Quat::from_rotation_y(-m.rotation_y / 360.0 * TAU);
+                        // Compose the render-only lean on top of yaw; absent/old senders → upright.
+                        let tilt = m
+                            .scene_driven_animation
+                            .as_ref()
+                            .map(|s| avatar_tilt_quat(s.tilt_pitch(), s.tilt_roll()))
+                            .unwrap_or(Quat::IDENTITY);
+                        let rot = Quat::from_rotation_y(-m.rotation_y / 360.0 * TAU) * tilt;
                         let dcl_transform = DclTransformAndParent {
                             translation: DclTranslation::from_bevy_translation(pos),
                             rotation: DclQuat::from_bevy_quat(rot),
@@ -681,10 +687,16 @@ pub fn process_transport_updates(
                             &mut last_remote_anim_urn,
                             m.scene_driven_animation.clone(),
                         );
+                        // Compose the render-only lean on top of yaw; absent/old senders → upright.
+                        let tilt = m
+                            .scene_driven_animation
+                            .as_ref()
+                            .map(|s| avatar_tilt_quat(s.tilt_pitch(), s.tilt_roll()))
+                            .unwrap_or(Quat::IDENTITY);
                         let movement = MovementCompressed::from_proto(m);
                         let pos = movement.position(state.realm_bounds.0, state.realm_bounds.1);
                         let vel = movement.velocity();
-                        let rot = Quat::from_rotation_y(movement.temporal.rotation_f32());
+                        let rot = Quat::from_rotation_y(movement.temporal.rotation_f32()) * tilt;
                         let dcl_transform = DclTransformAndParent {
                             translation: DclTranslation::from_bevy_translation(pos),
                             rotation: DclQuat::from_bevy_quat(rot),
@@ -833,6 +845,10 @@ fn resolve_remote_anim(
         idle: anim.idle.unwrap_or(false),
         transition_seconds,
         seek: anim.playback_time,
+        // Carried for struct parity; the remote lean is composed directly into the
+        // received rotation at the packet sites, so these aren't read on this path.
+        tilt_pitch: anim.tilt_pitch.unwrap_or_default(),
+        tilt_roll: anim.tilt_roll.unwrap_or_default(),
         sounds: anim.sound_content_hashes,
     })
 }

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -845,10 +845,6 @@ fn resolve_remote_anim(
         idle: anim.idle.unwrap_or(false),
         transition_seconds,
         seek: anim.playback_time,
-        // Carried for struct parity; the remote lean is composed directly into the
-        // received rotation at the packet sites, so these aren't read on this path.
-        tilt_pitch: anim.tilt_pitch.unwrap_or_default(),
-        tilt_roll: anim.tilt_roll.unwrap_or_default(),
         sounds: anim.sound_content_hashes,
     })
 }

--- a/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/comms/rfc4/comms.proto
@@ -126,6 +126,12 @@ message SceneDrivenAnimation {
   // that carries an active anim, the same as `speed` / `loop`; defaults to false when
   // absent (older senders predating the field).
   optional bool idle = 9;
+  // Render-only avatar lean (degrees) carried for remote avatars, mirroring
+  // `PBAvatarMovement.tilt_pitch` / `tilt_roll`. Composed on top of the yaw in
+  // `Movement.rotation_y` (pitch about local X, roll about local Z); does not affect the
+  // remote's physics or the yaw other clients read. Absent/0 from senders without tilt.
+  optional float tilt_pitch = 10;
+  optional float tilt_roll = 11;
 }
 
 message MovementCompressed {

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_movement.proto
@@ -9,10 +9,12 @@ option (common.ecs_component_id) = 1501;
 
 message PBAvatarMovement {
   decentraland.common.Vector3 velocity = 1;
-  float orientation = 2;                                    // 0-360, we don't allow pitch/roll
+  float orientation = 2;                                    // 0-360, yaw only; this is the authoritative facing (other clients read it, and physics treats the avatar as upright). Lean is expressed separately via tilt_pitch/tilt_roll.
   optional decentraland.common.Vector3 ground_direction = 3;
   optional bool walk_success = 4;                           // set for one frame when a walk_target ends: true = reached target, false = failed; absent = in progress or no walk
   optional MovementAnimation animation = 5;                 // if set, the engine plays this animation instead of selecting one from velocity heuristics
+  optional float tilt_pitch = 6;                            // render-only forward/back lean in degrees, applied on top of `orientation` (rotation about the avatar's local X axis). Does not affect the physics capsule (stays upright) or the facing other clients read. Defaults to 0.
+  optional float tilt_roll = 7;                             // render-only sideways lean in degrees, applied on top of `orientation` (rotation about the avatar's local Z axis). Same constraints as tilt_pitch. Useful e.g. for glider banking. Defaults to 0.
 }
 
 // Describes the animation the movement scene wants the avatar to play.

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -90,6 +90,7 @@ impl Plugin for AvatarMovementPlugin {
         app.add_systems(
             PostUpdate,
             (
+                apply_rotation,
                 apply_ground_collider_movement,
                 resolve_collisions,
                 apply_impulses,
@@ -501,6 +502,38 @@ pub fn apply_impulses(
     }
 }
 
+// Whether scene-driven movement should be suppressed this frame: either an explicit
+// suppression is held (e.g. movePlayerTo interpolation), OR the active AvatarMovement
+// was initiated before the most recent movePlayerTo-imposed facing — such a tick read a
+// pre-teleport transform, so applying its orientation would clobber the imposed facing.
+// Strict `>` (here as `<=` to suppress) treats a same-frame dispatch as stale, since
+// `last_sent` is captured before the restricted-action runs and shares the frame's timestamp.
+fn movement_suppressed(
+    movement_control: &EngineMovementControl,
+    movement: &ActivePlayerComponent<AvatarMovement>,
+) -> bool {
+    !movement_control.suppress_avatar_physics.is_empty()
+        || movement.initiated_at <= movement_control.accept_movement_after
+}
+
+// Movement pipeline step 1 (see the PBAvatarMovement proto comment): set the avatar
+// orientation from the scene-driven movement info. Kept separate from velocity
+// application (`apply_movement`) and ordered ahead of `apply_ground_collider_movement`
+// so a rotating ground platform's rotation delta composes onto this orientation rather
+// than being overwritten by it.
+pub fn apply_rotation(
+    mut player: Query<(&mut Transform, &ActivePlayerComponent<AvatarMovement>), With<PrimaryUser>>,
+    movement_control: Res<EngineMovementControl>,
+) {
+    let Ok((mut transform, movement)) = player.single_mut() else {
+        return;
+    };
+
+    if !movement_suppressed(&movement_control, movement) {
+        transform.rotation = Quat::from_rotation_y(movement.component.orientation / 360.0 * TAU);
+    }
+}
+
 pub fn apply_movement(
     mut player: Query<
         (
@@ -522,17 +555,9 @@ pub fn apply_movement(
 
     info.0.step_time = time_res.delta_secs();
 
-    // Suppress while an explicit suppression is held (e.g. movePlayerTo interpolation),
-    // OR while the active AvatarMovement was initiated before the most recent
-    // movePlayerTo-imposed facing — such a tick read a pre-teleport transform, so
-    // applying its orientation would clobber the imposed facing. Strict `>` (here as
-    // `<=` to suppress) treats a same-frame dispatch as stale, since `last_sent` is
-    // captured before this restricted-action runs and shares the frame's timestamp.
-    let suppress = !movement_control.suppress_avatar_physics.is_empty()
-        || movement.initiated_at <= movement_control.accept_movement_after;
-    if !suppress {
-        transform.rotation = Quat::from_rotation_y(movement.component.orientation / 360.0 * TAU);
-    }
+    // Orientation was already set this frame by `apply_rotation` (pipeline step 1);
+    // here we only apply velocity. The same suppression gate still governs velocity.
+    let suppress = movement_suppressed(&movement_control, movement);
 
     if suppress || movement.component.velocity == Vec3::ZERO {
         dynamic_state.velocity = Vec3::ZERO;

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -11,8 +11,8 @@ use common::{
     dynamics::{PLAYER_COLLIDER_OVERLAP, PLAYER_COLLIDER_RADIUS, PLAYER_GROUND_THRESHOLD},
     sets::{PostUpdateSets, SceneSets},
     structs::{
-        AppConfig, AvatarDynamicState, EngineMovementControl, PrimaryPlayerRes, PrimaryUser,
-        SceneDrivenAnim, SceneDrivenAnimationFeedback, SceneDrivenAnimationRequest,
+        avatar_tilt_quat, AppConfig, AvatarDynamicState, EngineMovementControl, PrimaryPlayerRes,
+        PrimaryUser, SceneDrivenAnim, SceneDrivenAnimationFeedback, SceneDrivenAnimationRequest,
     },
 };
 use comms::global_crdt::GlobalCrdtState;
@@ -199,6 +199,8 @@ fn update_scene_driven_animation(
             transition_seconds: anim.transition_seconds.unwrap_or(0.2),
             seek: anim.playback_time,
             sounds,
+            tilt_pitch: active.component.tilt_pitch,
+            tilt_roll: active.component.tilt_roll,
         })
     })();
 
@@ -216,6 +218,10 @@ pub struct AvatarMovement {
     pub walk_success: Option<bool>,
     /// scene-driven movement animation request; if absent, engine falls back to velocity-based selection
     pub animation: Option<MovementAnimation>,
+    /// render-only lean (degrees) composed on top of `orientation`; does not affect physics
+    /// or the yaw broadcast to other clients. 0 = upright.
+    pub tilt_pitch: f32,
+    pub tilt_roll: f32,
 }
 
 impl Default for AvatarMovement {
@@ -226,6 +232,8 @@ impl Default for AvatarMovement {
             ground_direction: Vec3::NEG_Y,
             walk_success: None,
             animation: None,
+            tilt_pitch: 0.0,
+            tilt_roll: 0.0,
         }
     }
 }
@@ -265,6 +273,8 @@ impl From<PbAvatarMovement> for AvatarMovement {
                 .unwrap_or(Vec3::NEG_Y),
             walk_success: value.walk_success,
             animation: value.animation,
+            tilt_pitch: value.tilt_pitch.unwrap_or_default(),
+            tilt_roll: value.tilt_roll.unwrap_or_default(),
         }
     }
 }
@@ -530,7 +540,10 @@ pub fn apply_rotation(
     };
 
     if !movement_suppressed(&movement_control, movement) {
-        transform.rotation = Quat::from_rotation_y(movement.component.orientation / 360.0 * TAU);
+        // Yaw is authoritative (broadcast to other clients, used by physics); tilt is a
+        // render-only lean composed on top. `to_euler(YXZ).0` still recovers the yaw.
+        transform.rotation = Quat::from_rotation_y(movement.component.orientation / 360.0 * TAU)
+            * avatar_tilt_quat(movement.component.tilt_pitch, movement.component.tilt_roll);
     }
 }
 

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -199,8 +199,6 @@ fn update_scene_driven_animation(
             transition_seconds: anim.transition_seconds.unwrap_or(0.2),
             seek: anim.playback_time,
             sounds,
-            tilt_pitch: active.component.tilt_pitch,
-            tilt_roll: active.component.tilt_roll,
         })
     })();
 


### PR DESCRIPTION
Adds a render-only avatar lean (pitch/roll) on top of the authoritative yaw orientation, so scenes (e.g. the movement scene's glider) can bank without affecting physics or the yaw other clients read. Plus the supporting movement-animation pipeline fixes.

## Engine
- **Split the orientation set into its own pipeline step** (`apply_rotation`), ordered ahead of `apply_ground_collider_movement`, so a rotating ground platform's rotation delta composes onto the avatar orientation instead of being clobbered (matches the order-of-operations in the `PBAvatarMovement` proto comment).
- **Render-only tilt**: `PBAvatarMovement.tilt_pitch` / `tilt_roll` (degrees) composed as `from_rotation_y(yaw) * tilt` in `apply_rotation` and the point-at body-yaw override. Yaw stays authoritative — `rotation_y` on the wire is still clean (`to_euler(YXZ).0`), so Unity / older clients render upright. Physics capsule is unaffected (stays upright). Remote avatars get it via the bevy-local `SceneDrivenAnimation` carrier, composed into the received rotation in `global_crdt`.
- **Seamless movement-anim prop swaps**: when a scene-driven clip carries an embedded prop (e.g. the glider), keep the old prop scene alive until the replacement is initialised (no gap), and carry a one-shot scene `playback_time` across the deferred prop spawn via a stashed clip-start time so the avatar + prop resume in phase regardless of load time.

## Dependency
Bumps bevy to `robtfm/bevy@8edbc49` (on `release-0.16-dcl`), which threads freshly-added `AnimationGraph`s the same frame — removing the one-frame bind/T-pose on first play for avatars and props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)