### PR TITLE
feat: billboard target entity

### DIFF
--- a/crates/dcl_component/src/proto/decentraland/sdk/components/billboard.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/billboard.proto
@@ -7,14 +7,20 @@ import "decentraland/sdk/components/common/id.proto";
 // https://adr.decentraland.org/adr/ADR-198
 option (common.ecs_component_id) = 1090;
 
-// The Billboard component makes an Entity automatically reorient its rotation to face the camera. 
-// As the name indicates, it’s used to display in-game billboards and frequently combined with 
+// The Billboard component makes an Entity automatically reorient its rotation to face a target.
+// By default (when target_entity is unset), the billboard faces the main camera. When target_entity
+// is set, the billboard faces that entity instead. Setting target_entity to the camera reserved
+// entity (2) is equivalent to leaving the field unset. If the referenced target entity doesn’t exist
+// or is deleted, the billboard reorientation is disabled until the target exists again.
+//
+// As the name indicates, it’s used to display in-game billboards and frequently combined with
 // the TextShape component.
 //
-// Billboard only affects the Entity's rotation. Its scale and position are still determined by its
+// Billboard only affects the Entity’s rotation. Its scale and position are still determined by its
 // Transform.
 message PBBillboard {
   optional BillboardMode billboard_mode = 1; // the BillboardMode (default: BM_ALL)
+  optional uint32 target_entity = 2; // entity to face instead of the camera; if the referenced entity doesn’t exist, the billboard behavior is disabled until it does
 }
 
 // BillboardMode indicates one or more axis for automatic rotation, in OR-able bit flag form.

--- a/crates/scene_runner/src/update_world/billboard.rs
+++ b/crates/scene_runner/src/update_world/billboard.rs
@@ -8,7 +8,11 @@ use bevy::prelude::*;
 
 use common::{sets::PostUpdateSets, structs::PrimaryCamera};
 use dcl::interface::ComponentPosition;
-use dcl_component::{proto_components::sdk::components::PbBillboard, SceneComponentId};
+use dcl_component::{
+    proto_components::sdk::components::PbBillboard, SceneComponentId, SceneEntityId,
+};
+
+use crate::{RendererSceneContext, SceneEntity};
 
 use super::AddCrdtInterfaceExt;
 
