### PR TITLE
fix(macos): route ctrl+c to AppExit instead of Chromium's terminate path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "bevy",
  "cef",
  "cef-dll-sys",
+ "libc",
  "objc",
  "raw-window-handle",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ serde_json = { version = "1.0.92", features = ["raw_value"] }
 ts-rs = "12"
 
 itertools = "0.14"
+libc = "0.2"
 tokio = { version = "1.44", features = ["sync", "macros", "rt"] }
 tokio-util = "*"
 anyhow = "1.0.70"

--- a/crates/cef_offscreen/Cargo.toml
+++ b/crates/cef_offscreen/Cargo.toml
@@ -17,3 +17,4 @@ raw-window-handle = "0.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
+libc = { workspace = true }

--- a/crates/cef_offscreen/src/message_loop.rs
+++ b/crates/cef_offscreen/src/message_loop.rs
@@ -26,6 +26,10 @@ impl Plugin for MessageLoopPlugin {
 
         #[cfg(target_os = "macos")]
         app.add_systems(Main, cef_do_message_loop_work);
+        // .before so cef_shutdown's on_event condition sees the AppExit written here in the
+        // same frame — the runner exits right after it, so a lost race skips cef shutdown
+        #[cfg(target_os = "macos")]
+        app.add_systems(Update, exit_on_shutdown_signal.before(cef_shutdown));
     }
 }
 
@@ -96,6 +100,9 @@ impl Default for MessageLoopPlugin {
             ),
             1
         );
+        #[cfg(target_os = "macos")]
+        macos::install_shutdown_signal_handlers();
+
         Self {
             _app: Box::new(app),
             #[cfg(target_os = "macos")]
@@ -147,6 +154,14 @@ fn cef_do_message_loop_work(_: NonSend<RunOnMainThread>) {
     cef::do_message_loop_work();
 }
 
+#[cfg(target_os = "macos")]
+fn exit_on_shutdown_signal(mut sent: Local<bool>, mut exit: EventWriter<AppExit>) {
+    if !*sent && macos::shutdown_signal_received() {
+        *sent = true;
+        exit.write_default();
+    }
+}
+
 fn cef_shutdown(_: NonSend<RunOnMainThread>) {
     shutdown();
 }
@@ -177,6 +192,34 @@ mod macos {
 
     extern "C" fn set_handling_send_event(_: &Object, _: Sel, flag: bool) {
         IS_HANDLING_SEND_EVENT.swap(flag, Ordering::Relaxed);
+    }
+
+    static SHUTDOWN_SIGNAL: AtomicBool = AtomicBool::new(false);
+
+    pub fn shutdown_signal_received() -> bool {
+        SHUTDOWN_SIGNAL.load(Ordering::Relaxed)
+    }
+
+    extern "C" fn flag_shutdown_signal(signal: libc::c_int) {
+        if SHUTDOWN_SIGNAL.swap(true, Ordering::Relaxed) {
+            // a repeated signal means the graceful exit isn't getting there; bail out hard
+            unsafe { libc::_exit(128 + signal) };
+        }
+    }
+
+    /// Chromium installs SIGINT/SIGTERM/SIGHUP handlers during cef initialize that call
+    /// -[NSApplication terminate:] from the message pump. winit's applicationWillTerminate
+    /// delegate is then re-entered from inside cef_do_message_loop_work (itself inside a winit
+    /// event-loop callback) and panics across a cannot-unwind boundary; the abort() wedges in
+    /// __pthread_kill, leaving an unkillable zombie that still holds the CEF cache singleton
+    /// and blocks every relaunch. Replace the handlers: flag the signal and let the app wind
+    /// down through AppExit, which already runs cef shutdown.
+    pub fn install_shutdown_signal_handlers() {
+        unsafe {
+            for sig in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+                libc::signal(sig, flag_shutdown_signal as *const () as libc::sighandler_t);
+            }
+        }
     }
 
     pub fn install_cef_app_protocol() {


### PR DESCRIPTION
On macOS, ctrl+c on a terminal run of the explorer (with the CEF HUD) frequently left an **unkillable** process: Chromium's own SIGINT handler (installed during `cef initialize`) calls `-[NSApplication terminate:]` from the message pump, winit's `applicationWillTerminate` delegate gets re-entered from inside `cef_do_message_loop_work` (which itself runs inside a winit event-loop callback) and panics across a cannot-unwind boundary, and the resulting `abort()` wedges permanently in `__pthread_kill`. The zombie can't be killed even with SIGKILL (uninterruptible kernel wait) and still holds the CEF cache singleton — mach service registration + UKM db lock — so every relaunch fails with `bootstrap_check_in … Permission denied` / `UKM database is locked` until reboot.

Fix: after `initialize()`, replace Chromium's SIGINT/SIGTERM/SIGHUP handlers with one that just sets an atomic flag; a system turns the flag into `AppExit`, riding the existing `cef_shutdown.run_if(on_event::<AppExit>)` path (ordered `.before` it so the event is seen in the frame it's written — the runner exits right after). A second signal hard-exits with `_exit(128+sig)` as an escape hatch if the graceful path ever hangs.

macOS-only: the failure needs all three mac-specific ingredients (external message pump on the main thread, the `NSApp terminate:` shutdown route, and the abort wedge). Linux runs CEF's multi-threaded message loop so Chromium shutdown never re-enters winit; worst case there is an unclean-but-dead exit, and widening this to `cfg(unix)` is a one-line follow-up if a Linux test shows it's worth it.

Verified live on macOS: SIGINT → scene threads shut down in order → exit code 0 in ~2s, no zombie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)