### PR TITLE
Restore engine-side ui scenes alongside the react HUD

### DIFF
--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -173,7 +173,11 @@ window.set_url_params = (position, server, system_scene, portables, preview) => 
     else urlParams.delete('position')
     if (server !== DEFAULT_SERVER) urlParams.set('realm', server)
     else urlParams.delete('realm')
-    if (system_scene !== (config.systemScene ?? '')) urlParams.set('systemScene', system_scene)
+    // null = the engine runs NO ui scene (?systemScene=none) — keep that explicit across reloads.
+    // Compared against the page DEFAULT (not the boot value) so an explicit ?systemScene=
+    // override also survives a reload; only the default is omitted to keep the entry URL clean.
+    system_scene = system_scene ?? 'none'
+    if (system_scene !== (config.defaultSystemScene ?? config.systemScene ?? '')) urlParams.set('systemScene', system_scene)
     else urlParams.delete('systemScene')
     if (portables !== DEFAULT_PORTABLES) urlParams.set('portables', portables)
     else urlParams.delete('portables')

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -164,6 +164,8 @@ const DEFAULT_PORTABLES = 'basiccontroller.dcl.eth'
 // worlds-content-server…/world/name.dcl.eth) and echoes that back here. Reverse it so the address
 // bar keeps the short name the user typed; a reload re-expands it the same way.
 const WORLDS_PREFIX = 'https://worlds-content-server.decentraland.org/world/'
