### PR TITLE
Handle settings gets and sets in arrival order

### DIFF
--- a/crates/system_bridge/src/settings/mod.rs
+++ b/crates/system_bridge/src/settings/mod.rs
@@ -129,7 +129,7 @@ impl Plugin for SettingBridgePlugin {
             settings: Vec::default(),
         };
         app.add_event::<NewCameraEvent>();
-        app.add_systems(Update, (send_settings, receive_settings));
+        app.add_systems(Update, handle_settings);
 
         let mut schedule = Schedule::new(ApplyAppSettingsLabel);
         let config = app.world().resource::<AppConfig>().clone();
@@ -406,24 +406,25 @@ impl Settings {
     }
 }
 
-fn send_settings(mut ev: EventReader<SystemApi>, settings: Res<Settings>) {
-    for ev in ev.read() {
-        if let SystemApi::GetSettings(sender) = ev {
-            sender.send(settings.settings.iter().map(|s| s.info.clone()).collect());
-        }
-    }
-}
-
-fn receive_settings(
+// Gets and sets must be handled in arrival order: the scene->engine channel is FIFO, so a
+// GetSettings queued after SetSettings is only guaranteed to reflect them if a single system
+// processes both event kinds in sequence.
+fn handle_settings(
     mut ev: EventReader<SystemApi>,
     mut config: ResMut<AppConfig>,
     mut settings: ResMut<Settings>,
 ) {
     for ev in ev.read() {
-        if let SystemApi::SetSetting(name, val) = ev {
-            if let Err(e) = settings.set_value(&mut config, name, *val) {
-                error!("Error setting {name}: {e}");
+        match ev {
+            SystemApi::GetSettings(sender) => {
+                sender.send(settings.settings.iter().map(|s| s.info.clone()).collect());
             }
+            SystemApi::SetSetting(name, val) => {
+                if let Err(e) = settings.set_value(&mut config, name, *val) {
+                    error!("Error setting {name}: {e}");
+                }
+            }
+            _ => (),
         }
     }
 }


### PR DESCRIPTION
Follow-up to #947. `op_set_setting` is fire-and-forget, so a scene's `getSettings` issued right after `setSetting` calls lands in the same engine frame as the set events. `send_settings` and `receive_settings` were unordered, so the get could be answered from pre-set state, making every settings push one step behind the change that triggered it — most visibly, the graphics preset dropdown displayed the previous state after a change (e.g. showing Low/Custom right after clicking High).

This merges the two systems into one that processes both event kinds in arrival order. The scene→engine channel is FIFO, so a get queued after sets is now guaranteed to reflect them. This also fixes the same staleness for ordinary single-setting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)