### PR TITLE
Fix rust 1.97 clippy lints

### DIFF
--- a/crates/dcl_deno/src/js/inspector.rs
+++ b/crates/dcl_deno/src/js/inspector.rs
@@ -416,13 +416,13 @@ impl InspectorInfo {
     }
 
     pub fn get_websocket_debugger_url(&self, host: &str) -> String {
-        format!("ws://{}/ws/{}", host, &self.uuid)
+        format!("ws://{}/ws/{}", host, self.uuid)
     }
 
     fn get_frontend_url(&self, host: &str) -> String {
         format!(
             "devtools://devtools/bundled/js_app.html?ws={}/ws/{}&experiments=true&v8only=true",
-            host, &self.uuid
+            host, self.uuid
         )
     }
 

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -373,7 +373,7 @@ impl IpfsAssetServer<'_, '_> {
             .borrow()
             .as_ref()
             .and_then(|c| c.about.content.as_ref())
-            .map(|content| format!("{}/entities/active", &content.public_url))
+            .map(|content| format!("{}/entities/active", content.public_url))
     }
 
     pub fn ipfs(&self) -> &Arc<IpfsIo> {
@@ -1398,7 +1398,7 @@ impl IpfsIo {
             .borrow()
             .as_ref()
             .and_then(|c| c.about.content.as_ref())
-            .map(|content| format!("{}/contents/", &content.public_url))
+            .map(|content| format!("{}/contents/", content.public_url))
     }
 
     pub fn entities_endpoint(&self) -> Option<String> {
@@ -1406,7 +1406,7 @@ impl IpfsIo {
             .borrow()
             .as_ref()
             .and_then(|c| c.about.content.as_ref())
-            .map(|content| format!("{}/entities/", &content.public_url))
+            .map(|content| format!("{}/entities/", content.public_url))
     }
 
     async fn update_scene_urns(

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -953,15 +953,11 @@ impl ScenePointers {
             .into_iter()
             .enumerate()
         {
-            if let Some(sub_crc) = self.crc(
+            let sub_crc = self.crc(
                 (level_parcel << level as u32) + (offset << (level - 1) as u32),
                 level - 1,
-            ) {
-                calc ^= sub_crc.rotate_right(ix as u32);
-            } else {
-                // println!("failed {level}");
-                return None;
-            }
+            )?;
+            calc ^= sub_crc.rotate_right(ix as u32);
         }
         // println!("success {level}");
         self.crcs[level][index] = Some(calc);


### PR DESCRIPTION
Rust stable just moved to 1.97; CI clippy runs `-D warnings` on current stable, so every PR now fails on its new lints. Full-workspace sweep on 1.97:

- `useless_borrows_in_formatting`: 3× `crates/ipfs/src/lib.rs`, 2× `crates/dcl_deno/src/js/inspector.rs`
- `question_mark`: 1× `crates/scene_runner/src/initialize_scene.rs` (imposter crc sub-level loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)