### PR TITLE
login: poll the update check instead of blocking on it

### DIFF
--- a/crates/system_ui/src/login.rs
+++ b/crates/system_ui/src/login.rs
@@ -34,7 +34,7 @@ use wallet::{
     Wallet,
 };
 
-use crate::version_check::{check_update, check_update_sync};
+use crate::version_check::check_update;
 
 pub struct LoginPlugin;
 
@@ -70,6 +70,7 @@ fn login(
     dui: Res<DuiRegistry>,
     active_dialog: Res<ActiveDialog>,
     mut motd_shown: Local<bool>,
+    mut update_check: Local<Option<bevy::tasks::Task<Option<(String, String)>>>>,
     mut bridge: EventWriter<SystemApi>,
     native_active: Res<NativeUi>,
     config: Res<AppConfig>,
@@ -79,7 +80,15 @@ fn login(
     }
 
     if !*motd_shown {
-        let update = check_update_sync();
+        // don't block the main thread on the github release check
+        let task = update_check.get_or_insert_with(|| {
+            bevy::tasks::IoTaskPool::get().spawn(check_update())
+        });
+        let Some(update) = futures_lite::future::block_on(futures_lite::future::poll_once(task))
+        else {
+            return;
+        };
+        *update_check = None;
         let permit = active_dialog.try_acquire().unwrap();
 
         if let Some((desc, url)) = update {

--- a/crates/system_ui/src/login.rs
+++ b/crates/system_ui/src/login.rs
@@ -81,11 +81,8 @@ fn login(
 
     if !*motd_shown {
         // don't block the main thread on the github release check
-        let task = update_check.get_or_insert_with(|| {
-            bevy::tasks::IoTaskPool::get().spawn(check_update())
-        });
-        let Some(update) = futures_lite::future::block_on(futures_lite::future::poll_once(task))
-        else {
+        let task = update_check.get_or_insert_with(|| IoTaskPool::get().spawn(check_update()));
+        let Some(update) = task.complete() else {
             return;
         };
         *update_check = None;


### PR DESCRIPTION
Cherry-picks @eordano's [`4fbc7e6`](https://github.com/eordano/bevy-explorer/commit/4fbc7e6d9bc2d607570c8bda4c4f0e8cf2d4728b), with one follow-up.

## What

**From the cherry-picked commit:**
`check_update_sync` `block_on`'d a GitHub API round-trip on the main thread at first login (150-300ms on fast networks, seconds on slow ones). It now spawns the release check on the `IoTaskPool` and polls it across frames instead of blocking. Interleaved A/B, 8 runs each: loading frames >100ms went 11 → 2; worst loading frame per run 157-239ms → 95-104ms (the one-off boot frame).

**Follow-up commit:**
Replaced the manual `block_on(poll_once(..))` with the repo-standard `TaskExt::complete()` idiom (already used across `comms`, `collectibles`, `imposters`). On native it does the same `is_finished` + `poll`, and it's wasm-safe — same non-blocking behaviour, less boilerplate.

## Notes
- `cargo fmt --all`, `cargo clippy --all -- -D warnings`, and the WASM build all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)