### PR TITLE
fix(rpc): encode IPC with to_vec_named to fix skip_serializing_if misalignment

### DIFF
--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -299,9 +299,10 @@ pub struct EntityDefinitionResponse {
     pub base_url: String,
 }
 
-// rmp can't handle #[serde(flatten)] and json::Value without using named vec.
-// the message format is much larger but flattens and values are rare in our ipc api,
-// so we default try to encode without
+// encode named. to_vec is positional, so a skipped #[serde(skip_serializing_if)]
+// field shortens the array and shifts the rest, and decode then fails (e.g. a
+// sequence where a string is expected). to_vec doesn't error on that, so the old
+// to_vec_named fallback never fired. named is larger but from_slice reads both.
 pub fn rmp_encode<T: Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
-    rmp_serde::to_vec(value).or_else(|_| rmp_serde::to_vec_named(value))
+    rmp_serde::to_vec_named(value)
 }


### PR DESCRIPTION
## Summary

`rmp_encode` (the MessagePack codec for the native scene↔renderer IPC) tried `rmp_serde::to_vec` (positional/array struct encoding) first, falling back to `to_vec_named` only if `to_vec` returned `Err`. That fallback is unsound: `to_vec` does **not** error on a `#[serde(skip_serializing_if)]` field that is `None` — it silently omits it, shortening the positional array so every later field shifts one slot. Decode then fails with e.g. `invalid type: sequence, expected a string`. Because `to_vec` returns `Ok`, the `to_vec_named` fallback never fires.

This aborts the native `dcl_deno_ipc` scene host on avatar/profile RPCs — `getUserData`, `getPlayerData`, `getConnectedPlayers`, `SubscribeProfileChanged` — which return `SerializedProfile`. The outer struct is safe (its `#[serde(flatten)]` forces map mode), but the nested `AvatarWireFormat` has **8** `skip_serializing_if` optionals (`name`, `body_shape`, `eyes`, `hair`, `skin`, `force_render`, `emotes`, `snapshots`) that are routinely `None` — including on the default avatar — so it fires in normal gameplay, not just preview.

## Fix

Encode named (`to_vec_named`) so fields match by key and missing ones fall back to `#[serde(default)]`. This also covers the `flatten` / `json::Value` cases the old comment worried about. All decoders already use `rmp_serde::from_slice`, which reads both array- and map-encoded forms, and IPC is ephemeral between a parent and a same-build `dcl_deno_ipc` child, so there is no wire-compat concern.

## Scope

- **Native only.** `rmp_encode` is reached only through the `Remote` sender arm and `dcl_deno_ipc` (`cfg(not(target_arch = "wasm32"))`). The WASM/browser build runs scenes in-process via `Local` (by-move) channels and never serializes RPC values, so it is unaffected (and `to_vec_named` is pure serde, wasm-safe).
- **Trade-off:** all native IPC frames — including the `write_msg` hot path (CRDT/renderer updates) — now carry field-name strings instead of compact positional arrays. Correct, but larger on the wire; worth a sanity check on CRDT-heavy IPC throughput.

## Test

Adds `rmp_encode_roundtrips_struct_with_skipped_optional`: a struct with a leading `skip_serializing_if` `None` optional, then a `String`, then a `Vec`. It asserts `rmp_encode` round-trips **and** that the old positional `to_vec` path `is_err()` — so it fails on the old code and guards the regression.

## Follow-up (not in this PR)

`crates/common/src/rpc/result_sender.rs:158` does `rmp_serde::from_slice::<T>(&raw_bytes).unwrap()` — a latent engine-process abort on any decode mismatch (low severity: IPC is first-party, same-build). Worth changing to log-and-drop separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
