### PR TITLE
Remove egui (perf)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,22 +3,6 @@
 version = 4
 
 [[package]]
-name = "ab_glyph"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
-dependencies = [
- "ab_glyph_rasterizer",
- "owned_ttf_parser",
-]
-
-[[package]]
-name = "ab_glyph_rasterizer"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
-
-[[package]]
 name = "accesskit"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,12 +1014,11 @@ dependencies = [
 [[package]]
 name = "bevy_console"
 version = "0.14.0"
-source = "git+https://github.com/robtfm/bevy-console?branch=0.16#636e66e2c032ad32a7f21ec7ea5389b00ae42b90"
+source = "git+https://github.com/robtfm/bevy-console?branch=0.16#4a48b6bd3b85c87e26d0f80c837cedfc6c4ec34d"
 dependencies = [
  "ansi-parser",
  "bevy",
  "bevy_console_derive",
- "bevy_egui",
  "clap",
  "shlex",
  "strip-ansi-escapes",
@@ -1045,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "bevy_console_derive"
 version = "0.5.0"
-source = "git+https://github.com/robtfm/bevy-console?branch=0.16#636e66e2c032ad32a7f21ec7ea5389b00ae42b90"
+source = "git+https://github.com/robtfm/bevy-console?branch=0.16#4a48b6bd3b85c87e26d0f80c837cedfc6c4ec34d"
 dependencies = [
  "better-bae",
  "proc-macro2",
@@ -1169,39 +1152,6 @@ dependencies = [
  "cssparser-color",
  "smallvec",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "bevy_egui"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3d58a8afdb6100bca50251043a85320391742cae125d559f6cca3a16b84cdd"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_derive",
- "bevy_ecs",
- "bevy_image",
- "bevy_input",
- "bevy_log",
- "bevy_math",
- "bevy_platform",
- "bevy_reflect",
- "bevy_render",
- "bevy_time",
- "bevy_window",
- "bevy_winit",
- "bytemuck",
- "crossbeam-channel",
- "egui",
- "encase",
- "image",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-types",
- "winit",
 ]
 
 [[package]]
@@ -2408,18 +2358,6 @@ dependencies = [
  "rustix 1.1.4",
  "slab",
  "tracing",
-]
-
-[[package]]
-name = "calloop-wayland-source"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
-dependencies = [
- "calloop 0.13.0",
- "rustix 0.38.44",
- "wayland-backend",
- "wayland-client",
 ]
 
 [[package]]
@@ -4038,30 +3976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecolor"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
-dependencies = [
- "bytemuck",
- "emath",
-]
-
-[[package]]
-name = "egui"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
-dependencies = [
- "ahash",
- "bitflags 2.11.0",
- "emath",
- "epaint",
- "nohash-hasher",
- "profiling",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4084,15 +3998,6 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "emath"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -4205,29 +4110,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "epaint"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
-dependencies = [
- "ab_glyph",
- "ahash",
- "bytemuck",
- "ecolor",
- "emath",
- "epaint_default_fonts",
- "nohash-hasher",
- "parking_lot",
- "profiling",
-]
-
-[[package]]
-name = "epaint_default_fonts"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "equator"
@@ -7269,12 +7151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
 name = "noise"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7946,15 +7822,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "owned_ttf_parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
-dependencies = [
- "ttf-parser 0.25.1",
-]
 
 [[package]]
 name = "parity-scale-codec"
@@ -9791,19 +9658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sctk-adwaita"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
-dependencies = [
- "ab_glyph",
- "log",
- "memmap2",
- "smithay-client-toolkit 0.19.2",
- "tiny-skia",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10181,38 +10035,13 @@ dependencies = [
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
-dependencies = [
- "bitflags 2.11.0",
- "calloop 0.13.0",
- "calloop-wayland-source 0.3.0",
- "cursor-icon",
- "libc",
- "log",
- "memmap2",
- "rustix 0.38.44",
- "thiserror 1.0.69",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-client-toolkit"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
  "bitflags 2.11.0",
  "calloop 0.14.4",
- "calloop-wayland-source 0.4.1",
+ "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
@@ -10238,7 +10067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
 dependencies = [
  "libc",
- "smithay-client-toolkit 0.20.0",
+ "smithay-client-toolkit",
  "wayland-backend",
 ]
 
@@ -11478,12 +11307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-
-[[package]]
 name = "tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11569,7 +11392,6 @@ dependencies = [
  "bevy",
  "bevy_dui",
  "bevy_ecss",
- "bevy_egui",
  "bevy_simple_text_input",
  "common",
  "input_manager",
@@ -12238,19 +12060,6 @@ name = "wayland-protocols-misc"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "429b99200febaf95d4f4e46deff6fe4382bcff3280ee16a41cf887b3c3364984"
-dependencies = [
- "bitflags 2.11.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-plasma"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d392fc283a87774afc9beefcd6f931582bb97fe0e6ced0b306a62cb1d026527c"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -13061,7 +12870,6 @@ name = "winit"
 version = "0.30.12"
 source = "git+https://github.com/robtfm/winit?branch=v0.30.x#a8c6812b563f9c0974a17226f566705bbc9ee674"
 dependencies = [
- "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.0",
@@ -13076,7 +12884,6 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
- "memmap2",
  "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -13088,17 +12895,11 @@ dependencies = [
  "raw-window-handle",
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
- "sctk-adwaita",
- "smithay-client-toolkit 0.19.2",
  "smol_str",
  "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-plasma",
  "web-sys",
  "web-time",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,9 @@ bevy = { version = "0.16.1", default-features = false, features = [
   "reduce_image_sizes",
 ] }
 wgpu = "24"
-bevy_console = { git = "https://github.com/robtfm/bevy-console", branch = "0.16" }
+# default-features = false drops the egui console window (we only use the
+# command/print plumbing, piped to chat); this keeps egui out of the build entirely
+bevy_console = { git = "https://github.com/robtfm/bevy-console", branch = "0.16", default-features = false }
 # enables naga_oil function overrides on non-`virtual` bevy_pbr functions (e.g.
 # our shadow-darkness override in bound_material.wgsl). feature-unifies into the
 # naga_oil that bevy builds its shader composer with. version must match bevy's.
@@ -129,11 +131,6 @@ bevy_console = { git = "https://github.com/robtfm/bevy-console", branch = "0.16"
 naga_oil = { version = "0.17", default-features = false, features = [
   "override_any",
 ] }
-bevy_egui = { version = "0.34", default-features = false, features = [
-  "default_fonts",
-  "render",
-] }
-
 serde = "1.0.152"
 serde_json = { version = "1.0.92", features = ["raw_value"] }
 
@@ -321,7 +318,7 @@ prost-build = "0.11.8"
 # carried on a fork branch off the 0.17.1 tag. not an upstream backport —
 # naga_oil main is 0.22; revisit only if bevy's pinned naga_oil moves.
 naga_oil = { git = "https://github.com/robtfm/naga_oil", branch = "fix/deterministic-override-emit-order" }
-# mess required by egui referencing bevy crates directly
+# mess required by ecosystem crates referencing bevy subcrates directly
 bevy = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }
 bevy_a11y = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }
 bevy_asset = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1267,7 +1267,6 @@ pub enum ZOrder {
     Toast,
     Permission,
     DefaultComboPopup,
-    EguiBlocker,
 }
 
 impl ZOrder {

--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -37,7 +37,8 @@ impl DoAddConsoleCommand for App {
 }
 
 pub struct ConsolePlugin {
-    pub add_egui: bool,
+    // add the bevy_console command plumbing; false (tests) registers the bare events only
+    pub add_bevy_console: bool,
 }
 
 impl Plugin for ConsolePlugin {
@@ -53,7 +54,7 @@ impl Plugin for ConsolePlugin {
             ..Default::default()
         });
 
-        if self.add_egui {
+        if self.add_bevy_console {
             app.add_plugins(bevy_console::ConsolePlugin);
         } else {
             app.add_event::<ConsoleCommandEntered>();

--- a/crates/scene_runner/src/test/mod.rs
+++ b/crates/scene_runner/src/test/mod.rs
@@ -102,7 +102,9 @@ impl PluginGroup for TestPlugins {
             .add(InputPlugin)
             .add(ScenePlugin)
             .add(StatesPlugin)
-            .add(ConsolePlugin { add_egui: false })
+            .add(ConsolePlugin {
+                add_bevy_console: false,
+            })
             .add(WalletPlugin)
             .add(CommsPlugin)
             .add(DuiPlugin)

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -15,7 +15,7 @@ use common::{
     sets::{SceneSets, SetupSets},
     structs::{
         AppConfig, CurrentRealm, CursorLocks, DebugInfo, PreviewCommand, PreviewMode, PrimaryUser,
-        SettingsTab, ShowSettingsEvent, StartupScenes, Version, ZOrder,
+        SettingsTab, ShowSettingsEvent, StartupScenes, UiRoot, Version, ZOrder,
     },
     util::{ModifyComponentExt, TryPushChildrenEx},
 };
@@ -445,6 +445,7 @@ fn setup_minimap(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn update_minimap(
     q: Query<&DuiEntities, With<Minimap>>,
     mut maps: Query<&mut MapTexture>,
@@ -453,7 +454,18 @@ fn update_minimap(
     scenes: Query<(&RendererSceneContext, Option<&GltfLoadingCount>)>,
     mut text: Query<&mut Text>,
     preview: Res<PreviewMode>,
+    root: Query<&Node, With<UiRoot>>,
 ) {
+    // skip the scene lookup / string churn while the native hud is hidden (ui-scene
+    // mode); preview-server minimaps live outside the root so they always update
+    if preview.server.is_none()
+        && !root
+            .single()
+            .is_ok_and(|node| node.display == Display::Flex)
+    {
+        return;
+    }
+
     let Ok(gt) = player.single() else {
         return;
     };

--- a/crates/ui_core/Cargo.toml
+++ b/crates/ui_core/Cargo.toml
@@ -10,7 +10,6 @@ common = { workspace = true }
 input_manager = { workspace = true }
 
 bevy = { workspace = true }
-bevy_egui = { workspace = true }
 bevy_dui = { workspace = true }
 bevy_ecss = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/ui_core/src/color_picker.rs
+++ b/crates/ui_core/src/color_picker.rs
@@ -1,15 +1,8 @@
 use anyhow::anyhow;
-use bevy::{math::Vec3Swizzles, prelude::*, window::PrimaryWindow};
+use bevy::prelude::*;
 use bevy_dui::{DuiRegistry, DuiTemplate};
-use bevy_egui::{egui, EguiContext};
-use common::structs::ZOrder;
 
-use crate::{
-    ui_actions::{DataChanged, On},
-    Blocker,
-};
-
-use super::focus::Focus;
+use crate::ui_actions::{DataChanged, On};
 
 #[derive(Component)]
 pub struct ColorPicker {
@@ -32,91 +25,7 @@ pub struct ColorPickerPlugin;
 
 impl Plugin for ColorPickerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, setup)
-            .add_systems(Update, update_color_picker_components);
-    }
-}
-
-#[allow(clippy::type_complexity)]
-fn update_color_picker_components(
-    mut commands: Commands,
-    mut egui_ctx: Query<&mut EguiContext, With<PrimaryWindow>>,
-    mut color_pickers: Query<
-        (
-            Entity,
-            &mut ColorPicker,
-            &Node,
-            &ComputedNode,
-            &GlobalTransform,
-            Option<&mut Interaction>,
-            Option<&Focus>,
-        ),
-        Without<Blocker>,
-    >,
-    mut blocker: Local<Option<Entity>>,
-    mut blocker_display: Query<&mut Node, With<Blocker>>,
-    mut blocker_active: Local<bool>,
-) {
-    let Ok(mut ctx) = egui_ctx.single_mut() else {
-        return;
-    };
-    let ctx = ctx.get_mut();
-    let blocker = *blocker.get_or_insert_with(|| {
-        commands
-            .spawn((
-                Node {
-                    position_type: PositionType::Absolute,
-                    display: Display::None,
-                    left: Val::Px(0.0),
-                    right: Val::Px(0.0),
-                    top: Val::Px(0.0),
-                    bottom: Val::Px(0.0),
-                    ..Default::default()
-                },
-                bevy::ui::FocusPolicy::Block,
-                ZOrder::EguiBlocker.default(),
-                Blocker,
-            ))
-            .id()
-    });
-
-    let mut popup_active = false;
-
-    for (entity, mut color_picker, style, node, transform, _maybe_interaction, _maybe_focus) in
-        color_pickers.iter_mut()
-    {
-        let center = transform.translation().xy() / ctx.zoom_factor();
-        let size = node.size() / ctx.zoom_factor();
-        let topleft = center - size / 2.0;
-
-        if matches!(style.display, Display::Flex) {
-            egui::Window::new(format!("{entity:?}"))
-                .fixed_pos(topleft.to_array())
-                .fixed_size(size.to_array())
-                .frame(egui::Frame::NONE)
-                .title_bar(false)
-                .show(ctx, |ui| {
-                    let response = ui.color_edit_button_rgb(&mut color_picker.color);
-
-                    if ui.memory(|mem| mem.any_popup_open()) {
-                        popup_active = true;
-                    }
-
-                    // pass through focus and interaction
-                    if response.changed() {
-                        commands.entity(entity).try_insert(DataChanged);
-                    }
-                });
-        }
-    }
-
-    if popup_active != *blocker_active {
-        blocker_display.get_mut(blocker).unwrap().display = if popup_active {
-            Display::Flex
-        } else {
-            Display::None
-        };
-        *blocker_active = popup_active;
+        app.add_systems(Startup, setup);
     }
 }
 
@@ -124,6 +33,8 @@ fn setup(mut dui: ResMut<DuiRegistry>) {
     dui.register_template("color-picker", DuiColorPicker);
 }
 
+// display-only swatch; the egui edit widget it used to spawn is gone, and the
+// native ui hosting it is superseded by the ui scene
 pub struct DuiColorPicker;
 impl DuiTemplate for DuiColorPicker {
     fn render(
@@ -137,7 +48,8 @@ impl DuiTemplate for DuiColorPicker {
                 .take::<Color>("color")?
                 .ok_or(anyhow!("no initial color"))?,
         );
-        commands.try_insert(picker);
+        let swatch = BackgroundColor(picker.get_linear());
+        commands.try_insert((picker, swatch));
 
         if let Some(onchanged) = props.take::<On<DataChanged>>("onchanged")? {
             commands.try_insert(onchanged);

--- a/crates/ui_core/src/lib.rs
+++ b/crates/ui_core/src/lib.rs
@@ -27,7 +27,6 @@ use bevy::{
     text::CosmicFontSystem,
 };
 use bevy_dui::{DuiNodeList, DuiPlugin, DuiRegistry};
-use bevy_egui::EguiPlugin;
 use bound_node::BoundedNodePlugin;
 use button::{DuiButtonSetTemplate, DuiButtonTemplate, DuiTabGroupTemplate};
 use color_picker::ColorPickerPlugin;
@@ -82,9 +81,6 @@ impl Plugin for UiCorePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(DuiPlugin);
         app.add_plugins(BoundedNodePlugin);
-        app.add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: false,
-        });
         app.add_plugins(UiActionPlugin);
         app.add_plugins(FocusPlugin);
         app.add_plugins(InteractStylePlugin);
@@ -322,7 +318,3 @@ impl<S: States + FreelyMutableState> StateTracker<S> {
         system.into_configs()
     }
 }
-
-// blocker for egui elements to prevent interaction fallthrough
-#[derive(Component)]
-struct Blocker;

--- a/crates/ui_core/src/text_size.rs
+++ b/crates/ui_core/src/text_size.rs
@@ -4,7 +4,6 @@ use bevy::{
     window::{PrimaryWindow, WindowResized},
 };
 use bevy_dui::{DuiEntityCommandsExt, DuiProps, DuiRegistry, DuiTemplate};
-use bevy_egui::EguiContextSettings;
 use common::util::{ModifyComponentExt, ModifyDefaultComponentExt};
 
 use crate::{
@@ -126,7 +125,6 @@ pub fn update_fontsize(
     mut q: Query<(&mut TextFont, Ref<FontSize>)>,
     mut resized: EventReader<WindowResized>,
     window: Query<&Window, With<PrimaryWindow>>,
-    mut egui_settings: Query<&mut EguiContextSettings>,
 ) {
     let resized = resized.read().last().is_some();
     let Ok(window) = window.single() else {
@@ -138,11 +136,6 @@ pub fn update_fontsize(
     }
     for (mut text_font, size) in q.iter_mut().filter(|(_, sz)| resized || sz.is_changed()) {
         text_font.font_size = win_size * size.0;
-    }
-    if resized && win_size > 0.0 {
-        for mut ctx in egui_settings.iter_mut() {
-            ctx.scale_factor = win_size / 720.0;
-        }
     }
 }
 /*

--- a/crates/ui_core/src/ui_actions.rs
+++ b/crates/ui_core/src/ui_actions.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use bevy::{
     ecs::{query::QueryData, system::BoxedSystem},
-    platform::collections::{HashMap, HashSet},
+    platform::collections::HashSet,
     prelude::*,
     ui::UiSystem,
     window::PrimaryWindow,
@@ -355,25 +355,34 @@ fn gather_actions<M: ActionMarker>(
     }
 }
 
-pub fn run_actions<M: ActionMarker>(world: &mut World) {
-    let active_list: HashMap<usize, bool> = world
-        .query::<(&ActionIndex<M>, M::Component)>()
-        .iter(world)
-        .map(|(action, param)| (action.0, M::activate(param)))
-        .collect();
+type ActionQuery<M> = QueryState<(&'static ActionIndex<M>, <M as ActionMarker>::Component)>;
+
+fn run_actions<M: ActionMarker>(world: &mut World, mut query: Local<Option<ActionQuery<M>>>) {
+    if world.resource::<UiActions<M>>().0.is_empty() {
+        return;
+    }
+
+    // cache the query state; rebuilding it every frame re-matches all archetypes
+    let query = query.get_or_insert_with(|| world.query());
+    let mut active_list: Vec<Option<bool>> = vec![None; world.resource::<UiActions<M>>().0.len()];
+    for (action, param) in query.iter(world) {
+        if let Some(slot) = active_list.get_mut(action.0) {
+            *slot = Some(M::activate(param));
+        }
+    }
 
     let mut removed: HashSet<usize> = HashSet::default();
     world.resource_scope(|world: &mut World, mut ui_actions: Mut<UiActions<M>>| {
         let mut index = 0;
 
         ui_actions.0.retain_mut(|action| {
-            let Some(active) = active_list.get(&index) else {
+            let Some(active) = active_list.get(index).copied().flatten() else {
                 removed.insert(index);
                 index += 1;
                 return false;
             };
 
-            if *active && !action.run_already {
+            if active && !action.run_already {
                 if !action.initialized {
                     action.system.initialize(world);
                     action.initialized = true;
@@ -383,7 +392,7 @@ pub fn run_actions<M: ActionMarker>(world: &mut World) {
                 action.system.apply_deferred(world);
                 world.resource_mut::<UiCaller>().0 = Entity::PLACEHOLDER;
             }
-            action.run_already = *active && !M::repeat_activate();
+            action.run_already = active && !M::repeat_activate();
 
             index += 1;
             true

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -252,7 +252,9 @@ fn main() {
 
     app.add_plugins(UtilsPlugin)
         .add_plugins(UiCorePlugin)
-        .add_plugins(ConsolePlugin { add_egui: true })
+        .add_plugins(ConsolePlugin {
+            add_bevy_console: true,
+        })
         .add_plugins(SceneBoundPlugin)
         .add_plugins(SceneRunnerPlugin)
         .add_plugins(CommsPlugin)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,9 @@ impl DecentralandApp {
             .add_plugins(UserInputPlugin)
             .add_plugins(UiCorePlugin)
             .add_plugins(SystemUiPlugin)
-            .add_plugins(ConsolePlugin { add_egui: true })
+            .add_plugins(ConsolePlugin {
+                add_bevy_console: true,
+            })
             .add_plugins(VisualsPlugin {
                 no_fog: decentraland_app_config.arguments.no_fog,
             })


### PR DESCRIPTION
egui ran a full per-frame pass (input handling, begin/end pass, tessellation, its own render node) on every platform and accounted for ~3MB (2.7%) of the wasm binary, while its only remaining uses were the console window (never shown — console commands are piped through chat) and the wearables color picker in the superseded native UI.

- `bevy_console` is now consumed with `default-features = false`; the fork gained a default-on `ui` feature ([robtfm/bevy-console@4a48b6b](https://github.com/robtfm/bevy-console/commit/4a48b6bd3b85c87e26d0f80c837cedfc6c4ec34d)) so only the command/print plumbing is built. `ConsolePlugin::add_egui` is renamed `add_bevy_console` to match.
- The wearables color picker is reduced to a display-only swatch; the `color-picker` dui template and `ColorPicker` component API are unchanged.
- `EguiPlugin`, the resize-time egui scale-factor sync, `ZOrder::EguiBlocker` and the interaction `Blocker` are removed.

Two further wins from auditing per-frame native-UI cost in ui-scene mode:

- `update_minimap` skips its containing-scene lookup and string formatting while the native hud root is hidden (writes were already change-gated; the PageUp debug toggle picks up current values as soon as the hud is shown, and preview-server minimaps are unaffected).
- `run_actions::<M>` cached its `QueryState` in a `Local` instead of re-matching all archetypes for each of the 11 action markers every frame, collects activation state into a dense `Vec` instead of a per-frame `HashMap` (action indices are dense), and early-outs for markers with no registered handlers. Behavior is unchanged for all `On<M>` consumers, including sdk/scene ui.

wasm binary: 110,845,180 → 107,812,265 bytes (−2.7%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)