### PR TITLE
Replace total HTTP timeouts with headers + content-inactivity timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6056,6 +6056,7 @@ dependencies = [
  "crc",
  "futures-lite",
  "ipfs",
+ "platform",
  "reqwest 0.12.15",
  "scene_material",
  "scene_runner",
@@ -8313,6 +8314,7 @@ dependencies = [
  "bevy",
  "directories",
  "futures-lite",
+ "futures-timer",
  "futures-util",
  "js-sys",
  "reqwest 0.12.15",
@@ -9140,11 +9142,13 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "windows-registry 0.4.0",
 ]
@@ -12127,6 +12131,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "native-tls",
   "json",
   "blocking",
+  "stream",
 ] }
 kira = "0.9.6"
 zip = { version = "2", default-features = false }
@@ -181,6 +182,7 @@ async-trait = "0.1.68"
 fastrand = "2"
 rand = "0.8.5"
 futures-util = "0.3.28"
+futures-timer = "3"
 async-native-tls = { version = "0.5", features = ["runtime-async-std"] }
 boimp = { git = "https://github.com/robtfm/boimp", branch = "feat/composite-bake-via-storage-texture" }
 crc = "3"

--- a/crates/imposters/Cargo.toml
+++ b/crates/imposters/Cargo.toml
@@ -12,6 +12,7 @@ scene_material = { workspace = true }
 scene_runner = { workspace = true }
 tween = { workspace = true }
 console = { workspace = true }
+platform = { workspace = true }
 
 bevy = { workspace = true }
 boimp = { workspace = true }

