### PR TITLE
transparent surfaces attract depth-of-field focus by opacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1157,7 +1157,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1538,12 +1538,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#16b085d52ec448adf4d16aca25361e2ce78b88f2"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#b771bff2a673abe309d39878d142cdf0b1ff9b88"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/assets/src/assets/shaders/bound_material.wgsl
+++ b/crates/assets/src/assets/shaders/bound_material.wgsl
@@ -8,6 +8,7 @@
     mesh_view_bindings::{globals, view, lights},
     pbr_types,
     shadows,
+    view_transformations,
 }
 #import bevy_core_pipeline::tonemapping::approximate_inverse_tone_mapping
 
@@ -241,6 +242,16 @@ fn fragment(
         // avoid writing to the depth buffer for alpha-blend materials with low alpha
         discard;
     }
+
+#ifdef TRANSPARENT_FOCUS_OUTPUT
+    // accumulate alpha-weighted view depth + coverage for depth of field
+    out.focus = vec4(
+        -view_transformations::depth_ndc_to_view_z(in.position.z),
+        1.0,
+        0.0,
+        out.color.a,
+    );
+#endif
 
     return out;
 }

--- a/crates/assets/src/assets/shaders/loading.wgsl
+++ b/crates/assets/src/assets/shaders/loading.wgsl
@@ -2,6 +2,9 @@
     forward_io::{VertexOutput, FragmentOutput},
     mesh_view_bindings::globals,
 }
+#ifdef TRANSPARENT_FOCUS_OUTPUT
+#import bevy_pbr::view_transformations
+#endif
 #import "embedded://shaders/simplex.wgsl"::simplex_noise_3d
 
 struct LoadingData {
@@ -31,5 +34,16 @@ fn fragment(
 
     var out: FragmentOutput;
     out.color = vec4<f32>(noise, noise * 10.0, noise, pow((1.0 - clamp(dot(offset, offset) * 0.03, 0.0, 1.0)), 2.0));
+
+#ifdef TRANSPARENT_FOCUS_OUTPUT
+    // accumulate alpha-weighted view depth + coverage for depth of field
+    out.focus = vec4(
+        -view_transformations::depth_ndc_to_view_z(in.position.z),
+        1.0,
+        0.0,
+        out.color.a,
+    );
+#endif
+
     return out;
 }


### PR DESCRIPTION
The engine previously wrote depth for alpha-blended materials in the main pass so depth of field wouldn't blur fully-opaque alpha-blend pixels against the background. But those depth writes also depth-tested transparent fragments against each other, and since the transparent sort is per-object while the test is per-pixel, transparent geometry behind an already-drawn transparent pixel was dropped entirely (visible as missing transparent surfaces where transparents overlap).

This bumps bevy to robtfm/bevy@b771bff2a, which reverts the depth write and instead attaches an extra Rg16Float target to the main transparent pass when the view has depth of field. Transparent fragments alpha-blend `(view_depth, 1, 0, alpha)` into it, accumulating alpha-weighted view depth and total coverage; the dof shader computes focus depth as `r + (1 - coverage) * opaque_depth` (max_depth applied to the opaque term before the blend). Transparent surfaces attract focus in proportion to their opacity — a 90%-opaque window holds focus, a faint wisp barely nudges it — and transparent-vs-transparent occlusion can no longer reject fragments.

Explorer side: the scene material opts into the focus output (covering glTF content, primitives, video screens, and — via TextQuad inheriting the bound fragment — text shapes and nametags), as does the scene-loading overlay. Avatar masks and imposters deliberately don't contribute: masks overlay dither-opaque avatar surfaces whose depth is already in the buffer, and imposters sit beyond dof max_depth. Shaders that never write the new output are exact no-ops (wgsl zero-init + over-blending), so nothing else needs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gqzjybuqkNdgxcxjWH1rJ