### PR TITLE
Low default settings, graphics presets, one-time settings reset

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -480,7 +480,15 @@ pub struct AppConfig {
     pub scene_permissions: HashMap<String, HashMap<PermissionType, PermissionValue>>,
     pub inputs: InputMapSerialized,
     pub point_at_marker_visibility: PointAtMarkerVisibility,
+    // field-level default (0) so configs saved before this field existed read as outdated,
+    // rather than taking the current generation from the container-level default
+    #[serde(default)]
+    pub settings_generation: u32,
 }
+
+/// bump to force a one-time reset of the preset-managed settings in existing configs
+/// (see [`AppConfig::reset_outdated_settings`])
+pub const SETTINGS_GENERATION: u32 = 1;
 
 impl Default for AppConfig {
     fn default() -> Self {
@@ -492,8 +500,8 @@ impl Default for AppConfig {
             audio: Default::default(),
             cache_bytes: 1024 * 1024 * 1024 * 10, // 10gb
             scene_threads: 4,
-            scene_load_distance: 50.0,
-            scene_unload_extra_distance: 15.0,
+            scene_load_distance: 10.0,
+            scene_unload_extra_distance: 10.0,
             scene_imposter_distances: vec![100.0, 200.0, 400.0, 800.0, 1600.0, 99999.0],
             scene_imposter_multisample: false,
             scene_imposter_multisample_amount: 0.0,
@@ -501,7 +509,7 @@ impl Default for AppConfig {
             parcel_grass_setting: Default::default(),
             sysinfo_visible: false,
             scene_log_to_console: false,
-            max_avatars: 100,
+            max_avatars: 20,
             constrain_scene_ui: false,
             player_settings: Default::default(),
             max_videos: 1,
@@ -512,11 +520,40 @@ impl Default for AppConfig {
             scene_permissions: Default::default(),
             inputs: Default::default(),
             point_at_marker_visibility: Default::default(),
+            settings_generation: SETTINGS_GENERATION,
         }
     }
 }
 
 impl AppConfig {
+    /// one-time forced reinitialization: configs saved with an older generation get the
+    /// current defaults for the preset-managed settings, keeping everything else
+    pub fn reset_outdated_settings(&mut self) {
+        if self.settings_generation >= SETTINGS_GENERATION {
+            return;
+        }
+        let default = Self::default();
+        self.graphics.msaa = default.graphics.msaa;
+        self.graphics.shadow_distance = default.graphics.shadow_distance;
+        self.graphics.shadow_settings = default.graphics.shadow_settings;
+        self.graphics.light_count = default.graphics.light_count;
+        self.graphics.shadow_caster_count = default.graphics.shadow_caster_count;
+        self.graphics.fog = default.graphics.fog;
+        self.graphics.bloom = default.graphics.bloom;
+        self.graphics.dof = default.graphics.dof;
+        self.graphics.ssao = default.graphics.ssao;
+        self.graphics.oob = default.graphics.oob;
+        self.scene_load_distance = default.scene_load_distance;
+        self.scene_unload_extra_distance = default.scene_unload_extra_distance;
+        self.scene_imposter_distances = default.scene_imposter_distances;
+        self.scene_imposter_multisample = default.scene_imposter_multisample;
+        self.scene_imposter_multisample_amount = default.scene_imposter_multisample_amount;
+        self.parcel_grass_setting = default.parcel_grass_setting;
+        self.max_avatars = default.max_avatars;
+        self.max_videos = default.max_videos;
+        self.settings_generation = SETTINGS_GENERATION;
+    }
+
     pub fn get_permission(
         &self,
         ty: PermissionType,
@@ -584,16 +621,16 @@ impl Default for GraphicsSettings {
         Self {
             vsync: false,
             log_fps: true,
-            msaa: AaSetting::FxaaHigh,
+            msaa: AaSetting::FxaaLow,
             fps_target: 60,
-            shadow_distance: 200.0,
-            shadow_settings: ShadowSetting::High,
-            light_count: 32,
-            shadow_caster_count: 8,
+            shadow_distance: 20.0,
+            shadow_settings: ShadowSetting::Low,
+            light_count: 4,
+            shadow_caster_count: 0,
             window: WindowSetting::Windowed,
             // fullscreen_res: FullscreenResSetting(UVec2::new(1280,720)),
             fog: FogSetting::Atmospheric,
-            bloom: BloomSetting::Low,
+            bloom: BloomSetting::High,
             dof: DofSetting::High,
             ssao: SsaoSetting::Off,
             oob: 2.0,
@@ -1328,10 +1365,9 @@ impl<T> MonotonicTimestamp<T> {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ParcelGrassSetting {
     Off,
-    #[cfg_attr(target_arch = "wasm32", default)]
+    #[default]
     Low,
     Mid,
-    #[cfg_attr(not(target_arch = "wasm32"), default)]
     High,
 }
 

--- a/react-web/bridge-scene/src/domains/settings.ts
+++ b/react-web/bridge-scene/src/domains/settings.ts
@@ -1,13 +1,93 @@
 // Settings: the explorer settings list + changing one.
 //   from: BevyApi.getSettings() / setSetting().
+//
+// Also injects a synthetic "Graphics Preset" setting (Low/Medium/High/Custom) at the head
+// of the list. Presets are defined here, scene-side — the engine only knows the individual
+// settings, and its defaults match the Low preset. Setting the preset fans out to the
+// individual setSetting calls; the preset's own value is derived by matching the live
+// values against each preset (Custom when none match).
 import { BevyApi } from '../bevy-api'
+import type { Setting } from '../../../src/engine/protocol'
 import type { Ctx } from '../bridge'
+
+const PRESET_SETTING = 'Graphics Preset'
+const PRESET_NAMES = ['Low', 'Medium', 'High']
+const CUSTOM_INDEX = PRESET_NAMES.length
+
+// Per-setting values for [Low, Medium, High]. Strings name an enum variant (resolved
+// against the setting's namedVariants), numbers are raw slider values. Settings missing
+// from the engine's list (platform-dependent) are skipped.
+const PRESET_VALUES: Record<string, [number | string, number | string, number | string]> = {
+  'Anti-aliasing': ['FXAA (Low)', 'FXAA (High)', 'FXAA (High)'],
+  'Shadow Distance': [20, 100, 200],
+  'Shadow settings': ['Low', 'High', 'High'],
+  'Light Count': [4, 8, 32],
+  'Shadow Caster Count': [0, 4, 8],
+  Fog: ['Atmospheric', 'Atmospheric', 'Atmospheric'],
+  Bloom: ['High', 'High', 'High'],
+  'Depth of Field': ['High', 'High', 'High'],
+  'Out-of-bounds Effect': ['On', 'On', 'On'],
+  'Scene Load Distance': [10, 25, 100],
+  'Scene Unload Distance': [10, 15, 20],
+  'Distant Scene Rendering': ['Normal', 'Normal', 'Ultra'],
+  'Empty Parcel Props': ['Low', 'Mid', 'High'],
+  'Max Avatars': [20, 50, 100],
+  'Max Videos': [1, 2, 4]
+}
+
+function resolveValue(setting: Setting, value: number | string): number | undefined {
+  if (typeof value === 'number') return value
+  const ix = setting.namedVariants.findIndex((v) => v.name === value)
+  return ix < 0 ? undefined : ix
+}
+
+/** The (name, value) pairs preset `presetIx` would apply, given the live settings list. */
+function presetTargets(settings: Setting[], presetIx: number): Array<{ name: string; value: number }> {
+  const targets: Array<{ name: string; value: number }> = []
+  for (const [name, values] of Object.entries(PRESET_VALUES)) {
+    const setting = settings.find((s) => s.name === name)
+    if (!setting) continue
+    const value = resolveValue(setting, values[presetIx])
+    if (value !== undefined) targets.push({ name, value })
+  }
+  return targets
+}
+
+/** Which preset the current values match exactly, or CUSTOM_INDEX if none. */
+function currentPreset(settings: Setting[]): number {
+  for (let ix = 0; ix < PRESET_NAMES.length; ix++) {
+    const match = presetTargets(settings, ix).every(
+      (t) => settings.find((s) => s.name === t.name)?.value === t.value
+    )
+    if (match) return ix
+  }
+  return CUSTOM_INDEX
+}
+
+function withPreset(settings: Setting[]): Setting[] {
+  const preset: Setting = {
+    name: PRESET_SETTING,
+    category: 'Graphics',
+    description:
+      'Overall graphics quality. Picking a preset applies a bundle of the settings below; changing one of those settings individually shows here as Custom.',
+    minValue: 0,
+    maxValue: PRESET_NAMES.length + 1,
+    namedVariants: [
+      ...PRESET_NAMES.map((name) => ({ name, description: `Apply the ${name} preset.` })),
+      { name: 'Custom', description: 'Individually adjusted settings.' }
+    ],
+    value: currentPreset(settings),
+    default: 0,
+    stepSize: 1
+  }
+  return [preset, ...settings]
+}
 
 export function registerSettings(ctx: Ctx): void {
   const pushSettings = (): void => {
     BevyApi.getSettings()
       .then((settings) => {
-        ctx.send({ kind: 'settings', settings })
+        ctx.send({ kind: 'settings', settings: withPreset(settings) })
       })
       .catch((e: unknown) => {
         console.error('[settings] getSettings failed', e)
@@ -18,7 +98,19 @@ export function registerSettings(ctx: Ctx): void {
     pushSettings()
   })
   ctx.on('setSetting', (msg) => {
-    BevyApi.setSetting(msg.name, msg.value)
+    const apply =
+      msg.name === PRESET_SETTING
+        ? msg.value < PRESET_NAMES.length
+          ? BevyApi.getSettings().then(async (settings) => {
+              await Promise.all(
+                presetTargets(settings, msg.value).map(async (t) => {
+                  await BevyApi.setSetting(t.name, t.value)
+                })
+              )
+            })
+          : Promise.resolve() // Custom is a derived state, nothing to apply
+        : BevyApi.setSetting(msg.name, msg.value)
+    Promise.resolve(apply)
       .then(pushSettings)
       .catch((e: unknown) => {
         console.error('[settings] setSetting failed', e)

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn decentraland_serialized_app_config() -> AppConfig {
         .unwrap()
         .config_dir()
         .join("config.json");
-    let base_config: AppConfig = std::fs::read(&config_file)
+    let mut base_config: AppConfig = std::fs::read(&config_file)
         .ok()
         .and_then(|f| {
             info!("config file loaded from {config_file:?}");
@@ -89,6 +89,7 @@ fn decentraland_serialized_app_config() -> AppConfig {
             warn!("config file not found at {config_file:?}, generating default");
             Default::default()
         });
+    base_config.reset_outdated_settings();
 
     base_config
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -89,10 +89,11 @@ pub async fn engine_init() -> Result<JsValue, JsValue> {
         return Ok("failed to read".into());
     }
 
-    let Ok(config) = serde_json::from_str(&buf) else {
+    let Ok(mut config) = serde_json::from_str::<AppConfig>(&buf) else {
         warn!("failed to deserialize app config, using default");
         return Ok("failed to deserialize".into());
     };
+    config.reset_outdated_settings();
 
     let _ = INIT_DATA.set(config);
 


### PR DESCRIPTION
- Drop default settings to a Low quality tier: FXAA low, 20m shadow distance, low shadows, 4 lights, 0 shadow casters, bloom high, 10m scene load / 10m extra unload distance, 20 max avatars; `ParcelGrassSetting` now defaults to `Low` on all platforms.
- The react-web bridge scene injects a synthetic **Graphics Preset** setting (Low / Medium / High / Custom) at the head of the settings list. Selecting a preset fans out to the individual `setSetting` calls; the displayed value is derived by matching live values against each preset (Custom when none match). Presets are defined scene-side by variant name, so the engine and React panel need no changes and platform-absent settings (e.g. SSAO on wasm) are skipped.

Preset values:

| setting | Low | Medium | High |
|---|---|---|---|
| Anti-aliasing | FXAA (Low) | FXAA (High) | FXAA (High) |
| Shadow Distance | 20 | 100 | 200 |
| Shadow settings | Low | High | High |
| Light Count | 4 | 8 | 32 |
| Shadow Caster Count | 0 | 4 | 8 |
| Fog | Atmospheric | Atmospheric | Atmospheric |
| Bloom | High | High | High |
| Depth of Field | High | High | High |
| Out-of-bounds Effect | On | On | On |
| Scene Load Distance | 10 | 25 | 100 |
| Scene Unload Distance | 10 | 15 | 20 |
| Distant Scene Rendering | Normal | Normal | Ultra |
| Empty Parcel Props | Low | Mid | High |
| Max Avatars | 20 | 50 | 100 |
| Max Videos | 1 | 2 | 4 |

- One-time forced reinitialization: `AppConfig` gains a `settings_generation` marker (field-level `serde(default)` so pre-existing configs read as generation 0). Configs saved with an older generation get the current defaults for the preset-managed fields once, on load, on both native and web; login, permissions, inputs, audio and window settings are preserved. Engine defaults match the Low preset, so fresh installs and reset users both start on Low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)