### PR TITLE
Generate TypeScript types for the system-api boundary with ts-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,10 @@ jobs:
       - name: Install
         run: npm i
         working-directory: deploy/web
+      # react-web/src/engine/generated (TS types the HUD + bridge scene import) is generated
+      # from the Rust system-api structs and gitignored — regenerate before building.
+      - name: Generate TS bindings
+        run: ./scripts/gen-ts-bindings.sh
       # The React HUD is the production page: build it into deploy/web root (vite outDir).
       # PUBLIC_URL = the versioned CDN base prebuild.js just wrote into package.json homepage —
       # index.html asset refs must be ABSOLUTE because the entry URL (decentraland.zone/bevy-web)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,8 @@ jobs:
           echo "PUBLIC_URL=$PUBLIC_URL"
           npm ci --prefix react-web
           npm run build --prefix react-web
+      - name: react-web unit tests
+        run: npm run test --prefix react-web
       # The headless bridge scene the engine loads as its --ui systemScene. The realm (about) is
       # served same-origin with the engine iframe, but the scene CONTENT baseUrl is baked at
       # export — point it at the versioned CDN path so it's version-pinned + immutable and never

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -84,6 +84,16 @@ jobs:
           - uses: actions/setup-node@v4
             with:
                 node-version: 20
+          # moved up from below the CEF export: the TS-bindings build compiles the bevy dep
+          # graph (gilrs needs libudev) before the HUD bundle can build.
+          - name: Install alsa and udev
+            if: runner.os == 'linux'
+            run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+          # react-web/src/engine/generated (TS types the HUD + bridge scene import) is generated
+          # from the Rust system-api structs and gitignored — regenerate before bundling.
+          - name: Generate TS bindings
+            run: ./scripts/gen-ts-bindings.sh
+            shell: bash
           - name: Bundle react HUD (page + bridge scene -> assets/)
             run: |
                 cd react-web && npm ci
@@ -110,9 +120,6 @@ jobs:
                 fi
             shell: bash
 
-          - name: Install alsa and udev
-            if: runner.os == 'linux'
-            run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
           - name: install livekit deps
             if: runner.os == 'linux'
             run: sudo apt update -y; sudo apt install -y libssl-dev libx11-dev libgl1-mesa-dev libxext-dev fuse libfuse2t64

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ config.json
 /react-web/bridge-scene/static-native
 assets/react-hud/
 /assets/bridge-scene
