### PR TITLE
add camera smoothing setting

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -480,6 +480,7 @@ pub struct AppConfig {
     pub scene_permissions: HashMap<String, HashMap<PermissionType, PermissionValue>>,
     pub inputs: InputMapSerialized,
     pub point_at_marker_visibility: PointAtMarkerVisibility,
+    pub camera_smoothing: CameraSmoothing,
     // field-level default (0) so configs saved before this field existed read as outdated,
     // rather than taking the current generation from the container-level default
     #[serde(default)]
@@ -520,6 +521,7 @@ impl Default for AppConfig {
             scene_permissions: Default::default(),
             inputs: Default::default(),
             point_at_marker_visibility: Default::default(),
+            camera_smoothing: Default::default(),
             settings_generation: SETTINGS_GENERATION,
         }
     }
@@ -1506,6 +1508,25 @@ pub enum PointAtMarkerVisibility {
     All,
     Friends,
     None,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CameraSmoothing {
+    Raw,
+    #[default]
+    Smoothed,
+    Drunk,
+}
+
+impl CameraSmoothing {
+    /// exponential smoothing rate; `None` means no smoothing
+    pub fn rate(&self) -> Option<f32> {
+        match self {
+            CameraSmoothing::Raw => None,
+            CameraSmoothing::Smoothed => Some(15.0),
+            CameraSmoothing::Drunk => Some(5.0),
+        }
+    }
 }
 
 #[derive(Event)]

--- a/crates/system_bridge/src/settings/camera_smoothing.rs
+++ b/crates/system_bridge/src/settings/camera_smoothing.rs
@@ -1,0 +1,50 @@
+use common::structs::{AppConfig, CameraSmoothing};
+
+use super::{AppSetting, EnumAppSetting, SettingCategory};
+
+impl EnumAppSetting for CameraSmoothing {
+    fn variants() -> Vec<Self> {
+        vec![Self::Raw, Self::Smoothed, Self::Drunk]
+    }
+
+    fn name(&self) -> String {
+        match self {
+            Self::Raw => "Raw",
+            Self::Smoothed => "Smoothed",
+            Self::Drunk => "Drunk",
+        }
+        .to_owned()
+    }
+}
+
+impl AppSetting for CameraSmoothing {
+    type Param = ();
+
+    fn title() -> String {
+        "Camera smoothing".to_owned()
+    }
+
+    fn category() -> SettingCategory {
+        SettingCategory::Controls
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "How much the camera rotation is smoothed as you look around.\n\n{}",
+            match self {
+                Self::Raw => "Raw\nNo smoothing. The camera follows your input directly.",
+                Self::Smoothed =>
+                    "Smoothed\nA light exponential smoothing takes the edge off sharp movements.",
+                Self::Drunk => "Drunk\nHeavy smoothing for a loose, floaty feel.",
+            }
+        )
+    }
+
+    fn save(&self, config: &mut AppConfig) {
+        config.camera_smoothing = *self;
+    }
+
+    fn load(config: &AppConfig) -> Self {
+        config.camera_smoothing
+    }
+}

--- a/crates/system_bridge/src/settings/mod.rs
+++ b/crates/system_bridge/src/settings/mod.rs
@@ -26,8 +26,8 @@ use common::structs::SsaoSetting;
 use common::{
     sets::SceneSets,
     structs::{
-        AaSetting, AppConfig, BloomSetting, DofSetting, FogSetting, ParcelGrassSetting,
-        PointAtMarkerVisibility, PreviewMode, ShadowSetting, WindowSetting,
+        AaSetting, AppConfig, BloomSetting, CameraSmoothing, DofSetting, FogSetting,
+        ParcelGrassSetting, PointAtMarkerVisibility, PreviewMode, ShadowSetting, WindowSetting,
     },
 };
 use constrain_ui::ConstrainUiSetting;
@@ -54,6 +54,7 @@ pub mod aa_settings;
 pub mod ambient_brightness_setting;
 pub mod bloom_settings;
 pub mod cache_size;
+pub mod camera_smoothing;
 pub mod cel_shading_setting;
 pub mod constrain_ui;
 pub mod dof_setting;
