### PR TITLE
default text wrap false

### DIFF
--- a/crates/scene_runner/src/update_world/scene_ui/ui_text.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_text.rs
@@ -73,7 +73,7 @@ impl From<PbUiText> for UiText {
             },
             font: value.font(),
             font_size: value.font_size.unwrap_or(10) as f32,
-            wrapping: value.text_wrap() == components::TextWrap::TwWrap,
+            wrapping: value.text_wrap != Some(components::TextWrap::TwNoWrap as i32),
         }
     }
 }


### PR DESCRIPTION
change default text wrapping to TwNoWrap inline with unity/godot