### PR TITLE
ci: make Windows libclang/ffmpeg setup robust to runner image rolls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,21 @@ jobs:
       - name: install ffmpeg deps (windows)
         if: runner.os == 'windows' && matrix.os != 'self-hosted-windows'
         run: |
-          $VCINSTALLDIR = $(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath)
-          Add-Content $env:GITHUB_ENV "LIBCLANG_PATH=${VCINSTALLDIR}\VC\Tools\LLVM\x64\bin`n"
-          Invoke-WebRequest "https://github.com/GyanD/codexffmpeg/releases/download/6.0/ffmpeg-6.0-full_build-shared.7z" -OutFile ffmpeg-6.0-full_build-shared.7z
+          # Prefer the standalone LLVM install (stable across runner image rolls); fall back to the VS-bundled Clang toolset, whose version moves with the image and has produced opaque bindgen structs on rollover.
+          $vsLlvm = "$(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath)\VC\Tools\LLVM\x64\bin"
+          $libclang = @("C:\Program Files\LLVM\bin", $vsLlvm) | Where-Object { Test-Path "$_\libclang.dll" } | Select-Object -First 1
+          if (-not $libclang) { throw "libclang.dll not found (checked standalone LLVM and VS Clang toolset)" }
+          Write-Host "Using LIBCLANG_PATH=$libclang"
+          Add-Content $env:GITHUB_ENV "LIBCLANG_PATH=$libclang`n"
+          $ffUrl = "https://github.com/GyanD/codexffmpeg/releases/download/6.0/ffmpeg-6.0-full_build-shared.7z"
+          for ($i = 1; $i -le 3; $i++) {
+            try { Invoke-WebRequest $ffUrl -OutFile ffmpeg-6.0-full_build-shared.7z; break }
+            catch { if ($i -eq 3) { throw }; Write-Host "ffmpeg download failed (attempt $i), retrying..."; Start-Sleep -Seconds 5 }
+          }
           7z x ffmpeg-6.0-full_build-shared.7z
           mkdir ffmpeg
           mv ffmpeg-*/* ffmpeg/
+          if (-not (Test-Path "ffmpeg\include")) { throw "ffmpeg headers missing after extract (ffmpeg\include not found)" }
           Add-Content $env:GITHUB_ENV "FFMPEG_DIR=${pwd}\ffmpeg`n"
           Add-Content $env:GITHUB_PATH "${pwd}\ffmpeg\bin`n"          
       - name: Build Release

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -94,12 +94,21 @@ jobs:
           - name: install ffmpeg deps (windows)
             if: runner.os == 'windows' && matrix.os != 'self-hosted-windows'
             run: |
-              $VCINSTALLDIR = $(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath)
-              Add-Content $env:GITHUB_ENV "LIBCLANG_PATH=${VCINSTALLDIR}\VC\Tools\LLVM\x64\bin`n"
-              Invoke-WebRequest "https://github.com/GyanD/codexffmpeg/releases/download/6.0/ffmpeg-6.0-full_build-shared.7z" -OutFile ffmpeg-6.0-full_build-shared.7z
+              # Prefer the standalone LLVM install (stable across runner image rolls); fall back to the VS-bundled Clang toolset, whose version moves with the image and has produced opaque bindgen structs on rollover.
+              $vsLlvm = "$(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath)\VC\Tools\LLVM\x64\bin"
+              $libclang = @("C:\Program Files\LLVM\bin", $vsLlvm) | Where-Object { Test-Path "$_\libclang.dll" } | Select-Object -First 1
+              if (-not $libclang) { throw "libclang.dll not found (checked standalone LLVM and VS Clang toolset)" }
+              Write-Host "Using LIBCLANG_PATH=$libclang"
+              Add-Content $env:GITHUB_ENV "LIBCLANG_PATH=$libclang`n"
+              $ffUrl = "https://github.com/GyanD/codexffmpeg/releases/download/6.0/ffmpeg-6.0-full_build-shared.7z"
+              for ($i = 1; $i -le 3; $i++) {
+                try { Invoke-WebRequest $ffUrl -OutFile ffmpeg-6.0-full_build-shared.7z; break }
+                catch { if ($i -eq 3) { throw }; Write-Host "ffmpeg download failed (attempt $i), retrying..."; Start-Sleep -Seconds 5 }
+              }
               7z x ffmpeg-6.0-full_build-shared.7z
               mkdir ffmpeg
               mv ffmpeg-*/* ffmpeg/
+              if (-not (Test-Path "ffmpeg\include")) { throw "ffmpeg headers missing after extract (ffmpeg\include not found)" }
               Add-Content $env:GITHUB_ENV "FFMPEG_DIR=${pwd}\ffmpeg`n"
               Add-Content $env:GITHUB_PATH "${pwd}\ffmpeg\bin`n"          
           - name: install ffmpeg deps (windows)


### PR DESCRIPTION
## Problem

The Windows `Test Suite` job fails intermittently (rerunning clears it) with ~34 `E0609: no field … on type sys::AVFormatContext` errors deep inside `ffmpeg-next`, each noting `available field is: _address`. `_address`-only structs are bindgen's **opaque** placeholders: `ffmpeg-sys-next` ran bindgen but couldn't usefully parse the ffmpeg headers, so it emitted field-less structs, and the high-level crate then failed to compile against them.

## Root cause

The setup step pointed `LIBCLANG_PATH` at the **VS-bundled Clang toolset** (`…\VC\Tools\LLVM\x64\bin`). That toolset's version moves with the `windows-latest` image. Comparing the failing run against recent passing ones:

| Run | Image provisioner | VS Clang toolset |
|---|---|---|
| Failed (Jun 18) | `20260614.141` | 18.7.11812.201 |
| Passed (Jun 17) | `20260608.135` | 18.6.11706.339 |

The image rolled `20260608.135 → 20260614.141` (Clang `18.6 → 18.7`) and the failures start there. Because GitHub rolls images **gradually**, reruns sometimes land on a runner still serving the older image and pass — hence the apparent transience. As the rollout completes this would become a hard failure.

## Fix (CI only)

- Point `LIBCLANG_PATH` at the **standalone LLVM** install (stable across image rolls), fall back to the VS toolset, and **fail fast** if neither has `libclang.dll` — so a future breakage surfaces immediately instead of as opaque-struct compile errors.
- **Retry** the ffmpeg `Invoke-WebRequest` download (the release host occasionally flakes).
- **Verify** the ffmpeg headers extracted before continuing.

Applied to both `ci.yml` and `package.yml`. No source/runtime changes. Unblocks #863 (whose Windows failure is this same flake, unrelated to that PR's diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)