### PR TITLE
Add ?guest=1 and ?hud=0 flags for embedded scene previews

### DIFF
--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -45,6 +45,12 @@ const params = new URLSearchParams(location.search)
 // ENGINE (default): real engine in a same-origin iframe + super-user bridge scene.
 const MODE: 'mock' | 'engine' = params.get('mock') === '1' ? 'mock' : 'engine'
 const SHOWCASE = params.get('showcase') === '1'
+// Embedded mode (?hud=0): render ONLY the engine — no React HUD at all (no
+// sidebar, chat, pointer, panels, or the sign-in / loading overlays). Used by
+// the sites `/discover` embed, which frames the scene itself and supplies its
+// own chrome. Pair with ?guest=1 (auto guest-login) so the engine still enters
+// the world without the — now hidden — sign-in screen.
+const HIDE_HUD = params.get('hud') === '0'
 // Gate: don't mount the HUD/engine where the engine can't run — mobile (no WebGPU/SharedArrayBuffer)
 // or a non-Chromium desktop browser (the engine bundle renders its own "Browser Not Supported" page
 // there — see deploy/web/index.html — which the HUD would otherwise cover, leaving login frozen at
@@ -141,6 +147,23 @@ function Hud(): React.JSX.Element {
   // A full-screen MainMenuShell page is open (covers the whole HUD).
   const pageOpen =
     session.settings.open || session.backpack.open || session.communities.open || session.map.open || session.places.open || session.gallery.open
+
+  // Embedded mode: mount only the engine (+ the fatal-error surface so a crash
+  // isn't silently blank). No sidebar / chat / pointer / panels / sign-in UI.
+  if (HIDE_HUD) {
+    return (
+      <SessionProvider value={session}>
+        {rpc && <EngineHost rpc={rpc} />}
+        {session.fatalError && (
+          <EngineErrorModal
+            error={session.fatalError}
+            onReload={session.reload}
+            onDismiss={session.fatalError.source === 'runtime' || session.fatalError.source === 'realm' ? session.dismissFatal : undefined}
+          />
+        )}
+      </SessionProvider>
+    )
+  }
 
   return (
     <SessionProvider value={session}>

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -945,6 +945,18 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     setStatus('sign-in-or-guest')
   }, [busy])
 
+  // Embedded guest auto-login (?guest=1): skip the sign-in screen entirely and
+  // enter as a guest the moment the engine is warm. Used by the sites `/discover`
+  // embed, which shows the scene as a guest preview with no sign-in UI. The URL
+  // destination (?position / ?realm) is auto-picked by the effect above, so this
+  // takes the guest straight into the scene. Fires once — `submitted` flips true
+  // on the first call and gates re-entry.
+  const autoGuest = useRef(new URLSearchParams(location.search).get('guest') === '1')
+  useEffect(() => {
+    if (!autoGuest.current || !engineReady || submitted) return
+    exploreAsGuest()
+  }, [engineReady, submitted, exploreAsGuest])
+
   // Render-settle. When the scene flips from loading → loaded (visible true→false), hold the loader
   // a beat longer while the engine actually renders the world (compiling shaders / uploading
   // textures) — otherwise it's revealed as black models. Gated on the engine's `renderBusy` probe

--- a/react-web/src/test/session.test.tsx
+++ b/react-web/src/test/session.test.tsx
@@ -250,3 +250,34 @@ describe('session domain', () => {
     expect(h.session().chat.pendingMention).toBeNull()
   })
 })
+
+// DOMAIN: embedded mode — the sites `/discover` embed loads bevy-web with
+// ?guest=1 (auto guest-login, no sign-in screen) and ?hud=0 (no React HUD).
+// ?hud=0 is a pure App.tsx render gate; the auto-guest flow lives in the hook.
+describe('embedded auto-guest (?guest=1)', () => {
+  afterEach(() => window.history.replaceState(null, '', '/'))
+
+  it('skips the sign-in screen and enters as a guest without any manual action', async () => {
+    window.history.replaceState(null, '', '/?guest=1')
+    const h = renderSession({ userId: null })
+    // No exploreAsGuest() call in the test — the flag alone drives it. With no
+    // URL destination it lands on the picker (a positioned embed skips that too).
+    await waitFor(() => expect(h.session().phase).toBe('picking'))
+  })
+
+  it('with a ?position, drives a guest straight into the world', async () => {
+    window.history.replaceState(null, '', '/?guest=1&position=10,20')
+    const h = renderSession({ userId: null })
+    await waitFor(() => expect(h.session().phase).toBe('entering'))
+    // The deferred login runs a paint after the pick, so wait for the call.
+    await waitFor(() => expect(h.driver.calls).toContain('loginGuest'))
+    h.driver.emit({ kind: 'event', name: 'playerReady' })
+    await waitFor(() => expect(h.session().phase).toBe('world'))
+  })
+
+  it('does not auto-login without the flag (normal sign-in screen)', async () => {
+    const h = renderSession({ userId: null })
+    await waitFor(() => expect(h.session().login.status).toBe('sign-in-or-guest'))
+    expect(h.session().phase).toBe('login')
+  })
+})


### PR DESCRIPTION
Adds two independent, default-off URL-param flags to react-web for chrome-less guest scene previews (used by the sites /discover scene watcher, which frames the scene itself):

- ?guest=1 — auto guest-login: an effect in useEngineSession calls exploreAsGuest() once the engine is warm, so the login flow completes headlessly (no sign-in screen). With the existing ?position/?realm auto-pick, a guest goes straight into the scene.
- ?hud=0 — hide the entire React HUD: App's Hud early-returns just the engine + fatal-error surface (no sidebar, chat, pointer, panels, sign-in, or loading overlays).

The sites embed pairs both flags. ?hud=0 alone would leave the engine at a login it can't show; documented inline.

How to test: cd react-web && npm test — 3 new cases in session.test.tsx (guest auto-advance; ?guest=1&position -> world; no flag -> normal sign-in). Full suite 41 files / 229 tests pass.