### PR TITLE
Exempt portables from current-scene load deferral

### DIFF
--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -1544,7 +1544,13 @@ pub fn process_scene_lifecycle(
             .map(|(h, u)| ((h, u), false)),
     );
 
-    // add any portables to requirements
+    // add any portables to requirements. Portables are exempt from the
+    // current-scene deferral below (see `retain`) so they load immediately
+    // instead of queueing behind the spawn-point parcel scene at startup.
+    let portable_ids: HashSet<(String, Option<String>)> = portables
+        .iter()
+        .map(|(hash, source)| (hash.clone(), Some(source.pid.clone())))
+        .collect();
     required_scene_ids.extend(
         portables
             .iter()
@@ -1635,7 +1641,10 @@ pub fn process_scene_lifecycle(
         {
             defer_to_current_scene = true;
             // if the current scene is not even spawned, spawn only that scene
-            required_scene_ids.retain(|scene, super_user| *super_user || (scene == &current_scene));
+            // (plus super-user scenes and portables, which are exempt).
+            required_scene_ids.retain(|scene, super_user| {
+                *super_user || scene == &current_scene || portable_ids.contains(scene)
+            });
         }
     }
     // publish for imposter loading: defer while the current scene is loading


### PR DESCRIPTION
## Summary

At startup, `process_scene_lifecycle` defers all not-yet-spawned scenes behind the active parcel (spawn-point) scene until it has run past its load (`tick_number > 6`), so the current scene gets loading bandwidth first. Portables loaded via `--portables` were caught by this deferral and only began loading once the current scene was up.

This exempts portables from the deferral `retain` alongside super-user scenes, so they load immediately and in parallel with the current scene — **without** needing super-user status.

## Details

- Collect the portable scene keys into `portable_ids` where portables are added to `required_scene_ids`.
- Add `|| portable_ids.contains(scene)` to the deferral `retain` predicate (the same exemption super-user scenes already get via `*super_user`).
- Imposter deferral (`CurrentSceneLoading`) is intentionally unchanged — imposters still wait on the current scene.