+// captured from the ENTRY url (later syncs rewrite location.search)
+const explicitSystemScene = new URLSearchParams(window.location.search).has('systemScene')
 window.set_url_params = (position, server, system_scene, portables, preview) => {
   try {
     if (server.startsWith(WORLDS_PREFIX)) server = server.slice(WORLDS_PREFIX.length)
@@ -173,11 +175,10 @@ window.set_url_params = (position, server, system_scene, portables, preview) => 
     else urlParams.delete('position')
     if (server !== DEFAULT_SERVER) urlParams.set('realm', server)
     else urlParams.delete('realm')
-    // null = the engine runs NO ui scene (?systemScene=none) — keep that explicit across reloads.
-    // Compared against the page DEFAULT (not the boot value) so an explicit ?systemScene=
-    // override also survives a reload; only the default is omitted to keep the entry URL clean.
-    system_scene = system_scene ?? 'none'
-    if (system_scene !== (config.defaultSystemScene ?? config.systemScene ?? '')) urlParams.set('systemScene', system_scene)
+    // An explicit ?systemScene= boot override stays in the URL across reloads (null from the
+    // engine = NO ui scene running, i.e. systemScene=none); only the default scene is omitted
+    // to keep the canonical entry URL clean.
+    if (explicitSystemScene || system_scene !== (config.systemScene ?? '')) urlParams.set('systemScene', system_scene ?? 'none')
     else urlParams.delete('systemScene')
     if (portables !== DEFAULT_PORTABLES) urlParams.set('portables', portables)
     else urlParams.delete('portables')

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -53,7 +53,11 @@ const SHOWCASE = params.get('showcase') === '1'
 // the sites `/discover` embed, which frames the scene itself and supplies its
 // own chrome. Pair with ?guest=1 (auto guest-login) so the engine still enters
 // the world without the — now hidden — sign-in screen.
-const HIDE_HUD = params.get('hud') === '0'
+// An explicit ?systemScene= (debug: substitute the super-user ui scene, e.g. the
+// component inspector, or "none" for the engine's builtin ui) also hides the HUD —
+// the substituted scene owns the UI, and the engine boots straight away with no
+// React sign-in (see useEngineSession's systemScene boot).
+const HIDE_HUD = params.get('hud') === '0' || params.has('systemScene')
 // Gate: don't mount the HUD/engine where the engine can't run — mobile (no WebGPU/SharedArrayBuffer)
 // or a non-Chromium desktop browser (the engine bundle renders its own "Browser Not Supported" page
 // there — see deploy/web/index.html — which the HUD would otherwise cover, leaving login frozen at

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -35,6 +35,7 @@ import { useExitGuard } from './lib/useExitGuard'
 import { useHudScale } from './lib/useHudScale'
 import { useGlobalHotkey } from './lib/useGlobalHotkey'
 import { useMenuShortcuts } from './lib/useMenuShortcuts'
+import { bootMode } from './lib/bootMode'
 import { isMobile, isChromiumBased, hasBypassCookie } from './lib/isMobile'
 import { MobileGate } from './features/gate/MobileGate'
 import { ErrorBoundary } from './features/error/ErrorBoundary'
@@ -48,16 +49,11 @@ const params = new URLSearchParams(location.search)
 const MODE: 'mock' | 'engine' | 'native' =
   params.get('mock') === '1' ? 'mock' : params.get('native') === '1' ? 'native' : 'engine'
 const SHOWCASE = params.get('showcase') === '1'
-// Embedded mode (?hud=0): render ONLY the engine — no React HUD at all (no
-// sidebar, chat, pointer, panels, or the sign-in / loading overlays). Used by
-// the sites `/discover` embed, which frames the scene itself and supplies its
-// own chrome. Pair with ?guest=1 (auto guest-login) so the engine still enters
-// the world without the — now hidden — sign-in screen.
-// An explicit ?systemScene= (debug: substitute the super-user ui scene, e.g. the
-// component inspector, or "none" for the engine's builtin ui) also hides the HUD —
-// the substituted scene owns the UI, and the engine boots straight away with no
-// React sign-in (see useEngineSession's systemScene boot).
-const HIDE_HUD = params.get('hud') === '0' || params.has('systemScene')
+// Embedded/debug mode (?hud=0 or ?systemScene= — see lib/bootMode.ts): render ONLY the
+// engine — no React HUD at all (no sidebar, chat, pointer, panels, or the sign-in /
+// loading overlays). Something else owns the UI: the sites `/discover` embed's own
+// chrome, or the substituted ui scene in-engine.
+const HIDE_HUD = bootMode().hideHud
 // Gate: don't mount the HUD/engine where the engine can't run — mobile (no WebGPU/SharedArrayBuffer)
 // or a non-Chromium desktop browser (the engine bundle renders its own "Browser Not Supported" page
 // there — see deploy/web/index.html — which the HUD would otherwise cover, leaving login frozen at

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect } from 'react'
 import type { EngineRpc } from '../../engine/engineRpc'
+import { bootMode } from '../../lib/bootMode'
 import { PAGE_DIR } from '../../lib/publicUrl'
 
 // The main (Genesis City) realm. Exported: parcel launches pass it EXPLICITLY so a ?realm
@@ -45,10 +46,7 @@ function injectEngine(): void {
   // pkg/ fetch base: the versioned CDN in prod builds (BASE_URL), the served engine dir otherwise.
   window.PUBLIC_URL = new URL('engine', new URL(import.meta.env.BASE_URL, PAGE_DIR)).href
   window.__bevyBootConfig = {
-    systemScene: params.get('systemScene') ?? SYSTEM_SCENE,
-    // the URL sync (boot.js set_url_params) omits only the DEFAULT scene from the address bar,
-    // so an explicit ?systemScene= override survives reloads
-    defaultSystemScene: SYSTEM_SCENE,
+    systemScene: bootMode().systemScene ?? SYSTEM_SCENE,
     portables: params.get('portables') ?? undefined,
     preview: params.has('preview')
   }
@@ -68,12 +66,7 @@ function injectEngine(): void {
 declare global {
   interface Window {
     PUBLIC_URL?: string
-    __bevyBootConfig?: {
-      systemScene?: string
-      defaultSystemScene?: string
-      portables?: string
-      preview?: boolean
-    }
+    __bevyBootConfig?: { systemScene?: string; portables?: string; preview?: boolean }
   }
 }
 

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -46,6 +46,9 @@ function injectEngine(): void {
   window.PUBLIC_URL = new URL('engine', new URL(import.meta.env.BASE_URL, PAGE_DIR)).href
   window.__bevyBootConfig = {
     systemScene: params.get('systemScene') ?? SYSTEM_SCENE,
+    // the URL sync (boot.js set_url_params) omits only the DEFAULT scene from the address bar,
+    // so an explicit ?systemScene= override survives reloads
+    defaultSystemScene: SYSTEM_SCENE,
     portables: params.get('portables') ?? undefined,
     preview: params.has('preview')
   }
@@ -65,7 +68,12 @@ function injectEngine(): void {
 declare global {
   interface Window {
     PUBLIC_URL?: string
-    __bevyBootConfig?: { systemScene?: string; portables?: string; preview?: boolean }
+    __bevyBootConfig?: {
+      systemScene?: string
+      defaultSystemScene?: string
+      portables?: string
+      preview?: boolean
+    }
   }
 }
 

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -7,6 +7,7 @@ import type { LoginDriver } from '../../engine/driver'
 import type { FatalError } from '../error/EngineErrorModal'
 import { DEFAULT_REALM } from '../engine/EngineHost'
 import { closeTopPopup } from '../../design'
+import { bootMode } from '../../lib/bootMode'
 import { getCursor } from '../pointer/cursorStore'
 import { openProfileCard } from '../profileCard/ProfileCard'
 import type {
@@ -812,6 +813,9 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     requestAnimationFrame(() => requestAnimationFrame(run))
     setTimeout(run, 60)
   }, [])
+  // Boot-mode flags (?hud=0 / ?guest=1 / ?systemScene= — see lib/bootMode.ts), captured once
+  // per session mount so tests can vary location.search between mounts.
+  const boot = useRef(bootMode())
   // ?position=x,y / ?realm= (parity with the plain engine page): skip the Places picker and launch
   // straight there. realm wins when both are given, carrying the position along — letting
   // ?position shadow ?realm made a reload in a custom realm respawn in Genesis at the same
@@ -829,9 +833,9 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       if (realm != null && realm !== '')
         return { kind: 'world', realm, position: hasPosition ? `${x},${y}` : undefined }
       if (hasPosition) return { kind: 'parcel', x, y }
-      // Explicit ?systemScene= with no destination: there is no picker (the HUD is hidden) —
-      // land at Genesis 0,0 so the auto-boot below actually launches (parity with picker "skip").
-      if (q.has('systemScene')) return { kind: 'parcel', x: 0, y: 0 }
+      // A hidden HUD renders no picker — land at Genesis 0,0 so the boot doesn't strand on an
+      // invisible screen (parity with the picker's "skip").
+      if (boot.current.hideHud) return { kind: 'parcel', x: 0, y: 0 }
       return null
     })()
   )
@@ -1053,27 +1057,18 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     setStatus('sign-in-or-guest')
   }, [busy])
 
