### PR TITLE
Fix 16-bit texture sampler + sRGB loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1588,12 +1588,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1707,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#2c88f99a15d5e37940de6544e3e130a5ca8aa2ee"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "webgpu_build"
 # - copy ./assets to deploy/web/assets
 # - copy ./crates/dcl/src/js/modules to deploy/web/modules
 # - rustup default nightly # (tested with 2026-04-15)
-# - wasm-pack build --target web --out-dir ./deploy/web/pkg --no-default-features --features="livekit" && npx serve deploy/web
+# - wasm-pack build --target web --out-dir ./deploy/web/engine/pkg --no-default-features --features="livekit,social" (then serve via react-web; see react-web/README.md)
 
 [features]
 default = ["livekit", "ffmpeg", "inspect", "social"]

--- a/crates/nft/src/extended_image_loader.rs
+++ b/crates/nft/src/extended_image_loader.rs
@@ -51,10 +51,16 @@ impl AssetLoader for SvgLoader {
         )
         .map_err(|_| "image construction failed")?;
 
-        #[cfg(target_arch = "wasm32")]
+        // NFT/SVG images are always sRGB colour; there is no 16-bit sRGB format,
+        // so downconvert 16-bit -> 8-bit sRGB on all platforms (wasm also can't
+        // sample Rgba16Unorm). Leaving it linear would render too bright.
         if image.texture_descriptor.format
             == bevy::render::render_resource::TextureFormat::Rgba16Unorm
         {
+            // preserve sampler/view-descriptor and keep the sRGB format — Image::new
+            // otherwise resets the sampler and leaves sRGB data in a linear format.
+            let sampler = image.sampler.clone();
+            let texture_view_descriptor = image.texture_view_descriptor.clone();
             let data = image
                 .data
                 .unwrap()
@@ -68,9 +74,11 @@ impl AssetLoader for SvgLoader {
                 image.texture_descriptor.size,
                 image.texture_descriptor.dimension,
                 data,
-                bevy::render::render_resource::TextureFormat::Rgba8Unorm,
+                bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
                 image.asset_usage,
             );
+            image.sampler = sampler;
+            image.texture_view_descriptor = texture_view_descriptor;
         }
 
         debug!("svg load ok");


### PR DESCRIPTION
Bumps the `robtfm/bevy` fork (`release-0.16-dcl` → `d8c1f672`) and fixes the NFT loader, addressing texture wrapping **and** colour being lost on 16-bit-depth textures.

## Problem

The 16-bit → 8-bit texture downconversion rebuilds the image with `Image::new(...)`, which resets `sampler`/`texture_view_descriptor` to defaults **and** picks a linear format. So a 16-bit-depth texture:
- lost its glTF sampler — `Repeat` wrap became `ClampToEdge`, so tiling textures rendered clamped (no wrapping); and
- if sRGB (a colour texture), ended up with sRGB-encoded data in a *linear* format, so it rendered too bright.

Genesis Plaza's floor hit both (16-bit basecolor/normal art). It reproduced reliably on **local realms**, where content isn't cached — on deployed content the KTX reprocess masks it (the cached image is 8-bit).

## Fix

In the fork, at all three reconstruction sites (image loader for external textures, and the two glTF embedded paths — buffer-view and data-URI):
- preserve `sampler` + `texture_view_descriptor` across the rebuild;
- choose `Rgba8UnormSrgb` / `Rgba8Unorm` from `is_srgb`, mirroring `from_dynamic`.

The downconversion now also runs on **native** for sRGB textures (there is no `Rgba16UnormSrgb` format, so 16-bit sRGB colour would otherwise stay linear and render too bright), while leaving linear 16-bit at full precision. wasm still downconverts all 16-bit as before (wgpu on web can't sample `Rgba16Unorm`).

This PR also applies the same fix to `nft/extended_image_loader.rs` (its own copy of the downconversion for SVG/NFT images), and corrects the stale wasm-pack `--out-dir` in the `Cargo.toml` build comment (`deploy/web/pkg` → `deploy/web/engine/pkg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)