--- a/crates/imposters/src/imposter_spec.rs
+++ b/crates/imposters/src/imposter_spec.rs
@@ -193,12 +193,10 @@ pub async fn load_imposter_remote(
         .replace("%", "%25");
     debug!("zip_url {zip_url}");
 
-    // Bulk imposter-zip download; generous total-timeout floor until the
-    // content-inactivity timeout (Tier 2) replaces it.
-    let request = client
-        .get(&zip_url)
-        .timeout(std::time::Duration::from_secs(120))
-        .build()?;
+    // Bulk imposter-zip download. No total request timeout: platform::fetch below
+    // bounds the connect+headers phase and the body by an inactivity timeout, so a
+    // slow-but-progressing download isn't killed.
+    let request = client.get(&zip_url).build()?;
     // Race the network fetch + body read against the cancel token. If the
     // owning `ImposterLoadTask` Component is dropped (entity despawn / out of
     // range), this future is dropped together with the `select!`, releasing
@@ -206,11 +204,26 @@ pub async fn load_imposter_remote(
     // to abort the in-flight browser fetch.
     let bytes = tokio::select! {
         fetched = async {
-            let response = ipfs.async_request(request, client).await?;
-            if response.status() != reqwest::StatusCode::OK {
-                return Ok(None);
-            }
-            Ok::<_, anyhow::Error>(Some(response.bytes().await?))
+            let fetched = match platform::fetch(
+                ipfs.async_request(request, client),
+                std::time::Duration::from_secs(30),
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            {
+                Ok(fetched) => fetched,
+                // a missing imposter for this area is an expected 404
+                Err(platform::FetchError::Status(_)) => return Ok(None),
+                Err(platform::FetchError::Send(e)) => return Err(e),
+                Err(platform::FetchError::Headers) => {
+                    anyhow::bail!("imposter request timed out awaiting headers")
+                }
+                Err(platform::FetchError::Stalled) => {
+                    anyhow::bail!("imposter download stalled (no data for 10s)")
+                }
+                Err(platform::FetchError::Body(e)) => return Err(anyhow::anyhow!(e)),
+            };
+            Ok::<_, anyhow::Error>(Some(fetched.body))
         } => match fetched? {
             Some(bytes) => bytes,
             None => return Ok(()),

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -1057,25 +1057,32 @@ impl IpfsIo {
                 IoTaskPool::get().spawn_compat(async move {
                     let active_url = active_url.ok_or(anyhow!("not connected"))?;
                     let body = serde_json::to_string(&ActiveEntitiesPointersRequest { pointers })?;
-                    let response = client
-                        .post(active_url)
-                        // pointer resolution is a small JSON call; bound it so a stalled
-                        // connection can't wedge the single-in-flight resolver forever
-                        // (request-level timeout is the only one honoured on wasm).
-                        .timeout(Duration::from_secs(10))
-                        .header("content-type", "application/json")
-                        .body(body)
-                        .send()
-                        .await?;
-
-                    if response.status() != StatusCode::OK {
-                        return Err(anyhow::anyhow!("status: {}", response.status()));
-                    }
-
-                    let active_entities = response
-                        .json::<ActiveEntitiesResponse>()
-                        .await
-                        .map_err(|e| anyhow::anyhow!(e))?;
+                    // Headers-phase timeout + body inactivity timeout (the total is
+                    // left unbounded, so a large-but-progressing response — e.g. bulk
+                    // scene resolution — isn't killed mid-transfer).
+                    let fetched = platform::fetch(
+                        client
+                            .post(active_url)
+                            .header("content-type", "application/json")
+                            .body(body)
+                            .send(),
+                        Duration::from_secs(30),
+                        Duration::from_secs(10),
+                    )
+                    .await
+                    .map_err(|e| match e {
+                        platform::FetchError::Headers => {
+                            anyhow!("timed out awaiting active-entities headers")
+                        }
+                        platform::FetchError::Send(e) => anyhow!(e),
+                        platform::FetchError::Status(s) => anyhow!("status: {s}"),
+                        platform::FetchError::Stalled => {
+                            anyhow!("active-entities response stalled")
+                        }
+                        platform::FetchError::Body(e) => anyhow!(e),
+                    })?;
+                    let active_entities: ActiveEntitiesResponse =
+                        serde_json::from_slice(&fetched.body).map_err(|e| anyhow!(e))?;
                     let mut res = Vec::default();
                     for entity in active_entities.0 {
                         let id = entity.id.as_ref().unwrap();
@@ -1609,10 +1616,7 @@ impl AssetReader for IpfsIo {
             let data = loop {
                 attempt += 1;
 
-                let request = self
-                    .client
-                    .get(&remote)
-                    .timeout(Duration::from_secs(5 + 300 * attempt));
+                let request = self.client.get(&remote);
 
                 // in wasm we add a custom header to allow the service worker to cache ipfs requests across content servers
                 #[cfg(target_arch = "wasm32")]
@@ -1632,16 +1636,44 @@ impl AssetReader for IpfsIo {
                     ))))
                 }))?;
 
-                let response = self.client.execute(request).await;
+                // Headers-phase timeout + body inactivity timeout; the total transfer
+                // time is unbounded, so a slow-but-progressing download is never
+                // killed — only a stall (no chunk for 10s) or a dead connection trips.
+                let fetched = platform::fetch(
+                    self.client.execute(request),
+                    Duration::from_secs(30),
+                    Duration::from_secs(10),
+                )
+                .await;
 
-                debug!("[{token:?}]: attempt {attempt}: request: {remote}, response: {response:?}");
+                debug!("[{token:?}]: attempt {attempt}: request: {remote}");
 
-                let response = match response {
-                    Err(e) if e.is_timeout() && attempt <= 3 => {
+                let fetched = match fetched {
+                    Ok(fetched) => fetched,
+                    Err(platform::FetchError::Headers) if attempt <= 3 => {
+                        warn!("[{token:?}] timeout awaiting headers for `{remote}`, retrying");
+                        continue;
+                    }
+                    Err(platform::FetchError::Stalled) if attempt <= 3 => {
+                        warn!("[{token:?}] stalled retrieving `{remote}`, retrying");
+                        continue;
+                    }
+                    Err(platform::FetchError::Send(e)) if e.is_timeout() && attempt <= 3 => {
                         warn!("[{token:?}] timeout requesting `{remote}`, retrying");
                         continue;
                     }
                     Err(e) => {
+                        let detail = match e {
+                            platform::FetchError::Headers => {
+                                "timed out awaiting headers".to_owned()
+                            }
+                            platform::FetchError::Stalled => "stalled (no data for 10s)".to_owned(),
+                            platform::FetchError::Send(e) => format!("server responded `{e}`"),
+                            platform::FetchError::Status(s) => {
+                                format!("server responded with status {s}")
+                            }
+                            platform::FetchError::Body(e) => format!("body stream error: {e}"),
+                        };
                         self.context
                             .write()
                             .await
@@ -1649,28 +1681,13 @@ impl AssetReader for IpfsIo {
                             .insert(remote.clone(), Instant::now());
                         return ipfs_io_read_state.send_failure(Err(AssetReaderError::Io(
                             Arc::new(std::io::Error::other(format!(
-                                "[{token:?}]: server responded `{e}` requesting `{remote}`"
+                                "[{token:?}] failed to retrieve `{remote}`: {detail}"
                             ))),
                         )));
                     }
-                    Ok(response) if !matches!(response.status(), StatusCode::OK) => {
-                        self.context
-                            .write()
-                            .await
-                            .failed_remotes
-                            .insert(remote.clone(), Instant::now());
-                        return ipfs_io_read_state.send_failure(Err(AssetReaderError::Io(
-                            Arc::new(std::io::Error::other(format!(
-                                "[{token:?}]: server responded with status {} requesting `{}`",
-                                response.status(),
-                                remote,
-                            ))),
-                        )));
-                    }
-                    Ok(response) => response,
                 };
 
-                if let Some(cache_control) = response.headers().get("cache-control") {
+                if let Some(cache_control) = fetched.headers.get("cache-control") {
                     if cache_control
                         .to_str()
                         .unwrap_or_default()
@@ -1680,27 +1697,7 @@ impl AssetReader for IpfsIo {
                     }
                 }
 
-                let data = response.bytes().await;
-
-                match data {
-                    Ok(data) => break data,
-                    Err(e) => {
-                        if e.is_timeout() && attempt <= 3 {
-                            warn!("[{token:?}] timeout retrieving `{remote}`, retrying");
-                            continue;
-                        }
-                        self.context
-                            .write()
-                            .await
-                            .failed_remotes
-                            .insert(remote.clone(), Instant::now());
-                        return ipfs_io_read_state.send_failure(Err(AssetReaderError::Io(
-                            Arc::new(std::io::Error::other(format!(
-                                "[{token:?}] failed to convert to bytes: `{remote}`: {e}"
-                            ))),
-                        )));
-                    }
-                }
+                break fetched.body;
             };
 
             if let (Some(hash), Some(cache_path)) = (hash, self.cache_path()) {

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -13,6 +13,7 @@ bevy = { workspace = true }
 anyhow = { workspace = true }
 tungstenite = { workspace = true }
 futures-util = { workspace = true }
+futures-timer = { workspace = true }
 reqwest = { workspace = true }
 directories = { workspace = true }
 futures-lite = { workspace = true }
@@ -25,6 +26,8 @@ async-compat = { workspace = true }
 tokio = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# wasm-bindgen feature swaps futures-timer's backend to setTimeout (gloo-timers)
+futures-timer = { workspace = true, features = ["wasm-bindgen"] }
 web-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -7,3 +7,87 @@ pub use native::*;
 mod wasm;
 #[cfg(target_arch = "wasm32")]
 pub use wasm::*;
+
+use std::{future::Future, time::Duration};
+
+use futures_timer::Delay;
+use futures_util::{
+    future::{select, Either},
+    pin_mut, StreamExt,
+};
+
+/// Internal marker: the [`with_timeout`] timer fired before the future resolved.
+struct Elapsed;
+
+/// Race `fut` against a `dur` timer, returning `Err(Elapsed)` if the timer wins.
+///
+/// Cross-target replacement for `tokio::time::timeout` (which isn't available here
+/// — tokio is built without the `time` feature, and it wouldn't work on wasm
+/// anyway). `futures-timer` backs this with a native timer thread or wasm
+/// `setTimeout`.
+async fn with_timeout<F: Future>(dur: Duration, fut: F) -> Result<F::Output, Elapsed> {
+    pin_mut!(fut);
+    match select(fut, Delay::new(dur)).await {
+        Either::Left((out, _)) => Ok(out),
+        Either::Right(_) => Err(Elapsed),
+    }
+}
+
+/// A successfully-fetched response: its headers and fully-read body.
+pub struct FetchedResponse {
+    pub headers: reqwest::header::HeaderMap,
+    pub body: Vec<u8>,
+}
+
+/// Why a [`fetch`] failed. `E` is the error type of the supplied send future —
+/// `reqwest::Error` for a bare `RequestBuilder::send`, or e.g. `anyhow::Error` when
+/// the send is routed through a wrapper.
+pub enum FetchError<E> {
+    /// Timed out awaiting the response headers (connect + time-to-first-byte).
+    Headers,
+    /// The send itself failed before any response was obtained.
+    Send(E),
+    /// The server returned a non-success status; the body is not read.
+    Status(reqwest::StatusCode),
+    /// The body transfer stalled — no chunk arrived within the idle window.
+    Stalled,
+    /// The body stream errored mid-transfer.
+    Body(reqwest::Error),
+}
+
+/// Drive an HTTP request with two independent timeouts, returning the response
+/// headers and fully-read body.
+///
+/// `headers_timeout` bounds the connect + headers phase (the only hang-guard on
+/// wasm, which has no `connect_timeout`); `idle_timeout` bounds the gap between body
+/// chunks. The *total* transfer time is deliberately unbounded, so a slow-but-
+/// progressing download is never killed — only a genuine stall trips. A non-success
+/// status short-circuits with [`FetchError::Status`] before the body is read.
+/// Dropping the returned future cancels the in-flight request.
+pub async fn fetch<E>(
+    send: impl Future<Output = Result<reqwest::Response, E>>,
+    headers_timeout: Duration,
+    idle_timeout: Duration,
+) -> Result<FetchedResponse, FetchError<E>> {
+    let response = match with_timeout(headers_timeout, send).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(e)) => return Err(FetchError::Send(e)),
+        Err(Elapsed) => return Err(FetchError::Headers),
+    };
+
+    if !response.status().is_success() {
+        return Err(FetchError::Status(response.status()));
+    }
+
+    let headers = response.headers().clone();
+    let mut stream = Box::pin(response.bytes_stream());
+    let mut body = Vec::new();
+    loop {
+        match with_timeout(idle_timeout, stream.next()).await {
+            Ok(Some(Ok(chunk))) => body.extend_from_slice(&chunk),
+            Ok(Some(Err(e))) => return Err(FetchError::Body(e)),
+            Ok(None) => return Ok(FetchedResponse { headers, body }),
+            Err(Elapsed) => return Err(FetchError::Stalled),
+        }
+    }
+}


### PR DESCRIPTION
**Stacked on #863** (base = `fix/http-request-timeouts`). Supersedes the earlier #864.

## Problem

A total request `.timeout()` bounds the *whole* request, so it kills a response that's still making progress once the ceiling is hit. Tier 1 (#863) left the bulk paths on generous total timeouts as a stopgap, and even put a flat 10s total on `active_entities` — which was observed killing large **bulk scene-resolution** responses *mid-body-decode* (`error decoding response body … operation timed out` → `failed to retrieve active scenes, will retry` loops).

## Fix

Bound the **connect+headers** phase and the **gap between body chunks** separately, and leave total transfer time unbounded. A slow-but-progressing response runs to completion; only a genuine stall (no chunk within the idle window) or a dead connection trips, and existing retry logic recovers.

Applied to the three paths that can carry sizeable bodies:
- `IpfsIo::read` — main content download (all assets, incl. wearable GLTFs)
- `active_entities` — pointer/scene resolution (the avatar-bug path + bulk scene loading)
- imposter-zip download

Removes the prior crude bounds: the scaling `5 + 300*attempt` total on the download path, the 120s total on imposters, and the flat 10s total on `active_entities`.

## Packaging

All three now go through one helper:

```rust
platform::fetch(send_future, headers_timeout, idle_timeout)
    -> Result<FetchedResponse { headers, body }, FetchError<E>>
```

`FetchError` (`Headers` / `Send` / `Status` / `Stalled` / `Body`) is generic over the send error, so it serves both bare `reqwest` sends and the `anyhow`-wrapped `async_request`. Non-success status short-circuits before the body is read (so e.g. the expected imposter 404 doesn't read an error body). Backed by a small cross-target `with_timeout` combinator (private) — `tokio` is built without `time` and it wouldn't work on wasm anyway, so `futures-timer` provides the native timer thread / wasm `setTimeout`. On wasm the headers bound also doubles as the connect hang-guard (`connect_timeout` is a no-op there).

Enables reqwest's `stream` feature (`tokio-util` on native, `wasm-streams` on wasm).

Timeout values: 30s headers (TTFB varies under CDN load), 10s inactivity (once bytes flow, a 10s gap is a real stall).

Verified: `cargo clippy --all -- -D warnings` clean + wasm build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)