### PR TITLE
world ui: share the text quad mesh and cull text quads

### DIFF
--- a/crates/assets/src/assets/shaders/text_quad_vertex.wgsl
+++ b/crates/assets/src/assets/shaders/text_quad_vertex.wgsl
@@ -44,13 +44,18 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     );
 
     if (quad_data.vertex_billboard == 1u) {
+        // billboard faces the camera, but still honour the entity's x/y scale
+        // (column lengths of the model matrix) so culling, which applies the
+        // full model transform to the aabb, agrees with what we draw.
+        let scale_x = length(model[0].xyz);
+        let scale_y = length(model[1].xyz);
         out.world_position = mesh_functions::mesh_position_local_to_world(
             mat4x4<f32>(
-                vec4<f32>(view.world_from_view[0].xyz, 0.0),
-                vec4<f32>(view.world_from_view[1].xyz, 0.0),
+                vec4<f32>(view.world_from_view[0].xyz * scale_x, 0.0),
+                vec4<f32>(view.world_from_view[1].xyz * scale_y, 0.0),
                 vec4<f32>(view.world_from_view[2].xyz, 0.0),
                 vec4<f32>(model[3].xyz, 1.0)
-            ), 
+            ),
             vec4<f32>(modified_vertex_position, 1.0)
         );
     } else {

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -1,17 +1,18 @@
 use bevy::{
     asset::RenderAssetTransferPriority,
     diagnostic::FrameCount,
+    math::Vec3A,
     pbr::{ExtendedMaterial, MaterialExtension, NotShadowCaster},
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::{
         camera::RenderTarget,
+        primitives::Aabb,
         render_asset::RenderAssetUsages,
         render_resource::{
             AsBindGroup, Extent3d, ShaderRef, TextureDimension, TextureFormat, TextureUsages,
         },
         renderer::RenderDevice,
-        view::NoFrustumCulling,
     },
     transform::TransformSystem,
     ui::UiSystem,
@@ -39,6 +40,7 @@ impl Plugin for WorldUiPlugin {
             app.add_plugins(ImposterBakeMaterialPlugin::<TextShapeMaterial>::default());
         }
 
+        app.init_resource::<WorldUiQuadMesh>();
         app.add_systems(Update, add_worldui_materials.in_set(SceneSets::PostLoop));
         app.add_systems(
             PostUpdate,
@@ -51,6 +53,40 @@ impl Plugin for WorldUiPlugin {
 
 #[derive(Component)]
 pub struct WorldUiRenderTarget(Handle<Image>);
+
+/// shared unit-quad mesh: the shader positions/scales it, so one asset serves every text shape
+#[derive(Resource)]
+pub struct WorldUiQuadMesh(pub Handle<Mesh>);
+
+impl FromWorld for WorldUiQuadMesh {
+    fn from_world(world: &mut World) -> Self {
+        let mut meshes = world.resource_mut::<Assets<Mesh>>();
+        Self(meshes.add(bevy::math::primitives::Rectangle::default().mesh()))
+    }
+}
+
+/// conservative culling bounds from the same TextQuadData the vertex shader uses:
+/// |x| <= (0.5+|halign|)*region_w/ppm, |y| <= ((0.5+|valign|)*region_h+|add_y_pix|)/ppm.
+/// billboarded quads rotate freely around the origin, so use a half-diagonal cube,
+/// padded 2x because culling applies the entity scale that the billboard shader ignores.
+fn world_ui_quad_aabb(data: &TextQuadData) -> Aabb {
+    let region = (data.uvs.zw() - data.uvs.xy()).abs();
+    let pix_per_m = data.pix_per_m.abs().max(1e-3);
+    let half_x = (0.5 + data.halign.abs()) * region.x / pix_per_m;
+    let half_y = ((0.5 + data.valign.abs()) * region.y + data.add_y_pix.abs()) / pix_per_m;
+    if data.vertex_billboard != 0 {
+        let radius = (half_x * half_x + half_y * half_y).sqrt() * 2.0;
+        Aabb {
+            center: Vec3A::ZERO,
+            half_extents: Vec3A::splat(radius.max(0.01)),
+        }
+    } else {
+        Aabb {
+            center: Vec3A::ZERO,
+            half_extents: Vec3A::new(half_x.max(0.01), half_y.max(0.01), 0.01),
+        }
+    }
+}
 
 #[derive(Component)]
 pub struct WorldUi {
@@ -114,7 +150,7 @@ pub struct WorldUiMaterialRef(AssetId<TextShapeMaterial>, AssetId<Image>);
 pub fn add_worldui_materials(
     mut commands: Commands,
     q: Query<(Entity, &WorldUi, Option<&Children>), Changed<WorldUi>>,
-    mut meshes: ResMut<Assets<Mesh>>,
+    quad_mesh: Res<WorldUiQuadMesh>,
     mut materials: ResMut<Assets<TextShapeMaterial>>,
     config: Res<AppConfig>,
     targets: Query<&WorldUiRenderTarget>,
@@ -139,6 +175,8 @@ pub fn add_worldui_materials(
             _pad2: 0,
         };
 
+        let quad_aabb = world_ui_quad_aabb(&material_data);
+
         let material = materials.add(TextShapeMaterial {
             base: SceneMaterial {
                 base: StandardMaterial {
@@ -161,10 +199,10 @@ pub fn add_worldui_materials(
 
         let quad = commands
             .spawn((
-                Mesh3d(meshes.add(bevy::math::primitives::Rectangle::default().mesh())),
+                Mesh3d(quad_mesh.0.clone()),
                 MeshMaterial3d(material),
                 NotShadowCaster,
-                NoFrustumCulling, // TODO calculate aabb based on font size (and update when it changes)
+                quad_aabb,
             ))
             .id();
 
@@ -194,6 +232,7 @@ pub fn update_worldui_materials(
         )>,
     >,
     all: Query<(Entity, &WorldUiMaterialRef, &ComputedNode, &GlobalTransform)>,
+    mut quads: Query<(&MeshMaterial3d<TextShapeMaterial>, &mut Aabb)>,
     mut mats: ResMut<Assets<TextShapeMaterial>>,
     mut images: ResMut<Assets<Image>>,
     frame: Res<FrameCount>,
@@ -208,6 +247,7 @@ pub fn update_worldui_materials(
     }
 
     let mut target_sizes: HashMap<AssetId<Image>, UVec2> = HashMap::new();
+    let mut updated_aabbs: HashMap<AssetId<TextShapeMaterial>, Aabb> = HashMap::new();
 
     for (ent, ref_mat, node, gt) in all.iter() {
         if !changed_targets.contains(&ref_mat.1) {
@@ -225,7 +265,9 @@ pub fn update_worldui_materials(
         let bottomright = translation.xy() + node.size() / 2.0;
         let required_uvs = Vec4::new(topleft.x, topleft.y, bottomright.x, bottomright.y);
         if mat.extension.data.uvs != required_uvs {
-            mats.get_mut(ref_mat.0).unwrap().extension.data.uvs = required_uvs;
+            let mat = mats.get_mut(ref_mat.0).unwrap();
+            mat.extension.data.uvs = required_uvs;
+            updated_aabbs.insert(ref_mat.0, world_ui_quad_aabb(&mat.extension.data));
         }
         debug!(
             "[{}] img {:?}, {ent:?} uvs set to {} (size: {}, translation: {})",
@@ -238,6 +280,14 @@ pub fn update_worldui_materials(
 
         let max_extent = target_sizes.entry(ref_mat.1).or_default();
         *max_extent = max_extent.max(bottomright.ceil().as_uvec2());
+    }
+
+    if !updated_aabbs.is_empty() {
+        for (mat, mut aabb) in quads.iter_mut() {
+            if let Some(new_aabb) = updated_aabbs.get(&mat.id()) {
+                *aabb = *new_aabb;
+            }
+        }
     }
 
     *prev_changed_targets = target_sizes

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -67,15 +67,16 @@ impl FromWorld for WorldUiQuadMesh {
 
 /// conservative culling bounds from the same TextQuadData the vertex shader uses:
 /// |x| <= (0.5+|halign|)*region_w/ppm, |y| <= ((0.5+|valign|)*region_h+|add_y_pix|)/ppm.
-/// billboarded quads rotate freely around the origin, so use a half-diagonal cube,
-/// padded 2x because culling applies the entity scale that the billboard shader ignores.
+/// billboarded quads rotate freely around the origin, so use a half-diagonal cube;
+/// the shader applies the entity's x/y scale, so culling (which transforms this aabb
+/// by the full model) agrees and no extra padding is needed.
 fn world_ui_quad_aabb(data: &TextQuadData) -> Aabb {
     let region = (data.uvs.zw() - data.uvs.xy()).abs();
     let pix_per_m = data.pix_per_m.abs().max(1e-3);
     let half_x = (0.5 + data.halign.abs()) * region.x / pix_per_m;
     let half_y = ((0.5 + data.valign.abs()) * region.y + data.add_y_pix.abs()) / pix_per_m;
     if data.vertex_billboard != 0 {
-        let radius = (half_x * half_x + half_y * half_y).sqrt() * 2.0;
+        let radius = (half_x * half_x + half_y * half_y).sqrt();
         Aabb {
             center: Vec3A::ZERO,
             half_extents: Vec3A::splat(radius.max(0.01)),

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -222,7 +222,7 @@ pub fn add_worldui_materials(
     }
 }
 
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn update_worldui_materials(
     changed: Query<
         &WorldUiMaterialRef,


### PR DESCRIPTION
Builds on @eordano's [`2cbd2d0`](https://github.com/eordano/bevy-explorer/commit/2cbd2d0e54cf76da64528b3543ed941533010e81), cherry-picked here, with one follow-up.

## What

**From the cherry-picked commit:**
- Share a single unit-quad `Mesh` (`WorldUiQuadMesh`) across all text shapes instead of allocating an identical mesh per quad — the vertex shader does all placement/scaling.
- Replace `NoFrustumCulling` on text quads with a conservative `Aabb` derived from the same `TextQuadData` the shader uses, updated when the text region (UVs) changes. This lets off-frustum text drop out of rendering and closes the existing `// TODO calculate aabb based on font size` in `add_worldui_materials`.

**Follow-up commit:**
- The billboard path built its quad from the view basis, discarding the entity's scale, and hedged the mismatch with a 2x pad on the cull aabb. Instead, the billboard branch now scales the camera right/up axes by the entity's x/y scale (model column lengths), so the drawn quad matches the model transform that frustum culling applies to the aabb. The 2x pad is removed.

## Notes
- The non-billboard `TextShape` path gets a tight, exact aabb. The billboard path (legacy built-in avatar nametags, gated behind `--builtin-nametags` and off by default) now also agrees exactly with culling for non-sheared transforms.
- `cargo fmt --all`, `cargo clippy --all`, and the WASM build all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)