### PR TITLE
Fix i32 overflow crash in load_imposters on empty realm

### DIFF
--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -1216,7 +1216,11 @@ fn load_imposters(
                         let base_size = 1i32 << base_imposter.level;
                         let scene_size = 1i32 << scene_imposter.level;
                         let parcel_size = base_size as f32 / scene_size as f32;
-                        let bottomleft = (base_imposter.parcel - scene_imposter.parcel).as_vec2()
+                        // subtract in float space: parcels can momentarily carry
+                        // sentinel/degenerate values (e.g. an empty realm) that
+                        // overflow the i32 subtraction (panics in debug builds)
+                        let bottomleft = (base_imposter.parcel.as_vec2()
+                            - scene_imposter.parcel.as_vec2())
                             / scene_size as f32;
 
                         for uv in uvs.iter_mut() {


### PR DESCRIPTION
## Problem

`load_imposters` panics in debug builds with `attempt to subtract with overflow` (in `glam` `IVec2::sub`) when switching to an empty realm.

```
thread 'Compute Task Pool' panicked at 'attempt to subtract with overflow': glam .../i32/ivec2.rs:1039
  Encountered a panic in system `imposters::render::load_imposters`!
```

The substitute floor-imposter path computes `base_imposter.parcel - scene_imposter.parcel`, subtracting two parcels as `IVec2` (i32). When a parcel momentarily carries a sentinel/degenerate value (e.g. an empty realm leaves `ScenePointers` min/max at `IVec2::MAX`/`MIN`), the i32 subtraction overflows and panics.

## Fix

The result is immediately turned into f32 (`.as_vec2() / scene_size as f32`), so the subtraction is done in float space instead. Identical result for valid parcels (parcel coords are small); no panic on degenerate input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)