### PR TITLE
fix(livekit/web): honor destinationIdentities and reliable on web data publish

### DIFF
--- a/crates/comms/livekit_web_bindings.js
+++ b/crates/comms/livekit_web_bindings.js
@@ -291,14 +291,19 @@ export async function participant_is_local(participant) {
 }
 
 /**
- * 
+ *
  * @param {livekit.LocalParticipant} local_participant
- * @param {Uint8Array} payload 
- * @param {livekit.DataPublishOptions} payload 
- * @returns string
+ * @param {Uint8Array} payload
+ * @param {boolean} reliable
+ * @param {string | undefined} topic
+ * @param {string[]} destination_identities
  */
-export async function local_participant_publish_data(local_participant, payload, data_publish_options) {
-    local_participant.publishData(payload, data_publish_options).await;
+export async function local_participant_publish_data(local_participant, payload, reliable, topic, destination_identities) {
+    await local_participant.publishData(payload, {
+        reliable,
+        topic: topic ?? undefined,
+        destinationIdentities: destination_identities,
+    });
 }
 
 /**

--- a/crates/comms/src/livekit/web/local_participant.rs
+++ b/crates/comms/src/livekit/web/local_participant.rs
@@ -17,7 +17,9 @@ extern "C" {
     async fn local_participant_publish_data(
         local_participant: &LocalParticipant,
         data: &[u8],
-        data_publish_options: DataPublishOptions,
+        reliable: bool,
+        topic: Option<String>,
+        destination_identities: Vec<String>,
     ) -> RoomResult<()>;
     #[wasm_bindgen(catch)]
     async fn local_participant_publish_track(
@@ -54,16 +56,13 @@ impl LocalParticipant {
             destination_identities,
         } = data;
 
-        let data_publish_options = DataPublishOptions {
-            reliable,
-            topic,
-            destination_identities: destination_identities
-                .into_iter()
-                .map(|participant_identity| participant_identity.0)
-                .collect(),
-        };
+        let destination_identities = destination_identities
+            .into_iter()
+            .map(|participant_identity| participant_identity.0)
+            .collect();
 
-        local_participant_publish_data(self, &payload, data_publish_options).await
+        local_participant_publish_data(self, &payload, reliable, topic, destination_identities)
+            .await
     }
 
     pub async fn publish_track(
@@ -132,15 +131,4 @@ impl IntoWasmAbi for &LocalParticipant {
     fn into_abi(self) -> JsValueAbi {
         self.inner.clone().into_abi()
     }
-}
-
-#[expect(dead_code, reason = "Read on JavaScript side")]
-#[wasm_bindgen]
-struct DataPublishOptions {
-    #[wasm_bindgen = "reliable"]
-    reliable: bool,
-    #[wasm_bindgen = "topic"]
-    topic: Option<String>,
-    #[wasm_bindgen = "destinationIdentities"]
-    destination_identities: Vec<String>,
 }


### PR DESCRIPTION
## Problem

On the web (wasm) client, LiveKit data messages ignored **both** their intended recipient and their reliability, because the `DataPublishOptions` handed to `localParticipant.publishData` was a `#[wasm_bindgen]` struct with private fields (`#[wasm_bindgen = "…"]` is not a valid getter attribute). wasm-bindgen generated an opaque class with no property getters, so LiveKit read `options.destinationIdentities`, `.reliable`, and `.topic` all as `undefined`.

Consequences on the web client:
- **Recipient ignored** → directed sends broadcast to everyone. Auth-server-targeted avatar state (movement/emote) reached every human peer, and `Peer`-directed messages were no longer private.
- **Reliability ignored** → reliable messages (e.g. `ProfileUpdate`, announced on connect) were published lossy; large ones were truncated to a single datagram.

Native is unaffected — it publishes via the Rust LiveKit SDK's `DataPacket { reliable, destination_identities }`, which honors both.

## Fix

Pass `reliable`, `topic`, and `destination_identities` as plain arguments and construct a real options object (`{ reliable, topic, destinationIdentities }`) in the JS binding. Also `await` the publish — the previous `.await` was a property-access no-op that additionally swallowed publish errors.

Verified in-browser against two native peers on the same realm: before, the web client's movement produced hundreds of dropped legacy-LiveKit movement packets on the natives within a minute; after, zero — directed sends are now withheld from human peers by the SFU, matching native.

## Related

Likely fixes #871 (server-side `index out of range` / `invalid wire type` packet-decode errors when a bevy client connects to a local scene auth-server): the dropped `reliable` flag would publish large reliable messages (profiles, sent on connect) lossy → truncated → the server decodes a length prefix that runs past the end of the buffer. **Needs confirmation against a local auth-server.** Note this fix is web-only; if #871 was observed with the native client it does not apply, since native already honors reliability via the Rust SDK.
