### PR TITLE
expose native TextEncoder/TextDecoder to scenes

### DIFF
--- a/crates/dcl_deno/src/js/modules/init.js
+++ b/crates/dcl_deno/src/js/modules/init.js
@@ -128,12 +128,15 @@ globalThis.WebSocket = websocket.WebSocket;
 
 import * as _10 from "ext:deno_websocket/02_websocketstream.js";
 
+import * as textEncoding from "ext:deno_web/08_text_encoding.js";
+globalThis.TextEncoder = textEncoding.TextEncoder;
+globalThis.TextDecoder = textEncoding.TextDecoder;
+
 // we need to ensure all modules are evaluated, else deno complains in debug mode
 import * as _0 from "ext:deno_url/01_urlpattern.js"
 import * as _1 from "ext:deno_web/02_structured_clone.js"
 import * as _2 from "ext:deno_web/04_global_interfaces.js"
 import * as _3 from "ext:deno_web/05_base64.js"
-import * as _4 from "ext:deno_web/08_text_encoding.js"
 import * as _5 from "ext:deno_web/10_filereader.js"
 import * as _6 from "ext:deno_web/13_message_port.js"
 import * as _7 from "ext:deno_web/14_compression.js"


### PR DESCRIPTION
The deno_web extension is already registered in the scene runtime and its `08_text_encoding.js` module is already evaluated — it was imported in `init.js` only to satisfy the debug-mode module-evaluation assertion — but `TextEncoder`/`TextDecoder` were never bound to `globalThis`, so scene code sees them as undefined and falls back to slow JS polyfills (or fails outright when no polyfill was bundled).

This binds both globals in `init.js` in the same style as the existing `fetch`/`WebSocket` globals. The backing `op_encoding_*` ops are already registered by the deno_web extension, so no Rust changes are needed; the previous side-effect-only import of the module is folded into the new named import.

Scene-side effect: the natively backed implementations are GB/s-class versus the tens of MB/s of the JS polyfill the SDK bundles today, and published scenes pick this up with no rebuild — the SDK installs its polyfill only when the global is absent (`setGlobalPolyfill` assigns with `??`), so the native implementation wins automatically.

Related: decentraland/js-sdk-toolchain#1452 slims the SDK-side polyfill to a validating utf-8 codec; with this change bevy scenes never touch it.
