### PR TITLE
fix: pre-register fallback font so missing glyphs render on first paint

### DIFF
--- a/crates/ui_core/src/lib.rs
+++ b/crates/ui_core/src/lib.rs
@@ -120,6 +120,14 @@ fn setup(
     font_system
         .db_mut()
         .load_font_data(include_bytes!("NotoColorEmoji.ttf").to_vec());
+    // Pre-register a broad-coverage fallback so glyphs missing from the primary
+    // font (e.g. geometric shapes like U+25BC ▼) resolve on first paint. Fonts
+    // loaded via the AssetServer only enter the cosmic-text db when a span first
+    // uses them, so without this they are absent from the fallback scan during a
+    // text element's initial layout and render as tofu until the value changes.
+    font_system.db_mut().load_font_data(
+        include_bytes!("../../assets/src/assets/fonts/NotoSansMono-Regular.ttf").to_vec(),
+    );
 
     // tracker.load_asset(asset_server.load_folder("ui"));
     tracker.load_asset(asset_server.load::<DuiNodeList>("embedded://ui/app_settings.dui"));


### PR DESCRIPTION
## Summary

Fixes #809: a `uiText` element whose value contains a glyph missing from the primary font (e.g. `▼` U+25BC) rendered the missing-glyph box (tofu) on first paint, and only corrected itself once the element's `value` next changed.

## Cause

The triangle glyphs aren't in the UI font (NotoSans) at all — they resolve through cosmic-text's fallback scan over the font db:

| Glyph | NotoSans | NotoColorEmoji | NotoSansMono |
|---|---|---|---|
| `▶` U+25B6 | ✗ | ✓ (loaded sync) | ✓ |
| `▼` U+25BC | ✗ | ✗ | ✓ (async asset) |

`▶` painted fine from frame 0 because NotoColorEmoji is pre-loaded synchronously via `load_font_data`. Asset-loaded fonts (NotoSansMono/Serif) only enter the cosmic-text db **lazily, when a span first uses them** (`load_font_to_fontdb` in `pipeline.rs`). So at a text element's first layout no db face covered `▼`, the fallback scan produced tofu, and the element wasn't re-laid-out until its value changed.

This is late fallback-font registration, not an atlas-rasterization issue.

## Fix

Pre-register NotoSansMono-Regular (broad geometric-shape coverage) into the cosmic-text db at startup via `load_font_data`, mirroring the existing emoji fallback. A covering face is then present at first paint, so the fallback scan resolves these glyphs immediately.