### PR TITLE
Fix stuck modifiers after OS-consumed chords (Cmd+Shift+5 etc.)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1588,12 +1588,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1707,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#794172be404e4c8ec64572ba9aae7421f12225c5"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1588,12 +1588,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1707,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b096ebb4fdc6db60444580e2cf158ccac7686da9"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/input_manager/src/lib.rs
+++ b/crates/input_manager/src/lib.rs
@@ -13,7 +13,7 @@ use bevy::{
     },
     platform::collections::{HashMap, HashSet},
     prelude::*,
-    window::{PrimaryWindow, WindowFocused},
+    window::PrimaryWindow,
 };
 
 use common::{
@@ -107,6 +107,14 @@ fn any_unbound_modifier_held(key_input: &ButtonInput<KeyCode>, map: &InputMap) -
     SUPPRESSING_MODIFIERS
         .iter()
         .any(|m| key_input.pressed(*m) && !key_bound(map, *m))
+}
+
+// Shift doesn't trigger OS-shortcut suppression (it isn't in
+// SUPPRESSING_MODIFIERS) but it is still a modifier for stuck-key
+// force-release purposes: a genuinely-held bound Shift (e.g. shift-to-run)
+// must not be released alongside stuck non-modifiers.
+fn modifier_key(k: &KeyCode) -> bool {
+    SUPPRESSING_MODIFIERS.contains(k) || matches!(k, KeyCode::ShiftLeft | KeyCode::ShiftRight)
 }
 
 pub struct InputManagerPlugin;
@@ -462,42 +470,46 @@ struct CurrentNativeInputRequest {
 // (e.g. a focused text field, which reserves at TextEntry). In that state
 // gameplay keys are already blocked by priority, so there is nothing to
 // suppress — and that consumer reads raw ButtonInput modifier state (Shift
-// for selection/redo etc.) which suppression would otherwise clobber. On
-// leaving that state we reset any leftover non-modifier presses (e.g. a
-// macOS Cmd+V whose keyUp was suppressed) so gameplay resumes clean.
+// for selection/redo etc.) which suppression would otherwise clobber.
+//
+// Key-state correctness across focus loss is handled upstream (winit web
+// window-focus fix + bevy's KeyboardFocusLost release_all). The one state
+// workaround kept here is the force-release below: macOS (natively and in
+// Chrome) suppresses keyUp for non-modifier keys while Cmd is held, and no
+// focus transition covers that.
 fn handle_modifier_keys(
     mut key_input: ResMut<ButtonInput<KeyCode>>,
     map: Res<InputMap>,
     priorities: Res<InputPriorities>,
-    mut focus_events: EventReader<WindowFocused>,
     mut was_active: Local<bool>,
-    mut was_keyboard_claimed: Local<bool>,
+    mut was_super_held: Local<bool>,
 ) {
-    // An OS chord that steals focus (e.g. Cmd+Shift+5 screen grab) delivers the
-    // modifier keydown but its keyup lands while we're unfocused, so winit never
-    // reports the release and the modifier stays pressed() on return — latching
-    // suppression on forever. Clear all key state on focus loss so nothing
-    // survives the round trip.
-    if focus_events.read().any(|e| !e.focused) {
-        key_input.reset_all();
+    // Any non-modifier still marked pressed when the last Super key goes up
+    // may never receive its keyup — force-release them all. Scoped to Super:
+    // keyups are delivered normally while Ctrl/Alt/Shift are held, and
+    // force-releasing on those would strand genuinely-held keys (e.g. W while
+    // tapping a bound walk/run modifier). A key genuinely still held at
+    // Cmd-up can't be told apart from a stuck one; re-pressing it is the
+    // acceptable cost, and outside text entry it was already released at
+    // Cmd-down by the suppression below.
+    let super_held =
+        key_input.pressed(KeyCode::SuperLeft) || key_input.pressed(KeyCode::SuperRight);
+    if *was_super_held && !super_held {
+        let held: Vec<KeyCode> = key_input
+            .get_pressed()
+            .copied()
+            .filter(|k| !modifier_key(k))
+            .collect();
+        for key in held {
+            key_input.release(key);
+        }
     }
+    *was_super_held = super_held;
 
     let keyboard_claimed = priorities
         .get(InputType::All)
         .max(priorities.get(InputType::Keyboard))
         >= InputPriority::TextEntry;
-
-    if *was_keyboard_claimed && !keyboard_claimed {
-        let held: Vec<KeyCode> = key_input
-            .get_pressed()
-            .copied()
-            .filter(|k| !SUPPRESSING_MODIFIERS.contains(k))
-            .collect();
-        for key in held {
-            key_input.reset(key);
-        }
-    }
-    *was_keyboard_claimed = keyboard_claimed;
 
     let active = !keyboard_claimed && any_unbound_modifier_held(&key_input, &map);
 


### PR DESCRIPTION
## Summary

Recurring web report: after an OS chord like Cmd+Shift+5 (macOS screen record), all gameplay keys stop working until reload. Third attempt after #718/#789/#873 — this one is root-caused and A/B-tested.

### Root cause

Cmd+Shift+5 delivers the Cmd/Shift keydowns but the OS swallows the keyups **without any focus transition** — no canvas blur, no window blur, nothing. The modifier stays `pressed()` in `ButtonInput<KeyCode>` forever, which latches #789's unbound-modifier gameplay suppression on permanently.

Focus-loss cases (Cmd+Tab, click-away) were never the residual problem: canvas blur does fire on OS window deactivation in Chrome (verified empirically with winit unpatched — held-key movement stops immediately on defocus), and bevy's `KeyboardFocusLost` → `release_all` handles them. That also makes #873's `reset_all` redundant — and actively harmful, since it wiped the `just_released` edges `release_all` had just produced in the same frame.

### Fix

The real fix lands in the bevy fork ([b096ebb](https://github.com/robtfm/bevy/commit/b096ebb4fdc6db60444580e2cf158ccac7686da9), pinned here via the Cargo.lock bump): `bevy_winit` now consumes `WindowEvent::ModifiersChanged` — which winit re-derives from the authoritative modifier bits on every keyboard/pointer/wheel event — and reconciles it against `WinitWindowPressedKeys` at end-of-batch, synthesizing key events for transitions that never arrived as key events. A stuck modifier heals on the first subsequent input event of any kind. End-of-batch ordering means normal modifier presses synthesize nothing.

`handle_modifier_keys` then slims down to policy plus one remaining platform workaround:

- **Removed**: #873's `WindowFocused` reset (redundant + edge-eating, above) and the leaving-text-entry key reset.
- **Added**: force-release of non-modifier keys when the last Super key goes up — macOS (natively and in Chrome) suppresses keyUp for non-modifiers while Cmd is held (the #718 stuck-V case), and no focus transition covers it. Scoped to Super only: keyups arrive normally under Ctrl/Alt/Shift, so e.g. holding W while tapping a bound walk modifier is unaffected.

### Validation

Full manual matrix on macOS Chrome/wasm: Cmd+Shift+5 (overlay dismissed and grab taken) heals on first mouse-move/keypress; Cmd+Tab and click-away round trips clean including with held movement keys; Cmd+V-in-chat mic regression (#718) still fixed and stuck V now clears on Cmd release; W+Shift/Ctrl tap leaves movement uninterrupted; suppression, bound-modifier exemption, and Super binding rejection (#789) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)