### PR TITLE
Throttle stale-profile re-fetch to stop per-frame registry POSTs

### DIFF
--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -360,6 +360,10 @@ fn request_missing_profiles(
                         profile.version, player.profile_version, dbb,
                     );
                     manager.remove(player.address);
+                    // debounce the re-fetch: remove() cleared the cache, so without
+                    // this the next frame would re-spawn the catalyst request (and
+                    // its POST) every tick until the registry serves the new version.
+                    requested.insert(player.address, time.elapsed_secs());
                 }
                 continue;
             }


### PR DESCRIPTION
## Summary

`request_missing_profiles` was re-POSTing to `https://asset-bundle-registry.decentraland.org/profiles` continuously (effectively every tick) whenever a foreign player announced a profile version newer than what the registry currently serves.

When the registry returns a profile older than the announced version, the system evicts it from the cache via `manager.remove()` and `continue`s. The debounce map (`requested`) is only written on the RFC4 fallback path, so the now-empty cache caused `ProfileManager::get_data()` to re-spawn the catalyst request — and its POST — on the next frame, looping until the registry caught up.

This records the debounce timestamp on eviction so the retry follows the existing 10s cadence instead of firing every frame.

This is a long-standing latent bug (the eviction logic dates to comms 2.0 #149; the registry POST to #568), surfaced by a runtime condition — a peer announcing a version the registry hasn't propagated yet — not a recent code change. The June perf refactor (#861) rewrote the debounce but preserved this branch verbatim.

## What could break

- Minimal blast radius: one added line in the stale-eviction branch. A genuinely stale profile now retries every 10s instead of continuously, which is the intended cadence already used by the RFC4 path. Worst case is a slightly slower convergence (≤10s) when the registry finally serves the newer version — versus the current behavior of hammering it.

## How to test

1. Join a realm where a peer's announced profile version is ahead of what asset-bundle-registry serves (or reproduce by pointing at a registry lagging a fresh deploy).
2. Before: observe a continuous stream of `POST .../profiles` and repeated `removing stale profile ...` warns every frame.
3. After: the same request occurs at most once per 10s per address until the registry catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)