### PR TITLE
Include live worlds in the Places Live Now section

### DIFF
--- a/react-web/src/features/places/PlacesBrowser.tsx
+++ b/react-web/src/features/places/PlacesBrowser.tsx
@@ -59,7 +59,7 @@ export function PlacesBrowser({
   headExtra?: React.ReactNode
   onPick: (place: DiscoverPlace) => void
 }): React.JSX.Element {
-  const { places: list, loading, error, search, setSearch, category, setCategory, sort, setSort, section, setSection } = usePlaces()
+  const { places: list, liveWorlds, loading, error, search, setSearch, category, setCategory, sort, setSort, section, setSection } = usePlaces()
   // Local input value, debounced into the hook's `search` so we don't refetch on every keystroke.
   const [draft, setDraft] = useState(search)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -75,10 +75,14 @@ export function PlacesBrowser({
   // Highlights are derived from the full Explore-all list (most populated first / points of interest).
   // Each place belongs to ONE section only — priority Live Now → Featured → the discover grid — so a
   // place like Genesis Plaza (populated AND a POI) doesn't repeat across all three.
-  const liveNow = useMemo(
-    () => [...list].filter((p) => placePlayers(p) > 0).sort((a, b) => placePlayers(b) - placePlayers(a)).slice(0, LIVE_NOW_LIMIT),
-    [list]
-  )
+  // Live Now pools places with live worlds (worlds-content-server counts; /places is Genesis only).
+  const liveNow = useMemo(() => {
+    const ids = new Set(list.map((p) => p.id))
+    return [...list, ...liveWorlds.filter((w) => !ids.has(w.id))]
+      .filter((p) => placePlayers(p) > 0)
+      .sort((a, b) => placePlayers(b) - placePlayers(a))
+      .slice(0, LIVE_NOW_LIMIT)
+  }, [list, liveWorlds])
   const liveIds = useMemo(() => new Set(liveNow.map((p) => p.id)), [liveNow])
   const featured = useMemo(() => list.filter((p) => placeIsFeatured(p) && !liveIds.has(p.id)), [list, liveIds])
   const showHighlights = section === 'all' && category === 'all' && search.trim() === '' && !loading && !error

--- a/react-web/src/features/places/placesApi.ts
+++ b/react-web/src/features/places/placesApi.ts
@@ -98,6 +98,65 @@ export function fetchWorlds(args: FetchPlacesArgs = {}): Promise<PlacesResponse>
   return cachedGet('/worlds', buildParams(args, false))
 }
 
+// ---- live worlds ----
+// Current world occupancy comes from the worlds-content-server, not the places API: /places
+// only covers Genesis City, and /worlds user counts lag behind live presence. We fetch the
+// live counts and resolve card metadata for those names in one batch.
+
+const WORLDS_LIVE_URL = 'https://worlds-content-server.decentraland.org/live-data'
+
+type LiveWorldEntry = { worldName: string; users: number }
+
+let liveWorldsCache: { at: number; promise: Promise<DiscoverPlace[]> } | null = null
+
+export function fetchLiveWorlds(): Promise<DiscoverPlace[]> {
+  if (liveWorldsCache && Date.now() - liveWorldsCache.at < CACHE_TTL) return liveWorldsCache.promise
+  const promise = getLiveWorlds()
+  liveWorldsCache = { at: Date.now(), promise }
+  promise.catch(() => {
+    if (liveWorldsCache?.promise === promise) liveWorldsCache = null
+  })
+  return promise
+}
+
+async function getLiveWorlds(): Promise<DiscoverPlace[]> {
+  const res = await fetch(WORLDS_LIVE_URL)
+  if (!res.ok) throw new Error(`live-data failed: ${res.status}`)
+  const body = (await res.json()) as { data?: { perWorld?: LiveWorldEntry[] | Record<string, number> } }
+  const perWorld = body.data?.perWorld
+  const entries: LiveWorldEntry[] = Array.isArray(perWorld)
+    ? perWorld
+    : perWorld
+      ? Object.entries(perWorld).map(([worldName, users]) => ({ worldName, users }))
+      : []
+  const live = entries.filter((e) => !!e.worldName && e.users > 0)
+  if (live.length === 0) return []
+
+  const params = new URLSearchParams()
+  for (const e of live) params.append('names', e.worldName.toLowerCase())
+  const meta = await getPlaces('/worlds', params).catch(() => null)
+  const byName = new Map<string, DiscoverPlace>()
+  for (const w of meta?.data ?? []) {
+    if (w.world_name) byName.set(w.world_name.toLowerCase(), w)
+  }
+  return live.map((e) => {
+    const match = byName.get(e.worldName.toLowerCase())
+    if (match) return { ...match, user_count: e.users }
+    // Not listed in the places API — render with PlaceCard's gradient fallback.
+    return {
+      id: e.worldName.toLowerCase(),
+      title: e.worldName,
+      description: '',
+      image: '',
+      positions: [],
+      owner: null,
+      world: true,
+      world_name: e.worldName,
+      user_count: e.users
+    }
+  })
+}
+
 // The default "Explore all / most active" list usePlaces requests first — warmed during the login
 // screen so both the picker and the in-world page paint from cache.
 export const DEFAULT_PLACES_ARGS = { limit: 48, offset: 0, order_by: 'most_active' as const, order: 'desc' as const }

--- a/react-web/src/features/places/usePlaces.ts
+++ b/react-web/src/features/places/usePlaces.ts
@@ -6,13 +6,15 @@
 
 import { useEffect, useState } from 'react'
 import { getStoredLogin } from '../auth/sso'
-import { fetchPlaces, fetchWorlds, type DiscoverPlace, type PlacesOrderBy, type PlacesResponse } from './placesApi'
+import { fetchLiveWorlds, fetchPlaces, fetchWorlds, type DiscoverPlace, type PlacesOrderBy, type PlacesResponse } from './placesApi'
 
 export type PlacesSection = 'all' | 'favourites' | 'my'
 export type PlacesSort = 'most_active' | 'like_score_best' | 'created_at' | 'name'
 
 export interface UsePlaces {
   places: DiscoverPlace[]
+  /** Worlds with users online right now (for Live Now) — /places only covers Genesis City. */
+  liveWorlds: DiscoverPlace[]
   loading: boolean
   error: string | null
   search: string
@@ -29,6 +31,7 @@ const PAGE_LIMIT = 48
 
 export function usePlaces(): UsePlaces {
   const [places, setPlaces] = useState<DiscoverPlace[]>([])
+  const [liveWorlds, setLiveWorlds] = useState<DiscoverPlace[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
@@ -36,6 +39,18 @@ export function usePlaces(): UsePlaces {
   const [category, setCategory] = useState('all')
   const [sort, setSort] = useState<PlacesSort>('most_active')
   const [section, setSection] = useState<PlacesSection>('all')
+
+  useEffect(() => {
+    let cancelled = false
+    fetchLiveWorlds()
+      .then((w) => {
+        if (!cancelled) setLiveWorlds(w)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     // Favourites needs a signed (authenticated) request to the places API, which we can't sign here
@@ -100,5 +115,5 @@ export function usePlaces(): UsePlaces {
     }
   }, [search, category, sort, section])
 
-  return { places, loading, error, search, setSearch, category, setCategory, sort, setSort, section, setSection }
+  return { places, liveWorlds, loading, error, search, setSearch, category, setCategory, sort, setSort, section, setSection }
 }


### PR DESCRIPTION
## Summary

The Live Now section derived from the `/places` list alone, which only covers Genesis City — worlds with users online never showed up. This mirrors the approach used by the sites repo: fetch current world occupancy from `worlds-content-server.decentraland.org/live-data`, resolve card metadata for those names in one batch via `/worlds?names=…`, and pool places + live worlds when picking the most-populated highlights. Worlds unknown to the places API still render using PlaceCard's gradient fallback instead of being dropped.

## What could break

- Live Now can now surface worlds ahead of Genesis scenes when they have more users — intended, but changes what the first row shows.
- The live-data feed shares the existing 5-minute request cache, so counts can be up to 5 minutes stale (same as the rest of the Places page).
- If `/live-data` is down the section degrades to places-only (fetch failure is swallowed).

## How to test

1. `npx vitest run` in `react-web` — 201 tests pass; `npx tsc --noEmit` clean
2. Check `https://worlds-content-server.decentraland.org/live-data` returns worlds with `users > 0`
3. Open the Places page (or the post-jump-in picker) on the default Explore-all view — Live Now should list those worlds with their user badge, ordered by user count, deduped against Genesis scenes
4. Click a live world card — it should jump into that world