### PR TITLE
crdt: skip idle components, cache sent transforms, reuse buffers, emptiness guards

### DIFF
--- a/crates/dcl/src/interface/mod.rs
+++ b/crates/dcl/src/interface/mod.rs
@@ -134,6 +134,9 @@ impl CrdtStore {
     }
 
     pub fn clean_up(&mut self, dead: &HashSet<SceneEntityId>) {
+        if dead.is_empty() {
+            return;
+        }
         for state in self.lww.values_mut() {
             for id in dead {
                 state.last_write.remove(id);
@@ -148,19 +151,27 @@ impl CrdtStore {
     }
 
     pub fn take_updates(&mut self) -> CrdtStore {
-        let lww =
-            self.lww.iter_mut().map(|(component_id, state)| {
-                (
-                    *component_id,
-                    CrdtLWWState {
-                        last_write: HashMap::from_iter(state.updates.iter().map(|update| {
-                            (*update, state.last_write.get(update).unwrap().clone())
-                        })),
-                        updates: std::mem::take(&mut state.updates),
-                    },
-                )
-            });
-        let lww = HashMap::from_iter(lww);
+        let mut lww = HashMap::new();
+        for (component_id, state) in self.lww.iter_mut() {
+            if state.updates.is_empty() {
+                continue;
+            }
+            // last_write must retain authoritative state for future LWW conflict
+            // checks, so dirty entries are cloned rather than moved out.
+            let updates = std::mem::take(&mut state.updates);
+            let last_write = HashMap::from_iter(
+                updates
+                    .iter()
+                    .map(|update| (*update, state.last_write.get(update).unwrap().clone())),
+            );
+            lww.insert(
+                *component_id,
+                CrdtLWWState {
+                    last_write,
+                    updates,
+                },
+            );
+        }
 
         let go = std::mem::take(&mut self.go);
         CrdtStore { lww, go }

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -37,7 +37,7 @@ use dcl_component::{
         sdk::components::{PbRealmInfo, PbUiCanvasInformation},
     },
     transform_and_parent::DclTransformAndParent,
-    DclReader, DclWriter, FromDclReader, SceneComponentId, SceneEntityId,
+    DclReader, DclWriter, SceneComponentId, SceneEntityId,
 };
 use initialize_scene::{PortableScenes, TestingData};
 use ipfs::SceneIpfsLocation;
@@ -706,8 +706,10 @@ fn send_scene_updates(
     data_channel: Res<SceneRoomConnection>,
     interactable_area: Res<InteractableArea>,
     preview_mode: Res<PreviewMode>,
+    mut buf: Local<Vec<u8>>,
 ) {
     let updates = &mut *updates;
+    let buf = &mut *buf;
 
     // Peek at the next scene before popping. Priority scenes bypass the thread
     // limit (but still occupy slots, preventing non-priority scenes from
@@ -729,14 +731,14 @@ fn send_scene_updates(
     // collect components
 
     // generate updates for camera and player
-    let mut buf = Vec::default();
-    for (mut affine, id) in [
+    for (mut affine, id, is_player) in [
         (
             player
                 .single()
                 .map(Transform::compute_affine)
                 .unwrap_or_default(),
             SceneEntityId::PLAYER,
+            true,
         ),
         (
             camera
@@ -744,25 +746,19 @@ fn send_scene_updates(
                 .map(Transform::compute_affine)
                 .unwrap_or_default(),
             SceneEntityId::CAMERA,
+            false,
         ),
     ] {
-        buf.clear();
         affine.translation -= scene_transform.affine().translation * Vec3A::new(1.0, 0.0, 1.0);
         let relative_transform = Transform::from(GlobalTransform::from(affine));
 
-        DclWriter::new(&mut buf).write(&DclTransformAndParent::from_bevy_transform_and_parent(
-            &relative_transform,
-            SceneEntityId::ROOT,
-        ));
-
-        let update = context
-            .crdt_store
-            .get(SceneComponentId::TRANSFORM, CrdtType::LWW_ENT, id)
-            .map(|prev| {
-                DclTransformAndParent::from_reader(&mut DclReader::new(prev))
-                    .unwrap()
-                    .to_bevy_transform()
-            })
+        // delta-check against the last transform we sent
+        let last_sent = if is_player {
+            &mut context.last_sent_player_transform
+        } else {
+            &mut context.last_sent_camera_transform
+        };
+        let update = last_sent
             .map(|t| {
                 (t.translation - relative_transform.translation).length_squared() > 0.0001
                     || t.rotation.angle_between(relative_transform.rotation) > 0.0001
@@ -770,11 +766,17 @@ fn send_scene_updates(
             .unwrap_or(true);
 
         if update {
+            *last_sent = Some(relative_transform);
+            buf.clear();
+            DclWriter::new(buf).write(&DclTransformAndParent::from_bevy_transform_and_parent(
+                &relative_transform,
+                SceneEntityId::ROOT,
+            ));
             context.crdt_store.update_if_different(
                 SceneComponentId::TRANSFORM,
                 CrdtType::LWW_ENT,
                 id,
-                Some(&mut DclReader::new(&buf)),
+                Some(&mut DclReader::new(buf)),
             );
         }
     }
@@ -811,12 +813,12 @@ fn send_scene_updates(
         is_connected_scene_room: Some(room.is_some()),
     };
     buf.clear();
-    DclWriter::new(&mut buf).write(&realm_info);
+    DclWriter::new(buf).write(&realm_info);
     context.crdt_store.update_if_different(
         SceneComponentId::REALM_INFO,
         CrdtType::LWW_ANY,
         SceneEntityId::ROOT,
-        Some(&mut DclReader::new(&buf)),
+        Some(&mut DclReader::new(buf)),
     );
 
     // add canvas info
@@ -861,12 +863,12 @@ fn send_scene_updates(
     };
 
     buf.clear();
-    DclWriter::new(&mut buf).write(&canvas_info);
+    DclWriter::new(buf).write(&canvas_info);
     context.crdt_store.force_update(
         SceneComponentId::CANVAS_INFO,
         CrdtType::LWW_ROOT,
         SceneEntityId::ROOT,
-        Some(&mut DclReader::new(&buf)),
+        Some(&mut DclReader::new(buf)),
     );
 
     // Engine-initiated census to push to the scene. Drained here (only when this

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -68,6 +68,10 @@ pub struct RendererSceneContext {
 
     // time of last message sent to scene
     pub last_sent: f32,
+    // last player/camera transforms sent to the scene, used to delta-check
+    // without deserializing the stored crdt entry every frame
+    pub last_sent_player_transform: Option<Transform>,
+    pub last_sent_camera_transform: Option<Transform>,
     // time of last updates to bevy world from scene
     pub last_update_frame: u32,
     // currently running?
@@ -164,6 +168,8 @@ impl RendererSceneContext {
             unparented_entities: HashSet::new(),
             hierarchy_changed: false,
             last_sent: 0.0,
+            last_sent_player_transform: None,
+            last_sent_camera_transform: None,
             last_update_frame: 0,
             in_flight: false,
             broken: false,

--- a/crates/scene_runner/src/update_world/mod.rs
+++ b/crates/scene_runner/src/update_world/mod.rs
@@ -351,6 +351,11 @@ pub(crate) fn process_crdt_lww_updates<
     <C as TryFrom<D>>::Error: std::fmt::Display,
 {
     for (_root, scene_context, mut updates, deleted_entities) in scenes.iter_mut() {
+        // avoid triggering change detection when there is nothing to do
+        if updates.last_write.is_empty() && deleted_entities.0.is_empty() {
+            continue;
+        }
+
         // remove crdt state for dead entities
         for deleted in &deleted_entities.0 {
             updates.last_write.remove(deleted);
@@ -417,6 +422,11 @@ fn process_crdt_go_updates<
     mut existing: Query<&mut C>,
 ) {
     for (_root, scene_context, mut updates, deleted_entities) in scenes.iter_mut() {
+        // avoid triggering change detection when there is nothing to do
+        if updates.0.is_empty() && deleted_entities.0.is_empty() {
+            continue;
+        }
+
         // remove crdt state for dead entities
         for deleted in &deleted_entities.0 {
             updates.0.remove(deleted);

--- a/crates/scene_runner/src/update_world/transform_and_parent.rs
+++ b/crates/scene_runner/src/update_world/transform_and_parent.rs
@@ -98,6 +98,11 @@ pub(crate) fn process_transform_and_parent_updates(
     // mut restricted_actions: EventWriter<RpcCall>,
 ) {
     for (root, mut scene_context, mut updates, deleted_entities) in scenes.iter_mut() {
+        // avoid triggering change detection when there is nothing to do
+        if updates.last_write.is_empty() && deleted_entities.0.is_empty() {
+            continue;
+        }
+
         // remove crdt state for dead entities
         for deleted in &deleted_entities.0 {
             updates.last_write.remove(deleted);


### PR DESCRIPTION
Cherry-picks @eordano's [`b57f7ed`](https://github.com/eordano/bevy-explorer/commit/b57f7ed52afea34a599eef865f0571025dd46250) — a set of small, behaviour-preserving CRDT hot-path optimizations. A/B: ~-1.5% frame, scales with scene count.

## What

- **`take_updates` skips idle components** — no longer rebuilds an (empty) `CrdtLWWState` entry for components with no pending updates; emits only the components that actually changed. Same delta the receiver applies, just smaller.
- **Cache sent player/camera transforms** — `RendererSceneContext` now holds `last_sent_player_transform` / `last_sent_camera_transform`, so the per-frame delta-check no longer deserializes the stored CRDT entry every frame. Only serializes + stores when the transform actually changed.
- **Reuse the scratch buffer** — `send_scene_updates` keeps a `Local<Vec<u8>>` instead of allocating a fresh `Vec` each call; cleared before each write.
- **Emptiness guards** — early-outs in `clean_up` and in the LWW/GO/transform CRDT appliers, avoiding spurious `Changed<>` change-detection ticks when there is nothing to apply.

## Notes
- The transform cache is equivalent to the prior store-deserialize because the store is written only by the same path, and both `last_sent_*` and `crdt_store` live on `RendererSceneContext` and are reset together on scene (re)start — they can't desync.
- `cargo fmt --all`, `cargo clippy --all -- -D warnings`, and the WASM build all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)