### PR TITLE
Drop the orphaned bridge-scene commit stamp

### DIFF
--- a/react-web/bridge-scene/package.json
+++ b/react-web/bridge-scene/package.json
@@ -3,10 +3,9 @@
   "version": "1.0.0",
   "description": "UI Scene shows a functional UI for the Bevy Explorer",
   "scripts": {
-    "update-version": "node -e \"const {execSync} = require('child_process'); const hash = execSync('git rev-parse --short HEAD').toString().trim(); require('fs').writeFileSync('src/version.ts', 'export const COMMIT_HASH = \\x27' + hash + '\\x27\\n');\"",
-    "start": "npm run update-version && sdk-commands start",
+    "start": "sdk-commands start",
     "deploy": "sdk-commands deploy",
-    "build": "npm run update-version && sdk-commands build",
+    "build": "sdk-commands build",
     "export-static": "sdk-commands export-static --destination static/ --realmName BevyExplorerUI --baseUrl ${SCENE_BASE_URL:-/bridge-scene/static/} --commsAdapter ws-room:ws-room-service.decentraland.org/rooms/bevy-explorer-ui",
     "bundle": "npm run build && npm run export-static && rm -rf ../../deploy/web/bridge-scene && mkdir -p ../../deploy/web/bridge-scene && cp -R static ../../deploy/web/bridge-scene/static",
     "lint": "eslint \"./src/**/*.{ts,tsx}\"",

--- a/react-web/bridge-scene/src/version.ts
+++ b/react-web/bridge-scene/src/version.ts
@@ -1,1 +1,0 @@
-export const COMMIT_HASH = 'f9393e2'


### PR DESCRIPTION
## Summary
`update-version` rewrote `src/version.ts` with the repo HEAD on every build/start — permanent tracked-file churn that kept leaking into unrelated commits — and nothing reads `COMMIT_HASH` since the bridge scene was rebuilt clean (its build-marker logging is gone). Deployed-scene provenance already exists via the versioned CDN path.

## What could break
Nothing imports the module (verified by grep + the sdk build type-check passing without it).

## How to test
`cd react-web/bridge-scene && npm run build` — type-checks clean; `git status` stays clean after builds.