### PR TITLE
Suppress web HUD hotkeys while an engine text field has keyboard focus

### DIFF
--- a/crates/input_manager/src/lib.rs
+++ b/crates/input_manager/src/lib.rs
@@ -81,6 +81,13 @@ impl InputPriorities {
             .copied()
             .unwrap_or(InputPriority::None)
     }
+
+    /// true while any consumer holds the keyboard at TextEntry level or above (e.g. a
+    /// focused text field). in this state gameplay key bindings are blocked and consumers
+    /// read raw ButtonInput, so keys must be treated as "being typed", not as shortcuts.
+    pub fn keyboard_claimed(&self) -> bool {
+        self.get(InputType::All).max(self.get(InputType::Keyboard)) >= InputPriority::TextEntry
+    }
 }
 
 // Holding any of these triggers OS-shortcut suppression for non-modifier
@@ -506,12 +513,7 @@ fn handle_modifier_keys(
     }
     *was_super_held = super_held;
 
-    let keyboard_claimed = priorities
-        .get(InputType::All)
-        .max(priorities.get(InputType::Keyboard))
-        >= InputPriority::TextEntry;
-
-    let active = !keyboard_claimed && any_unbound_modifier_held(&key_input, &map);
+    let active = !priorities.keyboard_claimed() && any_unbound_modifier_held(&key_input, &map);
 
     if active && !*was_active {
         let held: Vec<KeyCode> = key_input

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -10,6 +10,8 @@
 //     __bevyReadyToLaunch / __bevyLaunch(realm?, position?) — deferred engine_run
 //     __bevyPanic — readable Rust panic text (the JS throw is a generic "unreachable" trap)
 //     __engineHeartbeat / reportEngineError / __rearmCrashWatchdog — crash watchdog plumbing
+//     __engineTextFocus — true while an engine-rendered text field holds keyboard focus (the
+//       wasm keeps it current via __setEngineTextFocus); HUD hotkeys must not fire while set
 //     __onEngineCrash(message, source) — OPTIONAL host callback; the watchdog calls it instead of
 //       rendering any overlay (React owns the error UI)
 //     window.engine / engine_console_command — the console RPC (built by engine.js post-launch)
@@ -143,6 +145,15 @@ publish()
 
 // Host-provided config (set before this module is injected).
 const config = window.__bevyBootConfig ?? {}
+
+// ---- engine text focus (CALLED BY THE WASM — src/web.rs update_text_focus) -----------------------
+// True while an engine-rendered text field (e.g. a scene textinput) holds keyboard focus. Those
+// fields live on the canvas, so DOM focus checks can't see them — HUD hotkey handlers read this
+// flag instead (useMenuShortcuts) to leave keys alone while the user is typing.
+window.__engineTextFocus = false
+window.__setEngineTextFocus = (focused) => {
+  window.__engineTextFocus = !!focused
+}
 
 // ---- URL sync (CALLED BY THE WASM — src/web.rs set_url_params) -----------------------------------
 // Keeps the browser URL in step with the player's realm/position so a reload/share lands back at

--- a/react-web/src/lib/useMenuShortcuts.ts
+++ b/react-web/src/lib/useMenuShortcuts.ts
@@ -8,6 +8,11 @@
 import { useEffect, useRef } from 'react'
 import type { EngineSession } from '../features/session/useEngineSession'
 
+// Set by the wasm via boot.js __setEngineTextFocus: true while an engine-rendered text field
+// (e.g. a scene textinput) holds keyboard focus. Those fields live on the canvas, so the
+// e.target tag check below can't see them.
+type EngineFocusWindow = Window & { __engineTextFocus?: boolean }
+
 // key → the session toggle it triggers. Keep in sync with the nav/sidebar `shortcut` hints.
 const SHORTCUTS: Record<string, (s: EngineSession) => () => void> = {
   m: (s) => s.map.toggle,
@@ -32,6 +37,7 @@ export function useMenuShortcuts(session: EngineSession): void {
       const target = e.target as HTMLElement | null
       const tag = target?.tagName
       if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return
+      if ((window as EngineFocusWindow).__engineTextFocus) return
 
       const s = sessionRef.current
       if (s.phase !== 'world') return

--- a/src/web.rs
+++ b/src/web.rs
@@ -17,6 +17,7 @@ use common::{
 };
 use dcl_wasm::init_runtime;
 use futures_lite::io::AsyncReadExt;
+use input_manager::InputPriorities;
 use once_cell::sync::OnceCell;
 use scene_runner::vec3_to_parcel;
 use system_bridge::{SystemApi, SystemBridge};
@@ -61,6 +62,14 @@ extern "C" {
     /// watchdog surfaces the crash overlay. Defined in index.html before the engine runs.
     #[wasm_bindgen(js_name = "__engineHeartbeat")]
     fn engine_heartbeat();
+
+    /// Mirror "an engine text field holds keyboard focus" to the page (boot.js stores it
+    /// on window.__engineTextFocus). The react HUD's hotkey handlers see key events before
+    /// the engine does (capture-phase window listener vs the canvas), and an engine-rendered
+    /// text field is invisible to their DOM-focus checks — this flag is how they know to
+    /// leave keys alone while the user types into scene UI.
+    #[wasm_bindgen(js_name = "__setEngineTextFocus")]
+    fn set_engine_text_focus(focused: bool);
 }
 
 /// call from a separate worker to initialize a channel for asset load processing
@@ -149,6 +158,7 @@ pub fn engine_run(
 
     app.add_systems(Update, update_winit_fps)
         .add_systems(Update, update_url_params)
+        .add_systems(Update, update_text_focus)
         .add_systems(Last, engine_heartbeat_system);
 
     app.add_systems(
@@ -245,6 +255,14 @@ fn extract_js_api(config: Res<ConsoleConfiguration>) {
 /// Pings the JS watchdog each frame so it can detect a stalled engine loop.
 fn engine_heartbeat_system() {
     engine_heartbeat();
+}
+
+fn update_text_focus(priorities: Res<InputPriorities>, mut prev: Local<bool>) {
+    let focused = priorities.keyboard_claimed();
+    if focused != *prev {
+        *prev = focused;
+        set_engine_text_focus(focused);
+    }
 }
 
 pub fn update_winit_fps(config: Res<AppConfig>, mut winit: ResMut<WinitSettings>) {


### PR DESCRIPTION
## Problem

On web, the react HUD's single-letter menu shortcuts (`o` for communities, `m`, `i`, ...) fire even while the user is typing into a scene textinput. The shortcut handler is a capture-phase `window` keydown listener whose only suppression check is `e.target` being a DOM `INPUT`/`TEXTAREA`/contentEditable — but scene textinputs are engine-rendered, so their key events target the `<canvas>` and sail past the check.

## Fix

The engine already knows when a text field owns the keyboard: any `(All|Keyboard)` reservation at `>= InputPriority::TextEntry` — the same condition `handle_modifier_keys` uses to back off OS-shortcut suppression. This PR:

- promotes that inline expression to `InputPriorities::keyboard_claimed()` and reuses it in `handle_modifier_keys` (no behaviour change),
- mirrors it to the page from a change-detecting system in `src/web.rs` via a new `window.__setEngineTextFocus(bool)` hook defined in `boot.js` (stored on `window.__engineTextFocus`),
- bails out of `useMenuShortcuts` while the flag is set.

Native is untouched (`src/web.rs` is wasm-only, and the flag is simply absent/falsy elsewhere). The worst-case staleness is one frame between focusing a scene textinput and the flag reaching JS, well below click-then-type latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)