### PR TITLE
Fix web preview mode and the react-web dev environment

### DIFF
--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -149,10 +149,12 @@ const config = window.__bevyBootConfig ?? {}
 // the same place. Defaults are omitted so the canonical entry URL stays clean.
 const DEFAULT_SERVER = 'https://realm-provider-ea.decentraland.org/main'
 const DEFAULT_PORTABLES = 'basiccontroller.dcl.eth'
-window.set_url_params = (x, y, server, system_scene, portables, preview) => {
+window.set_url_params = (position, server, system_scene, portables, preview) => {
   try {
     const urlParams = new URLSearchParams(window.location.search)
-    urlParams.set('position', `${x},${y}`)
+    // absent when the realm won't honour a position (worlds spawn at their base scene)
+    if (position != null) urlParams.set('position', position)
+    else urlParams.delete('position')
     if (server !== DEFAULT_SERVER) urlParams.set('realm', server)
     else urlParams.delete('realm')
     if (system_scene !== (config.systemScene ?? '')) urlParams.set('systemScene', system_scene)

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -4,7 +4,7 @@
 //
 // Contract with the host page (react-web/src/engine/engineRpc.ts):
 //   set BEFORE injecting:  window.PUBLIC_URL   — base for pkg/ fetches (versioned CDN in prod)
-//                          window.__bevyBootConfig = { systemScene, portables }
+//                          window.__bevyBootConfig = { systemScene, portables, preview }
 //   provided by this module:
 //     __bevyLoadProgress / __bevyLoadStep  — weighted boot progress for the login bar
 //     __bevyReadyToLaunch / __bevyLaunch(realm?, position?) — deferred engine_run
@@ -189,7 +189,7 @@ initEngine()
     window.setLoadingStepCompleted('gpu')
     // Deferred launch: the host calls this once the user picks a destination — avoiding a wasted
     // default-realm load. One engine per page (see start()'s __bevyStarted guard).
-    window.__bevyLaunch = (realm, position) => start({ realm, position, systemScene: config.systemScene, portables: config.portables })
+    window.__bevyLaunch = (realm, position) => start({ realm, position, systemScene: config.systemScene, portables: config.portables, preview: config.preview })
     window.__bevyReadyToLaunch = true
   })
   .catch((e) => {

--- a/react-web/bridge-scene/.gitignore
+++ b/react-web/bridge-scene/.gitignore
@@ -9,3 +9,5 @@ yarn-debug.log*
 yarn-error.log*
 # export-static output (regenerate with `npm run export-static`)
 static/
+# sdk-commands build context (regenerated on every build)
+dclcontext/

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -173,7 +173,10 @@ export type SessionPhase = 'login' | 'picking' | 'entering' | 'world'
 
 // Where the user chose to spawn after login (the post-jump-in Places picker). `null` = skip → the
 // engine's default spawn (Genesis Plaza). A world switches realm; a parcel teleports once spawned.
-export type Destination = { kind: 'parcel'; x: number; y: number } | { kind: 'world'; realm: string } | null
+export type Destination =
+  | { kind: 'parcel'; x: number; y: number }
+  | { kind: 'world'; realm: string; position?: string }
+  | null
 
 export interface LoginFlow {
   status: LoginStatus
@@ -658,7 +661,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       // strand a Genesis pick "Reconnecting to the realm" forever.
       try {
         if (dest == null) driver.launch?.(DEFAULT_REALM, '0,0')
-        else if (dest.kind === 'world') driver.launch?.(dest.realm, undefined)
+        else if (dest.kind === 'world') driver.launch?.(dest.realm, dest.position)
         else driver.launch?.(DEFAULT_REALM, `${dest.x},${dest.y}`)
       } catch (e) {
         // A boot-time engine panic throws synchronously out of launch() (a generic "unreachable"
@@ -700,19 +703,22 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     setTimeout(run, 60)
   }, [])
   // ?position=x,y / ?realm= (parity with the plain engine page): skip the Places picker and launch
-  // straight there. position wins when both are given (the realm still applies — EngineHost feeds
-  // it to the iframe as initialRealm, which a position-only launch inherits). Consumed once —
-  // after a sign-out the picker shows normally.
+  // straight there. realm wins when both are given, carrying the position along — letting
+  // ?position shadow ?realm made a reload in a custom realm respawn in Genesis at the same
+  // coordinates (a parcel launch passes DEFAULT_REALM explicitly). The engine's URL sync only
+  // writes ?position when the realm honours one; realms with fixed scene urns (worlds) spawn at
+  // their base scene and ignore it anyway. Consumed once — after a sign-out the picker shows
+  // normally.
   const urlDestination = useRef<Destination>(
     (() => {
       const q = new URLSearchParams(location.search)
       const raw = q.get('position')
-      if (raw != null) {
-        const [x, y] = raw.split(',').map((n) => parseInt(n.trim(), 10))
-        if (Number.isFinite(x) && Number.isFinite(y)) return { kind: 'parcel', x, y }
-      }
+      const [x, y] = raw?.split(',').map((n) => parseInt(n.trim(), 10)) ?? []
+      const hasPosition = Number.isFinite(x) && Number.isFinite(y)
       const realm = q.get('realm')
-      if (realm != null && realm !== '') return { kind: 'world', realm }
+      if (realm != null && realm !== '')
+        return { kind: 'world', realm, position: hasPosition ? `${x},${y}` : undefined }
+      if (hasPosition) return { kind: 'parcel', x, y }
       return null
     })()
   )

--- a/react-web/src/lib/coiServiceWorker.ts
+++ b/react-web/src/lib/coiServiceWorker.ts
@@ -1,11 +1,13 @@
-// COOP/COEP escape hatch for production. The hosting site (decentraland.zone/bevy-web) serves
-// `COEP: require-corp`, which blocks plain <img> loads from catalysts (they send no CORP header).
-// The shared service worker at the PACKAGE ROOT (deploy/web/service_worker.js) rewrites
-// same-origin navigations to `COEP: credentialless`, which allows credential-less no-CORP images
-// while keeping crossOriginIsolated for the engine. The engine page registers the SAME script
-// (engine/main.js), so one registration scopes both.
+// COOP/COEP escape hatch AND the engine's IPFS cache. The hosting site (decentraland.zone/
+// bevy-web) serves `COEP: require-corp`, which blocks plain <img> loads from catalysts (they
+// send no CORP header). The shared service worker at the PACKAGE ROOT (deploy/web/
+// service_worker.js) rewrites same-origin navigations to `COEP: credentialless`, which allows
+// credential-less no-CORP images while keeping crossOriginIsolated for the engine.
 //
-// Dev is a no-op: Vite already serves credentialless headers directly and doesn't host the SW.
+// The SW is REQUIRED in dev too (vite serves it at /service_worker.js): the engine tags
+// cacheable asset fetches with an X-IPFS header for the SW to strip + cache. Uncontrolled,
+// that custom header forces a CORS preflight the peer catalysts reject — scene content and
+// avatar wearables all fail to download.
 import { PAGE_DIR } from './publicUrl'
 
 // One-shot reload guard. Deliberately NOT the engine's `sw_reloaded` — the iframe shares this
@@ -13,7 +15,7 @@ import { PAGE_DIR } from './publicUrl'
 const FLAG = 'coi_sw_reloaded'
 
 export function registerCoiServiceWorker(): void {
-  if (!import.meta.env.PROD || !('serviceWorker' in navigator)) return
+  if (!('serviceWorker' in navigator)) return
 
   // The SW scope is the package DIRECTORY (…/bevy-web/), but the production entry URL has no
   // trailing slash (…/bevy-web) — OUTSIDE that scope, so this page load is never controlled and

--- a/react-web/vite.config.ts
+++ b/react-web/vite.config.ts
@@ -20,7 +20,9 @@ function bridgeScenePreview(): Plugin {
       probe.once('connect', () => probe.destroy()) // already running — reuse it
       probe.once('error', () => {
         console.log('[bridge-scene] starting live preview on :8100')
-        const child = spawn('npx', ['sdk-commands', 'start', '--no-browser', '--port', '8100'], {
+        // --no-install: only run the locally-installed @dcl/sdk-commands bin. Without it, a stale
+        // bridge-scene/node_modules makes npx fetch the UNRELATED registry package "sdk-commands".
+        const child = spawn('npx', ['--no-install', 'sdk-commands', 'start', '--no-browser', '--port', '8100'], {
           cwd: fileURLToPath(new URL('./bridge-scene', import.meta.url)),
           stdio: ['ignore', 'inherit', 'inherit'],
           detached: true
@@ -137,6 +139,11 @@ export default defineConfig(({ command }) => ({
     bridgeScenePreview(),
     coiHeadersExceptAuth(),
     serveStatic('/engine/', '../deploy/web/engine'),
+    // The IPFS-cache service worker, at the ROOT so its scope covers the page (like prod). The
+    // engine tags cacheable asset fetches with an X-IPFS header for it; without a SW to strip
+    // that header the requests need a CORS preflight, which the peer catalysts reject — no
+    // scenes, no avatars. (serveStatic handles a single file fine: rel resolves to the root.)
+    serveStatic('/service_worker.js', '../deploy/web/service_worker.js'),
     // Our headless super-user bridge scene (exported deployable). Pointed at by
     // the engine's systemScene so it loads as the trusted --ui scene.
     serveStatic('/bridge-scene/static/', './bridge-scene/static')

--- a/src/web.rs
+++ b/src/web.rs
@@ -40,8 +40,7 @@ extern "C" {
 extern "C" {
     #[wasm_bindgen(js_name = set_url_params)]
     fn set_url_params(
-        x: i32,
-        y: i32,
+        position: Option<String>,
         realm: String,
         system_scene: Option<String>,
         portables: Option<String>,
@@ -263,7 +262,7 @@ pub fn update_winit_fps(config: Res<AppConfig>, mut winit: ResMut<WinitSettings>
 
 #[derive(PartialEq, Default, Clone)]
 struct UrlParams {
-    parcel: IVec2,
+    parcel: Option<IVec2>,
     server: String,
     ui_scene: Option<String>,
     portables: Option<String>,
@@ -277,7 +276,15 @@ fn update_url_params(
     preview: Res<PreviewMode>,
     mut prev: Local<UrlParams>,
 ) {
-    let parcel = vec3_to_parcel(player.single().map(|p| p.translation()).unwrap_or_default());
+    // realms with fixed scene urns (worlds) spawn at their base scene and ignore an explicit
+    // position (see load_active_entities' base-position handling) - don't write one into the url
+    let position_honoured = current_realm
+        .config
+        .scenes_urn
+        .as_ref()
+        .is_none_or(Vec::is_empty);
+    let parcel = position_honoured
+        .then(|| vec3_to_parcel(player.single().map(|p| p.translation()).unwrap_or_default()));
     let Some(server) = current_realm.about_url.strip_suffix("/about") else {
         return;
     };
@@ -308,8 +315,9 @@ fn update_url_params(
     if params != *prev {
         *prev = params.clone();
         set_url_params(
-            params.parcel.x,
-            params.parcel.y,
+            params
+                .parcel
+                .map(|parcel| format!("{},{}", parcel.x, parcel.y)),
             params.server,
             params.ui_scene,
             params.portables,


### PR DESCRIPTION
Four fixes for the web front-end after the react-web integration (#901/#925/#926):

**Preview mode was dropped in the launch chain.** `EngineHost` reads `?preview` into `__bevyBootConfig` and `engine.js start()` forwards it to `engine_run`, but `boot.js`'s `__bevyLaunch` sat between them and didn't pass it — so `is_preview` was always false on web (no preview-server hot-reload socket, and the wasm URL sync then scrubbed `?preview` from the address bar). One line to pass it through.

**Scenes and avatars didn't load under `npm run dev`.** The engine tags cacheable asset fetches with an `X-IPFS` header for the service worker to strip and cache (`crates/ipfs/src/lib.rs`), but the SW was only registered in PROD builds. Uncontrolled, the custom header forces a CORS preflight which the peer catalysts reject (`Access-Control-Allow-Headers` doesn't include it — verified uniform across peer.decentraland.org, peer.dclnodes.io, peer-ec2, interconnected.online), so every Genesis City content download failed. Worlds and local scenes were unaffected (worlds-content-server reflects arbitrary preflight headers), which is why HUD-focused dev, prod builds, and the e2e suite (which asserts bridge round-trips, not rendered geometry) never caught it. Fix: vite serves the SW at the dev root and registration no longer gates on PROD. The SW's existing localhost bypass keeps local bridge-scene content uncached and HMR is untouched. Verified end-to-end: guest login → Genesis Plaza spawns, renders, avatars load.

**Reloading in a custom realm respawned the player in Genesis City.** The wasm URL sync always wrote `?position`, and the reload reader preferred it over `?realm` (a parcel launch passes `DEFAULT_REALM` explicitly), so a reload in any non-default realm landed in Genesis at the same coordinates. Engine side: realms with fixed scene urns (worlds) spawn at their designated base scene and ignore an explicit position, so the URL sync no longer writes one for them (and clears any stale one) — mirroring `load_active_entities`' base-position handling. React side: realm wins over position on reload, carrying the position into the launch; a `?position` in the URL now always means the realm honours it. Verified live for all three shapes: world reload returns to the world (no position param), Genesis reload lands at the exact parcel, and a parcel-space custom realm restores both realm and position.

**`npx sdk-commands` could fetch a look-alike registry package.** With a stale `bridge-scene/node_modules`, the dev plugin's `npx sdk-commands start` fell back to the public registry, which has an unrelated package named `sdk-commands` (it 404s on a bogus `@dck/` scope — but only after attempting to install untrusted code shadowing Decentraland's CLI name). `--no-install` makes a missing local install fail loudly instead.

Plus: ignore the `dclcontext/` dir that `sdk-commands build` regenerates in `bridge-scene` (deleted from the repo in #901).

🤖 Generated with [Claude Code](https://claude.com/claude-code)