### PR TITLE
Bump bevy fork to fix wasm asset-loader Atomics.wait crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -938,10 +938,9 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "async-broadcast",
- "async-channel 2.5.0",
  "async-fs",
  "async-lock",
  "atomicow",
@@ -960,6 +959,7 @@ dependencies = [
  "disqualified",
  "downcast-rs 2.0.2",
  "either",
+ "futures-channel",
  "futures-io",
  "futures-lite",
  "gloo-timers 0.3.0",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1121,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1255,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1362,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1587,12 +1587,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#8edbc493620fec992a49a71016ca3dececa66481"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
 dependencies = [
  "accesskit",
  "accesskit_winit",


### PR DESCRIPTION
Advances the `robtfm/bevy` pin to [`794172b`](https://github.com/robtfm/bevy/commit/794172be404e4c8ec64572ba9aae7421f12225c5), which switches the wasm threaded asset loader from `async-channel` to `futures-channel` mpsc.

## Why

`async-channel`'s send/notify path takes a blocking lock (`event_listener`'s `std::Mutex`). On `wasm32` with atomics, a contended lock lowers to `memory.atomic.wait`, which is only legal on a worker — on the main (window) thread it **traps**. `AssetServer` drives loads from the main thread, so the trap intermittently aborted an in-flight load mid-poll, leaving the asset **stuck** (never completing, never erroring). This presented as the recurring `RuntimeError: Atomics.wait cannot be called in this context` and occasional assets that silently never loaded.

`futures-channel`'s `unbounded_send`/notify path is lock-free (a brief spinlock, not a futex), so the main thread never reaches `memory.atomic.wait`. `futures-channel` is already in bevy's tree via `bevy_tasks`, so the bevy-side change adds no new dependency.

## Scope

`Cargo.lock` only — 47× bevy commit-hash bump plus one `bevy_asset` dependency edge (`async-channel` → `futures-channel`). `Cargo.toml` is unchanged (branch ref stays `release-0.16-dcl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)