### PR TITLE
justfile: npm install before bundling the react HUD

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,6 +11,8 @@ wasm:
 
 # bundle the react HUD page + bridge scene into assets/ (the files native runs from)
 bundle-native:
+    cd react-web && npm install
+    cd react-web/bridge-scene && npm install
     cd react-web && npm run bundle:native
     mkdir -p target && touch target/.bundle-native-stamp
 


### PR DESCRIPTION
`just native-debug` / `just bundle-native` fail on a fresh clone or worktree with `tsc: command not found`: `tsc` and the bridge-scene export tooling are local devDependencies of `react-web` and `react-web/bridge-scene`, and nothing in the recipe installs them.

Run `npm install` for both packages before bundling. It's a fast no-op when `node_modules` is already present, and the staleness check in `_bundle-native-if-stale` already prunes `node_modules` so this doesn't cause rebundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gqzjybuqkNdgxcxjWH1rJ