### PR TITLE
Fix web preview launch, mock SSO leak, and world-name URL echo

### DIFF
--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -149,8 +149,13 @@ const config = window.__bevyBootConfig ?? {}
 // the same place. Defaults are omitted so the canonical entry URL stays clean.
 const DEFAULT_SERVER = 'https://realm-provider-ea.decentraland.org/main'
 const DEFAULT_PORTABLES = 'basiccontroller.dcl.eth'
+// The engine connects to the EXPANDED world url (ipfs map_realm_name turns `name.dcl.eth` into
+// worlds-content-server…/world/name.dcl.eth) and echoes that back here. Reverse it so the address
+// bar keeps the short name the user typed; a reload re-expands it the same way.
+const WORLDS_PREFIX = 'https://worlds-content-server.decentraland.org/world/'
 window.set_url_params = (position, server, system_scene, portables, preview) => {
   try {
+    if (server.startsWith(WORLDS_PREFIX)) server = server.slice(WORLDS_PREFIX.length)
     const urlParams = new URLSearchParams(window.location.search)
     // absent when the realm won't honour a position (worlds spawn at their base scene)
     if (position != null) urlParams.set('position', position)

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -138,6 +138,9 @@ const DEFAULTS: MockOptions = {
 
 // In ?mock=1&previousLogin=1, seed a fake same-domain SSO identity so the session's
 // localStorage read lights up the "welcome back" reuse flow (no real auth site in mock).
+// The 0xmock… address is DELIBERATELY not hex: localStorage is shared with real engine
+// sessions on this origin, and sso.ts ignores non-hex identities — a valid-looking address
+// here would leak into a real session's /login_identity and fail after launch.
 function seedMockSso(o: MockOptions): void {
   const key = `single-sign-on-${o.userId}`
   if (o.hasPreviousLogin) {

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -138,9 +138,7 @@ const DEFAULTS: MockOptions = {
 
 // In ?mock=1&previousLogin=1, seed a fake same-domain SSO identity so the session's
 // localStorage read lights up the "welcome back" reuse flow (no real auth site in mock).
-// The 0xmock… address is DELIBERATELY not hex: localStorage is shared with real engine
-// sessions on this origin, and sso.ts ignores non-hex identities — a valid-looking address
-// here would leak into a real session's /login_identity and fail after launch.
+// The 0xmock… address is deliberately non-hex so sso.ts hides it from real engine sessions.
 function seedMockSso(o: MockOptions): void {
   const key = `single-sign-on-${o.userId}`
   if (o.hasPreviousLogin) {

--- a/react-web/src/features/auth/sso.ts
+++ b/react-web/src/features/auth/sso.ts
@@ -40,9 +40,6 @@ function expirationMs(identity: AuthIdentity): number {
   return m ? new Date(m[1]).getTime() : 0
 }
 
-// A real root (wallet) address. Guards against non-loginable identities under the SSO prefix —
-// e.g. the mock bridge's seeded `0xmock…` identity (?mock=1&previousLogin=1 on this origin) —
-// which the engine's /login_identity would reject with a cryptic "bad root address" AFTER launch.
 function isHexAddress(address: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(address)
 }
@@ -55,8 +52,7 @@ function readIdentity(address: string): AuthIdentity | null {
     const identity = JSON.parse(raw) as AuthIdentity
     if (!identity?.ephemeralIdentity?.privateKey || !Array.isArray(identity.authChain)) return null
     if (expirationMs(identity) <= Date.now()) return null
-    // Same lookup as the engine (login.rs parse_auth_identity): the SIGNER link's payload is the
-    // root address it will hex-parse.
+    // Non-hex addresses (e.g. the mock bridge's 0xmock… seed) would fail the engine's login parse.
     const signer = identity.authChain.find((l) => l.type === 'SIGNER')
     if (!signer || !isHexAddress(signer.payload?.trim() ?? '')) return null
     return identity

--- a/react-web/src/features/auth/sso.ts
+++ b/react-web/src/features/auth/sso.ts
@@ -40,13 +40,25 @@ function expirationMs(identity: AuthIdentity): number {
   return m ? new Date(m[1]).getTime() : 0
 }
 
+// A real root (wallet) address. Guards against non-loginable identities under the SSO prefix —
+// e.g. the mock bridge's seeded `0xmock…` identity (?mock=1&previousLogin=1 on this origin) —
+// which the engine's /login_identity would reject with a cryptic "bad root address" AFTER launch.
+function isHexAddress(address: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(address)
+}
+
 function readIdentity(address: string): AuthIdentity | null {
+  if (!isHexAddress(address)) return null
   const raw = localStorage.getItem(SSO_PREFIX + address)
   if (!raw) return null
   try {
     const identity = JSON.parse(raw) as AuthIdentity
     if (!identity?.ephemeralIdentity?.privateKey || !Array.isArray(identity.authChain)) return null
     if (expirationMs(identity) <= Date.now()) return null
+    // Same lookup as the engine (login.rs parse_auth_identity): the SIGNER link's payload is the
+    // root address it will hex-parse.
+    const signer = identity.authChain.find((l) => l.type === 'SIGNER')
+    if (!signer || !isHexAddress(signer.payload?.trim() ?? '')) return null
     return identity
   } catch {
     return null

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -178,6 +178,16 @@ export type Destination =
   | { kind: 'world'; realm: string; position?: string }
   | null
 
+// A ?realm pointing at a local dev/preview server (`sdk-commands start`).
+function isLocalRealm(realm: string): boolean {
+  try {
+    const host = new URL(realm).hostname
+    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '0.0.0.0'
+  } catch {
+    return false
+  }
+}
+
 export interface LoginFlow {
   status: LoginStatus
   /** Root wallet address of the stored SSO identity (shown on the "welcome back" screen). */
@@ -741,6 +751,18 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     if (!submitted || destinationPicked || urlDestination.current == null) return
     const dest = urlDestination.current
     if (dest != null && dest.kind === 'world') {
+      // Local preview realms (`sdk-commands start` opens ?preview=true&realm=http://127.0.0.1:8000):
+      // launch WITHOUT the availability probe. From the hosted site, a fetch to 127.0.0.1 sits behind
+      // the browser's local-network permission (Chrome LNA, Brave shields) — it can hang on a pending
+      // prompt or reject even when the server is fine, and the failure path below would drop the
+      // destination onto the Places picker instead of the preview scene. The engine's own realm
+      // fetch triggers the same permission prompt and surfaces real connection errors, like the old
+      // boot page (which never pre-validated).
+      if (isLocalRealm(dest.realm)) {
+        urlDestination.current = null
+        pickDestination(dest)
+        return
+      }
       // Validate the realm BEFORE launching — a typo'd ?realm= would otherwise strand the loading
       // overlay forever. Same bare-name mapping as the engine (ipfs map_realm_name). The ref is
       // consumed only on resolution, so phase stays 'entering' (no picker flash) while checking.

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -747,17 +747,19 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
         dest.realm.endsWith('.dcl.eth') && !dest.realm.startsWith('https://')
           ? `https://worlds-content-server.decentraland.org/world/${dest.realm}`
           : dest.realm
-      // Only a 404 blocks the launch (the world doesn't exist). Any other outcome — ok, error,
-      // timeout, or a blocked local fetch (browser local-network permission) — launches and lets
-      // the engine surface real connection errors.
+      // Launching against an unreachable realm strands the engine in a cryptic login failure, so
+      // block up front: 404 → not found, no/failed answer (incl. timeout) → unreachable.
       const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 4000))
+      const unreachable = (): void =>
+        setFatalError({ message: `The world "${dest.realm}" isn't reachable right now.`, source: 'realm' })
       Promise.race([fetch(`${base.replace(/\/+$/, '')}/about`), timeout])
         .then((r) => {
-          if (r?.status === 404)
+          if (r?.ok) pickDestination(dest)
+          else if (r?.status === 404)
             setFatalError({ message: `The world "${dest.realm}" doesn't exist.`, source: 'realm' })
-          else pickDestination(dest)
+          else unreachable()
         })
-        .catch(() => pickDestination(dest))
+        .catch(unreachable)
         .finally(() => {
           urlDestination.current = null
           validatingRealm.current = false

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -178,16 +178,6 @@ export type Destination =
   | { kind: 'world'; realm: string; position?: string }
   | null
 
-// A ?realm pointing at a local dev/preview server (`sdk-commands start`).
-function isLocalRealm(realm: string): boolean {
-  try {
-    const host = new URL(realm).hostname
-    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '0.0.0.0'
-  } catch {
-    return false
-  }
-}
-
 export interface LoginFlow {
   status: LoginStatus
   /** Root wallet address of the stored SSO identity (shown on the "welcome back" screen). */
@@ -751,38 +741,25 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     if (!submitted || destinationPicked || urlDestination.current == null) return
     const dest = urlDestination.current
     if (dest != null && dest.kind === 'world') {
-      // Local preview realms (`sdk-commands start` opens ?preview=true&realm=http://127.0.0.1:8000):
-      // launch WITHOUT the availability probe. From the hosted site, a fetch to 127.0.0.1 sits behind
-      // the browser's local-network permission (Chrome LNA, Brave shields) — it can hang on a pending
-      // prompt or reject even when the server is fine, and the failure path below would drop the
-      // destination onto the Places picker instead of the preview scene. The engine's own realm
-      // fetch triggers the same permission prompt and surfaces real connection errors, like the old
-      // boot page (which never pre-validated).
-      if (isLocalRealm(dest.realm)) {
-        urlDestination.current = null
-        pickDestination(dest)
-        return
-      }
-      // Validate the realm BEFORE launching — a typo'd ?realm= would otherwise strand the loading
-      // overlay forever. Same bare-name mapping as the engine (ipfs map_realm_name). The ref is
-      // consumed only on resolution, so phase stays 'entering' (no picker flash) while checking.
       if (validatingRealm.current) return
       validatingRealm.current = true
       const base =
         dest.realm.endsWith('.dcl.eth') && !dest.realm.startsWith('https://')
           ? `https://worlds-content-server.decentraland.org/world/${dest.realm}`
           : dest.realm
-      fetch(`${base.replace(/\/+$/, '')}/about`)
+      // Only a 404 blocks the launch (the world doesn't exist). Any other outcome — ok, error,
+      // timeout, or a blocked local fetch (browser local-network permission) — launches and lets
+      // the engine surface real connection errors.
+      const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 4000))
+      Promise.race([fetch(`${base.replace(/\/+$/, '')}/about`), timeout])
         .then((r) => {
-          urlDestination.current = null
-          if (r.ok) pickDestination(dest)
-          else setFatalError({ message: `The world "${dest.realm}" doesn't exist.`, source: 'realm' })
+          if (r?.status === 404)
+            setFatalError({ message: `The world "${dest.realm}" doesn't exist.`, source: 'realm' })
+          else pickDestination(dest)
         })
-        .catch(() => {
-          urlDestination.current = null
-          setFatalError({ message: `The world "${dest.realm}" isn't reachable right now.`, source: 'realm' })
-        })
+        .catch(() => pickDestination(dest))
         .finally(() => {
+          urlDestination.current = null
           validatingRealm.current = false
         })
       return

--- a/react-web/src/test/session.test.tsx
+++ b/react-web/src/test/session.test.tsx
@@ -58,8 +58,8 @@ describe('session domain', () => {
     await waitFor(() => expect(h.driver.calls).toContain('jumpIn'))
   })
 
-  // A ?realm/?position launch goes straight in — never the Places picker. Only a 404 from the
-  // /about probe blocks it (World-not-found); a failed probe still launches.
+  // A ?realm/?position launch goes straight in — never the Places picker. The /about probe blocks
+  // it with a modal on 404 (not found) or on no answer (unreachable).
   async function launchFromUrl(search: string, driver: LaunchRecordingDriver): Promise<ReturnType<typeof renderSession>> {
     history.replaceState(null, '', search)
     const h = renderSession({ userId: null }, driver)
@@ -68,31 +68,35 @@ describe('session domain', () => {
     return h
   }
 
-  it('a preview ?realm launches even when the probe is blocked (local-network permission)', async () => {
+  it('a preview ?realm launches straight in when /about answers — no picker', async () => {
     const url = new URL(location.href)
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }))
     try {
       const driver = new LaunchRecordingDriver()
       const h = await launchFromUrl('/?preview=true&realm=http://127.0.0.1:8000&position=0,0', driver)
       await waitFor(() => expect(driver.launches).toHaveLength(1))
       expect(h.session().phase).toBe('entering')
       expect(driver.launches[0]).toEqual(['http://127.0.0.1:8000', '0,0'])
+      expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:8000/about')
     } finally {
       fetchSpy.mockRestore()
       history.replaceState(null, '', url.pathname + url.search)
     }
   })
 
-  it('a world ?realm probes /about and launches on 200 — no picker', async () => {
+  it('an unreachable ?realm shows the not-reachable modal and never launches', async () => {
     const url = new URL(location.href)
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }))
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
     try {
       const driver = new LaunchRecordingDriver()
-      const h = await launchFromUrl('/?realm=some.dcl.eth', driver)
-      await waitFor(() => expect(driver.launches).toHaveLength(1))
-      expect(h.session().phase).toBe('entering')
-      expect(driver.launches[0]).toEqual(['some.dcl.eth', undefined])
-      expect(fetchSpy).toHaveBeenCalledWith('https://worlds-content-server.decentraland.org/world/some.dcl.eth/about')
+      const h = await launchFromUrl('/?realm=http://127.0.0.1:9999', driver)
+      await waitFor(() =>
+        expect(h.session().fatalError).toEqual({
+          message: 'The world "http://127.0.0.1:9999" isn\'t reachable right now.',
+          source: 'realm'
+        })
+      )
+      expect(driver.launches).toHaveLength(0)
     } finally {
       fetchSpy.mockRestore()
       history.replaceState(null, '', url.pathname + url.search)
@@ -112,6 +116,7 @@ describe('session domain', () => {
         })
       )
       expect(driver.launches).toHaveLength(0)
+      expect(fetchSpy).toHaveBeenCalledWith('https://worlds-content-server.decentraland.org/world/nope.dcl.eth/about')
     } finally {
       fetchSpy.mockRestore()
       history.replaceState(null, '', url.pathname + url.search)

--- a/react-web/src/test/session.test.tsx
+++ b/react-web/src/test/session.test.tsx
@@ -58,12 +58,8 @@ describe('session domain', () => {
     await waitFor(() => expect(h.driver.calls).toContain('jumpIn'))
   })
 
-  // A ?realm/?position launch goes straight in — never the Places picker. Remote realms are probed
-  // (fetch <realm>/about) so a typo'd world shows "World not found" instead of stranding the
-  // loading overlay; LOCAL preview realms (`sdk-commands start` opens
-  // ?preview=true&realm=http://127.0.0.1:8000&position=0,0) skip the probe — from the hosted site
-  // it sits behind the browser's local-network permission (Chrome LNA / Brave shields) and hung or
-  // failed even with the server up, rerouting preview launches to the picker.
+  // A ?realm/?position launch goes straight in — never the Places picker. Only a 404 from the
+  // /about probe blocks it (World-not-found); a failed probe still launches.
   async function launchFromUrl(search: string, driver: LaunchRecordingDriver): Promise<ReturnType<typeof renderSession>> {
     history.replaceState(null, '', search)
     const h = renderSession({ userId: null }, driver)
@@ -72,17 +68,15 @@ describe('session domain', () => {
     return h
   }
 
-  it('a local preview ?realm launches directly — no picker, no /about probe', async () => {
+  it('a preview ?realm launches even when the probe is blocked (local-network permission)', async () => {
     const url = new URL(location.href)
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
     try {
       const driver = new LaunchRecordingDriver()
       const h = await launchFromUrl('/?preview=true&realm=http://127.0.0.1:8000&position=0,0', driver)
-      // Straight to entering — never 'picking'.
       await waitFor(() => expect(driver.launches).toHaveLength(1))
       expect(h.session().phase).toBe('entering')
       expect(driver.launches[0]).toEqual(['http://127.0.0.1:8000', '0,0'])
-      expect(fetchSpy).not.toHaveBeenCalled()
     } finally {
       fetchSpy.mockRestore()
       history.replaceState(null, '', url.pathname + url.search)

--- a/react-web/src/test/session.test.tsx
+++ b/react-web/src/test/session.test.tsx
@@ -1,6 +1,14 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { act, waitFor } from '@testing-library/react'
 import { renderSession, enterAsGuest, FakeDriver } from './harness'
+
+// Records launch() so tests can assert the realm/position the engine was booted with.
+class LaunchRecordingDriver extends FakeDriver {
+  launches: Array<[string?, string?]> = []
+  launch(realm?: string, position?: string): void {
+    this.launches.push([realm, position])
+  }
+}
 
 // Simulates a boot-time engine panic: `throwOnLaunch` makes launch() throw synchronously (the generic
 // "unreachable" wasm trap), and `panic` is the readable message the iframe stashes and the host reads
@@ -48,6 +56,72 @@ describe('session domain', () => {
     await waitFor(() => expect(h.session().phase).toBe('picking'))
     act(() => h.session().pickDestination(null))
     await waitFor(() => expect(h.driver.calls).toContain('jumpIn'))
+  })
+
+  // A ?realm/?position launch goes straight in — never the Places picker. Remote realms are probed
+  // (fetch <realm>/about) so a typo'd world shows "World not found" instead of stranding the
+  // loading overlay; LOCAL preview realms (`sdk-commands start` opens
+  // ?preview=true&realm=http://127.0.0.1:8000&position=0,0) skip the probe — from the hosted site
+  // it sits behind the browser's local-network permission (Chrome LNA / Brave shields) and hung or
+  // failed even with the server up, rerouting preview launches to the picker.
+  async function launchFromUrl(search: string, driver: LaunchRecordingDriver): Promise<ReturnType<typeof renderSession>> {
+    history.replaceState(null, '', search)
+    const h = renderSession({ userId: null }, driver)
+    await waitFor(() => expect(h.session().login.status).toBe('sign-in-or-guest'))
+    act(() => h.session().login.exploreAsGuest())
+    return h
+  }
+
+  it('a local preview ?realm launches directly — no picker, no /about probe', async () => {
+    const url = new URL(location.href)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    try {
+      const driver = new LaunchRecordingDriver()
+      const h = await launchFromUrl('/?preview=true&realm=http://127.0.0.1:8000&position=0,0', driver)
+      // Straight to entering — never 'picking'.
+      await waitFor(() => expect(driver.launches).toHaveLength(1))
+      expect(h.session().phase).toBe('entering')
+      expect(driver.launches[0]).toEqual(['http://127.0.0.1:8000', '0,0'])
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      fetchSpy.mockRestore()
+      history.replaceState(null, '', url.pathname + url.search)
+    }
+  })
+
+  it('a world ?realm probes /about and launches on 200 — no picker', async () => {
+    const url = new URL(location.href)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }))
+    try {
+      const driver = new LaunchRecordingDriver()
+      const h = await launchFromUrl('/?realm=some.dcl.eth', driver)
+      await waitFor(() => expect(driver.launches).toHaveLength(1))
+      expect(h.session().phase).toBe('entering')
+      expect(driver.launches[0]).toEqual(['some.dcl.eth', undefined])
+      expect(fetchSpy).toHaveBeenCalledWith('https://worlds-content-server.decentraland.org/world/some.dcl.eth/about')
+    } finally {
+      fetchSpy.mockRestore()
+      history.replaceState(null, '', url.pathname + url.search)
+    }
+  })
+
+  it('a world ?realm whose /about 404s shows World-not-found and never launches', async () => {
+    const url = new URL(location.href)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }))
+    try {
+      const driver = new LaunchRecordingDriver()
+      const h = await launchFromUrl('/?realm=nope.dcl.eth', driver)
+      await waitFor(() =>
+        expect(h.session().fatalError).toEqual({
+          message: 'The world "nope.dcl.eth" doesn\'t exist.',
+          source: 'realm'
+        })
+      )
+      expect(driver.launches).toHaveLength(0)
+    } finally {
+      fetchSpy.mockRestore()
+      history.replaceState(null, '', url.pathname + url.search)
+    }
   })
 
   it('nav(mic) posts a navAction', async () => {


### PR DESCRIPTION
## Summary

Fixes for the react-web launch flow, found while debugging why scene preview (`sdk-commands start` → `?preview=true&realm=http://127.0.0.1:8000`) landed on the Places list instead of the preview scene:

- **Every `?realm`/`?position` launch goes straight in — never the Places picker.** The `/about` probe still runs before launch, but its outcome is explicit: **ok** launches, **404** shows the World-not-found modal, and **anything else** (network/permission failure, or a 4s timeout — the probe used to hang forever on a pending browser local-network prompt) shows the not-reachable modal. Previously the picker could reappear behind the error, and a hung probe stranded the loading screen silently.
- **Non-hex SSO identities are ignored by the stored-login scan.** The mock bridge (`?mock=1&previousLogin=1`) seeds `single-sign-on-0xmock…` into per-origin localStorage; real engine sessions on the same origin picked it up, showed "Welcome back!", and `/login_identity` failed after launch with `bad root address: Invalid character 'm' at position 0`. The scan now requires a real `0x`+40-hex key and SIGNER payload, mirroring the engine's parse (login.rs).
- **World URLs keep their short name.** Entering `realm=boedo.dcl.eth` rewrote the param to the expanded `worlds-content-server…/world/…` form via the engine's URL sync; boot.js now reverses the `map_realm_name` expansion when writing the param.

## What could break

- Non-404 HTTP errors from `/about` (e.g. a 500) now read as "isn't reachable" instead of "doesn't exist".
- The probe adds up to 4s before the error surfaces when the target hangs (timeout races the fetch); success is as fast as before.
- The boot.js prefix strip assumes the production worlds-content-server host; worlds served from other hosts keep their full URL in the param (same as before).

## How to test

1. `cd react-web && npx vitest run` — 204 tests, including: probe ok launches with no picker, 404 shows World-not-found, unreachable realm shows not-reachable without launching.
2. Preview: run a scene (`npm run start` in any scene folder), then open `http://localhost:5173/?preview=true&realm=http://127.0.0.1:8000&position=0,0` (react-web `npm run dev`) — after Jump in it should enter the scene directly, no Places list. Stop the scene server and retry — the not-reachable modal should appear instead of a broken launch.
3. Mock leak: visit `?mock=1&previousLogin=1` once, then reload without `?mock` — the login screen should offer sign-in/guest, not a broken "Welcome back!".
4. World name: open `?realm=boedo.dcl.eth`, enter, and confirm the address bar still shows `realm=boedo.dcl.eth`; `?realm=nope.dcl.eth` should show the World-not-found modal.

Note: testers running from a locally built engine need a wasm built after #928 (`wasm-pack build --target web …`) — older local builds call the pre-#928 `set_url_params` convention and scramble the URL params.