### PR TITLE
Write avatar-attached entity transforms back to the scene

### DIFF
--- a/crates/avatar/src/attach.rs
+++ b/crates/avatar/src/attach.rs
@@ -62,8 +62,8 @@ pub fn update_attached(
     attachments: Query<(Entity, &AvatarAttachment), Changed<AvatarAttachment>>,
     mut removed_attachments: RemovedComponents<AvatarAttachment>,
     visibility_component: Query<&VisibilityComponent>,
-    primary_user: Query<&AttachPoints, With<PrimaryUser>>,
-    all_users: Query<(&AttachPoints, &AvatarShape, Has<PrimaryUser>)>,
+    primary_user: Query<(Entity, &AttachPoints), With<PrimaryUser>>,
+    all_users: Query<(Entity, &AttachPoints, &AvatarShape, Has<PrimaryUser>)>,
 ) {
     for removed in removed_attachments.read() {
         if let Ok(mut commands) = commands.get_entity(removed) {
@@ -87,31 +87,31 @@ pub fn update_attached(
     }
 
     for (ent, attach) in attachments.iter() {
-        let (is_primary, attach_points) = match attach.0.avatar_id.as_ref() {
+        let (is_primary, player, attach_points) = match attach.0.avatar_id.as_ref() {
             None => {
-                let Ok(data) = primary_user.single() else {
+                let Ok((player, data)) = primary_user.single() else {
                     warn!("no primary user");
                     continue;
                 };
-                (true, data)
+                (true, player, data)
             }
             Some(id) => {
                 let id = id.to_lowercase();
-                let Some((attach_points, _, has_primary)) = all_users
+                let Some((player, attach_points, _, has_primary)) = all_users
                     .iter()
-                    .find(|(_, avatar_shape, _)| avatar_shape.0.id.to_lowercase() == id)
+                    .find(|(_, _, avatar_shape, _)| avatar_shape.0.id.to_lowercase() == id)
                 else {
                     warn!("avatar shape id {:?} not found", id);
                     warn!(
                         "available avatar shapes: {:?}",
                         all_users
                             .iter()
-                            .map(|(_, avatar_shape, _)| &avatar_shape.0.id)
+                            .map(|(_, _, avatar_shape, _)| &avatar_shape.0.id)
                             .collect::<Vec<_>>()
                     );
                     continue;
                 };
-                (has_primary, attach_points)
+                (has_primary, player, attach_points)
             }
         };
 
@@ -146,7 +146,7 @@ pub fn update_attached(
 
         let mut commands = commands.entity(ent);
         commands.try_insert((
-            ParentPositionSync::<AvatarAttachStage>::new(sync_entity),
+            ParentPositionSync::<AvatarAttachStage>::new_with_scene_writeback(sync_entity, player),
             DisableCollisions,
             AttachedToPlayer { is_primary },
         ));

--- a/crates/scene_runner/src/update_world/transform_and_parent.rs
+++ b/crates/scene_runner/src/update_world/transform_and_parent.rs
@@ -10,7 +10,10 @@ use bevy::{
     transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
 use common::{anim_last_system, sets::PostUpdateSets, util::ModifyComponentExt};
-use dcl::{crdt::lww::CrdtLWWState, interface::ComponentPosition};
+use dcl::{
+    crdt::lww::CrdtLWWState,
+    interface::{ComponentPosition, CrdtType},
+};
 
 use crate::{
     initialize_scene::process_scene_lifecycle,
@@ -20,8 +23,8 @@ use crate::{
 };
 use common::sets::SceneLoopSets;
 use dcl_component::{
-    transform_and_parent::DclTransformAndParent, DclReader, FromDclReader, SceneComponentId,
-    SceneEntityId,
+    transform_and_parent::DclTransformAndParent, DclReader, DclWriter, FromDclReader,
+    SceneComponentId, SceneEntityId,
 };
 
 use super::{AddCrdtInterfaceExt, CrdtStateComponent};
@@ -280,11 +283,32 @@ pub(crate) fn process_transform_and_parent_updates(
 // also this will lag if the parent of the syncee is moving so they should
 // be parented to the scene root generally.
 #[derive(Component)]
-pub struct ParentPositionSync<T: ParentPositionSyncStage>(pub Entity, PhantomData<fn() -> T>);
+pub struct ParentPositionSync<T: ParentPositionSyncStage> {
+    pub sync_to: Entity,
+    /// when set, the synced transform is also written back to the owning
+    /// scene's crdt, relative to this entity (normally the attached player's
+    /// root). unity semantics, which the sdk world-transform helpers build on:
+    /// rotation is made relative to the target, translation is the unrotated
+    /// world-axis delta from the target.
+    pub translation_target: Option<Entity>,
+    _p: PhantomData<fn() -> T>,
+}
 
 impl<T: ParentPositionSyncStage> ParentPositionSync<T> {
-    pub fn new(parent: Entity) -> Self {
-        Self(parent, Default::default())
+    pub fn new(sync_to: Entity) -> Self {
+        Self {
+            sync_to,
+            translation_target: None,
+            _p: Default::default(),
+        }
+    }
+
+    pub fn new_with_scene_writeback(sync_to: Entity, translation_target: Entity) -> Self {
+        Self {
+            sync_to,
+            translation_target: Some(translation_target),
+            _p: Default::default(),
+        }
     }
 }
 
@@ -296,6 +320,7 @@ impl ParentPositionSyncStage for AvatarAttachStage {}
 pub struct SceneProxyStage;
 impl ParentPositionSyncStage for SceneProxyStage {}
 
+#[allow(clippy::type_complexity)]
 pub fn parent_position_sync<T: ParentPositionSyncStage>(
     mut commands: Commands,
     syncees: Query<(
@@ -303,25 +328,82 @@ pub fn parent_position_sync<T: ParentPositionSyncStage>(
         &ParentPositionSync<T>,
         &ChildOf,
         Option<&VisibilityComponent>,
+        Option<(&SceneEntity, &Transform)>,
     )>,
     globals: Query<&GlobalTransform>,
     gt_helper: TransformHelperPub,
     inherited_visibility: Query<&InheritedVisibility>,
+    mut contexts: Query<&mut RendererSceneContext>,
+    mut buf: Local<Vec<u8>>,
 ) {
-    for (ent, sync, parent, maybe_explicit_visibility) in syncees.iter() {
+    for (ent, sync, parent, maybe_explicit_visibility, maybe_scene_entity) in syncees.iter() {
         let Ok(parent_transform) = globals.get(parent.parent()) else {
             continue;
         };
 
-        let Ok(gt) = gt_helper.compute_global_transform(sync.0, None) else {
+        let Ok(gt) = gt_helper.compute_global_transform(sync.sync_to, None) else {
             continue;
         };
 
         let transform = gt.reparented_to(parent_transform);
+
+        // write the synced transform back to the owning scene, so it can read
+        // the anchor pose. the value is relative to the translation target
+        // (the attached player's root), matching unity and the sdk
+        // world-transform helpers which compose
+        // `player transform * entity transform` for entities with
+        // AvatarAttach: rotation is made relative to the target, but the
+        // translation delta is deliberately NOT rotated into the target's
+        // frame - that's what unity writes, and scenes in the wild correct
+        // for exactly that. scale and the declared parent are passed through
+        // unchanged.
+        if let (Some(target), Some((scene_entity, current_transform))) =
+            (sync.translation_target, maybe_scene_entity)
+        {
+            if let (Ok(target_gt), Ok(mut context)) = (
+                gt_helper.compute_global_transform(target, None),
+                contexts.get_mut(scene_entity.root),
+            ) {
+                let (_, anchor_rotation, anchor_translation) = gt.to_scale_rotation_translation();
+                let (_, target_rotation, target_translation) =
+                    target_gt.to_scale_rotation_translation();
+
+                let parent_id = context
+                    .crdt_store
+                    .get(
+                        SceneComponentId::TRANSFORM,
+                        CrdtType::LWW_ENT,
+                        scene_entity.id,
+                    )
+                    .and_then(|data| {
+                        DclTransformAndParent::from_reader(&mut DclReader::new(data)).ok()
+                    })
+                    .map(|t| t.parent)
+                    .unwrap_or(SceneEntityId::ROOT);
+
+                let dcl_transform = DclTransformAndParent::from_bevy_transform_and_parent(
+                    &Transform {
+                        translation: anchor_translation - target_translation,
+                        rotation: target_rotation.inverse() * anchor_rotation,
+                        scale: current_transform.scale,
+                    },
+                    parent_id,
+                );
+
+                buf.clear();
+                DclWriter::new(&mut buf).write(&dcl_transform);
+                context.crdt_store.update_if_different(
+                    SceneComponentId::TRANSFORM,
+                    CrdtType::LWW_ENT,
+                    scene_entity.id,
+                    Some(&mut DclReader::new(&buf)),
+                );
+            }
+        }
         let maybe_override_visibility = if maybe_explicit_visibility.is_some() {
             None
         } else {
-            let inherited_visibility = inherited_visibility.get(sync.0).unwrap();
+            let inherited_visibility = inherited_visibility.get(sync.sync_to).unwrap();
 
             Some(match inherited_visibility.get() {
                 true => Visibility::Visible,


### PR DESCRIPTION
Unity-explorer writes each `AvatarAttach`'d entity's transform back into the scene CRDT every frame (`AvatarAttachHandlerSystem.UpdateAvatarAttachedEntitySDKTransform`): rotation relative to the player root, translation as the **unrotated** world-axis delta from the player root, scale and declared parent passed through. The SDK's world-transform helpers assume a renderer-written value (`getWorldTransform` composes `player ∘ stored` for attached entities, ignoring the declared parent), and scenes in the wild read anchor poses through this — e.g. Genesis Plaza's fishing line derives the rod-tip position from the right-hand attach root (complete with a workaround that inverts unity's unrotated delta). Bevy wrote nothing back, so the scene read the identity transform it created and the line connected to the player's feet.

This adds `translation_target: Option<Entity>` to `ParentPositionSync`. When set, `parent_position_sync` writes the transform it just computed back to the owning scene's CRDT, relative to the target, matching unity's convention — including deliberately *not* rotating the positional delta into the target's frame, since existing content corrects for exactly that quirk. Avatar attachments pass the attached player's root as the target; the scene proxies don't set one (player/camera transforms are already written by `send_scene_updates`, so this also gates the write-back).

One divergence from unity: for `avatarId` attachments to other players, the delta is relative to *that* player's root, where unity always uses the main player. The SDK helper composes with the target player (`findPlayerTransform(avatarId)`), so unity's choice looks like an oversight rather than intent.

Longer-term, the convention itself deserves a protocol conversation: the SDK helper rotates the stored position by the player rotation, so unity's unrotated delta means `getWorldPosition` returns wrong values for attached entities on every client, and scenes carry inversion workarounds. Aligning unity + the SDK helper (and then deleting scene workarounds) would let this become a plain player-relative local transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)