### PR TITLE
just wasm: npm install react-web + bridge-scene before serving

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,6 +7,8 @@ wasm:
     wasm-pack build --target web --out-dir ./deploy/web/engine/pkg --no-default-features --features="livekit,social"
     rm -f ./deploy/web/engine/pkg/.gitignore
     WASM_SIZE=$(wc -c < ./deploy/web/engine/pkg/webgpu_build_bg.wasm) && echo "{\"wasmSize\":${WASM_SIZE}}" > ./deploy/web/engine/pkg/manifest.json
+    cd react-web && npm install
+    cd react-web/bridge-scene && npm install
     cd react-web && npm run dev -- --open
 
 # regenerate the TypeScript bindings for the ~system/BevyExplorerApi boundary from the Rust


### PR DESCRIPTION
`just wasm` jumped straight to `npm run dev`, which fails on a fresh checkout: `react-web` has no `node_modules`, and a missing `bridge-scene/node_modules` makes the preview plugin's `npx` fetch the unrelated registry package `sdk-commands` (per the warning comment in `react-web/vite.config.ts`). Mirror the two installs `bundle-native` already runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)