### PR TITLE
fix(profile): force map-mode IPC encoding for AvatarWireFormat

### DIFF
--- a/crates/common/src/profile.rs
+++ b/crates/common/src/profile.rs
@@ -36,7 +36,7 @@ impl AvatarColor {
 
 // Optional fields are omitted when absent, not serialized as `null`: other explorers
 // fail to parse present-but-null fields in deployed profiles.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AvatarWireFormat {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -56,6 +56,13 @@ pub struct AvatarWireFormat {
     pub emotes: Option<Vec<AvatarEmote>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snapshots: Option<AvatarSnapshots>,
+    // Load-bearing: this flatten field forces map-mode (named) encoding. Without it,
+    // rmp's compact `to_vec` (see rmp_encode) writes this struct as a positional array,
+    // and the `skip_serializing_if` fields above silently shorten it and shift the
+    // remaining slots, corrupting the native scene<->renderer IPC round-trip. As a
+    // bonus it preserves unknown avatar keys, mirroring SerializedProfile::extra_fields.
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

#942 added `#[serde(skip_serializing_if = \"Option::is_none\")]` to `AvatarWireFormat` so deployed/announced profile JSON omits null fields (other explorers fail to parse present-but-null fields). That attribute is serializer-agnostic, so it also changed the **native MessagePack IPC** encoding used between the renderer and the `dcl_deno_ipc` scene host.

rmp's compact `to_vec` encodes a struct as a **positional array**. A skipped `Option::None` field shortens that array and shifts every later field by one slot, so profile RPCs returning `SerializedProfile` — `getUserData`, `getPlayerData`, `getConnectedPlayers`, `SubscribeProfileChanged` — fail to decode (`invalid type: sequence, expected a string`) and abort the scene host. The default avatar already leaves several optionals `None`, so it fires in normal gameplay. `rmp_encode`'s `to_vec_named` fallback never helps, because `to_vec` returns `Ok` here (the outer `#[serde(flatten)]` makes the *outer* struct a map, but the nested `AvatarWireFormat`, having no flatten of its own, stays a positional array).

## Fix

Give `AvatarWireFormat` its own `#[serde(flatten)]` field. That forces it to serialize as a **map** (named keys) instead of a positional array, so `skip_serializing_if` merely omits keys and decode fills them from defaults — order-independent and skip-safe. This:

- keeps the JSON null-omission from #942 (all three profile-JSON sinks: deploy + two comms announcements);
- leaves the **compact IPC hot path untouched** — only `AvatarWireFormat` becomes a map, every CRDT/component frame stays positional (unlike a blanket `to_vec_named`, cf. the closed #950);
- as a bonus, **preserves unknown avatar keys on round-trip** instead of silently dropping them. This is the same class of bug we hit before: redeploying a profile used to drop a `name_color` set by another client until #877 modeled it explicitly — with this flatten capture, fields we don't yet model round-trip instead of being discarded.

`Eq` is dropped from the derive because `serde_json::Value` isn't `Eq` (`SerializedProfile` already omits it for the same reason); nothing relied on `AvatarWireFormat: Eq`.

The flatten field is load-bearing for the wire encoding, so it carries a comment to that effect.