+# ts-rs default export dir, written when the export_bindings tests run without
+# TS_RS_EXPORT_DIR (plain `cargo test`); the real output is scripts/gen-ts-bindings.sh's
+/crates/system_api_types/bindings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,6 +2708,7 @@ dependencies = [
  "smallvec",
  "strum 0.27.2",
  "strum_macros 0.27.2",
+ "system_api_types",
  "tokio",
  "tokio-util",
  "url",
@@ -3424,6 +3425,7 @@ dependencies = [
  "prost-reflect",
  "serde",
  "serde_json",
+ "ts-rs",
 ]
 
 [[package]]
@@ -10746,6 +10748,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system_api_types"
+version = "0.1.0"
+dependencies = [
+ "dcl_component",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "ts-rs",
+]
+
+[[package]]
 name = "system_bridge"
 version = "0.1.0"
 dependencies = [
@@ -10762,6 +10777,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "system_api_types",
  "tokio",
  "urlencoding",
  "wasm-bindgen",
@@ -11475,6 +11491,29 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ts-rs"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
+dependencies = [
+ "serde_json",
+ "thiserror 2.0.18",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
+]
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ collectibles = { path = "crates/collectibles" }
 social = { path = "crates/social" }
 imposters = { path = "crates/imposters" }
 system_bridge = { path = "crates/system_bridge" }
+system_api_types = { path = "crates/system_api_types" }
 scene_inspector = { path = "crates/scene_inspector" }
 texture_camera = { path = "crates/texture_camera" }
 platform = { path = "crates/platform" }
@@ -149,6 +150,7 @@ naga_oil = { version = "0.17", default-features = false, features = [
 ] }
 serde = "1.0.152"
 serde_json = { version = "1.0.92", features = ["raw_value"] }
+ts-rs = "12"
 
 itertools = "0.14"
 tokio = { version = "1.44", features = ["sync", "macros", "rt"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -11,6 +11,7 @@ dcl-assert = []
 [dependencies]
 platform = { workspace = true }
 dcl_component = { workspace = true }
+system_api_types = { workspace = true }
 
 bevy = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -16,7 +16,7 @@ use bevy::{
 use dcl_component::proto_components::sdk::components::common::CameraTransition;
 use ethers_core::abi::Address;
 use serde::{Deserialize, Serialize};
-use strum_macros::EnumIter;
+pub use system_api_types::{PermissionLevel, PermissionType, PermissionValue, PointerTargetType};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::inputs::InputMapSerialized;
@@ -382,29 +382,6 @@ pub struct HeadSync {
     pub pitch_deg: f32,
     pub yaw_enabled: bool,
     pub pitch_enabled: bool,
-}
-
-/// Classifier for pointer-target hits — distinguishes scene world geometry,
-/// scene UI overlays, and avatars. Lives here (not in system_bridge) because
-/// the engine's pointer pipeline produces it before any scene API surface is
-/// involved; system_bridge re-exports the same value into its HoverEvent.
-#[derive(
-    Hash,
-    Clone,
-    Copy,
-    serde_repr::Serialize_repr,
-    serde_repr::Deserialize_repr,
-    Debug,
-    PartialEq,
-    Eq,
-    Default,
-)]
-#[repr(u32)]
-pub enum PointerTargetType {
-    #[default]
-    World = 0,
-    Ui = 1,
-    Avatar = 2,
 }
 
 /// World-space point-at state. On the local player, populated when the PointAt
@@ -877,32 +854,6 @@ pub struct SceneMeta {
     pub authoritative_multiplayer: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum PermissionValue {
-    Allow,
-    Deny,
-    Ask,
-}
-
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug, EnumIter)]
-pub enum PermissionType {
-    MovePlayer,
-    ForceCamera,
-    PlayEmote,
-    SetLocomotion,
-    HideAvatarsNametags,
-    DisableVoice,
-    Teleport,
-    ChangeRealm,
-    SpawnPortable,
-    KillPortables,
-    Web3,
-    CopyToClipboard,
-    Fetch,
-    Websocket,
-    OpenUrl,
-}
-
 pub trait PermissionStrings {
     fn active(&self) -> &str;
     fn passive(&self) -> &str;
@@ -1015,13 +966,6 @@ impl PermissionStrings for PermissionType {
             PermissionType::CopyToClipboard => "copying text into the clipboard",
         }
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum PermissionLevel {
-    Scene(String),
-    Realm(String),
-    Global,
 }
 
 #[derive(Clone, Serialize, Deserialize, Event)]

--- a/crates/dcl/src/js/modules/SystemApi.js
+++ b/crates/dcl/src/js/modules/SystemApi.js
@@ -118,7 +118,7 @@ module.exports.kernelFetch = async function (body) {
 // }
 // => deployed version
 module.exports.setAvatar = async function(avatar) {
-    return await Deno.core.ops.op_set_avatar(avatar.base, avatar.equip, avatar.hasClaimedName, avatar.profileExtras, avatar.nameColor)
+    return await Deno.core.ops.op_set_avatar(avatar)
 }
 
 module.exports.getProfileExtras = async function() {

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -246,7 +246,7 @@ pub async fn op_set_avatar(
                 equip,
                 has_claimed_name,
                 profile_extras,
-                name_color: name_color.map(ClearableColor3::to_color3),
+                name_color,
             },
             sx,
         ))?;

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -8,10 +8,7 @@ use common::{
         PermissionValue,
     },
 };
-use dcl_component::proto_components::{
-    common::Vector2,
-    sdk::components::{PbAvatarBase, PbAvatarEquippedData},
-};
+use dcl_component::proto_components::common::Vector2;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::{cell::RefCell, rc::Rc};
@@ -24,7 +21,7 @@ use system_bridge::{
     SetPermanentPermission, SetSinglePermission, SystemApi, VoiceMessage,
 };
 
-use crate::{interface::crdt_context::CrdtContext, js::player_identity, ClearableColor3, RpcCalls};
+use crate::{interface::crdt_context::CrdtContext, js::player_identity, RpcCalls};
 
 use super::{State, SuperUserScene};
 
@@ -229,27 +226,14 @@ pub async fn op_kernel_fetch_headers(
 
 pub async fn op_set_avatar(
     state: Rc<RefCell<impl State>>,
-    base: Option<PbAvatarBase>,
-    equip: Option<PbAvatarEquippedData>,
-    has_claimed_name: Option<bool>,
-    profile_extras: Option<std::collections::HashMap<String, serde_json::Value>>,
-    name_color: Option<ClearableColor3>,
+    avatar: SetAvatarData,
 ) -> Result<u32, anyhow::Error> {
     let (sx, rx) = RpcResultSender::channel();
 
     state
         .borrow_mut()
         .borrow_mut::<SuperUserScene>()
-        .send(SystemApi::SetAvatar(
-            SetAvatarData {
-                base,
-                equip,
-                has_claimed_name,
-                profile_extras,
-                name_color,
-            },
-            sx,
-        ))?;
+        .send(SystemApi::SetAvatar(avatar, sx))?;
 
     rx.await?.map_err(|e| anyhow::anyhow!(e))
 }

--- a/crates/dcl/src/lib.rs
+++ b/crates/dcl/src/lib.rs
@@ -1,8 +1,9 @@
 use bevy::{platform::collections::HashSet, prelude::Entity};
 use common::rpc::{CompareSnapshot, RpcCall};
 
-use dcl_component::{proto_components::common::Color3, SceneComponentId, SceneEntityId};
+use dcl_component::{SceneComponentId, SceneEntityId};
 use serde::{Deserialize, Serialize};
+pub use system_bridge::ClearableColor3;
 
 use self::interface::{CrdtComponentInterfaces, CrdtStore};
 
@@ -103,26 +104,4 @@ pub struct SceneLogMessage {
     pub timestamp: f64, // scene local time
     pub level: SceneLogLevel,
     pub message: String,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct ClearableColor3 {
-    pub r: f32,
-    pub g: f32,
-    pub b: f32,
-    pub clear: bool,
-}
-
-impl ClearableColor3 {
-    pub fn to_color3(self) -> Option<Color3> {
-        if self.clear {
-            None
-        } else {
-            Some(Color3 {
-                r: self.r,
-                g: self.g,
-                b: self.b,
-            })
-        }
-    }
 }

--- a/crates/dcl_component/Cargo.toml
+++ b/crates/dcl_component/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 dcl-rpc = { workspace = true, optional = true }
 async-trait = { workspace = true }
+ts-rs = { workspace = true }
 
 [build-dependencies]
 prost-build = "0.11.8"

--- a/crates/dcl_component/build.rs
+++ b/crates/dcl_component/build.rs
@@ -110,6 +110,22 @@ fn gen_sdk_components() -> Result<()> {
         );
     }
 
+    // ts-rs: inject `#[derive(ts_rs::TS)]` on exactly the proto types the system-api boundary
+    // embeds (and their transitive fields), so system_api_types can export TypeScript for them.
+    // Proto enum fields are stored as i32 by prost, so the enums themselves need no derive.
+    let ts_components = [
+        "Color3",
+        "Vector2",
+        "Vector3",
+        "PBAvatarBase",
+        "PBAvatarEquippedData",
+        "PBPointerEvents.Entry",
+        "PBPointerEvents.Info",
+    ];
+    for component in ts_components {
+        config.type_attribute(component, "#[derive(ts_rs::TS)]");
+    }
+
     let hash_components = [
         "PBMaterial",
         "GltfMaterial",

--- a/crates/dcl_deno/src/js/op_wrappers/system_api.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/system_api.rs
@@ -2,14 +2,8 @@ use common::{
     inputs::SystemActionEvent,
     structs::{MicState, PermissionType, PermissionUsed, PermissionValue},
 };
-use dcl::{
-    js::system_api::{JsBindingsData, PermissionTypeDetail},
-    ClearableColor3,
-};
-use dcl_component::proto_components::{
-    common::Vector2,
-    sdk::components::{PbAvatarBase, PbAvatarEquippedData},
-};
+use dcl::js::system_api::{JsBindingsData, PermissionTypeDetail};
+use dcl_component::proto_components::common::Vector2;
 use deno_core::{anyhow, error::AnyError, op2, OpDecl, OpState};
 use std::collections::HashMap;
 use std::{cell::RefCell, rc::Rc};
@@ -17,7 +11,8 @@ use system_bridge::{
     settings::SettingInfo, AvatarModifierState, BlockUpdateData, BlockedUserData,
     BlockingStatusData, ChatMessage, FriendConnectivityEvent, FriendData, FriendRequestData,
     FriendStatusData, FriendshipEventUpdate, HomeScene, HoverEvent, LiveSceneInfo,
-    PermanentPermissionItem, PermissionRequest, ProximityEvent, SceneLoadingUi, VoiceMessage,
+    PermanentPermissionItem, PermissionRequest, ProximityEvent, SceneLoadingUi, SetAvatarData,
+    VoiceMessage,
 };
 
 // list of op declarations
@@ -192,21 +187,9 @@ pub async fn op_kernel_fetch_headers(
 #[op2(async)]
 pub async fn op_set_avatar(
     state: Rc<RefCell<OpState>>,
-    #[serde] base: Option<PbAvatarBase>,
-    #[serde] equip: Option<PbAvatarEquippedData>,
-    has_claimed_name: Option<bool>,
-    #[serde] profile_extras: Option<std::collections::HashMap<String, serde_json::Value>>,
-    #[serde] name_color: Option<ClearableColor3>,
+    #[serde] avatar: SetAvatarData,
 ) -> Result<u32, anyhow::Error> {
-    dcl::js::system_api::op_set_avatar(
-        state,
-        base,
-        equip,
-        has_claimed_name,
-        profile_extras,
-        name_color,
-    )
-    .await
+    dcl::js::system_api::op_set_avatar(state, avatar).await
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
@@ -104,28 +104,14 @@ pub async fn op_kernel_fetch_headers(
 }
 
 #[wasm_bindgen]
-pub async fn op_set_avatar(
-    state: &WorkerContext,
-    base: JsValue,
-    equip: JsValue,
-    has_claimed_name: Option<bool>,
-    profile_extras: JsValue,
-    name_color: JsValue,
-) -> Result<u32, WasmError> {
-    serde_parse!(base);
-    serde_parse!(equip);
-    serde_parse!(profile_extras);
-    serde_parse!(name_color);
-    dcl::js::system_api::op_set_avatar(
-        state.rc(),
-        base,
-        equip,
-        has_claimed_name,
-        profile_extras,
-        name_color,
-    )
-    .await
-    .map_err(WasmError::from)
+pub async fn op_set_avatar(state: &WorkerContext, avatar: JsValue) -> Result<u32, WasmError> {
+    // map_err rather than serde_parse!'s unwrap: with deny_unknown_fields a caller mistake
+    // must surface as a catchable JS error, not a worker panic.
+    let avatar = serde_wasm_bindgen::from_value(avatar)
+        .map_err(|e| WasmError::from(anyhow::anyhow!("setAvatar: {e}")))?;
+    dcl::js::system_api::op_set_avatar(state.rc(), avatar)
+        .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -1888,7 +1888,7 @@ fn handle_proximity_stream(
             cand.entity,
             ProximityEvent {
                 entered: true,
-                entity: cand.entity.to_bits(),
+                entity: cand.entity.index(),
                 entity_position: Vector3::world_vec_from_vec3(&cand.entity_position),
                 actions,
             },

--- a/crates/system_api_types/Cargo.toml
+++ b/crates/system_api_types/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "system_api_types"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+serde_repr = "0.1"
+strum = { workspace = true }
+strum_macros = { workspace = true }
+dcl_component = { workspace = true }
+
+ts-rs = { workspace = true, features = ["serde-json-impl"] }

--- a/crates/system_api_types/src/lib.rs
+++ b/crates/system_api_types/src/lib.rs
@@ -1,0 +1,389 @@
+//! Plain serde data structs that cross the `~system/BevyExplorerApi` boundary.
+//!
+//! Split out of `system_bridge` so they can be compiled without bevy and fed to
+//! `ts-rs` (scripts/gen-ts-bindings.sh) to generate the TypeScript the react-web
+//! page and bridge scene consume. `system_bridge` re-exports everything here.
+
+use dcl_component::proto_components::{
+    common::{Color3, Vector2, Vector3},
+    sdk::components::{pb_pointer_events, PbAvatarBase, PbAvatarEquippedData},
+};
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
+
+/// A Color3 with a `clear` flag, distinguishing "set this color" from "clear the
+/// stored color" while remaining representable in JSON (where an absent field
+/// already means "leave unchanged").
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ts_rs::TS)]
+pub struct ClearableColor3 {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub clear: bool,
+}
+
+impl ClearableColor3 {
+    pub fn to_color3(self) -> Option<Color3> {
+        if self.clear {
+            None
+        } else {
+            Some(Color3 {
+                r: self.r,
+                g: self.g,
+                b: self.b,
+            })
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ts_rs::TS)]
+#[ts(export)]
+pub struct SetAvatarData {
+    pub base: Option<PbAvatarBase>,
+    pub equip: Option<PbAvatarEquippedData>,
+    pub has_claimed_name: Option<bool>,
+    pub profile_extras: Option<std::collections::HashMap<String, serde_json::Value>>,
+    pub name_color: Option<ClearableColor3>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct LiveSceneInfo {
+    pub hash: String,
+    pub base_url: Option<String>,
+    pub title: String,
+    pub parcels: Vec<Vector2>,
+    pub is_portable: bool,
+    pub is_broken: bool,
+    pub is_blocked: bool,
+    pub is_super: bool,
+    pub sdk_version: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, ts_rs::TS)]
+#[ts(export)]
+pub struct HomeScene {
+    pub realm: String,
+    pub parcel: Vector2,
+}
+
+#[derive(Clone, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export)]
+pub struct ChatMessage {
+    pub sender_address: String,
+    pub message: String,
+    pub channel: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export)]
+pub struct VoiceMessage {
+    pub sender_address: String,
+    pub channel: String,
+    pub active: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct HoverAction {
+    #[serde(flatten)]
+    pub event: pb_pointer_events::Entry,
+    pub enabled: bool,
+}
+
+/// Classifier for pointer-target hits — distinguishes scene world geometry,
+/// scene UI overlays, and avatars. The engine's pointer pipeline produces it
+/// before any scene API surface is involved; `common::structs` re-exports it
+/// for engine use, and `HoverEvent` carries the same value across the
+/// system-api boundary.
+#[derive(
+    Hash,
+    Clone,
+    Copy,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    Debug,
+    PartialEq,
+    Eq,
+    Default,
+)]
+#[repr(u32)]
+pub enum PointerTargetType {
+    #[default]
+    World = 0,
+    Ui = 1,
+    Avatar = 2,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct HoverEvent {
+    pub entered: bool,
+    #[ts(type = "number")]
+    pub target_type: PointerTargetType,
+    pub actions: Vec<HoverAction>,
+}
+
+/// Streamed to the system scene whenever an entity carrying PROXIMITY pointer
+/// entries enters or leaves the avatar's interaction range, or when one of its
+/// per-entry distance gates flips (so the `enabled` flag on an action changes).
+/// `entity` is an opaque session-stable identifier so the scene can match
+/// enter/leave pairs. `entity_position` is the world-space AABB centre of the
+/// specific collider on the entity that produced the closest-point hit — for
+/// multi-collider entities (e.g. GltfContainers) this anchors UI on the part
+/// of the entity the player is actually nearest. The scene is responsible for
+/// projecting it to screen space per frame; the active camera's vertical FOV
+/// is available via `Runtime.getCameraFov`.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct ProximityEvent {
+    pub entered: bool,
+    pub entity: u32,
+    pub entity_position: Vector3,
+    pub actions: Vec<HoverAction>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct SceneLoadingUi {
+    pub visible: bool,
+    pub realm_connected: bool,
+    pub title: String,
+    pub pending_assets: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct AvatarModifierState {
+    pub user_id: String,
+    pub hide_avatar: bool,
+    pub hide_profile: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct NameColor {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct FriendData {
+    pub address: String,
+    pub name: String,
+    pub has_claimed_name: bool,
+    pub profile_picture_url: String,
+    pub name_color: Option<NameColor>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct FriendRequestData {
+    pub address: String,
+    pub name: String,
+    pub has_claimed_name: bool,
+    pub profile_picture_url: String,
+    pub name_color: Option<NameColor>,
+    #[ts(type = "number")]
+    pub created_at: i64,
+    pub message: Option<String>,
+    pub id: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all_fields = "camelCase")]
+#[serde(tag = "type")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub enum FriendshipEventUpdate {
+    #[serde(rename = "request")]
+    Request {
+        address: String,
+        name: String,
+        has_claimed_name: bool,
+        profile_picture_url: String,
+        name_color: Option<NameColor>,
+        #[ts(type = "number")]
+        created_at: i64,
+        message: Option<String>,
+        id: String,
+    },
+    #[serde(rename = "accept")]
+    Accept { address: String },
+    #[serde(rename = "reject")]
+    Reject { address: String },
+    #[serde(rename = "cancel")]
+    Cancel { address: String },
+    #[serde(rename = "delete")]
+    Delete { address: String },
+    #[serde(rename = "block")]
+    Block { address: String },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct FriendStatusData {
+    pub address: String,
+    pub name: String,
+    pub has_claimed_name: bool,
+    pub profile_picture_url: String,
+    pub name_color: Option<NameColor>,
+    /// "online", "offline", or "away"
+    pub status: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct BlockedUserData {
+    pub address: String,
+    pub name: String,
+    pub has_claimed_name: bool,
+    pub profile_picture_url: String,
+    pub name_color: Option<NameColor>,
+}
+
+/// Both directions of the blocking relationship for the local user,
+/// addresses only (no profiles).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct BlockingStatusData {
+    pub blocked_users: Vec<String>,
+    pub blocked_by_users: Vec<String>,
+}
+
+/// Emitted when another user blocks / unblocks the local user.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct BlockUpdateData {
+    pub address: String,
+    pub is_blocked: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct FriendConnectivityEvent {
+    pub address: String,
+    pub name: String,
+    pub has_claimed_name: bool,
+    pub profile_picture_url: String,
+    pub name_color: Option<NameColor>,
+    /// "online", "offline", or "away"
+    pub status: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug, ts_rs::TS)]
+pub enum PermissionValue {
+    Allow,
+    Deny,
+    Ask,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug, EnumIter, ts_rs::TS)]
+pub enum PermissionType {
+    MovePlayer,
+    ForceCamera,
+    PlayEmote,
+    SetLocomotion,
+    HideAvatarsNametags,
+    DisableVoice,
+    Teleport,
+    ChangeRealm,
+    SpawnPortable,
+    KillPortables,
+    Web3,
+    CopyToClipboard,
+    Fetch,
+    Websocket,
+    OpenUrl,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, ts_rs::TS)]
+pub enum PermissionLevel {
+    Scene(String),
+    Realm(String),
+    Global,
+}
+
+#[derive(Serialize, Deserialize, Clone, ts_rs::TS)]
+#[ts(export)]
+pub struct PermanentPermissionItem {
+    pub ty: PermissionType,
+    pub allow: PermissionValue,
+}
+
+#[derive(Clone, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export)]
+pub struct PermissionRequest {
+    pub ty: PermissionType,
+    pub additional: Option<String>,
+    pub scene: String,
+    pub id: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export)]
+pub struct SetSinglePermission {
+    pub id: usize,
+    pub allow: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export)]
+pub struct SetPermanentPermission {
+    pub ty: PermissionType,
+    pub level: PermissionLevel,
+    pub allow: Option<PermissionValue>,
+}
+
+#[derive(Serialize, Deserialize, Clone, ts_rs::TS)]
+#[ts(export)]
+pub struct NamedVariant {
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+#[derive(ts_rs::TS)]
+#[ts(export)]
+pub struct SettingInfo {
+    pub name: String,
+    pub category: String,
+    pub description: String,
+    pub min_value: f32,
+    pub max_value: f32,
+    pub named_variants: Vec<NamedVariant>,
+    pub step_size: f32,
+    pub value: f32,
+    pub default: f32,
+}

--- a/crates/system_api_types/src/lib.rs
+++ b/crates/system_api_types/src/lib.rs
@@ -37,12 +37,18 @@ impl ClearableColor3 {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ts_rs::TS)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[ts(export)]
 pub struct SetAvatarData {
+    #[ts(optional)]
     pub base: Option<PbAvatarBase>,
+    #[ts(optional)]
     pub equip: Option<PbAvatarEquippedData>,
+    #[ts(optional)]
     pub has_claimed_name: Option<bool>,
+    #[ts(optional)]
     pub profile_extras: Option<std::collections::HashMap<String, serde_json::Value>>,
+    #[ts(optional)]
     pub name_color: Option<ClearableColor3>,
 }
 

--- a/crates/system_bridge/Cargo.toml
+++ b/crates/system_bridge/Cargo.toml
@@ -22,6 +22,7 @@ ipfs = { workspace = true }
 serde_json = { workspace = true }
 dcl_component = { workspace = true }
 platform = { workspace = true }
+system_api_types = { workspace = true }
 
 serde_repr = "0.1"
 urlencoding = { workspace = true }

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -15,19 +15,11 @@ use bevy_console::{ConsoleCommandEntered, ConsoleConfiguration, ConsoleResponder
 use common::{
     inputs::{BindingsData, InputIdentifier, SystemActionEvent},
     rpc::{RpcResultSender, RpcStreamSender},
-    structs::{
-        AppConfig, MicState, PermissionLevel, PermissionType, PermissionUsed, PermissionValue,
-        PointerTargetType,
-    },
-};
-use dcl_component::proto_components::{
-    common::{Color3, Vector2, Vector3},
-    sdk::components::{pb_pointer_events, PbAvatarBase, PbAvatarEquippedData},
+    structs::{AppConfig, MicState, PermissionUsed},
 };
 use serde::{Deserialize, Serialize};
 use settings::SettingBridgePlugin;
-
-use crate::settings::SettingInfo;
+pub use system_api_types::*;
 
 pub struct SystemBridgePlugin {
     pub bare: bool,
@@ -55,93 +47,6 @@ impl Plugin for SystemBridgePlugin {
 
         app.add_plugins((SettingBridgePlugin, agent_commands::AgentCommandsPlugin));
     }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SetAvatarData {
-    pub base: Option<PbAvatarBase>,
-    pub equip: Option<PbAvatarEquippedData>,
-    pub has_claimed_name: Option<bool>,
-    pub profile_extras: Option<std::collections::HashMap<String, serde_json::Value>>,
-    pub name_color: Option<Option<Color3>>,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct LiveSceneInfo {
-    pub hash: String,
-    pub base_url: Option<String>,
-    pub title: String,
-    pub parcels: Vec<Vector2>,
-    pub is_portable: bool,
-    pub is_broken: bool,
-    pub is_blocked: bool,
-    pub is_super: bool,
-    pub sdk_version: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct HomeScene {
-    pub realm: String,
-    pub parcel: Vector2,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct ChatMessage {
-    pub sender_address: String,
-    pub message: String,
-    pub channel: String,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct VoiceMessage {
-    pub sender_address: String,
-    pub channel: String,
-    pub active: bool,
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct HoverAction {
-    #[serde(flatten)]
-    pub event: pb_pointer_events::Entry,
-    pub enabled: bool,
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct HoverEvent {
-    pub entered: bool,
-    pub target_type: PointerTargetType,
-    pub actions: Vec<HoverAction>,
-}
-
-/// Streamed to the system scene whenever an entity carrying PROXIMITY pointer
-/// entries enters or leaves the avatar's interaction range, or when one of its
-/// per-entry distance gates flips (so the `enabled` flag on an action changes).
-/// `entity` is an opaque session-stable identifier so the scene can match
-/// enter/leave pairs. `entity_position` is the world-space AABB centre of the
-/// specific collider on the entity that produced the closest-point hit — for
-/// multi-collider entities (e.g. GltfContainers) this anchors UI on the part
-/// of the entity the player is actually nearest. The scene is responsible for
-/// projecting it to screen space per frame; the active camera's vertical FOV
-/// is available via `Runtime.getCameraFov`.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct ProximityEvent {
-    pub entered: bool,
-    pub entity: u64,
-    pub entity_position: Vector3,
-    pub actions: Vec<HoverAction>,
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct SceneLoadingUi {
-    pub visible: bool,
-    pub realm_connected: bool,
-    pub title: String,
-    pub pending_assets: Option<u32>,
 }
 
 /// Prefix on login error strings when the failure was fetching the user's profile —
@@ -230,123 +135,6 @@ pub enum SystemApi {
     GetParams(RpcResultSender<HashMap<String, String>>),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct AvatarModifierState {
-    pub user_id: String,
-    pub hide_avatar: bool,
-    pub hide_profile: bool,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NameColor {
-    pub r: f32,
-    pub g: f32,
-    pub b: f32,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FriendData {
-    pub address: String,
-    pub name: String,
-    pub has_claimed_name: bool,
-    pub profile_picture_url: String,
-    pub name_color: Option<NameColor>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FriendRequestData {
-    pub address: String,
-    pub name: String,
-    pub has_claimed_name: bool,
-    pub profile_picture_url: String,
-    pub name_color: Option<NameColor>,
-    pub created_at: i64,
-    pub message: Option<String>,
-    pub id: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all_fields = "camelCase")]
-#[serde(tag = "type")]
-pub enum FriendshipEventUpdate {
-    #[serde(rename = "request")]
-    Request {
-        address: String,
-        name: String,
-        has_claimed_name: bool,
-        profile_picture_url: String,
-        name_color: Option<NameColor>,
-        created_at: i64,
-        message: Option<String>,
-        id: String,
-    },
-    #[serde(rename = "accept")]
-    Accept { address: String },
-    #[serde(rename = "reject")]
-    Reject { address: String },
-    #[serde(rename = "cancel")]
-    Cancel { address: String },
-    #[serde(rename = "delete")]
-    Delete { address: String },
-    #[serde(rename = "block")]
-    Block { address: String },
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FriendStatusData {
-    pub address: String,
-    pub name: String,
-    pub has_claimed_name: bool,
-    pub profile_picture_url: String,
-    pub name_color: Option<NameColor>,
-    /// "online", "offline", or "away"
-    pub status: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BlockedUserData {
-    pub address: String,
-    pub name: String,
-    pub has_claimed_name: bool,
-    pub profile_picture_url: String,
-    pub name_color: Option<NameColor>,
-}
-
-/// Both directions of the blocking relationship for the local user,
-/// addresses only (no profiles).
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BlockingStatusData {
-    pub blocked_users: Vec<String>,
-    pub blocked_by_users: Vec<String>,
-}
-
-/// Emitted when another user blocks / unblocks the local user.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BlockUpdateData {
-    pub address: String,
-    pub is_blocked: bool,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FriendConnectivityEvent {
-    pub address: String,
-    pub name: String,
-    pub has_claimed_name: bool,
-    pub profile_picture_url: String,
-    pub name_color: Option<NameColor>,
-    /// "online", "offline", or "away"
-    pub status: String,
-}
-
 #[derive(Resource, Default, Clone, Debug)]
 pub struct SceneParams(pub HashMap<String, String>);
 
@@ -371,33 +159,6 @@ impl SceneParams {
             .collect();
         Self(map)
     }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub struct PermanentPermissionItem {
-    pub ty: PermissionType,
-    pub allow: PermissionValue,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct PermissionRequest {
-    pub ty: PermissionType,
-    pub additional: Option<String>,
-    pub scene: String,
-    pub id: usize,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SetSinglePermission {
-    pub id: usize,
-    pub allow: bool,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SetPermanentPermission {
-    pub ty: PermissionType,
-    pub level: PermissionLevel,
-    pub allow: Option<PermissionValue>,
 }
 
 #[derive(Resource)]

--- a/crates/system_bridge/src/settings/mod.rs
+++ b/crates/system_bridge/src/settings/mod.rs
@@ -38,7 +38,6 @@ use max_downloads::MaxDownloadsSetting;
 use oob_setting::OobSetting;
 use player_settings::{JumpSetting, RunSpeedSetting, WalkSpeedSetting};
 use scene_threads::SceneThreadsSetting;
-use serde::{Deserialize, Serialize};
 use shadow_settings::{LightCountSetting, ShadowCasterCountSetting, ShadowDistanceSetting};
 #[cfg(target_arch = "wasm32")]
 use tokio::sync::watch;
@@ -275,25 +274,7 @@ pub trait IntAppSetting: AppSetting + Sized + std::fmt::Debug {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct NamedVariant {
-    name: String,
-    description: String,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct SettingInfo {
-    pub name: String,
-    pub category: String,
-    pub description: String,
-    pub min_value: f32,
-    pub max_value: f32,
-    pub named_variants: Vec<NamedVariant>,
-    pub step_size: f32,
-    pub value: f32,
-    pub default: f32,
-}
+pub use system_api_types::{NamedVariant, SettingInfo};
 
 pub struct Setting {
     pub info: SettingInfo,

--- a/crates/system_ui/src/profile.rs
+++ b/crates/system_ui/src/profile.rs
@@ -511,7 +511,7 @@ fn process_profile(
         }
 
         if let Some(name_color) = set_avatar.name_color {
-            profile.content.name_color = name_color;
+            profile.content.name_color = name_color.to_color3();
         }
 
         profile.version += 1;

--- a/justfile
+++ b/justfile
@@ -9,8 +9,14 @@ wasm:
     WASM_SIZE=$(wc -c < ./deploy/web/engine/pkg/webgpu_build_bg.wasm) && echo "{\"wasmSize\":${WASM_SIZE}}" > ./deploy/web/engine/pkg/manifest.json
     cd react-web && npm run dev -- --open
 
-# bundle the react HUD page + bridge scene into assets/ (the files native runs from)
-bundle-native:
+# regenerate the TypeScript bindings for the ~system/BevyExplorerApi boundary from the Rust
+# structs in crates/system_api_types, into react-web/src/engine/generated (+ a barrel index.ts).
+ts-bindings:
+    {{justfile_directory()}}/scripts/gen-ts-bindings.sh
+
+# bundle the react HUD page + bridge scene into assets/ (the files native runs from).
+# ts-bindings first so the TS the page + bridge scene import is regenerated from the Rust structs.
+bundle-native: ts-bindings
     cd react-web && npm run bundle:native
     mkdir -p target && touch target/.bundle-native-stamp
 

--- a/react-web/.gitignore
+++ b/react-web/.gitignore
@@ -5,6 +5,9 @@ dist-ssr
 *.local
 .DS_Store
 
+# ts-rs bindings generated from crates/system_api_types (just ts-bindings)
+src/engine/generated
+
 # Playwright (tier-2 e2e) artifacts
 test-results
 playwright-report

--- a/react-web/bridge-scene/src/bevy-api.ts
+++ b/react-web/bridge-scene/src/bevy-api.ts
@@ -13,10 +13,10 @@ import type {
   HoverAction,
   HoverEvent,
   LiveSceneInfo,
-  PbAvatarEquippedData,
   PermissionRequest,
   ProximityEvent,
   SceneLoadingUi,
+  SetAvatarData,
   SetSinglePermission,
   Vector3
 } from '../../src/engine/generated'
@@ -103,7 +103,7 @@ export type BevyApiInterface = {
   setPermanentPermission: (body: SetPermanentPermissionBody) => void
   /** Live scenes, for resolving a permission request's scene name (hash → title). */
   liveSceneInfo: () => Promise<LiveSceneInfo[]>
-  setAvatar: (data: { equip: PbAvatarEquippedData }) => Promise<unknown>
+  setAvatar: (data: SetAvatarData) => Promise<unknown>
   kernelFetch: (req: KernelFetchRequest) => Promise<KernelFetchResponse>
   getRealmProvider: () => Promise<string>
   getPreviousLogin: () => Promise<{ userId: string | null }>

--- a/react-web/bridge-scene/src/bevy-api.ts
+++ b/react-web/bridge-scene/src/bevy-api.ts
@@ -3,6 +3,7 @@
 // the wire shapes React sees live in the shared protocol. Only the methods the domains use
 // are declared — extend as needed.
 import type { Setting } from '../../src/engine/protocol'
+import type { ChatMessage, LiveSceneInfo } from '../../src/engine/generated'
 
 // --- raw social-service shapes (BevyApi.social.*) ---
 export type FriendStatusData = {
@@ -39,7 +40,7 @@ export type SocialApi = {
   unblockUser: (address: string) => Promise<void>
 }
 
-export type ChatStreamMessage = { sender_address: string; message: string; channel: string }
+export type ChatStreamMessage = ChatMessage
 export type SceneLoadingState = { visible?: boolean; realmConnected?: boolean; title?: string; pendingAssets?: number | null }
 export type MicState = { enabled: boolean; available: boolean }
 
@@ -107,8 +108,8 @@ export type BevyApiInterface = {
   getPermissionRequestStream: () => Promise<AsyncIterable<PermissionRequestRaw>>
   setSinglePermission: (body: { id: number; allow: boolean }) => void
   setPermanentPermission: (body: SetPermanentPermissionBody) => void
-  /** Live scenes (hash → title), for resolving a permission request's scene name. */
-  liveSceneInfo: () => Promise<Array<{ hash: string; title: string }>>
+  /** Live scenes, for resolving a permission request's scene name (hash → title). */
+  liveSceneInfo: () => Promise<LiveSceneInfo[]>
   setAvatar: (data: { equip: { wearableUrns: string[]; emoteUrns: string[]; forceRender: string[] } }) => Promise<unknown>
   kernelFetch: (req: KernelFetchRequest) => Promise<KernelFetchResponse>
   getRealmProvider: () => Promise<string>

--- a/react-web/bridge-scene/src/bevy-api.ts
+++ b/react-web/bridge-scene/src/bevy-api.ts
@@ -3,26 +3,32 @@
 // the wire shapes React sees live in the shared protocol. Only the methods the domains use
 // are declared — extend as needed.
 import type { Setting } from '../../src/engine/protocol'
-import type { ChatMessage, LiveSceneInfo } from '../../src/engine/generated'
+import type {
+  AvatarModifierState,
+  BlockedUserData,
+  BlockingStatusData,
+  ChatMessage,
+  FriendRequestData,
+  FriendStatusData,
+  HoverAction,
+  HoverEvent,
+  LiveSceneInfo,
+  PbAvatarEquippedData,
+  PermissionRequest,
+  ProximityEvent,
+  SceneLoadingUi,
+  SetSinglePermission,
+  Vector3
+} from '../../src/engine/generated'
 
-// --- raw social-service shapes (BevyApi.social.*) ---
-export type FriendStatusData = {
-  address: string
-  name: string
-  hasClaimedName: boolean
-  profilePictureUrl: string
-  status: 'online' | 'offline' | 'away'
-}
-export type FriendRequestData = {
-  address: string
-  name: string
-  hasClaimedName: boolean
-  profilePictureUrl: string
-  createdAt: number
-  message?: string
-  id: string
-}
-export type BlockingStatus = { blockedUsers: string[]; blockedByUsers: string[] }
+// --- raw social-service shapes (BevyApi.social.*), generated from the Rust structs ---
+export type { FriendStatusData, FriendRequestData }
+export type BlockingStatus = BlockingStatusData
+
+// Per-player modifiers from AvatarModifierArea (privacy zones etc), only for players carrying one —
+// e.g. hideProfile means the local player is standing in a DISABLE_PASSPORTS area, so `userId`'s
+// passport should not be opened. Only present in the array when at least one flag is set.
+export type { AvatarModifierState }
 
 export type SocialApi = {
   getSocialInitialized: () => Promise<boolean>
@@ -30,7 +36,7 @@ export type SocialApi = {
   getReceivedFriendRequests: () => Promise<FriendRequestData[]>
   getSentFriendRequests: () => Promise<FriendRequestData[]>
   getBlockingStatus?: () => Promise<BlockingStatus>
-  getBlockedUsers: () => Promise<Array<{ address: string }>>
+  getBlockedUsers: () => Promise<BlockedUserData[]>
   sendFriendRequest: (address: string, message?: string) => Promise<unknown>
   acceptFriendRequest: (address: string) => Promise<void>
   rejectFriendRequest: (address: string) => Promise<void>
@@ -41,28 +47,20 @@ export type SocialApi = {
 }
 
 export type ChatStreamMessage = ChatMessage
-export type SceneLoadingState = { visible?: boolean; realmConnected?: boolean; title?: string; pendingAssets?: number | null }
+export type SceneLoadingState = SceneLoadingUi
 export type MicState = { enabled: boolean; available: boolean }
 
-// Per-player modifiers from AvatarModifierArea (privacy zones etc), only for players carrying one —
-// e.g. hideProfile means the local player is standing in a DISABLE_PASSPORTS area, so `userId`'s
-// passport should not be opened. Only present in the array when at least one flag is set.
-export type AvatarModifierState = { userId: string; hideAvatar: boolean; hideProfile: boolean }
-
 // World-entity hover events. targetType: 0=WORLD, 1=UI, 2=AVATAR. eventType: PointerEventType.
-export type HoverEntry = {
-  eventType: number
-  enabled?: boolean
-  // maxPlayerDistance absent/null → the entry is range-gated by camera distance only (the PBPointerEvents
-  // default when neither is set is a 10m camera check), per pointer_events.proto's distance-rule doc.
-  eventInfo?: { button?: number; hoverText?: string; showFeedback?: boolean; maxPlayerDistance?: number | null }
-}
-export type SystemHoverEvent = { entered: boolean; targetType: number; actions: HoverEntry[] }
+// eventInfo.maxPlayerDistance absent/null → the entry is range-gated by camera distance only (the
+// PBPointerEvents default when neither is set is a 10m camera check), per pointer_events.proto's
+// distance-rule doc.
+export type HoverEntry = HoverAction
+export type SystemHoverEvent = HoverEvent
 
 // Proximity (in-range) events for world entities. entityPosition is world-space; the bridge
 // projects it to screen each frame so React can anchor a tooltip on it.
-export type Vec3 = { x: number; y: number; z: number }
-export type SystemProximityEvent = { entered: boolean; entity: number; entityPosition: Vec3; actions: HoverEntry[] }
+export type Vec3 = Vector3
+export type SystemProximityEvent = ProximityEvent
 
 // Global engine input actions. `action` is the SystemAction variant name (e.g. 'Cancel' = Escape,
 // 'Map', 'Chat'); `pressed` is press vs release. Emitted authoritatively by the engine even while it
@@ -78,12 +76,7 @@ export type KernelFetchResponse = { ok: boolean; status: number; statusText?: st
 
 // A scene's pending permission request (e.g. ChangeRealm). `ty` is the serde enum name
 // (e.g. 'ChangeRealm'); `scene` is the scene HASH — resolve its title via liveSceneInfo().
-export type PermissionRequestRaw = {
-  ty: string
-  additional?: string | null
-  scene: string
-  id: number
-}
+export type PermissionRequestRaw = PermissionRequest
 // Persist a permission at a level. `value` is the scene hash (Scene) or realm url (Realm),
 // unused for Global. `allow: null` clears the stored value.
 export type SetPermanentPermissionBody = {
@@ -106,11 +99,11 @@ export type BevyApiInterface = {
   setMicEnabled: (enabled: boolean) => void
   getAvatarModifiers: () => Promise<AvatarModifierState[]>
   getPermissionRequestStream: () => Promise<AsyncIterable<PermissionRequestRaw>>
-  setSinglePermission: (body: { id: number; allow: boolean }) => void
+  setSinglePermission: (body: SetSinglePermission) => void
   setPermanentPermission: (body: SetPermanentPermissionBody) => void
   /** Live scenes, for resolving a permission request's scene name (hash → title). */
   liveSceneInfo: () => Promise<LiveSceneInfo[]>
-  setAvatar: (data: { equip: { wearableUrns: string[]; emoteUrns: string[]; forceRender: string[] } }) => Promise<unknown>
+  setAvatar: (data: { equip: PbAvatarEquippedData }) => Promise<unknown>
   kernelFetch: (req: KernelFetchRequest) => Promise<KernelFetchResponse>
   getRealmProvider: () => Promise<string>
   getPreviousLogin: () => Promise<{ userId: string | null }>

--- a/react-web/bridge-scene/src/domains/friends.ts
+++ b/react-web/bridge-scene/src/domains/friends.ts
@@ -10,13 +10,14 @@ const toFriend = (f: FriendStatusData): Friend => ({
   address: f.address,
   name: f.name,
   picture: f.profilePictureUrl !== '' ? f.profilePictureUrl : undefined,
-  status: f.status
+  // the engine only emits "online" | "offline" | "away" (generated type widens to string)
+  status: f.status as Friend['status']
 })
 const toRequest = (r: FriendRequestData): FriendRequest => ({
   address: r.address,
   name: r.name,
   picture: r.profilePictureUrl !== '' ? r.profilePictureUrl : undefined,
-  message: r.message,
+  message: r.message ?? undefined,
   id: r.id,
   createdAt: r.createdAt
 })

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -7,6 +7,8 @@
 // Domain types mirror scene/src/bevy-api/interface.ts so the bridge scene can
 // forward SystemApi results verbatim.
 
+import type { SceneLoadingUi } from './generated'
+
 export const BRIDGE_CHANNEL = 'bevy-ui-bridge'
 
 /** Mirrors SystemApi.getPreviousLogin(): userId is absent for a fresh user. */
@@ -120,12 +122,7 @@ export interface LoginCodeMessage {
 }
 
 /** Mirrors SystemApi SceneLoadingWindow — the scene-asset loading state. */
-export interface SceneLoadingState {
-  visible: boolean
-  realmConnected: boolean
-  title: string
-  pendingAssets: number | null
-}
+export type SceneLoadingState = SceneLoadingUi
 
 /** Streamed scene-asset loading updates (drives the React loading screen). */
 export interface SceneLoadingMessage {

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -214,25 +214,11 @@ export interface FriendActionRequest {
   address: string
 }
 
-export interface SettingVariant {
-  name: string
-  description: string
-}
-
 /** Mirrors the engine's ExplorerSetting (BevyApi.getSettings). A setting is a
  *  Select when it has namedVariants, otherwise a numeric Slider; a 2-variant or
  *  0..1 setting renders as a Toggle. */
-export interface Setting {
-  name: string
-  category: string
-  description: string
-  minValue: number
-  maxValue: number
-  namedVariants: SettingVariant[]
-  value: number
-  default: number
-  stepSize: number
-}
+import type { SettingInfo as Setting, NamedVariant as SettingVariant } from './generated'
+export type { Setting, SettingVariant }
 
 export interface SettingsMessage {
   kind: 'settings'

--- a/react-web/src/test/session.test.tsx
+++ b/react-web/src/test/session.test.tsx
@@ -272,6 +272,12 @@ describe('embedded auto-guest (?guest=1)', () => {
     // The deferred login runs a paint after the pick, so wait for the call.
     await waitFor(() => expect(h.driver.calls).toContain('loginGuest'))
     h.driver.emit({ kind: 'event', name: 'playerReady' })
+    // No loading state received counts as still-loading, so report "done" like the real
+    // bridge-scene's stream does (same as harness enterAsGuest).
+    h.driver.emit({
+      kind: 'sceneLoading',
+      state: { visible: false, realmConnected: true, title: '', pendingAssets: null }
+    })
     await waitFor(() => expect(h.session().phase).toBe('world'))
   })
 

--- a/scripts/gen-ts-bindings.sh
+++ b/scripts/gen-ts-bindings.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Generate the TypeScript bindings for the ~system/BevyExplorerApi boundary from the Rust
+# structs in crates/system_api_types, into react-web/src/engine/generated (+ a barrel index.ts).
+# Called by `just ts-bindings` and by CI (ci.yml deploy-web, package.yml) before the
+# react-web / bridge-scene builds, which import the generated (gitignored) types.
+set -eu
+root="$(cd "$(dirname "$0")/.." && pwd)"
+# git-bash (windows CI): cargo is a native process, so hand it a windows-style path —
+# the POSIX /d/... form would be misresolved.
+case "$(uname -s)" in
+MINGW* | MSYS*) root="$(cd "$root" && pwd -W)" ;;
+esac
+out="$root/react-web/src/engine/generated"
+rm -rf "$out"
+mkdir -p "$out"
+TS_RS_EXPORT_DIR="$out" cargo test --manifest-path "$root/Cargo.toml" -p system_api_types export_bindings
+cd "$out"
+: >index.ts
+for f in $(ls ./*.ts 2>/dev/null | grep -v '^\./index\.ts$' | LC_ALL=C sort); do
+    f="${f#./}"
+    echo "export * from './${f%.ts}'" >>index.ts
+done


### PR DESCRIPTION
Adopts [ts-rs](https://github.com/aleph-alpha/ts-rs) to generate the TypeScript types for the `~system/BevyExplorerApi` boundary from the Rust structs, replacing the hand-mirrored interfaces in react-web and the bridge scene.

## What

- New `system_api_types` crate holds the plain serde structs that cross the boundary (moved from `system_bridge`, plus the `Permission*`/`PointerTargetType` enums from `common` and `ClearableColor3` from `dcl`; all re-exported from their old paths so no call sites change). `dcl_component`'s build.rs injects `TS` derives on the proto types the boundary embeds. Derives are unconditional — no feature gate — since they have no runtime cost and dead-code strip out of the binaries.
- `scripts/gen-ts-bindings.sh` (single source of truth, called by `just ts-bindings` and CI) exports the bindings to `react-web/src/engine/generated/`, which is gitignored: CI regenerates before building the HUD and bridge scene, so the typechecks double as a drift check between the Rust structs and their TS consumers.
- `bevy-api.ts` and the verbatim subset of `protocol.ts` now import generated types. Hand-written shapes remain only where the wire genuinely differs from the engine-event struct (`SetPermanentPermission`'s level/value op args) or the type lives outside the boundary crates (`MicState`, `SystemActionEvent`). Reshaped page-side types (Friend, page HoverAction, ProximityTip, community aggregations) are bridge-scene contracts with no Rust source of truth and stay hand-written.
- `setAvatar` now passes `SetAvatarData` across both runtimes' ops whole (camelCased, `deny_unknown_fields`) instead of five destructured args, so the generated type is enforced end-to-end.
- CI also gains the react-web vitest suite (~6s, previously never run in CI).

## Bugs fixed along the way

- `LiveSceneInfo.baseUrl` — the hand-written TS declared `base_url`, which never matched the camelCase wire; the generated type is wire-true.
- "Clear name color" was a silent no-op across the native scene-process IPC: `Option<Option<Color3>>`'s `Some(None)` and `None` both encode as msgpack nil. `SetAvatarData` now carries `ClearableColor3` end-to-end.
- `ProximityEvent.entity` sent `Entity::to_bits()` (u64), which exceeds JSON's exact-integer range once generations climb; it now sends the u32 entity index (the value is only used to pair enter/leave events).
- The `?guest=1` + `?position` test from #972 failed deterministically — it hand-rolled the entry flow and never emitted the loading-done state the real bridge always streams.

## Notes

- `Option<T>` generates `T | null` (wire-true). `skip_serializing_if`/`?:` is deliberately not used on shared structs: these types cross the native IPC via rmp's positional encoding, where skipped fields shorten the array and break decoding. Inbound-only types use `#[ts(optional)]` (TS-emission only) instead.
- 64-bit fields are overridden to `number` — the transport is JSON, where `JSON.parse` produces lossy doubles either way; `bigint` would be a lie that also breaks `JSON.stringify`.
- No runtime test covers `setAvatar`; a manual equip-a-wearable smoke in the client is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)