### PR TITLE
gate per-frame systems on actual change

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1161,7 +1161,7 @@ pub struct StartupScenes {
     pub scenes: Vec<StartupScene>,
 }
 
-#[derive(Resource, Default, Clone, Debug)]
+#[derive(Resource, Default, Clone, Debug, PartialEq)]
 pub struct SceneGlobalLight {
     pub source: Option<Entity>,
     pub dir_color: Color,

--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -259,6 +259,14 @@ pub fn spawn_imposters(
 
     let origin = focus.origin * Vec2::new(1.0, -1.0);
 
+    // snap to the focused parcel's centre so tile selection is a deterministic function of the
+    // parcel cell (matching the recompute gate below). using the raw focus position would let the
+    // tile set drift up to a full parcel diagonal stale as the focus moves within one parcel, and
+    // would make the result depend on which edge the parcel was entered from. (the bake-request
+    // origin further down is intentionally left on the raw focus position.)
+    let origin_parcel = (origin / PARCEL_SIZE).floor().as_ivec2();
+    let origin = (origin_parcel.as_vec2() + 0.5) * PARCEL_SIZE;
+
     // record live parcels
     let current_imposter_scene = match &current_imposter_scene.0 {
         Some((PointerResult::Exists { hash, .. }, _)) => Some(hash),
@@ -289,7 +297,7 @@ pub fn spawn_imposters(
     // tile membership is parcel-granular, so we only need to recompute when the focus
     // crosses a parcel boundary (or scale/extents/live parcels/ingredients change).
     let run_state = (
-        (origin / PARCEL_SIZE).floor().as_ivec2(),
+        origin_parcel,
         focus.min_distance,
         focus.distance_scale,
         manager.pointers.min(),

--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -217,6 +217,7 @@ pub fn spawn_imposters(
     config: Res<AppConfig>,
     focus: Res<ImposterFocus>,
     mut required: Local<HashMap<(IVec2, usize), bool>>,
+    mut last_run_state: Local<Option<(IVec2, f32, f32, IVec2, IVec2, HashSet<IVec2>)>>,
     current_imposters: Query<(Entity, &SceneImposter)>,
     current_realm: Res<CurrentRealm>,
     ingredients: Res<BakingIngredients>,
@@ -234,6 +235,7 @@ pub fn spawn_imposters(
         }
 
         manager.clear();
+        *last_run_state = None;
 
         debug!("purge");
         return;
@@ -282,6 +284,23 @@ pub fn spawn_imposters(
         .flatten()
         .copied()
         .collect::<HashSet<_>>();
+
+    // skip the full tile recompute when nothing that affects the result has changed.
+    // tile membership is parcel-granular, so we only need to recompute when the focus
+    // crosses a parcel boundary (or scale/extents/live parcels/ingredients change).
+    let run_state = (
+        (origin / PARCEL_SIZE).floor().as_ivec2(),
+        focus.min_distance,
+        focus.distance_scale,
+        manager.pointers.min(),
+        manager.pointers.max(),
+        live_parcels,
+    );
+    if required.is_empty() && !config.is_changed() && last_run_state.as_ref() == Some(&run_state) {
+        return;
+    }
+    let live_parcels = &run_state.5;
+
     let live_min = live_parcels.iter().fold(IVec2::MAX, |x, y| x.min(*y));
     let live_max = live_parcels.iter().fold(IVec2::MIN, |x, y| x.max(*y));
 
@@ -420,6 +439,8 @@ pub fn spawn_imposters(
     for (_, ent) in old.drain() {
         manager.store_removed(None, ent);
     }
+
+    *last_run_state = Some(run_state);
 }
 
 #[derive(Debug)]

--- a/crates/input_manager/src/lib.rs
+++ b/crates/input_manager/src/lib.rs
@@ -268,6 +268,23 @@ impl InputManager<'_, '_> {
         })
     }
 
+    // true if any binding for the action was just pressed, ignoring priority reservations.
+    // `just_down` can only return true (for any priority) if this returns true.
+    pub fn just_down_any_priority<T: Into<Action>>(&self, action: T) -> bool {
+        self.inputs(action.into()).any(|item| match item {
+            InputIdentifier::Key(k) => self.key_input.just_pressed(*k),
+            InputIdentifier::Mouse(mb) => self.mouse_input.just_pressed(*mb),
+            InputIdentifier::Gamepad(b) => self
+                .gamepads
+                .iter()
+                .flat_map(|gp| gp.get_just_pressed())
+                .any(|p| p == b),
+            InputIdentifier::Analog(axis, input_direction) => {
+                self.axis_data.just_down(*axis, *input_direction)
+            }
+        })
+    }
+
     pub fn just_up<T: Into<Action>>(&self, action: T) -> bool {
         self.inputs(action.into()).any(|item| match item {
             InputIdentifier::Key(k) => self.key_input.just_released(*k),

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -518,8 +518,11 @@ pub fn parcel_to_vec3(parcel: IVec2) -> Vec3 {
 }
 
 impl ContainingScene<'_, '_> {
-    // true if any resource determining scene membership changed this frame
-    pub fn is_changed(&self) -> bool {
+    // true if the set/placement of scenes changed this frame (pointer grid, live scenes,
+    // portables). NOTE: this does NOT track entity movement — the `get*`/`get_area` lookups that
+    // map an entity position to a scene also depend on that entity's GlobalTransform, so callers
+    // gating on this must additionally detect the relevant position changing themselves.
+    pub fn scene_layout_changed(&self) -> bool {
         self.pointers.is_changed()
             || self.live_scenes.is_changed()
             || self.portable_scenes.is_changed()

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -518,6 +518,13 @@ pub fn parcel_to_vec3(parcel: IVec2) -> Vec3 {
 }
 
 impl ContainingScene<'_, '_> {
+    // true if any resource determining scene membership changed this frame
+    pub fn is_changed(&self) -> bool {
+        self.pointers.is_changed()
+            || self.live_scenes.is_changed()
+            || self.portable_scenes.is_changed()
+    }
+
     // just the parcel at the position
     pub fn get_parcel_position(&self, position: Vec3) -> Option<Entity> {
         let parcel = vec3_to_parcel(position);

--- a/crates/scene_runner/src/update_world/lights.rs
+++ b/crates/scene_runner/src/update_world/lights.rs
@@ -384,6 +384,10 @@ fn manage_shadow_casters(
     };
     let player_t = player_gt.translation();
 
+    if read_lights.is_empty() {
+        return;
+    }
+
     let active_scenes = containing_scene.get_area(player, PLAYER_COLLIDER_RADIUS);
 
     // collect lights
@@ -421,32 +425,30 @@ fn manage_shadow_casters(
         max_enabled,
         max_casters
     );
+    // only write (and trigger change detection) when the target value differs
     for (light, _, importance, shadows_enabled) in lights.drain(..).rev() {
         let (maybe_p, maybe_s, mut vis) = write_lights.get_mut(light).unwrap();
 
         if importance.0 != 0.0 && max_enabled > 0 {
-            *vis = Visibility::Visible;
+            vis.set_if_neq(Visibility::Visible);
             max_enabled -= 1;
 
-            if shadows_enabled && max_casters > 0 {
-                if let Some(mut p) = maybe_p {
-                    p.shadows_enabled = true;
-                }
-                if let Some(mut s) = maybe_s {
-                    s.shadows_enabled = true;
-                }
-
+            let cast = shadows_enabled && max_casters > 0;
+            if cast {
                 max_casters -= 1;
-            } else {
-                if let Some(mut p) = maybe_p {
-                    p.shadows_enabled = false;
+            }
+            if let Some(mut p) = maybe_p {
+                if p.shadows_enabled != cast {
+                    p.shadows_enabled = cast;
                 }
-                if let Some(mut s) = maybe_s {
-                    s.shadows_enabled = false;
+            }
+            if let Some(mut s) = maybe_s {
+                if s.shadows_enabled != cast {
+                    s.shadows_enabled = cast;
                 }
             }
         } else {
-            *vis = Visibility::Hidden;
+            vis.set_if_neq(Visibility::Hidden);
         }
     }
 }

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -151,8 +151,12 @@ pub fn add_collider_systems<T: ColliderType>(app: &mut App) {
     // clean up colliders from SceneColliderData whenever HasCollider is removed (including entity despawn)
     app.add_observer(on_collider_removed::<T>);
 
-    // show debugs whenever
-    app.add_systems(Update, render_debug_colliders::<T>);
+    // show debugs whenever (skip entirely unless debug is enabled or was just disabled)
+    app.add_systems(
+        Update,
+        render_debug_colliders::<T>
+            .run_if(|debug: Res<DebugColliders>| debug.0 != 0 || debug.is_changed()),
+    );
 }
 
 impl Plugin for MeshColliderPlugin {

--- a/crates/scene_runner/src/update_world/pointer_events.rs
+++ b/crates/scene_runner/src/update_world/pointer_events.rs
@@ -272,16 +272,20 @@ fn hover_text(
         process(cand.entity, ActionCandidateMode::Proximity, &synthetic);
     }
 
-    // make unique
-    texts = texts
-        .into_iter()
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect();
+    // make unique (sorted, avoiding the Vec -> HashSet -> Vec round trip)
+    texts.sort_unstable();
+    texts.dedup();
 
-    tooltip
+    // avoid marking the resource changed when the value is identical
+    if tooltip
         .0
-        .insert(TooltipSource::Label("pointer_events"), texts);
+        .get(&TooltipSource::Label("pointer_events"))
+        .is_none_or(|prev| prev != &texts)
+    {
+        tooltip
+            .0
+            .insert(TooltipSource::Label("pointer_events"), texts);
+    }
 }
 
 #[derive(Default, Resource, Deref, DerefMut)]

--- a/crates/system_ui/src/map.rs
+++ b/crates/system_ui/src/map.rs
@@ -284,7 +284,10 @@ fn update_map_data(
             .and_then(|c| c.first())
             .and_then(|c| text.get_mut(*c).ok())
         {
-            text.0 = format!("({},{})", parcel.x, parcel.y + 1);
+            let value = format!("({},{})", parcel.x, parcel.y + 1);
+            if text.0 != value {
+                text.0 = value;
+            }
         }
     }
 }

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -257,14 +257,21 @@ fn update_scene_load_state(
         let mut ix = 0;
         let children = q_children.get(sysinfo).unwrap();
         let mut set_child = |value: String| {
-            if value.is_empty() {
-                style.get_mut(children[ix]).unwrap().display = Display::None;
+            // avoid touching Node/Text when unchanged - any write triggers relayout
+            let display = if value.is_empty() {
+                Display::None
             } else {
-                style.get_mut(children[ix]).unwrap().display = Display::Flex;
+                Display::Flex
+            };
+            let mut style = style.get_mut(children[ix]).unwrap();
+            if style.display != display {
+                style.display = display;
             }
             let container = q_children.get(children[ix]).unwrap();
             let mut text = text.get_mut(container[1]).unwrap();
-            text.0 = value;
+            if text.0 != value {
+                text.0 = value;
+            }
             ix += 1;
         };
 
@@ -483,15 +490,22 @@ fn update_minimap(
 
     if let Ok(components) = q.single() {
         if let Ok(mut map) = maps.get_mut(components.named("map-node")) {
-            map.center = map_center;
+            if map.center != map_center {
+                map.center = map_center;
+            }
         }
 
         if let Ok(mut text) = text.get_mut(components.named("title")) {
-            text.0 = title;
+            if text.0 != title {
+                text.0 = title;
+            }
         }
 
         if let Ok(mut text) = text.get_mut(components.named("position")) {
-            text.0 = format!("({},{})   {sdk}   {state}", parcel.x, parcel.y);
+            let position = format!("({},{})   {sdk}   {state}", parcel.x, parcel.y);
+            if text.0 != position {
+                text.0 = position;
+            }
         }
     }
 }

--- a/crates/ui_core/src/focus.rs
+++ b/crates/ui_core/src/focus.rs
@@ -90,6 +90,12 @@ fn focus(
     focused_elements: Query<(Entity, &Interaction, Option<&UiActionPriority>, &Focusable)>,
     input_manager: InputManager,
 ) {
+    // just_down can only succeed if the raw binding was just pressed; skip the per-entity
+    // scan entirely otherwise
+    if !input_manager.just_down_any_priority(CommonInputAction::IaPointer) {
+        return;
+    }
+
     for (entity, interaction, maybe_priority, focusable) in focused_elements.iter() {
         if interaction != &Interaction::None
             && input_manager.just_down(

--- a/crates/ui_core/src/interact_style.rs
+++ b/crates/ui_core/src/interact_style.rs
@@ -36,7 +36,36 @@ pub struct InteractStylePlugin;
 
 impl Plugin for InteractStylePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, set_interaction_style);
+        // only run when a style input (or styled target) changed, or while any node is
+        // hovered/pressed (the pressed state depends on global input state)
+        app.add_systems(
+            Update,
+            set_interaction_style.run_if(
+                |changed: Query<
+                    (),
+                    (
+                        With<InteractStyles>,
+                        Or<(
+                            Changed<InteractStyles>,
+                            Changed<Interaction>,
+                            Changed<Active>,
+                            Changed<Enabled>,
+                            Changed<UiActionPriority>,
+                            Changed<BackgroundColor>,
+                            Changed<BorderColor>,
+                            Changed<Ui9Slice>,
+                            Changed<ImageNode>,
+                            Changed<BoundedNode>,
+                            Changed<NodeBounds>,
+                        )>,
+                    ),
+                >,
+                 interactions: Query<&Interaction, With<InteractStyles>>| {
+                    !changed.is_empty()
+                        || interactions.iter().any(|i| i != &Interaction::None)
+                },
+            ),
+        );
     }
 }
 
@@ -144,7 +173,10 @@ pub fn set_interaction_style(
 
         if let Some(mut border) = maybe_border {
             if let Some(border_color) = style.border {
-                *border = BorderColor::all(border_color);
+                let new_border = BorderColor::all(border_color);
+                if *border != new_border {
+                    *border = new_border;
+                }
             }
         }
     }

--- a/crates/ui_core/src/interact_style.rs
+++ b/crates/ui_core/src/interact_style.rs
@@ -40,33 +40,37 @@ impl Plugin for InteractStylePlugin {
         // hovered/pressed (the pressed state depends on global input state)
         app.add_systems(
             Update,
-            set_interaction_style.run_if(
-                |changed: Query<
-                    (),
-                    (
-                        With<InteractStyles>,
-                        Or<(
-                            Changed<InteractStyles>,
-                            Changed<Interaction>,
-                            Changed<Active>,
-                            Changed<Enabled>,
-                            Changed<UiActionPriority>,
-                            Changed<BackgroundColor>,
-                            Changed<BorderColor>,
-                            Changed<Ui9Slice>,
-                            Changed<ImageNode>,
-                            Changed<BoundedNode>,
-                            Changed<NodeBounds>,
-                        )>,
-                    ),
-                >,
-                 interactions: Query<&Interaction, With<InteractStyles>>| {
-                    !changed.is_empty()
-                        || interactions.iter().any(|i| i != &Interaction::None)
-                },
-            ),
+            set_interaction_style.run_if(interaction_style_dirty),
         );
     }
+}
+
+// run condition for `set_interaction_style`: a style input (or styled target) changed, or some
+// node is still hovered/pressed (the pressed style tracks global input state, not a component).
+#[allow(clippy::type_complexity)]
+fn interaction_style_dirty(
+    changed: Query<
+        (),
+        (
+            With<InteractStyles>,
+            Or<(
+                Changed<InteractStyles>,
+                Changed<Interaction>,
+                Changed<Active>,
+                Changed<Enabled>,
+                Changed<UiActionPriority>,
+                Changed<BackgroundColor>,
+                Changed<BorderColor>,
+                Changed<Ui9Slice>,
+                Changed<ImageNode>,
+                Changed<BoundedNode>,
+                Changed<NodeBounds>,
+            )>,
+        ),
+    >,
+    interactions: Query<&Interaction, With<InteractStyles>>,
+) -> bool {
+    !changed.is_empty() || interactions.iter().any(|i| i != &Interaction::None)
 }
 
 #[allow(clippy::type_complexity)]

--- a/crates/visuals/src/day_night.rs
+++ b/crates/visuals/src/day_night.rs
@@ -98,13 +98,34 @@ fn start_clock(mut commands: Commands) {
 }
 
 #[expect(clippy::type_complexity, reason = "Queries are complex")]
+#[allow(clippy::too_many_arguments)]
 fn fetch_time_from_scene(
     mut commands: Commands,
     primary_player: Res<PrimaryPlayerRes>,
     containing_scene: ContainingScene,
     scenes: Query<(Entity, &RendererSceneContext, &SceneTime)>,
     time_keeper: Single<(Entity, Option<&SceneTime>, Option<&SceneTimeSource>), With<TimeKeeper>>,
+    added_times: Query<(), Added<SceneTime>>,
+    mut removed_times: RemovedComponents<SceneTime>,
+    mut last_player_state: Local<Option<Option<(IVec2, bool)>>>,
 ) {
+    // only recompute the time source when the scenes at the player position may have changed
+    let player_state = containing_scene
+        .transforms
+        .get(primary_player.0)
+        .ok()
+        .map(|(gt, oow)| (scene_runner::vec3_to_parcel(gt.translation()), oow));
+    let any_removed = removed_times.read().next().is_some();
+    removed_times.clear();
+    let dirty = containing_scene.is_changed()
+        || !added_times.is_empty()
+        || any_removed
+        || last_player_state.as_ref() != Some(&player_state);
+    *last_player_state = Some(player_state);
+    if !dirty {
+        return;
+    }
+
     let containing_primary_player = containing_scene.get(primary_player.0);
     let maybe_scene_time = scenes
         .iter_many_unique(EntityHashSet::from_iter(containing_primary_player))
@@ -139,6 +160,7 @@ fn fetch_time_from_scene(
 }
 
 #[expect(clippy::type_complexity, reason = "Queries are complex")]
+#[allow(clippy::too_many_arguments)]
 fn fetch_time_from_skybox(
     mut commands: Commands,
     primary_player: Res<PrimaryPlayerRes>,
@@ -146,7 +168,28 @@ fn fetch_time_from_skybox(
     scenes: Query<(Entity, &RendererSceneContext, Ref<SkyboxTime>)>,
     time_keeper: Single<(Entity, Option<&SkyboxTime>, Option<&SkyboxTimeSource>), With<TimeKeeper>>,
     scene_time_component_id: ComponentIdFor<SceneTime>,
+    added_times: Query<(), Added<SkyboxTime>>,
+    mut removed_times: RemovedComponents<SkyboxTime>,
+    mut last_player_state: Local<Option<Option<(IVec2, bool)>>>,
 ) {
+    // only recompute the time source when the scenes at the player position may have changed.
+    // SkyboxTime is an immutable component so value updates re-insert it (-> Added fires).
+    let player_state = containing_scene
+        .transforms
+        .get(primary_player.0)
+        .ok()
+        .map(|(gt, oow)| (scene_runner::vec3_to_parcel(gt.translation()), oow));
+    let any_removed = removed_times.read().next().is_some();
+    removed_times.clear();
+    let dirty = containing_scene.is_changed()
+        || !added_times.is_empty()
+        || any_removed
+        || last_player_state.as_ref() != Some(&player_state);
+    *last_player_state = Some(player_state);
+    if !dirty {
+        return;
+    }
+
     let containing_primary_player = containing_scene.get(primary_player.0);
     let maybe_skybox_time = scenes
         .iter_many_unique(EntityHashSet::from_iter(containing_primary_player))

--- a/crates/visuals/src/day_night.rs
+++ b/crates/visuals/src/day_night.rs
@@ -117,7 +117,7 @@ fn fetch_time_from_scene(
         .map(|(gt, oow)| (scene_runner::vec3_to_parcel(gt.translation()), oow));
     let any_removed = removed_times.read().next().is_some();
     removed_times.clear();
-    let dirty = containing_scene.is_changed()
+    let dirty = containing_scene.scene_layout_changed()
         || !added_times.is_empty()
         || any_removed
         || last_player_state.as_ref() != Some(&player_state);
@@ -181,7 +181,7 @@ fn fetch_time_from_skybox(
         .map(|(gt, oow)| (scene_runner::vec3_to_parcel(gt.translation()), oow));
     let any_removed = removed_times.read().next().is_some();
     removed_times.clear();
-    let dirty = containing_scene.is_changed()
+    let dirty = containing_scene.scene_layout_changed()
         || !added_times.is_empty()
         || any_removed
         || last_player_state.as_ref() != Some(&player_state);

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -148,9 +148,17 @@ fn apply_global_light(
     scene_distance: Res<SceneLoadDistance>,
     scene_global_light: Res<SceneGlobalLight>,
     mut prev: Local<(f32, SceneGlobalLight)>,
-    config: Res<AppConfig>,
     mut cloud_dt: Local<f32>,
+    // note: Added<DistanceFog> would conflict with the `&mut DistanceFog` access in `cameras`,
+    // so new fog components are detected by counting instead
+    new_cameras: Query<(), Added<Camera3d>>,
+    fog_cameras: Query<(), (With<Camera3d>, With<DistanceFog>)>,
+    mut last_fog_count: Local<usize>,
+    mut last_primary_distance: Local<f32>,
 ) {
+    // the transition has settled once the previous output exactly matches the target
+    let settled = prev.0 >= TRANSITION_TIME && prev.1 == *scene_global_light;
+
     let next_light = if prev.0 >= TRANSITION_TIME && prev.1.source == scene_global_light.source {
         scene_global_light.clone()
     } else {
@@ -204,6 +212,28 @@ fn apply_global_light(
 
     atmosphere.time += time.delta_secs() * *cloud_dt;
 
+    // skip the light/fog/ambient writes (which trigger change detection and re-extraction)
+    // when the light has settled and nothing else affecting them has changed
+    let primary_distance = cameras
+        .iter()
+        .find_map(|(maybe_primary, _)| maybe_primary.map(|camera| camera.distance))
+        .unwrap_or(0.0);
+    let fog_count = fog_cameras.iter().count();
+    let skip_writes = settled
+        && !setting.is_changed()
+        && !scene_distance.is_changed()
+        && new_cameras.is_empty()
+        && fog_count == *last_fog_count
+        && *last_primary_distance == primary_distance;
+    *last_primary_distance = primary_distance;
+    *last_fog_count = fog_count;
+
+    if skip_writes {
+        prev.0 += time.delta_secs();
+        prev.1 = next_light;
+        return;
+    }
+
     let mut directional_layers = RenderLayers::none();
     for (entity, layer, mut light_trans, mut directional) in sun.iter_mut() {
         if !next_light.layers.intersects(&RenderLayers::layer(layer.0)) {
@@ -227,15 +257,15 @@ fn apply_global_light(
             layer = layer.union(&PRIMARY_AVATAR_LIGHT_LAYER);
         }
 
-        let (shadows_enabled, cascade_shadow_config) = match config.graphics.shadow_settings {
+        let (shadows_enabled, cascade_shadow_config) = match setting.graphics.shadow_settings {
             ShadowSetting::Off => (false, Default::default()),
             ShadowSetting::Low => (
                 true,
                 CascadeShadowConfigBuilder {
                     num_cascades: 1,
                     minimum_distance: 0.1,
-                    maximum_distance: config.graphics.shadow_distance,
-                    first_cascade_far_bound: config.graphics.shadow_distance,
+                    maximum_distance: setting.graphics.shadow_distance,
+                    first_cascade_far_bound: setting.graphics.shadow_distance,
                     overlap_proportion: 0.2,
                 }
                 .build(),
@@ -245,8 +275,8 @@ fn apply_global_light(
                 CascadeShadowConfigBuilder {
                     num_cascades: 4,
                     minimum_distance: 0.1,
-                    maximum_distance: config.graphics.shadow_distance,
-                    first_cascade_far_bound: config.graphics.shadow_distance / 15.0,
+                    maximum_distance: setting.graphics.shadow_distance,
+                    first_cascade_far_bound: setting.graphics.shadow_distance / 15.0,
                     overlap_proportion: 0.2,
                 }
                 .build(),
@@ -303,7 +333,7 @@ fn apply_global_light(
     }
 
     ambient.brightness =
-        next_light.ambient_brightness * config.graphics.ambient_brightness as f32 * 20.0;
+        next_light.ambient_brightness * setting.graphics.ambient_brightness as f32 * 20.0;
     ambient.color = next_light.ambient_color;
 
     if prev.1.source == scene_global_light.source {

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -149,11 +149,6 @@ fn apply_global_light(
     scene_global_light: Res<SceneGlobalLight>,
     mut prev: Local<(f32, SceneGlobalLight)>,
     mut cloud_dt: Local<f32>,
-    // note: Added<DistanceFog> would conflict with the `&mut DistanceFog` access in `cameras`,
-    // so new fog components are detected by counting instead
-    new_cameras: Query<(), Added<Camera3d>>,
-    fog_cameras: Query<(), (With<Camera3d>, With<DistanceFog>)>,
-    mut last_fog_count: Local<usize>,
     mut last_primary_distance: Local<f32>,
 ) {
     // the transition has settled once the previous output exactly matches the target
@@ -218,15 +213,20 @@ fn apply_global_light(
         .iter()
         .find_map(|(maybe_primary, _)| maybe_primary.map(|camera| camera.distance))
         .unwrap_or(0.0);
-    let fog_count = fog_cameras.iter().count();
+    // a (re)inserted DistanceFog fires `is_added` and must be written even when the light has
+    // settled. reading the tick through the existing `&mut` access avoids the query conflict an
+    // `Added<DistanceFog>` filter would have with `cameras`; `is_added` (not `is_changed`) is used
+    // because our own per-frame fog writes set `changed`, which would otherwise never let the gate
+    // re-engage.
+    let fog_added = cameras
+        .iter_mut()
+        .any(|(_, fog)| fog.is_some_and(|fog| fog.is_added()));
     let skip_writes = settled
         && !setting.is_changed()
         && !scene_distance.is_changed()
-        && new_cameras.is_empty()
-        && fog_count == *last_fog_count
+        && !fog_added
         && *last_primary_distance == primary_distance;
     *last_primary_distance = primary_distance;
-    *last_fog_count = fog_count;
 
     if skip_writes {
         prev.0 += time.delta_secs();


### PR DESCRIPTION
Cherry-picks @eordano's [`6884fbe`](https://github.com/eordano/bevy-explorer/commit/6884fbee2b2460043dd2737456f02f01fc6589d6) — gates a range of per-frame systems on actual change (early-outs, compare-before-write, change-detection gates). A/B: p50 at noise, run-p90 tail −0.13 to −0.22ms; gates engage fully in static scenes.

Each gate was verified for unintended side effects (missed inputs, stale caches, first-frame init, change-detection semantics). 9 of the 13 files were correct as-is; the follow-up commit tightens three gates that had real or latent gaps plus one lint fix:

## Follow-up changes

- **imposters** (`render.rs`): the recompute gate keys on the parcel cell, but the body classified tile LOD from the *raw* focus origin — so the tile set could drift up to a full parcel diagonal (~22.6m) stale within a single parcel, and depended on which edge the parcel was entered from. Now the tile-selection origin is snapped to the focused parcel **centre**, making the result a deterministic function of the cell (worst-case error halved to the ~11.3m half-diagonal) and idempotent per cell. The recompute-on-crossing optimization is fully preserved. The bake-request origin is intentionally left on the raw focus position.

- **scene_runner** (`lib.rs`): renamed `ContainingScene::is_changed()` → `scene_layout_changed()` and documented that it covers only the scene-pointer/live/portable resources and **not** entity movement — the entity-position lookups (`get`/`get_area`) also read `GlobalTransform`, so callers gating on this must track position themselves (as `day_night` already does). Prevents a future stale-on-movement misuse.

- **visuals** (`lib.rs`): a `DistanceFog` reinserted on an existing camera with an unchanged fog-camera count wasn't re-detected. Replaced the count proxy with `is_added()` read through the existing `&mut DistanceFog` access (no second-query conflict). `is_added()` — not `is_changed()` — is used because this system writes fog every ungated frame, and `is_changed()` would create a self-write feedback loop that never lets the gate re-engage. Drops the now-unneeded `new_cameras`/`fog_cameras`/`last_fog_count`.

- **ui_core** (`interact_style.rs`): lifted the `set_interaction_style` run condition from an inline closure into a named fn so it can carry `#[allow(clippy::type_complexity)]` (an inline closure param can't).

## Notes
- `cargo fmt --all`, a clean (from-scratch) `cargo clippy --all -- -D warnings`, and the WASM build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)