### PR TITLE
dependabot: lockfile-only for cargo and bridge-scene updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 2
+    # Only update Cargo.lock within the ranges Cargo.toml already allows. Rust's 0.x
+    # convention makes update-type filters useless (0.15 -> 0.17 classifies as "minor"
+    # but is breaking); cargo's caret semantics encode compatibility correctly, so the
+    # manifest ranges are the policy. Crossing a range boundary is deliberate manual work.
+    versioning-strategy: lockfile-only
     groups:
       cargo-deps:
         patterns: ['*']
@@ -25,6 +30,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 2
+    # Exact pins here are deliberate — notably the @dcl/* commit-snapshot SDK builds
+    # (7.x-<run>.commit-<sha>) matched to the engine. lockfile-only means dependabot
+    # can never rewrite a pin: no range, no update room. Ranged dev tooling still
+    # gets in-range lockfile bumps.
+    versioning-strategy: lockfile-only
     groups:
       bridge-scene-deps:
         patterns: ['*']


### PR DESCRIPTION
## Summary

Two follow-ups to the #924 dependabot config, prompted by the first grouped PRs it produced.

**cargo (#937):** the weekly group bundled 11 manifest-editing bumps, including prost 0.11→0.12 which can't move while `dcl_rpc` implements prost-build 0.11's `ServiceGenerator` — so one blocked dep turned all 42 updates red. Update-type filters can't fix this because dependabot classifies 0.x bumps literally (`cpal` 0.15→0.17 counts as "minor" but is breaking in Rust convention). `versioning-strategy: lockfile-only` makes Cargo.toml's caret ranges the policy: dependabot only updates Cargo.lock within existing ranges, so every proposed bump is compatible by construction. Crossing a range boundary becomes deliberate manual work. Security PRs are a separate mechanism and still propose out-of-range fixes.

**bridge-scene (#936):** the group replaced the `@dcl/*` commit-snapshot pins (`7.x-<run>.commit-<sha>`, matched to the engine) with plain releases. Dependabot can't filter on version shape (ignore rules are name-based), but lockfile-only protects the pins structurally: an exact pin has no update room, so it can never be rewritten — whatever the package is called. Ranged dev tooling (eslint etc.) still gets in-range lockfile bumps; majors become manual, same as cargo.

The react-web and deploy/web entries keep the default strategy — no deliberate pins there, and major-update PRs remain useful for them.

After merge, `@dependabot recreate` on #936/#937 regenerates them under the new rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)