@@ -185,6 +186,7 @@ impl Plugin for SettingBridgePlugin {
         add_int_setting::<ScrollSensitivitySetting>(app, &mut settings, &mut schedule, &config);
         add_int_setting::<MovementSensitivitySetting>(app, &mut settings, &mut schedule, &config);
         add_int_setting::<CameraSensitivitySetting>(app, &mut settings, &mut schedule, &config);
+        add_enum_setting::<CameraSmoothing>(app, &mut settings, &mut schedule, &config);
 
         add_int_setting::<VideoThreadsSetting>(app, &mut settings, &mut schedule, &config);
         add_int_setting::<MaxDownloadsSetting>(app, &mut settings, &mut schedule, &config);

--- a/crates/system_ui/src/app_settings/mod.rs
+++ b/crates/system_ui/src/app_settings/mod.rs
@@ -4,8 +4,8 @@ use bevy_dui::{DuiCommandsExt, DuiEntities, DuiEntityCommandsExt, DuiProps, DuiR
 use common::structs::SsaoSetting;
 use common::{
     structs::{
-        AaSetting, AppConfig, BloomSetting, DofSetting, FogSetting, PointAtMarkerVisibility,
-        PreviewMode, SettingsTab, ShadowSetting, WindowSetting,
+        AaSetting, AppConfig, BloomSetting, CameraSmoothing, DofSetting, FogSetting,
+        PointAtMarkerVisibility, PreviewMode, SettingsTab, ShadowSetting, WindowSetting,
     },
     util::TryPushChildrenEx,
 };
@@ -194,6 +194,7 @@ fn set_app_settings_content(
             spawn_int_setting_template::<ScrollSensitivitySetting>(&mut commands, &dui, &config),
             spawn_int_setting_template::<MovementSensitivitySetting>(&mut commands, &dui, &config),
             spawn_int_setting_template::<CameraSensitivitySetting>(&mut commands, &dui, &config),
+            spawn_enum_setting_template::<CameraSmoothing>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<PointAtMarkerVisibility>(&mut commands, &dui, &config),
         ]);
 

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -9,8 +9,8 @@ use bevy::{
 use common::{
     inputs::{Action, SystemAction, CAMERA_SET, CAMERA_ZOOM, POINTER_SET},
     structs::{
-        AvatarDynamicState, CameraOverride, CursorLocks, HeadSync, MoveKind, PrimaryCamera,
-        PrimaryUser,
+        AppConfig, AvatarDynamicState, CameraOverride, CursorLocks, HeadSync, MoveKind,
+        PrimaryCamera, PrimaryUser,
     },
     util::ModifyComponentExt,
 };
@@ -38,6 +38,8 @@ pub fn update_camera(
     mut cinematic_data: Local<Option<CinematicInitialData>>,
     input_manager: InputManager,
     gt_helper: TransformHelper,
+    config: Res<AppConfig>,
+    mut smoothed_delta: Local<Vec2>,
 ) {
     let dt = time.delta_secs();
 
@@ -117,6 +119,14 @@ pub fn update_camera(
     let mut mouse_delta = input_manager.get_analog(CAMERA_SET, InputPriority::Scene) * 10.0;
     if locks.0.contains("camera") {
         mouse_delta += input_manager.get_analog(POINTER_SET, InputPriority::Scroll);
+    }
+    match config.camera_smoothing.rate() {
+        Some(rate) => {
+            let factor = 1.0 - (-dt * rate).exp();
+            mouse_delta = factor * mouse_delta + (1.0 - factor) * *smoothed_delta;
+            *smoothed_delta = mouse_delta;
+        }
+        None => *smoothed_delta = mouse_delta,
     }
 
     if allow_cam_move {


### PR DESCRIPTION
Adds a **Camera smoothing** setting (Controls category) that lets the player choose how much the camera rotation is smoothed as they look around:

- **Raw** – no smoothing, camera follows input directly
- **Smoothed** – light exponential smoothing (rate 15), the default
- **Drunk** – heavy exponential smoothing (rate 5) for a loose, floaty feel

The selected rate is applied as exponential smoothing to the camera look delta in `update_camera`. The mode is stored in `AppConfig` and exposed through both the bridge settings (web UI) and the native settings dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)