### PR TITLE
Don't freeze portables on a pending getUserData

### DIFF
--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -1088,8 +1088,17 @@ fn get_user_data(
                 Some(profile) => response.send(Ok(profile.content.clone())),
                 None => {
                     if let Ok(mut ctx) = scenes.get_mut(*scene) {
-                        // force scene to wait till user data is available
-                        ctx.blocked.insert("get_user_data");
+                        // Force parcel scenes to wait until user data is available
+                        // (existing scenes rely on getUserData resolving before they
+                        // proceed). Portables/global scenes must NOT be frozen this
+                        // way: a startup portable would otherwise be held out of the
+                        // scheduler entirely until the local profile loads (~when the
+                        // player lands in-world), so it can't run `main()` — or issue
+                        // asset preloads — before login completes. The pending request
+                        // is still queued below and answered once the profile arrives.
+                        if !ctx.is_portable {
+                            ctx.blocked.insert("get_user_data");
+                        }
                     }
                     info!("cloning response");
                     pending_primary_requests.push((*scene, response.clone()))


### PR DESCRIPTION
`get_user_data` inserts `"get_user_data"` into a scene's `blocked` set until the local profile is available. For a non-super scene, a non-empty `blocked` set removes it from the scene scheduler's eligibility filter entirely (`update_scene_priority`) — correct for parcel scenes that rely on user data before proceeding, but it also freezes a **startup portable**: it's held out of the scheduler until the profile loads (~when the player lands in-world), so it can't run `main()` or issue asset preloads before login completes.

This skips the block for portables (`!ctx.is_portable`). The pending request is still queued and answered once the profile arrives, so a portable that genuinely needs user data still gets it — it just isn't frozen while waiting.