-  // Embedded guest auto-login (?guest=1): skip the sign-in screen entirely and
-  // enter as a guest the moment the engine is warm. Used by the sites `/discover`
-  // embed, which shows the scene as a guest preview with no sign-in UI. The URL
-  // destination (?position / ?realm) is auto-picked by the effect above, so this
-  // takes the guest straight into the scene. Fires once — `submitted` flips true
-  // on the first call and gates re-entry.
-  const autoGuest = useRef(new URLSearchParams(location.search).get('guest') === '1')
+  // Auto-login (see lib/bootMode.ts): skip the sign-in screen the moment the engine is warm —
+  // as a guest (?guest=1, the sites `/discover` embed), or with no React login at all
+  // (?systemScene=: the substituted ui scene owns login in-engine, pre-react behavior). The
+  // destination is auto-picked by the effect above (?position / ?realm, else the hidden-HUD
+  // Genesis fallback), so this goes straight into the scene. Fires once — `submitted` flips
+  // true on the first call and gates re-entry.
   useEffect(() => {
-    if (!autoGuest.current || !engineReady || submitted) return
-    exploreAsGuest()
-  }, [engineReady, submitted, exploreAsGuest])
-
-  // Explicit ?systemScene= (debug, HUD hidden — see App.tsx): the substituted ui scene owns
-  // login and UI in-engine (pre-react behavior), so there's no sign-in screen to wait for —
-  // boot the engine as soon as it's warm, with no deferred login. ?guest=1 still wins: its
-  // auto guest-login above runs first, and this must not clobber its pending login.
-  const systemSceneBoot = useRef(new URLSearchParams(location.search).has('systemScene'))
-  useEffect(() => {
-    if (!systemSceneBoot.current || autoGuest.current || !engineReady || submitted) return
-    submitLogin(() => Promise.resolve())
-  }, [engineReady, submitted, submitLogin])
+    if (boot.current.autoLogin == null || !engineReady || submitted) return
+    if (boot.current.autoLogin === 'guest') exploreAsGuest()
+    // scene-owned: no React login at all — just boot the engine (a no-op deferred login).
+    else submitLogin(() => Promise.resolve())
+  }, [engineReady, submitted, exploreAsGuest, submitLogin])
 
   // Render-settle. When the scene flips from loading → loaded (visible true→false), hold the loader
   // a beat longer while the engine actually renders the world (compiling shaders / uploading

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -829,6 +829,9 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       if (realm != null && realm !== '')
         return { kind: 'world', realm, position: hasPosition ? `${x},${y}` : undefined }
       if (hasPosition) return { kind: 'parcel', x, y }
