### PR TITLE
CI: cheaper dependabot runs, cached wasm builds, faster main deploys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Keep dependabot cheap: one grouped PR per ecosystem per week (each PR run of the full CI
+# matrix bills ~700 runner-minutes; the heavy jobs are also gated off dependabot in ci.yml).
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    groups:
+      cargo-deps:
+        patterns: ['*']
+
+  - package-ecosystem: npm
+    directory: /react-web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    groups:
+      react-web-deps:
+        patterns: ['*']
+
+  - package-ecosystem: npm
+    directory: /react-web/bridge-scene
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    groups:
+      bridge-scene-deps:
+        patterns: ['*']
+
+  - package-ecosystem: npm
+    directory: /deploy/web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 1
+    groups:
+      deploy-web-deps:
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
     open-pull-requests-limit: 1
+    groups:
+      actions-deps:
+        patterns: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,11 @@ concurrency:
 name: Continuous integration
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - name: Install protoc
-        uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623 # @master
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - name: install ffmpeg deps
-        run: sudo apt install -y --no-install-recommends clang curl pkg-config libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev
-      - name: install livekit deps
-        run: sudo apt update -y; sudo apt install -y libssl-dev libx11-dev libgl1-mesa-dev libxext-dev
-      - uses: actions/checkout@v6
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --locked
-
+  # No separate `cargo check` job: clippy compiles everything check does, plus lints.
   hardcore-test:
     name: Test Scenes
     # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
-    # minutes) — check/fmt/clippy still validate cargo bumps.
+    # minutes) — fmt/clippy still validate cargo bumps.
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
     steps:
@@ -50,6 +25,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
         uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623 # @master
         with:
@@ -75,7 +52,7 @@ jobs:
   test:
     name: Test Suite
     # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
-    # minutes) — check/fmt/clippy still validate cargo bumps.
+    # minutes) — fmt/clippy still validate cargo bumps.
     if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
@@ -161,15 +138,6 @@ jobs:
           toolchain: stable
           override: true
       - run: rustup component add rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - name: Install protoc
-        uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623 # @master
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - name: install ffmpeg deps (linux)
-        run: sudo apt install -y --no-install-recommends clang curl pkg-config libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -187,6 +155,8 @@ jobs:
           override: true
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
         uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623 # @master
         with:
@@ -224,9 +194,9 @@ jobs:
   build-deploy-web:
     name: Build and Deploy Web
     # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
-    # minutes) — check/fmt/clippy still validate cargo bumps.
+    # minutes) — fmt/clippy still validate cargo bumps.
     if: ${{ github.actor != 'dependabot[bot]' }}
-    # needs: [check, test, fmt, clippy]
+    # needs: [test, fmt, clippy]
     runs-on: ubuntu-latest
 
     permissions:
@@ -252,19 +222,31 @@ jobs:
           target: wasm32-unknown-unknown
           components: rust-src
           override: true
+      # Save only from main so PR runs restore main's cache instead of writing
+      # per-PR copies that thrash the repo's 10GB cache quota.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm-web
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
         uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623 # @master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
+        run: |
+          curl -fsSL https://github.com/rustwasm/wasm-pack/releases/download/v0.15.0/wasm-pack-v0.15.0-x86_64-unknown-linux-musl.tar.gz \
+            | tar -xz --strip-components=1 -C "$HOME/.cargo/bin" wasm-pack-v0.15.0-x86_64-unknown-linux-musl/wasm-pack
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: install deps (linux)
         run: sudo apt install -y --no-install-recommends clang curl
+      # wasm-opt costs ~9 min and only matters for the published binary — PRs
+      # never publish (see the Publish step's if), so they skip it.
       - name: Build WASM package
+        env:
+          WASM_OPT_FLAG: ${{ github.event_name == 'pull_request' && '--no-opt' || '' }}
         run: |
-          wasm-pack build --target web --out-dir ./deploy/web/engine/pkg --no-default-features --features="livekit,social"
+          wasm-pack build --target web $WASM_OPT_FLAG --out-dir ./deploy/web/engine/pkg --no-default-features --features="livekit,social"
           rm -f ./deploy/web/engine/pkg/.gitignore
           WASM_SIZE=$(wc -c < ./deploy/web/engine/pkg/webgpu_build_bg.wasm)
           echo "{\"wasmSize\":${WASM_SIZE}}" > ./deploy/web/engine/pkg/manifest.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
   # No separate `cargo check` job: clippy compiles everything check does, plus lints.
   hardcore-test:
     name: Test Scenes
-    # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
-    # minutes) — fmt/clippy still validate cargo bumps.
+    # Dependabot bumps skip this full release build; fmt/clippy still validate them.
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
     # Main runs no longer share a workflow group, so coalescing moves here: a
@@ -62,8 +61,8 @@ jobs:
 
   test:
     name: Test Suite
-    # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
-    # minutes) — fmt/clippy still validate cargo bumps.
+    # Dependabot bumps skip the heavy matrix (macOS bills 10x, Windows 2x minutes);
+    # fmt/clippy still validate cargo bumps and build-deploy-web covers npm ones.
     if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
@@ -209,9 +208,8 @@ jobs:
 
   build-deploy-web:
     name: Build and Deploy Web
-    # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
-    # minutes) — fmt/clippy still validate cargo bumps.
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Not gated off dependabot: this is the only job that builds the npm trees
+    # (react-web, bridge-scene, deploy/web), so npm bumps need it to merge safely.
     # needs: [test, fmt, clippy]
     runs-on: ubuntu-latest
     # Serialize deploys per ref so two main pushes can't publish concurrently.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,14 @@ jobs:
         run: |
           curl -fsSL https://github.com/rustwasm/wasm-pack/releases/download/v0.15.0/wasm-pack-v0.15.0-x86_64-unknown-linux-musl.tar.gz \
             | tar -xz --strip-components=1 -C "$HOME/.cargo/bin" wasm-pack-v0.15.0-x86_64-unknown-linux-musl/wasm-pack
-      # No alsa/udev here: those are native-target deps (cpal/gilrs), never
-      # compiled for wasm32.
+      # alsa/udev ARE still needed despite targeting wasm32: the build compiles a HOST-side
+      # graph too (build scripts + their deps, x86_64), and that graph links libudev via
+      # pkg-config — dropping them fails `libudev-sys` before wasm-pack even reaches the
+      # wasm target.
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: install deps (linux)
-        run: sudo apt-get update; sudo apt install -y --no-install-recommends clang
+        run: sudo apt install -y --no-install-recommends clang
       # wasm-opt costs ~9 min and only matters for the published binary — PRs
       # never publish (see the Publish step's if), so they skip it.
       - name: Build WASM package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
       - main
   pull_request:
 
+# PRs share a per-ref group so a superseded push cancels the in-flight run. Main
+# pushes get a unique group each (run_id): sharing one made every main run queue
+# behind the previous run's whole test matrix, delaying deploy starts by up to an
+# hour. Only the deploy job serializes, via its job-level group.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 name: Continuous integration
 
@@ -198,6 +202,9 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     # needs: [test, fmt, clippy]
     runs-on: ubuntu-latest
+    # Serialize deploys per ref so overlapping main pushes can't publish out of order.
+    concurrency:
+      group: ${{ github.workflow }}-deploy-web-${{ github.ref }}
 
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
 
   hardcore-test:
     name: Test Scenes
+    # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
+    # minutes) — check/fmt/clippy still validate cargo bumps.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions-rs/toolchain@v1
@@ -71,6 +74,9 @@ jobs:
 
   test:
     name: Test Suite
+    # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
+    # minutes) — check/fmt/clippy still validate cargo bumps.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -217,6 +223,9 @@ jobs:
 
   build-deploy-web:
     name: Build and Deploy Web
+    # Dependabot bumps don't need the expensive jobs (the macOS/Windows matrix bills 10x/2x
+    # minutes) — check/fmt/clippy still validate cargo bumps.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     # needs: [check, test, fmt, clippy]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
     steps:
+      # Checkout must precede rust-cache: the cache key hashes Cargo.lock, and
+      # without it the key is constant — saved once from main, then frozen stale.
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -47,7 +50,6 @@ jobs:
         run: sudo apt install -y --no-install-recommends clang curl pkg-config libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev
       - name: install livekit deps
         run: sudo apt update -y; sudo apt install -y libssl-dev libx11-dev libgl1-mesa-dev libxext-dev
-      - uses: actions/checkout@v6
       - name: Test Scenes
         continue-on-error: true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,10 @@ jobs:
         run: |
           curl -fsSL https://github.com/rustwasm/wasm-pack/releases/download/v0.15.0/wasm-pack-v0.15.0-x86_64-unknown-linux-musl.tar.gz \
             | tar -xz --strip-components=1 -C "$HOME/.cargo/bin" wasm-pack-v0.15.0-x86_64-unknown-linux-musl/wasm-pack
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      # No alsa/udev here: those are native-target deps (cpal/gilrs), never
+      # compiled for wasm32.
       - name: install deps (linux)
-        run: sudo apt install -y --no-install-recommends clang curl
+        run: sudo apt-get update; sudo apt install -y --no-install-recommends clang
       # wasm-opt costs ~9 min and only matters for the published binary — PRs
       # never publish (see the Publish step's if), so they skip it.
       - name: Build WASM package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
     # minutes) — fmt/clippy still validate cargo bumps.
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
+    # Main runs no longer share a workflow group, so coalescing moves here: a
+    # newer push cancels this job's superseded in-flight run.
+    concurrency:
+      group: ${{ github.workflow }}-scenes-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       # Checkout must precede rust-cache: the cache key hashes Cargo.lock, and
       # without it the key is constant — saved once from main, then frozen stale.
@@ -65,6 +70,11 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-15]
     runs-on: ${{ matrix.os }}
