### PR TITLE
Bound every engine HTTP request with a per-request timeout

### DIFF
--- a/crates/collectibles/src/wearables.rs
+++ b/crates/collectibles/src/wearables.rs
@@ -98,6 +98,7 @@ fn load_collections(
                 IoTaskPool::get().spawn_compat(async move {
                     let response = client
                         .get("https://realm-provider.decentraland.org/lambdas/collections")
+                        .timeout(std::time::Duration::from_secs(10))
                         .send()
                         .await
                         .map_err(|e| anyhow!(e))?;

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -237,6 +237,7 @@ fn connect_scene_room(
 
                 let mut request = client
                     .post(uri.to_string())
+                    .timeout(std::time::Duration::from_secs(10))
                     .header("Content-Type", "application/json");
                 for (k, v) in headers {
                     request = request.header(k, v);

--- a/crates/comms/src/profile.rs
+++ b/crates/comms/src/profile.rs
@@ -603,6 +603,8 @@ async fn deploy_profile(
 
         ipfs.client()
             .post(url)
+            // multipart deploy carries profile snapshots, so allow more headroom
+            .timeout(std::time::Duration::from_secs(60))
             .header(
                 "Content-Type",
                 format!("multipart/form-data; boundary={}", prepared.boundary()),
@@ -636,6 +638,7 @@ pub async fn get_remote_profile(
     let response = ipfs
         .client()
         .post("https://asset-bundle-registry.decentraland.org/profiles")
+        .timeout(std::time::Duration::from_secs(10))
         .body(format!("{{ \"ids\": [\"{:#x}\"] }}", address))
         .header("content-type", "application/json")
         .send()

--- a/crates/imposters/src/imposter_spec.rs
+++ b/crates/imposters/src/imposter_spec.rs
@@ -193,7 +193,12 @@ pub async fn load_imposter_remote(
         .replace("%", "%25");
     debug!("zip_url {zip_url}");
 
-    let request = client.get(&zip_url).build()?;
+    // Bulk imposter-zip download; generous total-timeout floor until the
+    // content-inactivity timeout (Tier 2) replaces it.
+    let request = client
+        .get(&zip_url)
+        .timeout(std::time::Duration::from_secs(120))
+        .build()?;
     // Race the network fetch + body read against the cancel token. If the
     // owning `ImposterLoadTask` Component is dropped (entity despawn / out of
     // range), this future is dropped together with the `select!`, releasing

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -1059,6 +1059,10 @@ impl IpfsIo {
                     let body = serde_json::to_string(&ActiveEntitiesPointersRequest { pointers })?;
                     let response = client
                         .post(active_url)
+                        // pointer resolution is a small JSON call; bound it so a stalled
+                        // connection can't wedge the single-in-flight resolver forever
+                        // (request-level timeout is the only one honoured on wasm).
+                        .timeout(Duration::from_secs(10))
                         .header("content-type", "application/json")
                         .body(body)
                         .send()
@@ -1205,7 +1209,13 @@ impl IpfsIo {
                 continue;
             };
             loop {
-                if let Ok(resp) = self.client.get(&url).send().await {
+                if let Ok(resp) = self
+                    .client
+                    .get(&url)
+                    .timeout(Duration::from_secs(10))
+                    .send()
+                    .await
+                {
                     if resp.status().is_success() {
                         break;
                     }

--- a/crates/scene_inspector/src/asset_commands.rs
+++ b/crates/scene_inspector/src/asset_commands.rs
@@ -103,6 +103,7 @@ fn asset_catalog_cmd(
                 let result: Result<String, String> = async {
                     let resp = client
                         .get(CATALOG_URL)
+                        .timeout(std::time::Duration::from_secs(30))
                         .send()
                         .await
                         .map_err(|e| e.to_string())?;
@@ -262,7 +263,12 @@ fn init_asset_cmd(
                         // scene folder right now — the immediate push, so the asset renders without
                         // waiting for a save (and the dev server can serve it on the live merge).
                         let url = format!("{CONTENTS_BASE}{hash}");
-                        match client.get(&url).send().await {
+                        match client
+                            .get(&url)
+                            .timeout(std::time::Duration::from_secs(60))
+                            .send()
+                            .await
+                        {
                             Ok(resp) => match resp.bytes().await {
                                 Ok(bytes) => {
                                     let _ = io.cache_bytes(hash, &bytes).await; // no-op on web

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -221,7 +221,11 @@ impl DiscoverSettings {
 
         let client = self.client.clone();
         self.task = Some(IoTaskPool::get().spawn_compat(async move {
-            let response = client.get(url).send().await?;
+            let response = client
+                .get(url)
+                .timeout(std::time::Duration::from_secs(10))
+                .send()
+                .await?;
 
             response
                 .json::<DiscoverPages>()

--- a/crates/system_ui/src/map.rs
+++ b/crates/system_ui/src/map.rs
@@ -202,7 +202,11 @@ fn set_map_content(
                         parcel,
                         IoTaskPool::get().spawn_compat(async move {
                             debug!("url: {url}");
-                            let response = client.get(url).send().await?;
+                            let response = client
+                                .get(url)
+                                .timeout(std::time::Duration::from_secs(10))
+                                .send()
+                                .await?;
                             response
                                 .json::<DiscoverPages>()
                                 .await

--- a/crates/wallet/src/signed_login.rs
+++ b/crates/wallet/src/signed_login.rs
@@ -19,7 +19,9 @@ pub async fn signed_login(
 ) -> Result<SignedLoginResponse, anyhow::Error> {
     let auth_chain = sign_request("post", &uri, &wallet, serde_json::to_string(&meta)?).await?;
 
-    let mut request = reqwest_client().post(uri.to_string());
+    let mut request = reqwest_client()
+        .post(uri.to_string())
+        .timeout(std::time::Duration::from_secs(5));
 
     for (key, value) in auth_chain {
         request = request.header(key, value)


### PR DESCRIPTION
## Problem

Engine-initiated HTTP requests relied on the client-level `connect_timeout`, which only bounds connection establishment on native and is a **no-op shim on wasm** (`platform::ReqwestBuilderExt`). A request that connected but then stalled before or mid-response could hang **forever** — and invisibly, since these paths take no `request_slot` and set no `IPFS_IN_FLIGHT` guard, so nothing shows up in the IPFS download-job overlay.

The most visible symptom is intermittent: the `active_entities` pointer-resolution POST (URN → entity hash) hangs, wedging the **single-in-flight** collectibles resolver in `request_collectibles`. Once wedged, no further pointer resolution happens for the session, so the local avatar's body shape never resolves to a hash and the avatar is **invisible on first join — with zero failed download jobs**.

## Fix

Add a per-request `.timeout()` — the only timeout reqwest honours on wasm (via `AbortController`; the download path at `ipfs/lib.rs` already relies on this) — to every previously-unbounded engine path:

| Path | Timeout |
|---|---|
| `active_entities` pointer resolution | 10s |
| `await_contents_available` content poll | 10s |
| wearable collections list | 10s |
| scene-room gatekeeper POST | 10s |
| remote profile fetch | 10s |
| map / discover place lookups | 10s |
| signed login | 5s (native parity) |
| profile deploy (multipart + snapshots) | 60s |
| asset catalog (inspector) | 30s |
| asset content file (inspector) | 60s |
| imposter-zip bulk download | 120s |

On timeout these paths surface a transient error that existing retry machinery recovers from (e.g. the resolver re-queues URNs on the next `RetryRenderAvatar` tick), turning a permanent hang into a recoverable error.

Scene `fetch()` is deliberately left unbounded — there's no timeout plumbed through `op_fetch`, and scenes manage their own via drop-and-refire (which fires reqwest's wasm `AbortGuard`).

## Follow-up

A content-inactivity timeout (fail on no-bytes-for-N-seconds rather than total time) for the large-download paths is a planned stacked follow-up; it needs reqwest's `stream` feature and a cross-target idle combinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)