### PR TITLE
Add double jump / glide fields to AvatarLocomotionSettings

### DIFF
--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_locomotion_settings.proto
@@ -15,4 +15,7 @@ message PBAvatarLocomotionSettings {
   optional float jump_height = 4;           // Height of a regular jump (in meters)
   optional float run_jump_height = 5;       // Height of a jump while running (in meters)
   optional float hard_landing_cooldown = 6; // Cooldown time after a hard landing before the avatar can move again (in seconds)
+  optional float double_jump_height = 7;    // Height of the double jump (in meters)
+  optional float gliding_speed = 8;         // Maximum speed when gliding (in meters per second)
+  optional float gliding_falling_speed = 9; // Maximum falling speed when gliding (in meters per second)
 }

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -254,6 +254,9 @@ impl FromConfig for AvatarLocomotionSettings {
             jump_height: Some(config.player_settings.jump_height),
             run_jump_height: Some(config.player_settings.run_jump_height),
             hard_landing_cooldown: Some(0.0),
+            double_jump_height: None,
+            gliding_speed: None,
+            gliding_falling_speed: None,
         })
     }
 }


### PR DESCRIPTION
Vendors the three `PBAvatarLocomotionSettings` tuning fields from protocol #407 — `double_jump_height`, `gliding_speed`, `gliding_falling_speed` — so they deserialize and forward to scenes unchanged via `AvatarMovementInfo`.

bevy has no native double-jump/glide config, so the `FromConfig` default leaves the three fields `None`; scenes fall back to their own defaults when unset. The mechanics that consume these values live in the movement portable, which reads them off `AvatarMovementInfo.activeAvatarLocomotionSettings`.

Requires the corresponding protocol change (decentraland/protocol#440).