+    # Same coalescing as Test Scenes, per matrix leg — without this, every push
+    # in a burst of main merges would bill the full 10x-macOS/2x-Windows matrix.
+    concurrency:
+      group: ${{ github.workflow }}-test-${{ matrix.os }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
@@ -204,7 +214,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     # needs: [test, fmt, clippy]
     runs-on: ubuntu-latest
-    # Serialize deploys per ref so overlapping main pushes can't publish out of order.
+    # Serialize deploys per ref so two main pushes can't publish concurrently.
     concurrency:
       group: ${{ github.workflow }}-deploy-web-${{ github.ref }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,33 @@ name: Continuous integration
 
 jobs:
   # No separate `cargo check` job: clippy compiles everything check does, plus lints.
+
+  # Did this change touch the rust dependency graph? The expensive jobs below scale
+  # their coverage on this. On pull_request the filter reads the PR file list from
+  # the API; on push it diffs against the pre-push commit (hence the checkout).
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust-deps: ${{ steps.filter.outputs.rust-deps }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            rust-deps:
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - '**/Cargo.toml'
+              - '.cargo/config.toml'
+
   hardcore-test:
     name: Test Scenes
-    # Dependabot bumps skip this full release build; fmt/clippy still validate them.
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: changes
+    # Runs only when the rust dep files change, and never for dependabot: its bumps
+    # are validated by the merge push to main, where the actor is the human merger.
+    if: ${{ needs.changes.outputs.rust-deps == 'true' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
     # Main runs no longer share a workflow group, so coalescing moves here: a
     # newer push cancels this job's superseded in-flight run.
@@ -61,13 +84,17 @@ jobs:
 
   test:
     name: Test Suite
-    # Dependabot bumps skip the heavy matrix (macOS bills 10x, Windows 2x minutes);
-    # fmt/clippy still validate cargo bumps and build-deploy-web covers npm ones.
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: changes
+    # Ubuntu always runs as the cheap unit-test leg. The 10x-macOS/2x-Windows legs
+    # only run when the rust dep files change — their main value is catching
+    # platform-specific dependency breakage. Dependabot cargo bumps get the ubuntu
+    # leg here plus the full matrix post-merge (main push: human actor + lock diff);
+    # its npm/actions bumps skip the job entirely (they can't affect the rust build).
+    if: ${{ needs.changes.outputs.rust-deps == 'true' || github.actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-15]
+        os: ${{ (needs.changes.outputs.rust-deps == 'true' && github.actor != 'dependabot[bot]') && fromJSON('["windows-latest", "ubuntu-latest", "macos-15"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     # Same coalescing as Test Scenes, per matrix leg — without this, every push
     # in a burst of main merges would bill the full 10x-macOS/2x-Windows matrix.


### PR DESCRIPTION
## Summary

Three changes to make CI cheaper and deploys faster.

**Dependabot was burning our quota**

Every dependabot PR ran the full CI matrix. macOS runners bill at 10x, so a single dependency bump cost around 700 billed minutes. Now dependabot PRs skip the test matrix and the scene tests. The web build still runs on them, because it's the only job that compiles the npm packages, so a broken npm bump can't merge green. There's also a new `dependabot.yml` that groups everything into one weekly PR per ecosystem instead of one PR per package.

**The web deploy was rebuilding everything, every time**

The deploy job took ~30 minutes, and almost all of it was avoidable:

- 15 min compiling the wasm engine from scratch (the job had no cache at all)
- 9 min of wasm-opt, even on PRs, whose binary is never published anywhere
- 1 min compiling wasm-pack from source instead of just downloading it

The interesting part is the cache. Some jobs already used rust-cache, but it barely helped, and the reason took a while to find. GitHub gives a repo 10 GB of cache space. Every PR run was saving its own ~2 GB copy of the build cache, and a cache saved by a PR can only be restored by that same PR. Other PRs and main can't read it. So the quota was full of copies nobody could reuse, and GitHub kept evicting the caches that actually mattered to make room. That's why even the jobs with caching kept running cold.

The fix: caches are now only saved from main (`save-if`). PRs restore main's cache and never write their own. This works because GitHub lets a PR read caches from its base branch, so every PR starts from the latest main build and only recompiles what it changed. It also means a PR can never write a cache that main reads, so there's no way to poison the deploy build from a PR.

And it's safe to restore a stale cache: it's just a warm `target/` folder. Cargo checks every crate's fingerprint against the real sources and lockfile and rebuilds whatever doesn't match. A stale cache costs minutes, never correctness.

Smaller things in the same area: wasm-opt is skipped on PRs (`--no-opt`) since only main publishes; wasm-pack is a pinned binary download now; the Check job is gone (clippy compiles the same code and lints on top of it); rustfmt lost a pile of apt installs it never needed.

Expected numbers: main deploys ~15 min (wasm-opt is the part we can't skip), PR deploy builds ~6-8 min once main has saved a cache. The first run after merging is still cold.

**Main pushes were queueing behind each other**

All main runs shared one concurrency group, so a new push couldn't start until the previous run's slowest job finished. The #925 deploy sat 26 minutes doing nothing, waiting for #901's Windows tests. Now every main run starts immediately. If a newer push lands while tests are still running, the older test jobs get cancelled (only the newest matters). The deploy job keeps its own group so two pushes can't publish at the same time.

## What could break

- Dependabot PRs don't run the test matrix. A cargo bump that compiles but fails tests would only surface on the main push after merge.
- On quick back-to-back merges, the older push's test jobs show as cancelled. Only the newest one finishes.
- The Check status disappears from PRs. Nothing depends on it (no branch protection).
- PR wasm binaries are bigger since they skip wasm-opt. The published artifact from main is unchanged.
- If main gets no pushes for 7 days the cache expires and the next run is cold. It re-seeds itself on that run.

## How to test

- Merge and watch the main run: the deploy should take ~15 min and save the `wasm-web` cache.
- Open any PR after that: the deploy build should restore it and finish in ~6-8 min, with `--no-opt` visible in the wasm-pack log.
- Next dependabot PR: matrix jobs skipped, web build runs.
- Push twice to main a few minutes apart: the second run starts right away and the first run's test jobs cancel.
