### PR TITLE
Fix scenes stranded OutOfWorld when revisiting an explicit-urn realm

### DIFF
--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -1036,6 +1036,7 @@ pub fn process_realm_change(
     mut commands: Commands,
     current_realm: Res<CurrentRealm>,
     mut live_scenes: ResMut<LiveScenes>,
+    mut pointers: ResMut<ScenePointers>,
     mut segment_config: Option<ResMut<SegmentConfig>>,
     scenes: Query<&RendererSceneContext>,
     player: Query<Entity, With<PrimaryUser>>,
@@ -1084,15 +1085,19 @@ pub fn process_realm_change(
             })
             .collect::<HashMap<_, _>>();
 
-        // pointers.0.retain(|_, pr| match pr {
-        //     PointerResult::Nothing{ .. } => false,
-        //     PointerResult::Exists{ hash, .. } => realm_scene_ids.contains_key(hash),
-        // });
         if !realm_scene_ids.is_empty() {
             // purge pointers and scenes that are not in the realm list (and not portable)
             live_scenes.scenes.retain(|hash, entity| {
                 realm_scene_ids.contains_key(hash)
                     || scenes.get(*entity).is_ok_and(|ctx| ctx.is_portable)
+            });
+            // Explicit-urn realms only request urns that aren't already cached and
+            // do no parcel sweep, so the active-entities reconciliation that clears
+            // stale pointers for active-entities realms never runs. Reconcile here
+            // against the realm's scene list
+            pointers.pointers.retain(|_, pr| match pr {
+                PointerResult::Nothing => false,
+                PointerResult::Exists { hash, .. } => realm_scene_ids.contains_key(hash),
             });
         }
 
@@ -1307,15 +1312,22 @@ fn load_active_entities(
                 })
                 .collect::<HashMap<_, _>>();
 
-            // make sure we still teleport even if we already have the hash
+            // make sure we still teleport even if we already have the hash (e.g.
+            // returning to a World whose pointers are still cached). `available_hashes`
+            // is keyed by hash but `teleport_on_resolve` is a urn, so match via
+            // `contains` as the resolve path below does, rather than a direct lookup.
             if let Some(teleport_on_resolve) = teleport_on_resolve.as_ref() {
-                if let Some(parcel) = available_hashes.get(teleport_on_resolve) {
+                if let Some(parcel) = available_hashes.iter().find_map(|(hash, parcel)| {
+                    teleport_on_resolve
+                        .contains(hash.as_str())
+                        .then_some(*parcel)
+                }) {
                     if let Some(mut commands) = player
                         .single()
                         .ok()
                         .and_then(|(p, _)| commands.get_entity(p).ok())
                     {
-                        commands.try_insert(teleport_components(*parcel));
+                        commands.try_insert(teleport_components(parcel));
                         debug!("already got the hash -> none");
                         *teleport_target = RealmInitialLocation::None;
                     }

--- a/crates/scene_runner/src/test/mod.rs
+++ b/crates/scene_runner/src/test/mod.rs
@@ -174,7 +174,7 @@ fn init_test_app(entity_json: &str) -> App {
         IVec2::ZERO,
         PointerResult::Exists {
             realm: "manual value".to_owned(),
-            hash: "whatever".to_owned(),
+            hash: entity_json.to_owned(),
             urn: Some(urn),
         },
     );


### PR DESCRIPTION
## Problem

Starting in realm A, going to realm B, then returning to realm A leaves the player stuck `OutOfWorld` with the scene lifecycle logging `pending ...` every frame. This affects realms whose scenes are listed explicitly in the about config (Worlds).

## Cause

Two compounding defects:

1. **Stale pointers are never reconciled for explicit-urn realms.** `ScenePointers` keeps cross-realm `Exists` entries on purpose — for active-entities realms, `load_active_entities` re-requests any parcel whose cached `realm` differs and confirms/replaces/clears it, so scenes shared between realms don't reboot. The explicit-urn branch only requests urns that aren't already cached and does no parcel sweep, so that reconciliation never runs and a previous realm's pointers live forever. On revisit they re-match the realm tag and are treated as already-resolved.

2. **The warm-cache teleport shortcut was broken.** It looked up a urn in a hash-keyed map (`available_hashes.get(teleport_on_resolve)`), so it always missed and the spawn teleport never resolved, leaving `teleport_target` stuck at `Base` → `pending ...` forever and the player never teleported in, so `OutOfWorld` was never cleared.

## Fix

- Reconcile in `process_realm_change` against the realm's scene list (enabling the `retain` that was sitting commented out), keeping pointers whose hash is still in the realm so scenes shared with the previous realm aren't rebooted, and dropping the rest. This also closes a latent staleness gap where a redeployed World would keep serving its old scene from cache.
- Match the cached hash against the target urn via `contains` (as the resolve path already does) instead of a direct `get`, so the teleport resolves from the warm cache on an unchanged same-World revisit.