### PR TITLE
Bump bevy fork: accept glTF accessors with no bufferView

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1157,7 +1157,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1538,12 +1538,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#fc901897d5999e69da8084c2aaf2f88ac8d82525"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
 dependencies = [
  "accesskit",
  "accesskit_winit",


### PR DESCRIPTION
Lockfile-only bump of the bevy fork to [robtfm/bevy@16b085d52](https://github.com/robtfm/bevy/commit/16b085d52ec448adf4d16aca25361e2ce78b88f2).

The glTF 2.0 spec allows an accessor to omit both `bufferView` and `sparse`: it is zero-filled, and sparse data may overlay a missing base view. Blender exports morph targets this way (all-zero displacement targets alongside sparse ones). The gltf crate's validation rejects such files outright (`accessors[N].bufferView: Missing data`) even though its accessor readers already handle them — sparse overlays iterate over a zero base, and plain zero accessors read as `None`, which the loader's morph path treats as zero displacement.

The fork's gltf loader now retries parsing without validation when every reported error is a `Missing` `bufferView` on an accessor. Draco-compressed accessors also legitimately lack bufferViews, but their data lives in an undecodable extension blob, so documents declaring `KHR_draco_mesh_compression` keep returning the original error rather than silently loading empty meshes.

Fixes the Genesis Plaza clocktower cuckoo animations on the fishing-game branch (`cuckoo_Sign.glb` / `cuckoo_Angry.glb`), which previously failed to load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)