+      // Explicit ?systemScene= with no destination: there is no picker (the HUD is hidden) —
+      // land at Genesis 0,0 so the auto-boot below actually launches (parity with picker "skip").
+      if (q.has('systemScene')) return { kind: 'parcel', x: 0, y: 0 }
       return null
     })()
   )
@@ -1061,6 +1064,16 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     if (!autoGuest.current || !engineReady || submitted) return
     exploreAsGuest()
   }, [engineReady, submitted, exploreAsGuest])
+
+  // Explicit ?systemScene= (debug, HUD hidden — see App.tsx): the substituted ui scene owns
+  // login and UI in-engine (pre-react behavior), so there's no sign-in screen to wait for —
+  // boot the engine as soon as it's warm, with no deferred login. ?guest=1 still wins: its
+  // auto guest-login above runs first, and this must not clobber its pending login.
+  const systemSceneBoot = useRef(new URLSearchParams(location.search).has('systemScene'))
+  useEffect(() => {
+    if (!systemSceneBoot.current || autoGuest.current || !engineReady || submitted) return
+    submitLogin(() => Promise.resolve())
+  }, [engineReady, submitted, submitLogin])
 
   // Render-settle. When the scene flips from loading → loaded (visible true→false), hold the loader
   // a beat longer while the engine actually renders the world (compiling shaders / uploading

--- a/react-web/src/lib/bootMode.ts
+++ b/react-web/src/lib/bootMode.ts
@@ -1,0 +1,30 @@
+// The interrelated "how does this page boot" decisions, derived from the entry URL in ONE
+// place. They cut across App.tsx (render gate), EngineHost (engine boot config) and
+// useEngineSession (login/destination flow) — deriving them independently from raw params in
+// each spot lets the combinations drift apart.
+//
+//   ?hud=0         render only the engine — no React HUD chrome (the sites /discover embed,
+//                  which frames the scene itself; pair with ?guest=1 for a no-UI guest preview)
+//   ?guest=1       skip the sign-in screen with an auto guest-login
+//   ?systemScene=  debug: substitute the super-user ui scene (a url/dir, or "none" for the
+//                  engine's builtin ui). The scene owns login/UI in-engine (pre-react
+//                  behavior), so this implies a hidden HUD and no React login at all.
+export interface BootMode {
+  /** explicit ?systemScene= override; null = the default bridge scene drives */
+  systemScene: string | null
+  /** render only the engine — no HUD chrome, no sign-in/loading overlays */
+  hideHud: boolean
+  /** skip the sign-in screen: auto guest-login, or no React login at all (the ui scene owns it) */
+  autoLogin: 'guest' | 'scene-owned' | null
+}
+
+// Computed per call, not a module const, so tests can set location.search before mounting.
+export function bootMode(): BootMode {
+  const q = new URLSearchParams(location.search)
+  const systemScene = q.get('systemScene') || null
+  return {
+    systemScene,
+    hideHud: q.get('hud') === '0' || systemScene != null,
+    autoLogin: q.get('guest') === '1' ? 'guest' : systemScene != null ? 'scene-owned' : null
+  }
+}

