### PR TITLE
Fix RotateContinuous tween axis handling

### DIFF
--- a/crates/tween/src/lib.rs
+++ b/crates/tween/src/lib.rs
@@ -23,6 +23,16 @@ use scene_runner::{
     ContainerEntity, SceneEntity,
 };
 
+/// Rotation axis for RotateContinuous: the direction quaternion's normalized
+/// imaginary part. The identity quaternion encodes no axis; fall back to Y to
+/// match unity-explorer.
+fn rotate_continuous_axis(direction: dcl_component::proto_components::common::Quaternion) -> Vec3 {
+    let quat = direction.to_bevy_normalized();
+    Vec3::new(quat.x, quat.y, quat.z)
+        .try_normalize()
+        .unwrap_or(Vec3::Y)
+}
+
 #[derive(Debug, Component, Deref, DerefMut)]
 pub struct Tween(PbTween);
 
@@ -174,16 +184,15 @@ impl Tween {
                 }
             }
             Some(Mode::RotateContinuous(data)) => {
-                let Some((axis, _)) = data
-                    .direction
-                    .map(|dcl_quat| dcl_quat.to_bevy_normalized().to_axis_angle())
-                else {
+                let Some(axis) = data.direction.map(rotate_continuous_axis) else {
                     return;
                 };
-                transform.rotation *= Quat::from_axis_angle(
+                // pre-multiply: the axis is in parent space (matches unity), so a
+                // tilted entity spins in place rather than swinging its own axes
+                transform.rotation = Quat::from_axis_angle(
                     axis,
                     ease_value * tween_apply_update.delta * -data.speed.to_radians(),
-                );
+                ) * transform.rotation;
             }
             Some(Mode::MoveContinuous(data)) => {
                 if let Some(direction) = data.direction {

--- a/crates/tween/src/tween_debug.rs
+++ b/crates/tween/src/tween_debug.rs
@@ -383,11 +383,7 @@ fn axis_gizmos(mut gizmos: Gizmos, tweens: Query<(&Tween, &GlobalTransform)>) {
                     Isometry3d::from_translation(global_transform.translation()),
                     2.5,
                 );
-                let axis = {
-                    let direction = data.direction.unwrap();
-                    let (axis, _) = direction.to_bevy_normalized().to_axis_angle();
-                    axis
-                };
+                let axis = crate::rotate_continuous_axis(data.direction.unwrap());
                 gizmos.arrow(
                     global_transform.translation(),
                     global_transform.translation() + axis * 2.5,


### PR DESCRIPTION
Two behaviour mismatches vs unity-explorer in the `RotateContinuous` tween mode, both visible on the Genesis Plaza fishing pond (`fishing-game` branch):

1. **Identity direction quaternion.** The rotation axis is the quaternion's normalized imaginary part, which the identity doesn't have. glam's `to_axis_angle` falls back to `Vec3::X`; unity-explorer explicitly falls back to `Vector3.up`. The pond scene passes `Quaternion.fromEulerDegrees(0, 0, 0)` for one of its water layers, which tumbled around X in bevy instead of spinning flat. Now derived via a shared helper with a Y fallback (identical to the previous axis for all non-degenerate quaternions), also used by the tween_debug gizmo so the drawn axis matches what's applied.

2. **Rotation composition order.** The per-frame increment was post-multiplied (`transform.rotation *= Δ`), which rotates around the entity's *local* axis. Unity computes `AngleAxis(angle, axis) * start` — a parent-space axis. For the pond's hover highlight (a spot light tilted 90° to point down, spun around Y) the local-Y spin swung the cone sideways like a searchlight instead of rotating the projected texture in place. Now pre-multiplied to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)