### PR TITLE
Bump bevy: render-instance mirrors + visibility-set optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1588,12 +1588,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1707,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#d8c1f672003de48c1001821064e22a5317bc493e"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1588,12 +1588,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1707,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
 dependencies = [
  "accesskit",
  "accesskit_winit",


### PR DESCRIPTION
## What

Cargo.lock-only bump of the bevy fork to [robtfm/bevy@31ef28842](https://github.com/robtfm/bevy/commit/31ef28842d38bd9a8d6b792ec33c5f531590db91) (47× hash bump, no dependency graph changes). Two stacked fork commits:

1. **Mesh/material instance mirror components** ([58e6bfa4e](https://github.com/robtfm/bevy/commit/58e6bfa4e77c1efc6065c9b07d47c7d68fdaff36))
2. **Previous-frame visibility on `ViewVisibility`** ([31ef28842](https://github.com/robtfm/bevy/commit/31ef28842d38bd9a8d6b792ec33c5f531590db91))

## Why

Genesis Plaza on wasm is fully main-thread CPU-bound (0.0% idle over a 10s profile), and ~38% of frame time was hashbrown/indexmap operations — `MainEntity`-keyed maps (`RenderMeshInstances`, `RenderMaterialInstances`) and `EntityHashSet` visibility tracking, all touched per entity **per phase per view** and multiplied by shadow-view count. Resolution scaling had no effect (44→42fps), confirming the bottleneck is per-entity CPU bookkeeping, not fragment/GPU cost.

**Commit 1 — instance mirrors:** the two hottest maps are mirrored into components on render-world entities (`Mesh3d` entities now sync to the render world to carry them), and the hot readers (specialize/queue for material, prepass and shadows; DrawMesh/SetMeshBindGroup/SetMaterialBindGroup) do component-first archetype lookups with map fallback. `RenderBin` carries real representative render entities so per-draw lookups hit the fast path. The maps stay authoritative and the public API is unchanged, so external consumers (e.g. boimp) are unaffected. Consistency verified in-app via a new `validate_instance_mirror` cargo feature (probe-time asserts + per-frame map↔component symmetry sweeps) over scene load/unload/teleport churn.

**Commit 2 — visibility:** `ViewVisibility` becomes `(current, previous)`, replacing the per-frame insert/remove `EntityHashSet` protocol; change-detection behavior is bit-exact, so render-world extraction is unaffected. Adapted from bevy#22226 with its post-merge fixes.

## Measured (wasm, Genesis Plaza, fixed viewpoint)

| | hashmap self-time | fps |
|---|---|---|
| baseline | 37.8% | ~30 |
| + instance mirrors | 27.5% | ~34 |
| + visibility | **22.0%** | **~36** |

The three converted structures (mesh map, material map, visibility sets) went from 19.8% combined to ~1.8%.

## Migration note

Both fork commits are 0.16 stopgaps, superseded structurally by bevy 0.19's change-list rework ([#22966](https://github.com/bevyengine/bevy/pull/22966)) and 0.18's visibility optimization ([#22226](https://github.com/bevyengine/bevy/pull/22226)). They get **dropped, not ported**, on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)