### PR TITLE
Bump bevy: animation evaluator dense-index rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1216,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1588,12 +1588,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1707,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#31ef28842d38bd9a8d6b792ec33c5f531590db91"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
 dependencies = [
  "accesskit",
  "accesskit_winit",


### PR DESCRIPTION
Pulls robtfm/bevy@fc901897d (`release-0.16-dcl`): `bevy_animation`'s per-target evaluator bookkeeping — `PreHashMap`/`TypeIdMap` probes per curve per target per frame in `get_or_insert_with`, `push_blend_register_all`, and the `commit_all` drain — replaced with a dense `Vec` of evaluators plus an index list for the current-target set. The distinct-evaluator count is bounded by the number of animatable properties (translation/rotation/scale/weights), so linear scans beat hashing and the per-graph-node loops become direct array indexing.

Measured on Genesis Plaza (wasm, dev-instrumented, 8 secondary shadow casters): animation group 7.55% → 5.03% of frame; the evaluator-map probe, `CurrentEvaluators::clear`, and `push_blend_register_all` profile entries disappear entirely.

Unlike the render-instance mirrors (#933), this is not throwaway on migration — upstream main retains the hashmap shape, so the change carries forward through a 0.19 rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)