### PR TITLE
Never deploy a default profile over an unfetchable one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10595,6 +10595,7 @@ version = "0.1.0"
 dependencies = [
  "analytics",
  "anyhow",
+ "async-std",
  "avatar",
  "base64 0.22.1",
  "bevy",

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -65,7 +65,7 @@ impl Plugin for UserProfilePlugin {
 
 enum ProfileDisplayState {
     Loaded(Box<UserProfile>),
-    Loading(Task<Result<UserProfile, anyhow::Error>>),
+    Loading(Task<Result<Option<UserProfile>, anyhow::Error>>),
     Failed,
 }
 
@@ -105,8 +105,8 @@ impl ProfileManager<'_, '_> {
 
         if let ProfileDisplayState::Loading(task) = state {
             match task.complete() {
-                Some(Ok(profile)) => *state = ProfileDisplayState::Loaded(Box::new(profile)),
-                Some(Err(_)) => *state = ProfileDisplayState::Failed,
+                Some(Ok(Some(profile))) => *state = ProfileDisplayState::Loaded(Box::new(profile)),
+                Some(Ok(None)) | Some(Err(_)) => *state = ProfileDisplayState::Failed,
                 None => (),
             }
         }
@@ -650,11 +650,14 @@ async fn deploy_profile(
     }
 }
 
+/// Ok(None) means the registry authoritatively reports no profile for the address; any
+/// failure to get a well-formed answer (no realm, transport error, bad status, parse
+/// failure) is an Err, so callers can tell "no profile" from "couldn't fetch".
 pub async fn get_remote_profile(
     address: Address,
     ipfs: std::sync::Arc<IpfsIo>,
     endpoint: Option<String>,
-) -> Result<UserProfile, anyhow::Error> {
+) -> Result<Option<UserProfile>, anyhow::Error> {
     let endpoint = match endpoint {
         Some(endpoint) => endpoint,
         None => ipfs.lambda_endpoint().ok_or(anyhow!("not connected"))?,
@@ -670,17 +673,18 @@ pub async fn get_remote_profile(
         .send()
         .await?;
 
-    let mut content = response.json::<Vec<LambdaProfiles>>().await?;
-    if content.is_empty() {
-        anyhow::bail!("not found");
+    if response.status() != StatusCode::OK {
+        anyhow::bail!("bad response: {}", response.status());
     }
 
-    let content = content
-        .remove(0)
-        .avatars
-        .into_iter()
-        .next()
-        .ok_or(anyhow!("not found"))?;
+    let mut content = response.json::<Vec<LambdaProfiles>>().await?;
+    if content.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(content) = content.remove(0).avatars.into_iter().next() else {
+        return Ok(None);
+    };
 
     // debug!("loaded profile content preclean: {content:#?}");
     // // clean up the lambda result
@@ -708,5 +712,5 @@ pub async fn get_remote_profile(
     };
 
     debug!("loaded profile: {profile:#?}");
-    Ok(profile)
+    Ok(Some(profile))
 }

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -83,7 +83,7 @@ pub async fn op_login_previous(state: Rc<RefCell<impl State>>) -> Result<(), any
     state
         .borrow_mut()
         .borrow_mut::<SuperUserScene>()
-        .send(SystemApi::LoginPrevious(sx))?;
+        .send(SystemApi::LoginPrevious(false, sx))?;
 
     rx.await
         .map_err(|e| anyhow::anyhow!(e))?
@@ -108,7 +108,7 @@ pub fn new_login(state: &mut impl State) -> &mut NewLogin {
         let (sx, result) = RpcResultSender::channel();
         state
             .borrow_mut::<SuperUserScene>()
-            .send(SystemApi::LoginNew(sc, sx))
+            .send(SystemApi::LoginNew(false, sc, sx))
             .unwrap();
 
         login.code = Some(code);

--- a/crates/system_bridge/src/agent_commands.rs
+++ b/crates/system_bridge/src/agent_commands.rs
@@ -39,16 +39,21 @@ fn login_guest_cmd(
 /// Login using previously saved credentials
 #[derive(clap::Parser, ConsoleCommand)]
 #[command(name = "/login_previous")]
-struct LoginPreviousCommand;
+struct LoginPreviousCommand {
+    /// if the current profile can't be fetched, continue with (and deploy) a default
+    /// profile — this overwrites the server-side profile
+    #[arg(long)]
+    default_on_error: bool,
+}
 
 fn login_previous_cmd(
     mut input: ConsoleCommand<LoginPreviousCommand>,
     mut events: EventWriter<SystemApi>,
     mut pending: ResMut<PendingConsoleResponses>,
 ) {
-    if let Some(Ok(_)) = input.take() {
+    if let Some(Ok(command)) = input.take() {
         let (sx, rx) = common::rpc::RpcResultSender::<Result<(), String>>::channel();
-        events.write(SystemApi::LoginPrevious(sx));
+        events.write(SystemApi::LoginPrevious(command.default_on_error, sx));
         let responder = input.take_responder();
         pending.push_receiver(
             rx,
@@ -71,6 +76,10 @@ fn login_previous_cmd(
 struct LoginIdentityCommand {
     /// base64(JSON) of the stored AuthIdentity.
     payload: String,
+    /// if the current profile can't be fetched, continue with (and deploy) a default
+    /// profile — this overwrites the server-side profile
+    #[arg(long)]
+    default_on_error: bool,
 }
 
 fn login_identity_cmd(
@@ -80,7 +89,11 @@ fn login_identity_cmd(
 ) {
     if let Some(Ok(command)) = input.take() {
         let (sx, rx) = common::rpc::RpcResultSender::<Result<(), String>>::channel();
-        events.write(SystemApi::LoginWithIdentity(command.payload.clone(), sx));
+        events.write(SystemApi::LoginWithIdentity(
+            command.payload.clone(),
+            command.default_on_error,
+            sx,
+        ));
         let responder = input.take_responder();
         pending.push_receiver(
             rx,

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -144,21 +144,32 @@ pub struct SceneLoadingUi {
     pub pending_assets: Option<u32>,
 }
 
+/// Prefix on login error strings when the failure was fetching the user's profile —
+/// UIs match on this to offer retrying with a default profile (see the login variants'
+/// `default_on_error` bool).
+pub const PROFILE_FETCH_FAILED: &str = "profile fetch failed";
+
 #[derive(Event, Clone, Debug, Serialize, Deserialize)]
 pub enum SystemApi {
     ConsoleCommand(String, Vec<String>, RpcResultSender<Result<String, String>>),
     CheckForUpdate(RpcResultSender<Option<(String, String)>>),
     MOTD(RpcResultSender<String>),
     GetPreviousLogin(RpcResultSender<Option<String>>),
-    LoginPrevious(RpcResultSender<Result<(), String>>),
+    /// bool: continue with (and deploy) a default profile if the user's current profile
+    /// can't be fetched — overwrites the server-side profile, so UIs should only set it
+    /// after a failed attempt and with explicit user consent.
+    LoginPrevious(bool, RpcResultSender<Result<(), String>>),
+    /// bool: as for LoginPrevious.
     LoginNew(
+        bool,
         RpcResultSender<Result<Option<i32>, String>>,
         RpcResultSender<Result<(), String>>,
     ),
     /// Log in with an AuthIdentity the web page already holds (base64-encoded AuthIdentity
     /// JSON read from localStorage) — no auth-server round-trip. The identity is the same
     /// regardless of how the user signed in (wallet, social, OTP, magic).
-    LoginWithIdentity(String, RpcResultSender<Result<(), String>>),
+    /// bool: as for LoginPrevious.
+    LoginWithIdentity(String, bool, RpcResultSender<Result<(), String>>),
     LoginGuest,
     LoginCancel,
     Logout,

--- a/crates/system_ui/Cargo.toml
+++ b/crates/system_ui/Cargo.toml
@@ -41,6 +41,7 @@ base64 = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+async-std = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 build-time = { workspace = true }

--- a/crates/system_ui/src/login.rs
+++ b/crates/system_ui/src/login.rs
@@ -21,9 +21,9 @@ use common::{
 use comms::profile::{get_remote_profile, CurrentUserProfile, UserProfile};
 use ethers_core::types::Address;
 use ethers_signers::LocalWallet;
-use ipfs::IpfsAssetServer;
+use ipfs::{IpfsAssetServer, IpfsIo};
 use scene_runner::Toaster;
-use system_bridge::{NativeUi, SystemApi};
+use system_bridge::{NativeUi, SystemApi, PROFILE_FETCH_FAILED};
 use tokio::sync::oneshot::error::TryRecvError;
 use ui_core::{
     button::DuiButton,
@@ -256,7 +256,7 @@ fn login(
                     "embedded://sounds/ui/toggle_enable.wav".to_owned(),
                 ));
                 let (sx, rx) = RpcResultSender::<Result<(), String>>::channel();
-                bridge.write(SystemApi::LoginPrevious(sx));
+                bridge.write(SystemApi::LoginPrevious(false, sx));
                 *req_done = Some(rx);
             }
             LoginType::NewRemote => {
@@ -267,7 +267,7 @@ fn login(
                 ));
                 let (scode, rcode) = RpcResultSender::<Result<Option<i32>, String>>::channel();
                 let (sx, rx) = RpcResultSender::<Result<(), String>>::channel();
-                bridge.write(SystemApi::LoginNew(scode, sx));
+                bridge.write(SystemApi::LoginNew(false, scode, sx));
                 *req_code = Some(rcode);
                 *req_done = Some(rx);
 
@@ -316,11 +316,12 @@ fn login(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn update_profile_for_realm(
     realm: Res<CurrentRealm>,
     wallet: Res<Wallet>,
     mut current_profile: ResMut<CurrentUserProfile>,
-    mut task: Local<Option<Task<Result<UserProfile, anyhow::Error>>>>,
+    mut task: Local<Option<Task<Result<Option<UserProfile>, anyhow::Error>>>>,
     ipfas: IpfsAssetServer,
 ) {
     if realm.is_changed() && !wallet.is_guest() {
@@ -335,11 +336,11 @@ fn update_profile_for_realm(
 
     if let Some(mut t) = task.take() {
         match t.complete() {
-            Some(Ok(profile)) => {
+            Some(Ok(Some(profile))) => {
                 current_profile.profile = Some(profile);
                 current_profile.is_deployed = true;
             }
-            Some(Err(_)) => {
+            Some(Ok(None)) | Some(Err(_)) => {
                 // keep existing profile
             }
             None => *task = Some(t),
@@ -445,6 +446,36 @@ fn parse_auth_identity(payload: &str) -> Result<(Address, LocalWallet, Vec<Chain
     Ok((root_address, local_wallet, auth))
 }
 
+/// Fetch the profile, retrying on failure. Ok(None) means the user has no profile (or
+/// `default_on_error` was set); a persistent failure must otherwise fail the login rather
+/// than fall back to a default profile, or we would deploy the default over the user's
+/// existing server-side profile. Retries are patient because the realm may still be
+/// resolving when login runs (on web the page can fire `/login_identity` at boot), which
+/// reads as a fetch failure. Errors carry the PROFILE_FETCH_FAILED prefix so UIs can
+/// offer retrying with `default_on_error`.
+async fn get_profile_with_retry(
+    address: Address,
+    ipfs: std::sync::Arc<IpfsIo>,
+    default_on_error: bool,
+) -> Result<Option<UserProfile>, String> {
+    const ATTEMPTS: u32 = 5;
+    let mut last_error = String::default();
+    for attempt in 0..ATTEMPTS {
+        if attempt > 0 {
+            async_std::task::sleep(std::time::Duration::from_secs(2)).await;
+        }
+        match get_remote_profile(address, ipfs.clone(), None).await {
+            Ok(maybe_profile) => return Ok(maybe_profile),
+            Err(e) => last_error = e.to_string(),
+        }
+    }
+    if default_on_error {
+        warn!("continuing with default profile after fetch failure: {last_error}");
+        return Ok(None);
+    }
+    Err(format!("{PROFILE_FETCH_FAILED}: {last_error}"))
+}
+
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 fn process_login_bridge(
     mut e: EventReader<SystemApi>,
@@ -485,7 +516,7 @@ fn process_login_bridge(
                 rpc_result_sender
                     .send(get_previous_login(&config).map(|pl| format!("{:#x}", pl.root_address)));
             }
-            SystemApi::LoginPrevious(rpc_result_sender) => {
+            SystemApi::LoginPrevious(default_on_error, rpc_result_sender) => {
                 let ipfs = ipfas.ipfs().clone();
                 let maybe_previous_login = get_previous_login(&config);
                 *login_task = Some(IoTaskPool::get().spawn_compat(async move {
@@ -500,7 +531,14 @@ fn process_login_bridge(
                         auth,
                     } = previous_login;
 
-                    let profile = get_remote_profile(root_address, ipfs, None).await.ok();
+                    let profile =
+                        match get_profile_with_retry(root_address, ipfs, default_on_error).await {
+                            Ok(maybe_profile) => maybe_profile,
+                            Err(e) => {
+                                rpc_result_sender.send(Err(e));
+                                return Err(());
+                            }
+                        };
 
                     let local_wallet = LocalWallet::from_bytes(&ephemeral_key).unwrap();
 
@@ -513,7 +551,7 @@ fn process_login_bridge(
                     ))
                 }));
             }
-            SystemApi::LoginNew(code_sender, result_sender) => {
+            SystemApi::LoginNew(default_on_error, code_sender, result_sender) => {
                 let ipfs = ipfas.ipfs().clone();
                 *login_task = Some(IoTaskPool::get().spawn_compat(async move {
                     let req = init_remote_ephemeral_request().await;
@@ -538,12 +576,19 @@ fn process_login_bridge(
                             }
                         };
 
-                    let profile = get_remote_profile(root_address, ipfs, None).await.ok();
+                    let profile =
+                        match get_profile_with_retry(root_address, ipfs, default_on_error).await {
+                            Ok(maybe_profile) => maybe_profile,
+                            Err(e) => {
+                                result_sender.send(Err(e));
+                                return Err(());
+                            }
+                        };
 
                     Ok((root_address, local_wallet, auth, profile, result_sender))
                 }));
             }
-            SystemApi::LoginWithIdentity(payload, rpc_result_sender) => {
+            SystemApi::LoginWithIdentity(payload, default_on_error, rpc_result_sender) => {
                 // The web page already holds a signed AuthIdentity (read from localStorage,
                 // produced by whatever sign-in method the user used) — finalize the wallet
                 // from it directly, no auth-server request/poll. Mirrors LoginPrevious.
@@ -557,7 +602,14 @@ fn process_login_bridge(
                         }
                     };
 
-                    let profile = get_remote_profile(root_address, ipfs, None).await.ok();
+                    let profile =
+                        match get_profile_with_retry(root_address, ipfs, default_on_error).await {
+                            Ok(maybe_profile) => maybe_profile,
+                            Err(e) => {
+                                rpc_result_sender.send(Err(e));
+                                return Err(());
+                            }
+                        };
 
                     Ok((root_address, local_wallet, auth, profile, rpc_result_sender))
                 }));

--- a/react-web/src/engine/EngineDriver.ts
+++ b/react-web/src/engine/EngineDriver.ts
@@ -47,8 +47,9 @@ export class EngineDriver implements LoginDriver {
     return { userId: login ? rootAddress(login.identity) : null }
   }
 
-  async loginPrevious(): Promise<unknown> {
-    const r = await this.rpc.command('/login_previous')
+  async loginPrevious(defaultOnError?: boolean): Promise<unknown> {
+    const flag = defaultOnError === true ? ' --default-on-error' : ''
+    const r = await this.rpc.command(`/login_previous${flag}`)
     this.scheduleReadyFallback()
     return r
   }
@@ -66,17 +67,18 @@ export class EngineDriver implements LoginDriver {
     await this.rpc.command('/logout')
   }
 
-  async loginWithIdentity(identity: AuthIdentity): Promise<void> {
-    await this.rpc.command(`/login_identity ${encodeIdentity(identity)}`)
+  async loginWithIdentity(identity: AuthIdentity, defaultOnError?: boolean): Promise<void> {
+    const flag = defaultOnError === true ? ' --default-on-error' : ''
+    await this.rpc.command(`/login_identity ${encodeIdentity(identity)}${flag}`)
     this.scheduleReadyFallback()
   }
 
   // "Jump in": reuse the SSO identity via `/login_identity`; if none is stored, fall back to
   // the engine's own saved login.
-  async jumpIn(): Promise<void> {
+  async jumpIn(defaultOnError?: boolean): Promise<void> {
     const login = getStoredLogin()
-    if (login) await this.loginWithIdentity(login.identity)
-    else await this.loginPrevious()
+    if (login) await this.loginWithIdentity(login.identity, defaultOnError)
+    else await this.loginPrevious(defaultOnError)
   }
 
   send(msg: PageToScene): void {

--- a/react-web/src/engine/driver.ts
+++ b/react-web/src/engine/driver.ts
@@ -12,16 +12,20 @@ import type { PageToScene, SceneToPage } from './protocol'
 
 export interface LoginDriver {
   getPreviousLogin(): Promise<{ userId: string | null }>
-  loginPrevious(): Promise<unknown>
+  loginPrevious(defaultOnError?: boolean): Promise<unknown>
   loginGuest(): Promise<void>
   loginCancel(): Promise<void>
   /** Sign out of the current account → back to the login screen. */
   logout(): Promise<void>
-  /** Hand a same-domain SSO identity to the engine (replaces the auth-server poll). */
-  loginWithIdentity(identity: AuthIdentity): Promise<void>
+  /** Hand a same-domain SSO identity to the engine (replaces the auth-server poll).
+   *  `defaultOnError` continues with (and deploys) a default profile if the user's current
+   *  profile can't be fetched — it OVERWRITES the server-side profile, so only pass it after
+   *  a failed attempt, with explicit user consent. */
+  loginWithIdentity(identity: AuthIdentity, defaultOnError?: boolean): Promise<void>
   /** Reuse the existing login (the "Jump in" button). Each backend logs in the way it
-   *  supports: console `/login_identity` for the engine, `loginPrevious` over the bridge. */
-  jumpIn(): Promise<void>
+   *  supports: console `/login_identity` for the engine, `loginPrevious` over the bridge.
+   *  `defaultOnError` as for loginWithIdentity. */
+  jumpIn(defaultOnError?: boolean): Promise<void>
   /** Post a message to the scene (e.g. sendChat). */
   send(msg: PageToScene): void
   /** Subscribe to every scene→page message. Returns an unsubscribe. */

--- a/react-web/src/features/login/LoadingAndLogin.module.css
+++ b/react-web/src/features/login/LoadingAndLogin.module.css
@@ -131,6 +131,29 @@
 .buttons .ctaSecondary:hover:not(:disabled) {
   background: var(--login-cta2-hover);
 }
+/* Destructive profile-reset offer, shown only after a profile-fetch login failure. */
+.resetBox {
+  margin-top: 4px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--error-text) 45%, transparent);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.resetText {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: var(--ink-65);
+  text-align: center;
+}
+.buttons .ctaDanger {
+  background: color-mix(in srgb, var(--error-text) 18%, transparent);
+}
+.buttons .ctaDanger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--error-text) 30%, transparent);
+}
 .label {
   flex: 1 1 auto;
   min-width: 0;

--- a/react-web/src/features/login/LoadingAndLogin.tsx
+++ b/react-web/src/features/login/LoadingAndLogin.tsx
@@ -169,12 +169,29 @@ function Panel({ flow, name }: { flow: LoginFlow; name?: string }): React.JSX.El
         {status === 'reuse-login-or-new' && (
           <>
             <Button variant="primary" size="lg" className={styles.cta} onClick={flow.jumpIn} disabled={flow.busy || enginePending}>
-              <span className={styles.label}>{enginePending ? pendingLabel(flow) : 'JUMP INTO DECENTRALAND'}</span>
+              <span className={styles.label}>{enginePending ? pendingLabel(flow) : flow.profileFetchFailed ? 'TRY AGAIN' : 'JUMP INTO DECENTRALAND'}</span>
               {!enginePending && <ArrowIcon />}
             </Button>
             <Button variant="secondary" size="lg" className={styles.ctaSecondary} onClick={flow.useDifferentAccount} disabled={flow.busy}>
               <span className={styles.label}>USE A DIFFERENT ACCOUNT</span>
             </Button>
+            {flow.profileFetchFailed && (
+              <div className={styles.resetBox}>
+                <p className={styles.resetText}>
+                  If the problem persists you can continue with a fresh default profile.
+                  This permanently replaces your account&apos;s current avatar and profile.
+                </p>
+                <Button
+                  variant="secondary"
+                  size="lg"
+                  className={`${styles.ctaSecondary} ${styles.ctaDanger}`}
+                  onClick={flow.resetProfileAndJumpIn}
+                  disabled={flow.busy || enginePending}
+                >
+                  <span className={styles.label}>RESET PROFILE & JUMP IN</span>
+                </Button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -196,6 +196,13 @@ export interface LoginFlow {
   exploreAsGuest: () => void
   /** Reuse the stored SSO identity (hand it to the engine). */
   jumpIn: () => void
+  /** The last login failed because the user's profile couldn't be fetched — offer
+   *  resetProfileAndJumpIn as the explicit recovery. */
+  profileFetchFailed: boolean
+  /** Retry the login, continuing with (and deploying) a default profile if the fetch still
+   *  fails. PERMANENTLY REPLACES the account's existing profile — only offered after a
+   *  profile-fetch failure, and the UI must make the consequence clear. */
+  resetProfileAndJumpIn: () => void
   /** Sign in with a different account → auth site. */
   useDifferentAccount: () => void
 }
@@ -692,11 +699,18 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       pendingLogin.current = null
       Promise.resolve(login?.(driver))
         .then(() => setBusy(false))
-        .catch((e: Error) => {
+        .catch((e: unknown) => {
           console.error('[login] post-launch login failed:', e)
-          setError(e.message)
+          // The engine driver rejects with a RAW STRING (wasm-bindgen JsValue), not an Error —
+          // e.message would be undefined and the login screen would show no error at all.
+          const msg = e instanceof Error ? e.message : String(e)
+          setError(msg !== '' ? msg : 'Login failed')
           setBusy(false)
-          setDestinationPicked(false) // back to the picker on failure
+          // Back to the LOGIN screen, not the picker: the picker renders no error, and the
+          // login screen is where the retry / profile-reset actions live. The engine stays
+          // launched (start()'s __bevyStarted guard makes the next launch a no-op).
+          setSubmitted(false)
+          setDestinationPicked(false)
         })
     }
     requestAnimationFrame(() => requestAnimationFrame(run))
@@ -868,6 +882,13 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   // Reuse the existing login. The driver picks the path its backend supports (console
   // `/login_identity` for the engine, `loginPrevious` over the bridge).
   const jumpIn = useCallback(() => submitLogin((d) => d.jumpIn()), [submitLogin])
+  // The engine tags profile-fetch login failures (vs bad credentials etc.) with this marker —
+  // mirrors PROFILE_FETCH_FAILED in system_bridge. Only then do we offer the destructive reset.
+  const profileFetchFailed = error != null && error.includes('profile fetch failed')
+  // Explicit recovery from an unfetchable/corrupt profile: retry, continuing with a default
+  // profile if it still fails. The engine deploys that default, permanently replacing the
+  // account's server-side profile — the button copy must carry that warning.
+  const resetProfileAndJumpIn = useCallback(() => submitLogin((d) => d.jumpIn(true)), [submitLogin])
 
   // Fresh sign-in (or signing in with a different account): bounce to the same-domain auth
   // site, which writes the identity back to this origin's localStorage and redirects here.
@@ -1015,6 +1036,8 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       startWithAccount,
       exploreAsGuest,
       jumpIn,
+      profileFetchFailed,
+      resetProfileAndJumpIn,
       useDifferentAccount
     }
   }

--- a/react-web/src/test/harness.tsx
+++ b/react-web/src/test/harness.tsx
@@ -174,6 +174,8 @@ export function fakeSession(): EngineSession {
       startWithAccount: vi.fn(),
       exploreAsGuest: vi.fn(),
       jumpIn: vi.fn(),
+      profileFetchFailed: false,
+      resetProfileAndJumpIn: vi.fn(),
       useDifferentAccount: vi.fn()
     }
   }


### PR DESCRIPTION
## Problem

Existing server-side profiles were sometimes overwritten with default values. All three web3 login paths (`LoginPrevious`, `LoginNew`, `LoginWithIdentity`) called `get_remote_profile(...).ok()`, so **any** fetch failure was treated as "user has no profile" — a default `UserProfile` (version 0) was created with `is_deployed = false`, and `setup_primary_profile` deployed it to the catalyst with a fresh timestamp, replacing the real profile.

Failures indistinguishable from genuine absence included:
- the realm-connection race at web boot (`/login_identity` fires before the realm `/about` resolves → `"not connected"`),
- request timeouts / network errors / registry 5xx,
- a registry response that fails to parse.

## Fix

- `get_remote_profile` returns `Result<Option<UserProfile>>`: `Ok(None)` only when the registry authoritatively reports no profile (well-formed 200 with no entry); everything else is an `Err`. New users still get their initial default deploy via `Ok(None)`.
- Login fetches through a retry helper (5 attempts, 2s apart — patient enough to cover realm resolution), then **fails the login** instead of falling back to a default. The error carries a `profile fetch failed` marker so UIs can tell it apart from credential errors.

## Explicit recovery (`default_on_error`)

A fetched-but-unusable (e.g. malformed) upstream profile would otherwise lock the user out, so the login SystemApi variants gain a `default_on_error: bool` (`--default-on-error` on `/login_previous` and `/login_identity`): when set and the fetch still fails, login proceeds with a default profile and deploys it, knowingly replacing the server-side profile.

react-web offers this only after a tagged profile-fetch failure, as a clearly-destructive "RESET PROFILE & JUMP IN" action with a warning. Two react-web bugs fixed on the way: login failures returned to the destination picker, which renders no error (now: back to the login screen), and the error message itself was always swallowed — the engine rejects with a raw string, so `e.message` was `undefined` and every login failure was silent.

**Note:** the native (dui) login UI has no means to access the overwrite fallback — it still just toasts the error. The console commands' `--default-on-error` flag is the only native-side route. The bridge-scene/`BevyApi` login path also cannot pass the flag (the JS op surface is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)