--- a/react-web/src/test/session.test.tsx
+++ b/react-web/src/test/session.test.tsx
@@ -251,10 +251,11 @@ describe('session domain', () => {
   })
 })
 
-// DOMAIN: embedded mode — the sites `/discover` embed loads bevy-web with
-// ?guest=1 (auto guest-login, no sign-in screen) and ?hud=0 (no React HUD).
-// ?hud=0 is a pure App.tsx render gate; the auto-guest flow lives in the hook.
-describe('embedded auto-guest (?guest=1)', () => {
+// DOMAIN: embedded/debug boot modes (lib/bootMode.ts) — the sites `/discover` embed loads
+// bevy-web with ?guest=1 (auto guest-login, no sign-in screen) and ?hud=0 (no React HUD);
+// ?systemScene= substitutes the super-user ui scene, which then owns login in-engine.
+// ?hud=0 is a pure App.tsx render gate; the auto-login flow lives in the hook.
+describe('embedded auto-boot (?guest=1 / ?systemScene=)', () => {
   afterEach(() => window.history.replaceState(null, '', '/'))
 
   it('skips the sign-in screen and enters as a guest without any manual action', async () => {
@@ -279,6 +280,15 @@ describe('embedded auto-guest (?guest=1)', () => {
       state: { visible: false, realmConnected: true, title: '', pendingAssets: null }
     })
     await waitFor(() => expect(h.session().phase).toBe('world'))
+  })
+
+  it('?systemScene= boots straight in with no React login at all (the scene owns it)', async () => {
+    window.history.replaceState(null, '', '/?systemScene=http://localhost:8100')
+    const h = renderSession({ userId: null })
+    // No destination params either — the hidden-HUD fallback lands at Genesis 0,0, so the
+    // boot never strands on the (invisible) picker.
+    await waitFor(() => expect(h.session().phase).toBe('entering'))
+    expect(h.driver.calls).not.toContain('loginGuest')
   })
 
   it('does not auto-login without the flag (normal sign-in screen)', async () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,9 @@ pub struct DecentralandArguments {
     pub location: Option<IVec2>,
     pub startup_scenes: Option<Vec<StartupScene>>,
     pub ui_scene: Option<String>,
+    /// run the react HUD (native: the CEF overlay). False when an explicit --ui opted out in
+    /// favour of the engine-side ui, and on wasm (the react page hosts the engine itself).
+    pub hud: bool,
     pub scene_params: Option<String>,
     pub scene_threads: Option<usize>,
     pub scene_load_distance: Option<f32>,
@@ -194,9 +197,10 @@ impl DecentralandApp {
         app.add_plugins(wasm_default_plugins(&decentraland_app_config));
 
         // POC: react-web HUD composited in-engine from CEF offscreen rendering. Skipped in test
-        // mode (automated scene tests run headless and must not boot CEF or gate input).
+        // mode (automated scene tests run headless and must not boot CEF or gate input) and when
+        // an explicit --ui opted out of the HUD in favour of the engine-side ui.
         #[cfg(all(not(target_arch = "wasm32"), feature = "react-hud-cef"))]
-        if !decentraland_app_config.arguments.test_mode {
+        if decentraland_app_config.arguments.hud && !decentraland_app_config.arguments.test_mode {
             app.add_plugins(react_hud_cef::ReactHudCefPlugin {
                 // a non-default boot server (explicit --server or a configured home realm)
                 // IS the destination: injected into the page URL as ?realm= so the HUD skips
@@ -351,9 +355,9 @@ impl DecentralandApp {
 
         // POC: the react-web overlay is the HUD — turn off the engine's native UI so it doesn't
         // render its own login/chat/etc. behind the webview. (Overrides the inserts above.)
-        // Test mode keeps the native UI: the HUD plugin is skipped there.
+        // Test mode and an explicit --ui keep the native UI: the HUD plugin is skipped there.
         #[cfg(all(not(target_arch = "wasm32"), feature = "react-hud-cef"))]
-        if !decentraland_app_config.arguments.test_mode {
+        if decentraland_app_config.arguments.hud && !decentraland_app_config.arguments.test_mode {
             app.insert_resource(NativeUi {
                 login: false,
                 emote_wheel: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,10 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
 
     let test_scenes = args.value_from_str("--test_scenes").ok();
     let startup_scenes_preview = args.contains("--ui-preview");
+    // An explicit --ui (a scene source, or "none" for the engine's builtin ui) opts out of the
+    // react HUD entirely — the given ui scene drives instead (see lib.rs).
+    let ui_scene = args.value_from_str::<_, String>("--ui").ok();
+    let hud = ui_scene.is_none();
 
     let dcl_args = DecentralandArguments {
         server: args.value_from_str("--server").ok(),
@@ -121,9 +125,7 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
                     .collect::<Vec<_>>()
             })
             .ok(),
-        ui_scene: args
-            .value_from_str("--ui")
-            .ok()
+        ui_scene: ui_scene
             .or_else(|| {
                 // react HUD builds default to the bundled bridge-scene static export (a file
                 // realm, loaded with no server; `npm run bundle:native` in react-web generates
@@ -146,6 +148,7 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
                 ))
             })
             .filter(|scene| scene != "none"),
+        hud,
         scene_params: args.value_from_str("--params").ok(),
         scene_threads: args.value_from_str("--threads").ok(),
         scene_load_distance: args.value_from_str("--distance").ok(),

--- a/src/react_hud_cef.rs
+++ b/src/react_hud_cef.rs
@@ -5,21 +5,22 @@
 //
 // Transport: the page's BroadcastChannel Envelopes ride cef_offscreen's IPC (`window.cef.emit` /
 // `window.cef.listen('bridge', ..)`, wired by react-web's cefNativeBridge when it detects
-// `window.cef`), and this file relays them. With `--ui <bridge-scene>` the
-// SDK7 bridge-scene owns the wire protocol (this file is a pure Envelope pipe via
-// BridgeToPage/GetBridgeStream); until it connects (scene boot takes seconds; the page is up
-// immediately) a built-in fallback handles the login rpcs, so the login screen is responsive
-// from the first frame. The fallback is a boot shim, not a HUD backend: it subscribes to no
-// engine streams, and the page assumes "loading" until the bridge-scene reports real state —
-// so with no bridge-scene at all (--ui none, missing bundle) login works but the world stays
-// behind the loading screen.
+// `window.cef`), and this file relays them. The bundled SDK7 bridge-scene (the default ui
+// scene when no --ui is given — see main.rs) owns the wire protocol (this file is a pure
+// Envelope pipe via BridgeToPage/GetBridgeStream); until it connects (scene boot takes seconds;
+// the page is up immediately) a built-in fallback handles the login rpcs, so the login screen
+// is responsive from the first frame. The fallback is a boot shim, not a HUD backend: it
+// subscribes to no engine streams, and the page assumes "loading" until the bridge-scene
+// reports real state — so with no bridge-scene at all (missing bundle) login works but the
+// world stays behind the loading screen. An explicit --ui (a scene, or "none" for the builtin
+// ui) skips this plugin entirely — the engine-side ui drives instead.
 //
 // Run (files only, no servers):
 //   cd react-web && npm run bundle:native   # page -> assets/react-hud, scene -> assets/bridge-scene
 //   cargo run --release --features react-hud-cef --bin decentra-bevy -- --server <realm>
 // The page loads from cef://localhost/react-hud (the bevy assets dir) and the bridge-scene loads
-// as a file realm from assets/bridge-scene. Overrides: REACT_HUD_URL (e.g. a vite dev server with
-// ?native=1 for HMR), --ui <url|dir|none>. The CEF framework loads bundle-relative
+// as a file realm from assets/bridge-scene. Override: REACT_HUD_URL (e.g. a vite dev server with
+// ?native=1 for HMR). The CEF framework loads bundle-relative
 // (Contents/Frameworks) with a dev fallback at ~/.local/share/cef (export-cef-dir).
 //
 // Input mirrors web semantics (where the page and the engine canvas share the document): all
@@ -123,7 +124,7 @@ struct ReactHudCef {
     // A HUD text field is focused (page focusin/focusout via the shim) — the engine's key-bound
     // actions are suppressed so WASD etc. type instead of moving the avatar.
     text_focused: bool,
-    // When the super-user bridge-scene is driving (--ui <bridge-scene>), this is its page->scene
+    // When the super-user bridge-scene is driving (the bundled default), this is its page->scene
     // stream; the relay becomes a pure Envelope pipe and the per-domain fallback is bypassed.
     bridge_sender: Option<RpcStreamSender<String>>,
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -308,15 +308,23 @@ fn update_url_params(
         return;
     };
     let (ui_scene, portables) = if let Some(s) = startup_scenes {
-        let scenes = s
+        // the ui scene is the super-user scene inserted at index 0 — when one was given at all
+        // (?systemScene=none boots with only regular startup scenes/portables)
+        let ui_scene = s
+            .scenes
+            .first()
+            .filter(|scene| scene.super_user)
+            .map(|scene| scene.source.clone());
+        let portables = s
             .scenes
             .iter()
+            .skip(ui_scene.is_some() as usize)
             .map(|scene| scene.source.clone())
             .collect::<Vec<_>>();
 
         (
-            scenes.first().cloned(),
-            scenes.get(1..).map(|scenes| scenes.join(";")),
+            ui_scene,
+            (!portables.is_empty()).then(|| portables.join(";")),
         )
     } else {
         (None, None)
@@ -409,7 +417,11 @@ fn decentraland_app_arguments(
                 .collect::<Vec<_>>(),
         )
         .filter(|startup_scenes| !startup_scenes.is_empty()),
-        ui_scene: (!ui_scene.is_empty()).then(|| ui_scene.to_owned()),
+        ui_scene: (!ui_scene.is_empty())
+            .then(|| ui_scene.to_owned())
+            .filter(|scene| scene != "none"),
+        // wasm has no engine-managed HUD: the react page hosting the engine is the HUD
+        hud: false,
         scene_params: Some(params.to_owned()),
         scene_threads: None,
         scene_load_distance: None,


### PR DESCRIPTION
The react HUD work left no way to run a non-react ui scene (e.g. the component-inspector debug scene). This restores the pre-react behaviour behind explicit opt-outs, defaulting to the HUD as before:

**Native**
- `--ui <scene>`: the CEF HUD process is not started; the given scene loads as the super-user ui scene and drives login/UI (with the `--builtin-*` flags respected, as before the HUD).
- `--ui none`: no HUD process and no ui scene — the engine's builtin UI drives.
- no `--ui`: unchanged — bundled bridge-scene + react HUD.

**Web** (`?systemScene=` query param)
- An explicit `?systemScene=` hides the react HUD (like `?hud=0`) and boots the engine directly with no react sign-in — the substituted scene owns login/UI in-engine. `?systemScene=none` runs the builtin ui. `?realm=`/`?position=` are honoured, defaulting to Genesis 0,0 (there is no visible picker).
- The URL sync now keeps an explicit `?systemScene=` across reloads (it previously self-erased on the first sync), and only reports a ui scene when one is actually running (the super-user first scene) rather than assuming `scenes.first()` is one.

The second commit consolidates the web boot-mode special cases (`?hud=0` / `?guest=1` / `?systemScene=`) into a single `lib/bootMode.ts` derivation: one auto-login effect instead of two racing ones, a shared hidden-HUD destination fallback (incidentally fixing `?hud=0&guest=1` without `?position` stranding on the invisible places picker), and boot.js observing param explicitness from its own entry URL instead of a `defaultSystemScene` config field.

Note: `--ui <url>` previously pointed the HUD's bridge-scene at a dev server; that reading is gone — `--ui` now always means "replace the HUD with this scene". (`REACT_HUD_URL` still overrides the HUD page itself; a separate flag can be added if the live bridge-scene dev loop is missed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)