### PR TITLE
Omit null fields from deployed profile JSON

### DIFF
--- a/crates/common/src/profile.rs
+++ b/crates/common/src/profile.rs
@@ -34,17 +34,27 @@ impl AvatarColor {
     }
 }
 
+// Optional fields are omitted when absent, not serialized as `null`: other explorers
+// fail to parse present-but-null fields in deployed profiles.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AvatarWireFormat {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body_shape: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub eyes: Option<AvatarColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hair: Option<AvatarColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub skin: Option<AvatarColor>,
     pub wearables: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub force_render: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub emotes: Option<Vec<AvatarEmote>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub snapshots: Option<AvatarSnapshots>,
 }
 
@@ -56,6 +66,7 @@ pub struct LambdaProfiles {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SerializedProfile {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
     #[serde(default)]
     pub name: String,
@@ -64,8 +75,10 @@ pub struct SerializedProfile {
     pub eth_address: String,
     #[serde(default)]
     pub has_claimed_name: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_connected_web3: Option<bool>,
     pub avatar: AvatarWireFormat,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name_color: Option<Color3>,
     #[serde(flatten)]
     pub extra_fields: HashMap<String, serde_json::Value>,

--- a/crates/system_ui/src/profile.rs
+++ b/crates/system_ui/src/profile.rs
@@ -465,9 +465,16 @@ fn process_profile(
         if let Some(base) = &set_avatar.base {
             profile.content.avatar.body_shape = Some(base.body_shape_urn.clone());
 
-            profile.content.avatar.hair = base.hair_color.map(AvatarColor::new);
-            profile.content.avatar.eyes = base.eyes_color.map(AvatarColor::new);
-            profile.content.avatar.skin = base.skin_color.map(AvatarColor::new);
+            // a base without colors must not strip them from the profile
+            if let Some(hair) = base.hair_color {
+                profile.content.avatar.hair = Some(AvatarColor::new(hair));
+            }
+            if let Some(eyes) = base.eyes_color {
+                profile.content.avatar.eyes = Some(AvatarColor::new(eyes));
+            }
+            if let Some(skin) = base.skin_color {
+                profile.content.avatar.skin = Some(AvatarColor::new(skin));
+            }
 
             profile.content.name = base.name.clone();
             profile.content.avatar.name = Some(base.name.clone());


### PR DESCRIPTION
## Summary

Profiles deployed by bevy-explorer serialize every `Option::None` field as an explicit `"field": null` (`nameColor`, `snapshots`, `avatar.name`, …), while other clients omit absent fields. Present-but-null fields can fail to parse in other explorers, leaving the profile unusable there until a clean entity is re-deployed. This started affecting accounts when #877 added the `nameColor` field: since then every re-deploy (e.g. any backpack change) writes `"nameColor": null`. Verified against a real broken profile entity on the catalyst.

Changes:
- `skip_serializing_if = "Option::is_none"` on all optional profile wire-format fields, so absent fields are omitted instead of null
- `process_profile`: a `setAvatar` base that omits eyes/hair/skin colors now preserves the existing values instead of wiping them

## What could break

- Any consumer that distinguished `"field": null` from an absent field in bevy-deployed profiles or comms profile messages. None known — JS sees `undefined` either way, serde deserializes missing `Option` as `None`, and omitted fields match what other clients already deploy.
- Colors can no longer be *cleared* via `setAvatar` base — intentional, they were never meaningfully clearable.

## How to test

1. Log in with a web3 account, change your look in the backpack, close it (triggers a re-deploy)
2. Fetch the deployed entity: `curl -s https://peer.decentraland.org/content/entities/active -X POST -H 'content-type: application/json' -d '{"pointers":["<address>"]}'` — verify the avatar JSON contains no `null` values and no `nameColor`/`snapshots` keys
3. Enter Decentraland with another explorer client using the same account — profile loads correctly