### PR TITLE
Fix non-deterministic shader composition breaking the GPU pipeline cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7087,8 +7087,7 @@ dependencies = [
 [[package]]
 name = "naga_oil"
 version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2464f7395decfd16bb4c33fb0cb3b2c645cc60d051bc7fb652d3720bfb20f18"
+source = "git+https://github.com/robtfm/naga_oil?branch=fix%2Fdeterministic-override-emit-order#9007b2ffe3e8f509ffc9b1481f039de78cf31699"
 dependencies = [
  "bit-set 0.5.3",
  "codespan-reporting 0.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,6 +314,13 @@ web-fs = { workspace = true }
 prost-build = "0.11.8"
 
 [patch.crates-io]
+# naga_oil with deterministic override-emit order (redirect.rs HashMap ->
+# IndexMap). without it, function overrides (e.g. the toon shadow override) emit
+# composed shaders in random per-page-load order on wasm, so the gpu pipeline
+# cache never converges and the main pass recompiles cold every load.
+# carried on a fork branch off the 0.17.1 tag. not an upstream backport —
+# naga_oil main is 0.22; revisit only if bevy's pinned naga_oil moves.
+naga_oil = { git = "https://github.com/robtfm/naga_oil", branch = "fix/deterministic-override-emit-order" }
 # mess required by egui referencing bevy crates directly
 bevy = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }
 bevy_a11y = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }

--- a/crates/assets/src/lib.rs
+++ b/crates/assets/src/lib.rs
@@ -13,8 +13,15 @@ impl Plugin for EmbedAssetsPlugin {
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+/// Salt for the GPU pipeline-cache key. `precomputed_shader_hash` only sees the
+/// shader *files*, so a change that alters generated shaders without touching
+/// them (e.g. the naga_oil override-emit-order fix) is invisible to it. Bump
+/// this to force every client to drop its stale cached pipelines on next load.
+#[cfg(target_arch = "wasm32")]
+const GPU_CACHE_SALT: u32 = 1;
+
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn gpu_cache_hash() -> String {
-    format!("{}", precomputed_shader_hash())
+    format!("{}-{}", precomputed_shader_hash(), GPU_CACHE_SALT)
 }


### PR DESCRIPTION
## Problem

On web, textures/objects show **black for a second or two at startup** on every load — the main pass isn't ready while the prepass has already written depth, so it's opaque black rather than transparent.

Root cause: the cel-shading work (#894) introduced `override fn shadows::fetch_directional_shadow` in `bound_material.wgsl` — our first naga_oil **function override**. That makes naga_oil run its override redirector, which in 0.17.1 emits functions in **`HashMap` iteration order**. The order is valid (dependents-first) but arbitrary and reseeds per process, so on wasm every page-load composes **byte-different fragment shaders**. The IndexedDB GPU pipeline cache (`deploy/web/gpu_cache.js`) keys on the generated source, so it **never converges** — each load recompiles every pipeline cold (and its required-set grows unbounded).

Only fragment shaders are affected (lighting uses the override); vertex shaders and bind-group layouts stay byte-stable, which is how it was tracked down.

## Fix

- **Bump `naga_oil`** to a fork branch that emits override-redirected functions in the deterministic function-arena order (`HashMap` → `IndexMap` in `redirect.rs`). Carried on a branch off the `0.17.1` tag — not an upstream backport (naga_oil main is 0.22).
- **Salt `gpu_cache_hash`** so existing clients drop their stale, pre-fix pipelines once on next load. `precomputed_shader_hash` only hashes the shader *files*, so a naga_oil-level change is invisible to it; bumping the salt forces a one-time cache clear for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)