### PR TITLE
Use ascending-edge smoothstep in nishita sky/star shader

### DIFF
--- a/crates/assets/src/assets/shaders/nishita_cloud.wgsl
+++ b/crates/assets/src/assets/shaders/nishita_cloud.wgsl
@@ -354,7 +354,7 @@ fn main(@builtin(global_invocation_id) original_invocation_id: vec3<u32>, @built
             let size = 0.99995 + 0.000025 * pow(fract(hash * 100000.0), 0.25);
             if stardirdot > size {
                 let color = vec3<f32>(0.25 + 0.75 * fract(hash * 1000.0), 0.625 + 0.375 * fract(hash * 1000.0), 1.0);
-                let brightness = smoothstep(0.99995 + 0.000025, 0.99995, size);
+                let brightness = 1.0 - smoothstep(0.99995, 0.99995 + 0.000025, size);
                 render_base += vec3<f32>(
                     color 
                     * clamp(1.0 - nishita.dir_light_intensity / 1000.0, 0.0, 1.0)) // sun brightness
@@ -367,7 +367,7 @@ fn main(@builtin(global_invocation_id) original_invocation_id: vec3<u32>, @built
 
     let render = render_cloud(render_base, nishita.ray_origin * 0.0, normalize(ray));
 
-    let store_value = mix(render, vec3(0.0), smoothstep(0.0, -0.5, initial_y));
+    let store_value = mix(render, vec3(0.0), 1.0 - smoothstep(-0.5, 0.0, initial_y));
 
     textureStore(
         image,


### PR DESCRIPTION
## Summary
Rewrite two reversed-edge `smoothstep(edge0 > edge1, …)` calls in the nishita sky/star shader into the equivalent `1.0 - smoothstep(low, high, x)` form (star brightness + skybox store value). Split out of the editor branch since it touches the production sky/star render path.

## What could break
Behaviour-preserving: `smoothstep(b,a,x) == 1 - smoothstep(a,b,x)`, and reversed edges are well-defined in WGSL (only `edge0 == edge1` is undefined, which doesn't apply). The ascending-edge form avoids relying on reversed-edge behaviour across backends. Renders for all players, so worth a visual sanity check of the sky/stars.

## How to test
`cargo check`; render a scene and eyeball the skybox + stars at dawn/dusk.