@@ -29,59 +33,100 @@ impl Plugin for BillboardPlugin {
 }
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Component, PartialEq, Eq)]
-pub enum Billboard {
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum BillboardMode {
     None,
     Y,
     YX,
     All,
 }
 
-impl From<Option<i32>> for Billboard {
+impl From<Option<i32>> for BillboardMode {
     fn from(value: Option<i32>) -> Self {
         match value {
-            Some(0) => Billboard::None,
-            Some(2) => Billboard::Y,
-            Some(3) => Billboard::YX,
-            _ => Billboard::All,
+            Some(0) => BillboardMode::None,
+            Some(2) => BillboardMode::Y,
+            Some(3) => BillboardMode::YX,
+            _ => BillboardMode::All,
         }
     }
 }
 
+#[derive(Component, PartialEq, Eq)]
+pub struct Billboard {
+    pub mode: BillboardMode,
+    // scene entity to face instead of the camera; `None` (unset, or the camera reserved entity)
+    // means face the main camera
+    pub target: Option<SceneEntityId>,
+}
+
 impl From<PbBillboard> for Billboard {
     fn from(value: PbBillboard) -> Self {
-        value.billboard_mode.into()
+        let target = value
+            .target_entity
+            .map(SceneEntityId::from_proto_u32)
+            .filter(|target| *target != SceneEntityId::CAMERA);
+        Billboard {
+            mode: value.billboard_mode.into(),
+            target,
+        }
     }
 }
 
 pub(crate) fn update_billboards(
     global_transforms: Query<&GlobalTransform>,
-    mut q: Query<(&mut Transform, &GlobalTransform, &Billboard, &ChildOf)>,
-    cam: Query<&GlobalTransform, With<PrimaryCamera>>,
+    mut q: Query<(
+        &mut Transform,
+        &GlobalTransform,
+        &Billboard,
+        &ChildOf,
+        &SceneEntity,
+    )>,
+    contexts: Query<&RendererSceneContext>,
+    cam: Query<&Transform, (With<PrimaryCamera>, Without<Billboard>)>,
 ) {
-    let Ok(cam_global_transform) = cam.single() else {
-        // no camera, no billboard
-        return;
-    };
-    let (_, cam_g_rotation, cam_g_translation) =
-        cam_global_transform.to_scale_rotation_translation();
-    let cam_z = cam_g_rotation.to_euler(EulerRot::YXZ).2;
+    // read the camera's local Transform rather than its GlobalTransform: this system runs after
+    // CameraUpdate (which writes the camera's local Transform) but before the frame's transform
+    // propagation, so the camera's GlobalTransform is still a frame stale. the camera is a root
+    // entity, so its GlobalTransform is just its Transform.
+    let cam_global_transform = cam.single().ok().map(|t| GlobalTransform::from(*t));
 
-    for (mut local_transform, global_transform, billboard, parent) in q.iter_mut() {
+    for (mut local_transform, global_transform, billboard, parent, scene_entity) in q.iter_mut() {
+        if billboard.mode == BillboardMode::None {
+            continue;
+        }
+
+        // resolve the transform to face: the main camera by default, or the target entity if set.
+        // if the target can't be resolved (missing / deleted), skip so the entity keeps its rotation.
+        let target_global_transform = match billboard.target {
+            None => cam_global_transform,
+            Some(target) => contexts
+                .get(scene_entity.root)
+                .ok()
+                .and_then(|ctx| ctx.bevy_entity(target))
+                .and_then(|entity| global_transforms.get(entity).ok().copied()),
+        };
+        let Some(target_global_transform) = target_global_transform else {
+            continue;
+        };
+        let (_, target_g_rotation, target_g_translation) =
+            target_global_transform.to_scale_rotation_translation();
+        let target_z = target_g_rotation.to_euler(EulerRot::YXZ).2;
+
         // get reference frame
         let frame = global_transforms.get(parent.parent()).unwrap();
 
-        match billboard {
-            Billboard::None => (),
-            Billboard::All => {
+        match billboard.mode {
+            BillboardMode::None => unreachable!(),
+            BillboardMode::All => {
                 // use global frame of reference
                 let (g_scale, _, g_translation) = global_transform.to_scale_rotation_translation();
-                let cam_direction = cam_g_translation - g_translation;
+                let target_direction = target_g_translation - g_translation;
                 let target_global_rotation = Quat::from_euler(
                     EulerRot::YXZ,
-                    cam_direction.x.atan2(cam_direction.z),
-                    -cam_direction.y.atan2(cam_direction.xz().length()),
-                    cam_z,
+                    target_direction.x.atan2(target_direction.z),
+                    -target_direction.y.atan2(target_direction.xz().length()),
+                    target_z,
                 );
                 let target_global_transform = Transform {
                     translation: g_translation,
@@ -95,23 +140,23 @@ pub(crate) fn update_billboards(
                 // just update the rotation so that scale and translation don't drift, or change on first frame if GlobalTransform is not yet updated
                 local_transform.rotation = target_transform.rotation;
             }
-            Billboard::Y | Billboard::YX => {
-                // map camera into local frame
+            BillboardMode::Y | BillboardMode::YX => {
+                // map target into local frame
                 // TODO use GlobalTransform::raparented_to
-                let cam_local_matrix =
-                    frame.compute_matrix().inverse() * cam_global_transform.compute_matrix();
-                let (_, _, cam_local_translation) =
-                    cam_local_matrix.to_scale_rotation_translation();
+                let target_local_matrix =
+                    frame.compute_matrix().inverse() * target_global_transform.compute_matrix();
+                let (_, _, target_local_translation) =
+                    target_local_matrix.to_scale_rotation_translation();
 
-                let cam_direction = cam_local_translation - local_transform.translation;
+                let target_direction = target_local_translation - local_transform.translation;
                 let mut euler_angles = local_transform.rotation.to_euler(EulerRot::YXZ);
 
                 // rotate to face / yaw
-                euler_angles.0 = cam_direction.x.atan2(cam_direction.z);
+                euler_angles.0 = target_direction.x.atan2(target_direction.z);
 
-                if billboard == &Billboard::YX {
+                if billboard.mode == BillboardMode::YX {
                     // tilt to face / pitch
-                    euler_angles.1 = -cam_direction.y.atan2(cam_direction.xz().length());
+                    euler_angles.1 = -target_direction.y.atan2(target_direction.xz().length());
                 }
 
                 local_transform.rotation = Quat::from_euler(


### PR DESCRIPTION
Implements `PBBillboard.target_entity` ([protocol#436](https://github.com/decentraland/protocol/pull/436)). A billboard can now reorient to face a target scene entity instead of the camera.

Closes #946.

## Behavior
- **Unset** `target_entity` → faces the main camera (unchanged).
- `target_entity` = camera reserved entity (`2`) → normalized to unset; faces the camera.
- `target_entity` = another entity → faces that entity, resolved per-scene via `RendererSceneContext::bevy_entity`.
- Target missing / deleted → reorientation is skipped so the entity keeps its last rotation, and resumes once the target exists again.

All three modes (`BM_ALL`, `BM_Y`, `BM_YX`) face the resolved target uniformly. For `BM_ALL` the roll now follows the target's Z roll (previously the camera's), matching the reference client and [sdk7-test-scenes#73](https://github.com/decentraland/sdk7-test-scenes/pull/73) station D.

## Drive-by
Fixes a one-frame lag when facing the camera. `update_billboards` runs after `CameraUpdate` but before transform propagation, so the camera's `GlobalTransform` was a frame stale. Since the camera is a root entity, we now read its live local `Transform`.

Related: [js-sdk-toolchain#1438](https://github.com/decentraland/js-sdk-toolchain/pull/1438), [#1445](https://github.com/decentraland/js-sdk-toolchain/pull/1445), [sdk7-test-scenes#73](https://github.com/decentraland/sdk7-test-scenes/pull/73).