### PR TITLE
fix/react-web-hud-03: backpack — outfits, decoupled equipped set, server-side pagination, explicit equip

### DIFF
--- a/react-web/bridge-scene/src/domains/catalog.ts
+++ b/react-web/bridge-scene/src/domains/catalog.ts
@@ -1,0 +1,33 @@
+// Generic server-side-paginated owned-items catalog (backpack grid). One `catalogQuery` handler
+// dispatches by `catalog` kind to a per-type page fetcher and emits a uniform `catalogPage`.
+//   wearables → wearables.ts fetchWearablesPage (catalyst /explorer/:address/wearables, paged)
+//   emotes    → TODO: reuse the same pattern (currently served by the getEmotes domain, uncapped).
+import { getPlayer } from '@dcl/sdk/players'
+import { fetchWearablesPage } from './wearables'
+import type { Ctx } from '../bridge'
+import type { Wearable } from '../../../src/engine/protocol'
+
+export function registerCatalog(ctx: Ctx): void {
+  ctx.on('catalogQuery', async (msg) => {
+    const me = getPlayer()
+    const empty: { items: Wearable[]; total: number } = { items: [], total: 0 }
+    let page = empty
+    if (me != null) {
+      if (msg.catalog === 'wearables') {
+        page = await fetchWearablesPage(me.userId, {
+          page: msg.page,
+          pageSize: msg.pageSize,
+          category: msg.category,
+          search: msg.search,
+          orderBy: msg.orderBy,
+          direction: msg.direction,
+          collectiblesOnly: msg.collectiblesOnly
+        }).catch(() => empty)
+      } else {
+        // TODO(emotes): route emotes through the same paged fetcher.
+        console.log('[catalog] emotes pagination not implemented yet')
+      }
+    }
+    ctx.send({ kind: 'catalogPage', catalog: msg.catalog, items: page.items, total: page.total, requestId: msg.requestId })
+  })
+}

--- a/react-web/bridge-scene/src/domains/outfits.ts
+++ b/react-web/bridge-scene/src/domains/outfits.ts
@@ -1,0 +1,125 @@
+// Outfits: the player's saved avatar looks (backpack Outfits tab).
+//   load  ← localStorage cache first, else catalyst GET /lambdas/outfits/:address (unsigned)
+//   save/delete → localStorage (Phase 1; Phase 2 will deploy a signed `outfits` entity)
+//   equip → BevyApi.setAvatar (body shape + colors + wearables)
+//
+// Mirrors bevy-ui-scene's outfits flow (localStorage-first read, host-mediated equip). The saved
+// shape matches the deployed catalyst `outfits` entity so Phase 2 can deploy it unchanged.
+import { getPlayer } from '@dcl/sdk/players'
+import { BevyApi } from '../bevy-api'
+import { catalystBase, getJson } from '../http'
+import type { Ctx } from '../bridge'
+import type { Outfit, OutfitsMetadata, RGBColor } from '../../../src/engine/protocol'
+
+// The Bevy engine injects a persistent localStorage into system scenes (same as bevy-ui-scene).
+declare const localStorage: {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+const EMPTY: OutfitsMetadata = { outfits: [], namesForExtraSlots: [] }
+const GREY: RGBColor = { r: 0.5, g: 0.5, b: 0.5 }
+
+const storageKey = (address: string): string => `outfits:${address.toLowerCase()}`
+
+function readLocal(address: string): OutfitsMetadata | null {
+  try {
+    const raw = localStorage.getItem(storageKey(address))
+    return raw != null ? (JSON.parse(raw) as OutfitsMetadata) : null
+  } catch {
+    return null
+  }
+}
+
+function writeLocal(address: string, metadata: OutfitsMetadata): void {
+  try {
+    localStorage.setItem(storageKey(address), JSON.stringify(metadata))
+  } catch (e) {
+    console.error('[outfits] localStorage write failed', e)
+  }
+}
+
+// localStorage-first (like bevy-ui-scene) so a local save survives reload; else the catalyst
+// lambdas endpoint, which returns { metadata: OutfitsMetadata } (missing → empty for new users).
+async function loadMetadata(address: string): Promise<OutfitsMetadata> {
+  const local = readLocal(address)
+  if (local != null) return local
+  const base = await catalystBase()
+  const res = await getJson<{ metadata?: OutfitsMetadata }>(`${base}/lambdas/outfits/${address}`).catch(() => undefined)
+  return res?.metadata ?? EMPTY
+}
+
+// Capture the player's CURRENT look into a deployable Outfit (colors default to grey if absent).
+function currentOutfit(player: NonNullable<ReturnType<typeof getPlayer>>): Outfit {
+  const a = player.avatar
+  return {
+    bodyShape: a?.bodyShapeUrn ?? '',
+    eyes: { color: a?.eyesColor ?? GREY },
+    hair: { color: a?.hairColor ?? GREY },
+    skin: { color: a?.skinColor ?? GREY },
+    wearables: (player.wearables ?? []).map(String),
+    forceRender: (player.forceRender ?? []).map(String)
+  }
+}
+
+export function registerOutfits(ctx: Ctx): void {
+  const emit = (metadata: OutfitsMetadata): void => ctx.send({ kind: 'outfits', metadata })
+
+  ctx.on('getOutfits', async () => {
+    const me = getPlayer()
+    if (me == null) {
+      emit(EMPTY)
+      return
+    }
+    emit(await loadMetadata(me.userId))
+  })
+
+  // Save the current look into `slot`, replacing any existing outfit there, then re-emit.
+  ctx.on('saveOutfit', async (msg) => {
+    const me = getPlayer()
+    if (me == null) return
+    const metadata = await loadMetadata(me.userId)
+    const outfits = metadata.outfits.filter((o) => o.slot !== msg.slot)
+    outfits.push({ slot: msg.slot, outfit: currentOutfit(me) })
+    outfits.sort((a, b) => a.slot - b.slot)
+    const next = { ...metadata, outfits }
+    writeLocal(me.userId, next)
+    emit(next)
+  })
+
+  ctx.on('deleteOutfit', async (msg) => {
+    const me = getPlayer()
+    if (me == null) return
+    const metadata = await loadMetadata(me.userId)
+    const next = { ...metadata, outfits: metadata.outfits.filter((o) => o.slot !== msg.slot) }
+    writeLocal(me.userId, next)
+    emit(next)
+  })
+
+  // Apply a saved outfit's body shape, colors and wearables to the live profile (keeps emotes).
+  ctx.on('equipOutfit', async (msg) => {
+    const me = getPlayer()
+    if (me == null) return
+    const metadata = await loadMetadata(me.userId)
+    const found = metadata.outfits.find((o) => o.slot === msg.slot)
+    if (found == null) return
+    const { outfit } = found
+    BevyApi.setAvatar({
+      base: {
+        name: me.name,
+        bodyShapeUrn: outfit.bodyShape,
+        eyesColor: outfit.eyes.color,
+        hairColor: outfit.hair.color,
+        skinColor: outfit.skin.color
+      },
+      equip: {
+        wearableUrns: outfit.wearables,
+        emoteUrns: (me.emotes ?? []).map(String),
+        forceRender: outfit.forceRender
+      }
+    }).catch((e: unknown) => {
+      console.error('[outfits] equip failed', e)
+    })
+  })
+}

--- a/react-web/bridge-scene/src/domains/wearables.ts
+++ b/react-web/bridge-scene/src/domains/wearables.ts
@@ -42,11 +42,15 @@ function accumulateTokens(elements: CatalogElement[]): void {
   }
 }
 
-// A deployed/owned urn may carry a tokenId (…:collections-v2:<contract>:<itemId>:<tokenId>); the
-// item form drops it. Base urns pass through.
+// A deployed/owned urn may carry a tokenId (…:collections-v{1,2}:<contract>:<itemId>:<tokenId>);
+// the item form drops it. Both v1 (ethereum) and v2 (matic) items are 6 segments, so a trailing
+// token makes it >6 — strip it for either, else the equipped-set resolve (which needs the bare
+// item urn) misses the item and its category slot renders empty. Base urns pass through.
 function itemUrnOf(urn: string): string {
   const parts = urn.split(':')
-  if (parts[3] === 'collections-v2' && parts.length > 6) return parts.slice(0, 6).join(':')
+  if ((parts[3] === 'collections-v2' || parts[3] === 'collections-v1') && parts.length > 6) {
+    return parts.slice(0, 6).join(':')
+  }
   return urn
 }
 

--- a/react-web/bridge-scene/src/domains/wearables.ts
+++ b/react-web/bridge-scene/src/domains/wearables.ts
@@ -1,6 +1,8 @@
-// Wearables / backpack: owned + equipped wearables, and equipping.
-//   from: catalyst GET /explorer/:address/wearables (catalog), @dcl/sdk getPlayer().wearables
-//         (equipped), BevyApi.setAvatar (equip).
+// Wearables / backpack: equipped wearables (category slots) + equipping, plus the paged owned
+// catalog fetcher used by the generic `catalog` domain.
+//   from: catalyst GET /explorer/:address/wearables (owned catalog, paged),
+//         GET /lambdas/collections/wearables?wearableId=… (equipped-by-urn resolve),
+//         @dcl/sdk getPlayer().wearables (equipped), BevyApi.setAvatar (equip).
 import { getPlayer } from '@dcl/sdk/players'
 import { BevyApi } from '../bevy-api'
 import { catalystBase, getJson } from '../http'
@@ -18,30 +20,12 @@ type CatalogElement = {
   entity?: { metadata?: { thumbnail?: string }; content?: Array<{ file: string; hash: string }> }
 }
 
-async function fetchCatalog(address: string): Promise<{ baseUrl: string; elements: CatalogElement[] }> {
-  const baseUrl = await catalystBase()
-  const url = `${baseUrl}/explorer/${address}/wearables?pageNum=1&pageSize=200&includeEntities=true`
-  const data = await getJson<{ elements?: CatalogElement[] }>(url).catch(() => undefined)
-  return { baseUrl, elements: data?.elements ?? [] }
-}
-
-// The owned-wearables catalog rarely changes within a session → cache it (and the token index it
-// feeds) per address, so re-opening the Backpack doesn't refetch. Equipped state is read live from
-// getPlayer().wearables on each getWearables, so it stays current without invalidating the cache.
-let catalogCache: { address: string; baseUrl: string; elements: CatalogElement[] } | null = null
-async function getCatalog(address: string): Promise<{ baseUrl: string; elements: CatalogElement[] }> {
-  if (catalogCache?.address === address) return catalogCache
-  const { baseUrl, elements } = await fetchCatalog(address)
-  indexTokens(elements)
-  catalogCache = { address, baseUrl, elements }
-  return catalogCache
-}
-
 // Collection wearables must be referenced in the DEPLOYED profile by their full token URN
 // (…:{contract}:{itemId}:{tokenId}); the catalyst rejects the bare item URN with
-// "should be an item, not an asset. The URN must include the tokenId.". The catalog's
-// individualData carries the owned tokenId per item, so we map item-urn → token-urn and send
-// the token form on equip. Base (off-chain) wearables have no tokenId and pass through unchanged.
+// "should be an item, not an asset. The URN must include the tokenId.". individualData carries the
+// owned tokenId per item, so we map item-urn → token-urn and send the token form on equip. Base
+// (off-chain) wearables have no tokenId and pass through unchanged. The map accumulates across
+// fetched pages + the equipped set, so any item the user has actually seen/equipped can be equipped.
 const tokenUrnByItem = new Map<string, string>()
 
 function tokenUrnFor(el: CatalogElement): string {
@@ -51,16 +35,15 @@ function tokenUrnFor(el: CatalogElement): string {
   return el.urn
 }
 
-function indexTokens(elements: CatalogElement[]): void {
-  tokenUrnByItem.clear()
+function accumulateTokens(elements: CatalogElement[]): void {
   for (const el of elements) {
     const full = tokenUrnFor(el)
     if (full !== el.urn) tokenUrnByItem.set(el.urn, full)
   }
 }
 
-// Reverse of tokenUrnFor: a deployed/owned urn may carry a tokenId
-// (…:collections-v2:<contract>:<itemId>:<tokenId>); the item form drops it. Base urns pass through.
+// A deployed/owned urn may carry a tokenId (…:collections-v2:<contract>:<itemId>:<tokenId>); the
+// item form drops it. Base urns pass through.
 function itemUrnOf(urn: string): string {
   const parts = urn.split(':')
   if (parts[3] === 'collections-v2' && parts.length > 6) return parts.slice(0, 6).join(':')
@@ -69,8 +52,8 @@ function itemUrnOf(urn: string): string {
 
 type WearableDef = { id: string; name?: string; rarity?: string; thumbnail?: string; data?: { category?: string } }
 
-// Resolve wearable definitions by item urn (for equipped items absent from the catalog page), to
-// learn each one's category (slot placement). Batched to keep the URL length bounded; failures skip.
+// Resolve wearable definitions by item urn (equipped set) to learn each one's category (slot
+// placement). Batched to keep the URL length bounded; failures skip.
 async function resolveByUrn(baseUrl: string, itemUrns: string[]): Promise<Map<string, WearableDef>> {
   const out = new Map<string, WearableDef>()
   const CHUNK = 50
@@ -82,13 +65,52 @@ async function resolveByUrn(baseUrl: string, itemUrns: string[]): Promise<Map<st
   return out
 }
 
-export function registerWearables(ctx: Ctx): void {
-  ctx.on('equip', async (msg) => {
-    const me = getPlayer()
-    // Ensure the item→token map is loaded (equipping before the catalog was fetched).
-    if (me != null && tokenUrnByItem.size === 0) {
-      await getCatalog(me.userId)
+export interface CatalogPageParams {
+  /** 0-based page. */
+  page: number
+  pageSize: number
+  category?: string
+  search?: string
+  orderBy?: 'rarity' | 'name'
+  direction?: 'asc' | 'desc'
+  collectiblesOnly?: boolean
+}
+
+// Server-side-paginated owned-wearables fetch (one page). Filters/sort are applied by the catalyst
+// so multi-thousand inventories never load at once. `equipped` per item reflects the live avatar.
+export async function fetchWearablesPage(address: string, p: CatalogPageParams): Promise<{ items: Wearable[]; total: number }> {
+  const baseUrl = await catalystBase()
+  let url = `${baseUrl}/explorer/${address}/wearables?pageNum=${p.page + 1}&pageSize=${p.pageSize}&includeEntities=true`
+  if (p.category != null && p.category !== 'all') url += `&category=${p.category}`
+  if (p.search != null && p.search !== '') url += `&name=${encodeURIComponent(p.search)}`
+  if (p.orderBy != null) url += `&orderBy=${p.orderBy}&direction=${p.direction === 'asc' ? 'ASC' : 'DESC'}`
+  // Explicit collection types (matches unity/bevy-ui-scene): collectibles-only drops base wearables.
+  const collectionTypes = p.collectiblesOnly ? ['on-chain', 'third-party'] : ['base-wearable', 'on-chain', 'third-party']
+  for (const t of collectionTypes) url += `&collectionType=${t}`
+
+  const data = await getJson<{ elements?: CatalogElement[]; totalAmount?: number }>(url).catch(() => undefined)
+  const elements = data?.elements ?? []
+  accumulateTokens(elements)
+  const owned = (getPlayer()?.wearables ?? []).map(String)
+  const items: Wearable[] = elements.map((el) => {
+    const file = el.entity?.metadata?.thumbnail
+    const hash = el.entity?.content?.find((c) => c.file === file)?.hash
+    return {
+      urn: el.urn,
+      name: el.name,
+      rarity: el.rarity,
+      category: el.category,
+      thumbnail: hash != null ? `${baseUrl}/content/contents/${hash}` : undefined,
+      count: el.amount,
+      equipped: owned.some((w) => w === el.urn || w.startsWith(`${el.urn}:`))
     }
+  })
+  return { items, total: data?.totalAmount ?? items.length }
+}
+
+export function registerWearables(ctx: Ctx): void {
+  ctx.on('equip', (msg) => {
+    const me = getPlayer()
     const wearableUrns = msg.urns.map((u) => tokenUrnByItem.get(u) ?? u)
     BevyApi.setAvatar({
       equip: { wearableUrns, emoteUrns: (me?.emotes ?? []).map(String), forceRender: [] }
@@ -97,44 +119,29 @@ export function registerWearables(ctx: Ctx): void {
     })
   })
 
+  // Equipped set (category slots), resolved by urn — DECOUPLED from the paged grid so every equipped
+  // item shows regardless of which catalog page it's on. Mirrors unity-explorer / bevy-ui-scene.
   ctx.on('getWearables', async () => {
     const player = getPlayer()
     if (player == null) {
-      ctx.send({ kind: 'wearables', wearables: [], equipped: [] })
+      ctx.send({ kind: 'wearables', equipped: [] })
       return
     }
-    const { baseUrl, elements } = await getCatalog(player.userId)
+    const baseUrl = await catalystBase()
     const owned = (player.wearables ?? []).map(String)
-    const wearables: Wearable[] = elements.map((el) => {
-      const file = el.entity?.metadata?.thumbnail
-      const hash = el.entity?.content?.find((c) => c.file === file)?.hash
-      return {
-        urn: el.urn,
-        name: el.name,
-        rarity: el.rarity,
-        category: el.category,
-        thumbnail: hash != null ? `${baseUrl}/content/contents/${hash}` : undefined,
-        count: el.amount,
-        equipped: owned.some((w) => w === el.urn || w.startsWith(`${el.urn}:`))
-      }
-    })
-
-    // Equipped slots are DECOUPLED from the (paginated) catalog: take the avatar's equipped urns,
-    // reuse the catalog entry when present, else batch-resolve the item's category by urn. Each
-    // slot's thumbnail is a pure function of the urn — so every equipped item resolves regardless
-    // of which catalog page it falls on. Mirrors unity-explorer / bevy-ui-scene.
-    const byItemUrn = new Map<string, Wearable>()
-    for (const w of wearables) byItemUrn.set(w.urn, w)
+    // Equipped urns are the deployable token form → index item→token now (equip needs it even
+    // before any grid page is fetched).
+    for (const u of owned) {
+      const item = itemUrnOf(u)
+      if (item !== u) tokenUrnByItem.set(item, u)
+    }
     const equippedItemUrns = [...new Set(owned.map(itemUrnOf))]
-    const missing = equippedItemUrns.filter((u) => !byItemUrn.has(u))
-    const resolved = missing.length > 0 ? await resolveByUrn(baseUrl, missing) : new Map<string, WearableDef>()
+    const resolved = equippedItemUrns.length > 0 ? await resolveByUrn(baseUrl, equippedItemUrns) : new Map<string, WearableDef>()
     const equipped: Wearable[] = equippedItemUrns
       .map((itemUrn): Wearable | null => {
-        const fromCatalog = byItemUrn.get(itemUrn)
-        if (fromCatalog != null) return { ...fromCatalog, equipped: true }
-        const def = resolved.get(itemUrn)
-        const category = def?.data?.category
+        const category = resolved.get(itemUrn)?.data?.category
         if (category == null) return null // can't place a slot without its category
+        const def = resolved.get(itemUrn)
         return {
           urn: itemUrn,
           name: def?.name ?? '',
@@ -146,6 +153,6 @@ export function registerWearables(ctx: Ctx): void {
       })
       .filter((w): w is Wearable => w != null)
 
-    ctx.send({ kind: 'wearables', wearables, equipped })
+    ctx.send({ kind: 'wearables', equipped })
   })
 }

--- a/react-web/bridge-scene/src/domains/wearables.ts
+++ b/react-web/bridge-scene/src/domains/wearables.ts
@@ -59,6 +59,29 @@ function indexTokens(elements: CatalogElement[]): void {
   }
 }
 
+// Reverse of tokenUrnFor: a deployed/owned urn may carry a tokenId
+// (…:collections-v2:<contract>:<itemId>:<tokenId>); the item form drops it. Base urns pass through.
+function itemUrnOf(urn: string): string {
+  const parts = urn.split(':')
+  if (parts[3] === 'collections-v2' && parts.length > 6) return parts.slice(0, 6).join(':')
+  return urn
+}
+
+type WearableDef = { id: string; name?: string; rarity?: string; thumbnail?: string; data?: { category?: string } }
+
+// Resolve wearable definitions by item urn (for equipped items absent from the catalog page), to
+// learn each one's category (slot placement). Batched to keep the URL length bounded; failures skip.
+async function resolveByUrn(baseUrl: string, itemUrns: string[]): Promise<Map<string, WearableDef>> {
+  const out = new Map<string, WearableDef>()
+  const CHUNK = 50
+  for (let i = 0; i < itemUrns.length; i += CHUNK) {
+    const qs = itemUrns.slice(i, i + CHUNK).map((u) => `wearableId=${u}`).join('&')
+    const data = await getJson<{ wearables?: WearableDef[] }>(`${baseUrl}/lambdas/collections/wearables?${qs}`).catch(() => undefined)
+    for (const w of data?.wearables ?? []) out.set(w.id, w)
+  }
+  return out
+}
+
 export function registerWearables(ctx: Ctx): void {
   ctx.on('equip', async (msg) => {
     const me = getPlayer()
@@ -77,7 +100,7 @@ export function registerWearables(ctx: Ctx): void {
   ctx.on('getWearables', async () => {
     const player = getPlayer()
     if (player == null) {
-      ctx.send({ kind: 'wearables', wearables: [] })
+      ctx.send({ kind: 'wearables', wearables: [], equipped: [] })
       return
     }
     const { baseUrl, elements } = await getCatalog(player.userId)
@@ -95,6 +118,34 @@ export function registerWearables(ctx: Ctx): void {
         equipped: owned.some((w) => w === el.urn || w.startsWith(`${el.urn}:`))
       }
     })
-    ctx.send({ kind: 'wearables', wearables })
+
+    // Equipped slots are DECOUPLED from the (paginated) catalog: take the avatar's equipped urns,
+    // reuse the catalog entry when present, else batch-resolve the item's category by urn. Each
+    // slot's thumbnail is a pure function of the urn — so every equipped item resolves regardless
+    // of which catalog page it falls on. Mirrors unity-explorer / bevy-ui-scene.
+    const byItemUrn = new Map<string, Wearable>()
+    for (const w of wearables) byItemUrn.set(w.urn, w)
+    const equippedItemUrns = [...new Set(owned.map(itemUrnOf))]
+    const missing = equippedItemUrns.filter((u) => !byItemUrn.has(u))
+    const resolved = missing.length > 0 ? await resolveByUrn(baseUrl, missing) : new Map<string, WearableDef>()
+    const equipped: Wearable[] = equippedItemUrns
+      .map((itemUrn): Wearable | null => {
+        const fromCatalog = byItemUrn.get(itemUrn)
+        if (fromCatalog != null) return { ...fromCatalog, equipped: true }
+        const def = resolved.get(itemUrn)
+        const category = def?.data?.category
+        if (category == null) return null // can't place a slot without its category
+        return {
+          urn: itemUrn,
+          name: def?.name ?? '',
+          rarity: def?.rarity ?? 'base',
+          category,
+          thumbnail: `${baseUrl}/lambdas/collections/contents/${itemUrn}/thumbnail`,
+          equipped: true
+        }
+      })
+      .filter((w): w is Wearable => w != null)
+
+    ctx.send({ kind: 'wearables', wearables, equipped })
   })
 }

--- a/react-web/bridge-scene/src/index.ts
+++ b/react-web/bridge-scene/src/index.ts
@@ -14,6 +14,7 @@ import { registerFriends } from './domains/friends'
 import { registerChat } from './domains/chat'
 import { registerEmotes } from './domains/emotes'
 import { registerWearables } from './domains/wearables'
+import { registerOutfits } from './domains/outfits'
 import { registerNotifications } from './domains/notifications'
 import { registerSettings } from './domains/settings'
 import { registerCommunities } from './domains/communities'
@@ -37,6 +38,7 @@ export function main(): void {
     registerChat(ctx)
     registerEmotes(ctx)
     registerWearables(ctx)
+    registerOutfits(ctx)
     registerNotifications(ctx)
     registerSettings(ctx)
     registerCommunities(ctx)

--- a/react-web/bridge-scene/src/index.ts
+++ b/react-web/bridge-scene/src/index.ts
@@ -14,6 +14,7 @@ import { registerFriends } from './domains/friends'
 import { registerChat } from './domains/chat'
 import { registerEmotes } from './domains/emotes'
 import { registerWearables } from './domains/wearables'
+import { registerCatalog } from './domains/catalog'
 import { registerOutfits } from './domains/outfits'
 import { registerNotifications } from './domains/notifications'
 import { registerSettings } from './domains/settings'
@@ -38,6 +39,7 @@ export function main(): void {
     registerChat(ctx)
     registerEmotes(ctx)
     registerWearables(ctx)
+    registerCatalog(ctx)
     registerOutfits(ctx)
     registerNotifications(ctx)
     registerSettings(ctx)

--- a/react-web/docs/backlog.md
+++ b/react-web/docs/backlog.md
@@ -180,13 +180,16 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     (DOM + the engine's `Cancel` action) so one source has to win. A follow-up on its own, deferred to
     spend time on higher-priority issues; the fragile `exitPointerLock()`-then-gesture-less-
     `requestPointerLock()` trick is NOT it — don't rely on it. Moot on native: no browser pointer lock
-    there, the engine owns the OS cursor grab and releases it on the `Chat` action.) **(b) the related bug:** full-screen menus
-    (settings/map/backpack…) opened via their **hotkey while camera-look is active** (`useMenuShortcuts`
-    fires even when the iframe holds focus) **don't free the cursor at all** — only profile-card + chat
-    do — so the menu renders over a still-locked cursor and is unusable until you click. Fold this into
-    the same pass: a single "any HUD panel/overlay open → engine cursor free" rule instead of the current
-    per-trigger frees. Kept Medium: chat + click-to-open panels work today, so it's not blocking — it's a
-    core-interaction UX/parity gap, not an MVP blocker.
+    there, the engine owns the OS cursor grab and releases it on the `Chat` action.) **(b) the related bug — web part SHIPPED (`fix/03-backpack`):**
+    full-screen menus (settings/map/backpack/communities/places/gallery) opened via their **hotkey while
+    camera-look is active** used to render over a still-locked cursor (only profile-card + chat freed it).
+    Now a single rule in `useEngineSession` releases the lock whenever any full-screen menu opens (a
+    `useEffect` on `menuPageOpen` → `document.exitPointerLock()`), replacing the per-trigger frees on web.
+    **Remaining — native:** `exitPointerLock` is a web no-op, so on native (CEF, engine owns the OS cursor
+    grab) a menu open does **not** yet free the cursor; if that proves needed, relay a bridge write
+    `PointerLock.isPointerLocked = false` on `CameraEntity` on menu open, the way `chat.ts` /
+    `avatarPointer.ts` already do for their surfaces. Kept Medium: chat + click-to-open panels + web
+    menus work today; only native menu-open cursor release is open.
 19. `[feature]` **Chat links: confirm popup before teleporting and before opening a URL** — *parity with
     `bevy-ui-scene`, safety*. The **parsing** has parity: `chatText.tsx`'s `TOKEN_RE` linkifies the same
     four kinds as the old `LINK_TYPE` (`components/chat/chat-message/ChatMessage.tsx:43`) — url, world,

--- a/react-web/src/design/WearableCard.tsx
+++ b/react-web/src/design/WearableCard.tsx
@@ -27,8 +27,10 @@ interface WearableCardProps {
   incompatible?: boolean
   /** Body-part glyph shown in the top-left flap (matches Unity's category badge). */
   categoryIcon?: React.ReactNode
-  /** Card click — selects the item (previews, does not persist). */
+  /** Card click — selects the item (shows its detail; does not equip or preview). */
   onClick?: () => void
+  /** Card double-click — the explicit equip action (persists), same as the pill. */
+  onDoubleClick?: () => void
   /** Hover EQUIP/UNEQUIP pill click — the explicit equip action (persists). */
   onEquip?: () => void
 }
@@ -44,6 +46,7 @@ export function WearableCard({
   incompatible = false,
   categoryIcon,
   onClick,
+  onDoubleClick,
   onEquip
 }: WearableCardProps): React.JSX.Element {
   const [failed, setFailed] = useState(false)
@@ -54,6 +57,7 @@ export function WearableCard({
       title={name}
       aria-label={name}
       onClick={onClick}
+      onDoubleClick={onDoubleClick}
     >
       {categoryIcon != null && <span className={styles.flap}>{categoryIcon}</span>}
       {thumbnail && !failed ? (

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -121,6 +121,13 @@ const mockOutfit = (urns: string[]): Outfit => ({
   forceRender: []
 })
 
+// An equipped wearable that is NOT in the catalog grid (simulates an item beyond the fetched page).
+// It must still drive its category slot via the decoupled `equipped` list — the bug this exercises.
+const MOCK_OFF_CATALOG_EQUIPPED: Wearable[] = [
+  { urn: 'urn:decentraland:off-chain:base-avatars:thug_life', name: 'Off-catalog Eyewear', rarity: 'epic', category: 'eyewear', thumbnail: thumb('urn:decentraland:off-chain:base-avatars:black_sun_glasses'), equipped: true }
+]
+const equippedNow = (): Wearable[] => [...mockWearables.filter((w) => w.equipped), ...MOCK_OFF_CATALOG_EQUIPPED]
+
 const v = (name: string): { name: string; description: string } => ({ name, description: '' })
 
 // Stateful so the mock's controls actually move when changed (setSetting → re-emit).
@@ -374,13 +381,13 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
     if (msg.kind === 'triggerEmote') return // no-op in the mock
     if (msg.kind === 'equipEmote') return // no-op in the mock
     if (msg.kind === 'getWearables') {
-      reply({ kind: 'wearables', wearables: mockWearables })
+      reply({ kind: 'wearables', wearables: mockWearables, equipped: equippedNow() })
       return
     }
     if (msg.kind === 'equip') {
       const set = new Set(msg.urns)
       for (const w of mockWearables) w.equipped = set.has(w.urn)
-      reply({ kind: 'wearables', wearables: mockWearables })
+      reply({ kind: 'wearables', wearables: mockWearables, equipped: equippedNow() })
       return
     }
     if (msg.kind === 'getOutfits') {
@@ -406,7 +413,7 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
       if (found) {
         const set = new Set(found.outfit.wearables)
         for (const w of mockWearables) w.equipped = set.has(w.urn)
-        reply({ kind: 'wearables', wearables: mockWearables })
+        reply({ kind: 'wearables', wearables: mockWearables, equipped: equippedNow() })
       }
       return
     }

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -381,13 +381,30 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
     if (msg.kind === 'triggerEmote') return // no-op in the mock
     if (msg.kind === 'equipEmote') return // no-op in the mock
     if (msg.kind === 'getWearables') {
-      reply({ kind: 'wearables', wearables: mockWearables, equipped: equippedNow() })
+      reply({ kind: 'wearables', equipped: equippedNow() })
+      return
+    }
+    if (msg.kind === 'catalogQuery') {
+      if (msg.catalog !== 'wearables') {
+        reply({ kind: 'catalogPage', catalog: msg.catalog, items: [], total: 0, requestId: msg.requestId })
+        return
+      }
+      let items = mockWearables.slice()
+      if (msg.category != null && msg.category !== 'all') items = items.filter((w) => w.category === msg.category)
+      if (msg.search != null && msg.search !== '') items = items.filter((w) => (w.name ?? '').toLowerCase().includes(msg.search!.toLowerCase()))
+      if (msg.collectiblesOnly === true) items = items.filter((w) => (w.rarity ?? 'base') !== 'base')
+      const dir = msg.direction === 'asc' ? 1 : -1
+      if (msg.orderBy === 'name') items.sort((a, b) => dir * (a.name ?? '').localeCompare(b.name ?? ''))
+      else if (msg.orderBy === 'rarity') items.sort((a, b) => dir * (RARITIES.indexOf(a.rarity) - RARITIES.indexOf(b.rarity)))
+      const total = items.length
+      const start = msg.page * msg.pageSize
+      reply({ kind: 'catalogPage', catalog: 'wearables', items: items.slice(start, start + msg.pageSize), total, requestId: msg.requestId })
       return
     }
     if (msg.kind === 'equip') {
       const set = new Set(msg.urns)
       for (const w of mockWearables) w.equipped = set.has(w.urn)
-      reply({ kind: 'wearables', wearables: mockWearables, equipped: equippedNow() })
+      reply({ kind: 'wearables', equipped: equippedNow() })
       return
     }
     if (msg.kind === 'getOutfits') {
@@ -413,7 +430,7 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
       if (found) {
         const set = new Set(found.outfit.wearables)
         for (const w of mockWearables) w.equipped = set.has(w.urn)
-        reply({ kind: 'wearables', wearables: mockWearables, equipped: equippedNow() })
+        reply({ kind: 'wearables', equipped: equippedNow() })
       }
       return
     }

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -412,9 +412,10 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
       return
     }
     if (msg.kind === 'saveOutfit') {
-      // Capture the currently-equipped mock wearables as the saved look.
+      // Capture the full current look (equippedNow includes the off-catalog item), so a saved slot
+      // equals the equipped set and shows the "matches current look" marker.
       mockOutfits.outfits = mockOutfits.outfits.filter((o) => o.slot !== msg.slot)
-      mockOutfits.outfits.push({ slot: msg.slot, outfit: mockOutfit(mockWearables.filter((w) => w.equipped).map((w) => w.urn)) })
+      mockOutfits.outfits.push({ slot: msg.slot, outfit: mockOutfit(equippedNow().map((w) => w.urn)) })
       mockOutfits.outfits.sort((a, b) => a.slot - b.slot)
       reply({ kind: 'outfits', metadata: mockOutfits })
       return

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -6,6 +6,8 @@
 import {
   BRIDGE_CHANNEL,
   type Envelope,
+  type Outfit,
+  type OutfitsMetadata,
   type PageToScene,
   type Profile,
   type SceneToPage,
@@ -108,6 +110,17 @@ const mockWearables: Wearable[] = BASE.map((b, i) => {
   }
 })
 
+// A saved outfit from a set of wearable urns (fixed colors/body shape — no real avatar in the mock).
+const BASE_MALE = 'urn:decentraland:off-chain:base-avatars:BaseMale'
+const mockOutfit = (urns: string[]): Outfit => ({
+  bodyShape: BASE_MALE,
+  eyes: { color: { r: 0.37, g: 0.22, b: 0.19 } },
+  hair: { color: { r: 0.6, g: 0.36, b: 0.2 } },
+  skin: { color: { r: 0.8, g: 0.6, b: 0.47 } },
+  wearables: urns,
+  forceRender: []
+})
+
 const v = (name: string): { name: string; description: string } => ({ name, description: '' })
 
 // Stateful so the mock's controls actually move when changed (setSetting → re-emit).
@@ -186,6 +199,14 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
     isPublic: i % 2 === 0,
     dateTime: String(Math.floor((mockNow - i * 3 * DAY) / 1000))
   }))
+  // Stateful saved outfits so save/delete persist across reopens (mirrors the real store).
+  const mockOutfits: OutfitsMetadata = {
+    outfits: [
+      { slot: 0, outfit: mockOutfit(mockWearables.slice(0, 5).map((w) => w.urn)) },
+      { slot: 2, outfit: mockOutfit(mockWearables.slice(5, 10).map((w) => w.urn)) }
+    ],
+    namesForExtraSlots: []
+  }
   const ch = new BroadcastChannel(BRIDGE_CHANNEL)
   const wait = (ms: number): Promise<void> =>
     new Promise((r) => setTimeout(r, ms))
@@ -360,6 +381,33 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
       const set = new Set(msg.urns)
       for (const w of mockWearables) w.equipped = set.has(w.urn)
       reply({ kind: 'wearables', wearables: mockWearables })
+      return
+    }
+    if (msg.kind === 'getOutfits') {
+      reply({ kind: 'outfits', metadata: mockOutfits })
+      return
+    }
+    if (msg.kind === 'saveOutfit') {
+      // Capture the currently-equipped mock wearables as the saved look.
+      mockOutfits.outfits = mockOutfits.outfits.filter((o) => o.slot !== msg.slot)
+      mockOutfits.outfits.push({ slot: msg.slot, outfit: mockOutfit(mockWearables.filter((w) => w.equipped).map((w) => w.urn)) })
+      mockOutfits.outfits.sort((a, b) => a.slot - b.slot)
+      reply({ kind: 'outfits', metadata: mockOutfits })
+      return
+    }
+    if (msg.kind === 'deleteOutfit') {
+      mockOutfits.outfits = mockOutfits.outfits.filter((o) => o.slot !== msg.slot)
+      reply({ kind: 'outfits', metadata: mockOutfits })
+      return
+    }
+    if (msg.kind === 'equipOutfit') {
+      // Reflect the outfit's wearables as equipped so the Wearables tab updates too.
+      const found = mockOutfits.outfits.find((o) => o.slot === msg.slot)
+      if (found) {
+        const set = new Set(found.outfit.wearables)
+        for (const w of mockWearables) w.equipped = set.has(w.urn)
+        reply({ kind: 'wearables', wearables: mockWearables })
+      }
       return
     }
     if (msg.kind === 'setMic') {

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -98,6 +98,10 @@ export type PageToScene =
   | GetWearablesRequest
   | EquipRequest
   | PreviewAvatarRequest
+  | GetOutfitsRequest
+  | SaveOutfitRequest
+  | DeleteOutfitRequest
+  | EquipOutfitRequest
   | GetCommunitiesRequest
   | CreateCommunityRequest
   | JoinCommunityRequest
@@ -639,6 +643,64 @@ export interface PreviewAvatarRequest {
   urns: string[] | null
 }
 
+/** RGB color, components 0..1 (matches PBAvatarBase / the deployed avatar entity). */
+export interface RGBColor {
+  r: number
+  g: number
+  b: number
+}
+
+/** A saved avatar look (backpack Outfits tab). The shape mirrors the catalyst `outfits` entity's
+ *  per-slot outfit so a saved look can later be deployed unchanged (Phase 2); Phase 1 persists
+ *  these locally (localStorage in the bridge scene). */
+export interface Outfit {
+  bodyShape: string
+  eyes: { color: RGBColor }
+  hair: { color: RGBColor }
+  skin: { color: RGBColor }
+  wearables: string[]
+  forceRender: string[]
+}
+
+/** One saved outfit at a fixed slot index (0-based). */
+export interface OutfitSlot {
+  slot: number
+  outfit: Outfit
+}
+
+/** The player's saved outfits + owned DCL names that unlock extra slots (beyond the 5 free). */
+export interface OutfitsMetadata {
+  outfits: OutfitSlot[]
+  namesForExtraSlots: string[]
+}
+
+export interface OutfitsMessage {
+  kind: 'outfits'
+  metadata: OutfitsMetadata
+}
+
+export interface GetOutfitsRequest {
+  kind: 'getOutfits'
+}
+
+/** Save the player's CURRENT look into a slot (scene captures getPlayer(); re-emits outfits). */
+export interface SaveOutfitRequest {
+  kind: 'saveOutfit'
+  slot: number
+}
+
+/** Remove a saved outfit slot (re-emits outfits). */
+export interface DeleteOutfitRequest {
+  kind: 'deleteOutfit'
+  slot: number
+}
+
+/** Equip a saved outfit: apply its body shape, colors and wearables to the profile. */
+export interface EquipOutfitRequest {
+  kind: 'equipOutfit'
+  slot: number
+}
+
 export interface GetEmotesRequest {
   kind: 'getEmotes'
 }
@@ -739,6 +801,7 @@ export type SceneToPage =
   | EmotesMessage
   | MicMessage
   | WearablesMessage
+  | OutfitsMessage
   | CommunitiesMessage
   | CommunityDetailMessage
   | MapMessage

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -96,6 +96,7 @@ export type PageToScene =
   | EquipEmoteRequest
   | SetMicRequest
   | GetWearablesRequest
+  | CatalogQueryRequest
   | EquipRequest
   | PreviewAvatarRequest
   | GetOutfitsRequest
@@ -621,18 +622,50 @@ export interface Wearable {
   equipped: boolean
 }
 
+/** Currently-equipped wearables, resolved by urn independently of the (paginated) grid so every
+ *  equipped item drives its per-category slot even when it isn't on the current catalog page. */
 export interface WearablesMessage {
   kind: 'wearables'
-  /** The owned-wearables catalog page (drives the grid). TODO: currently a single capped page
-   *  (200 items, see bridge-scene wearables.ts `fetchCatalog`) — needs server-side pagination. */
-  wearables: Wearable[]
-  /** Currently-equipped wearables, resolved independently of the (paginated) catalog so every
-   *  equipped item drives its per-category slot even when it falls outside the catalog page. */
   equipped: Wearable[]
 }
 
+/** Load the equipped-wearables set (category slots). The owned catalog itself is paged via
+ *  catalogQuery — this only carries the decoupled equipped items. */
 export interface GetWearablesRequest {
   kind: 'getWearables'
+}
+
+/** Which owned-items catalog a paged query targets. Emotes reuse the same query/response. */
+export type CatalogKind = 'wearables' | 'emotes'
+
+/** A generic server-side-paginated request for an owned-items catalog page (backpack grid). The
+ *  scene fetches exactly this page from the catalyst so multi-thousand inventories never load at
+ *  once. Filters/sort are applied server-side; `requestId` lets the page drop stale responses. */
+export interface CatalogQueryRequest {
+  kind: 'catalogQuery'
+  catalog: CatalogKind
+  /** 0-based page index. */
+  page: number
+  pageSize: number
+  /** Wearables body-part category filter ('all' → omit). */
+  category?: string
+  /** Free-text name filter (server-side). */
+  search?: string
+  orderBy?: 'rarity' | 'name'
+  direction?: 'asc' | 'desc'
+  /** Exclude base (off-chain) items → collectibles only. */
+  collectiblesOnly?: boolean
+  /** Monotonic per-catalog id echoed in the response; the page ignores out-of-order replies. */
+  requestId: number
+}
+
+/** One catalog page (response to CatalogQueryRequest). `total` drives the pager. */
+export interface CatalogPageMessage {
+  kind: 'catalogPage'
+  catalog: CatalogKind
+  items: Wearable[]
+  total: number
+  requestId: number
 }
 
 /** Equip a new full wearable set (page → scene → BevyApi.setAvatar). */
@@ -806,6 +839,7 @@ export type SceneToPage =
   | EmotesMessage
   | MicMessage
   | WearablesMessage
+  | CatalogPageMessage
   | OutfitsMessage
   | CommunitiesMessage
   | CommunityDetailMessage

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -623,7 +623,12 @@ export interface Wearable {
 
 export interface WearablesMessage {
   kind: 'wearables'
+  /** The owned-wearables catalog page (drives the grid). TODO: currently a single capped page
+   *  (200 items, see bridge-scene wearables.ts `fetchCatalog`) — needs server-side pagination. */
   wearables: Wearable[]
+  /** Currently-equipped wearables, resolved independently of the (paginated) catalog so every
+   *  equipped item drives its per-category slot even when it falls outside the catalog page. */
+  equipped: Wearable[]
 }
 
 export interface GetWearablesRequest {

--- a/react-web/src/features/backpack/BackpackPage.module.css
+++ b/react-web/src/features/backpack/BackpackPage.module.css
@@ -365,10 +365,6 @@
   font-weight: 700;
   cursor: pointer;
 }
-.pageArrow:disabled {
-  color: var(--ink-45);
-  cursor: default;
-}
 .pageNum:hover {
   background: var(--white-10);
 }

--- a/react-web/src/features/backpack/BackpackPage.module.css
+++ b/react-web/src/features/backpack/BackpackPage.module.css
@@ -285,6 +285,30 @@
     color 0.3s ease,
     transform 0.25s ease;
 }
+/* Hover unequip button on an occupied category slot (top-right), like Unity/bevy-ui-scene. */
+.catUnequip {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--r-pill);
+  background-color: var(--scrim);
+  color: var(--text);
+  font-size: 10px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--dur-fast) ease;
+  pointer-events: none;
+}
+.catTile:hover .catUnequip {
+  opacity: 1;
+  pointer-events: auto;
+}
 
 /* Grid area. */
 .gridArea {

--- a/react-web/src/features/backpack/BackpackPage.module.css
+++ b/react-web/src/features/backpack/BackpackPage.module.css
@@ -532,14 +532,134 @@
   color: var(--ink-6);
 }
 
-/* Saved Outfits placeholder — fills the catalog area (outfits aren't wired to the engine yet). */
+/* Saved Outfits — a slot grid filling the catalog area. */
 .outfits {
   flex: 1;
   min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  padding: 16px;
+}
+.outfitGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 148px));
+  grid-auto-rows: max-content;
+  justify-content: center;
+  gap: 16px;
+}
+.outfitCard,
+.outfitEmpty {
+  position: relative;
+  aspect-ratio: 1;
+  border: 1px solid var(--white-10);
+  border-radius: var(--r-card);
+  background-color: var(--fill-2);
+  overflow: hidden;
+}
+/* Empty slot — click to save the current look. */
+.outfitEmpty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--ink-45);
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+.outfitEmpty:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.outfitPlus {
+  font-size: 34px;
+  font-weight: 300;
+  line-height: 1;
+}
+.outfitEmptyLabel {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+/* Saved slot — composite of wearable thumbnails + a label, with hover actions. */
+.outfitCard {
+  display: flex;
+  flex-direction: column;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.outfitCardSel {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.outfitThumbs {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
+  gap: 4px;
+  padding: 10px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.outfitThumb {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 40px;
+  overflow: hidden;
+}
+.outfitThumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.outfitActions {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.outfitCard:hover .outfitActions,
+.outfitCardSel .outfitActions {
+  opacity: 1;
+}
+.outfitEquip {
+  border: none;
+  border-radius: var(--r-pill);
+  padding: 4px 10px;
+  background-color: var(--accent);
+  color: var(--accent-ink);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+.outfitDelete {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: var(--r-pill);
+  background-color: var(--scrim);
+  color: var(--text);
+  font-size: 11px;
+  cursor: pointer;
+}
+.outfitLabel {
+  padding: 6px 10px 10px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--ink-6);
 }
 
 .empty {

--- a/react-web/src/features/backpack/BackpackPage.module.css
+++ b/react-web/src/features/backpack/BackpackPage.module.css
@@ -612,6 +612,21 @@
   border-color: var(--accent);
   box-shadow: 0 0 0 1px var(--accent);
 }
+/* Matches the current look — mirrors the equipped wearable (accent ring + dot). */
+.outfitEquipped {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.outfitDot {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px var(--scrim);
+}
 .outfitThumbs {
   flex: 1;
   min-height: 0;
@@ -680,6 +695,28 @@
   text-transform: uppercase;
   text-align: center;
   color: var(--ink-6);
+}
+/* Selected-outfit detail: every wearable thumbnail (the card composite shows only four). */
+.outfitDetailGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  width: 100%;
+  margin-top: 4px;
+}
+.outfitDetailThumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  background: var(--fill-3);
+  overflow: hidden;
+}
+.outfitDetailThumb img {
+  width: 86%;
+  height: 86%;
+  object-fit: contain;
 }
 
 .empty {

--- a/react-web/src/features/backpack/BackpackPage.tsx
+++ b/react-web/src/features/backpack/BackpackPage.tsx
@@ -48,16 +48,23 @@ const CATEGORY_ORDER = [
   'hat', 'eyewear', 'mask', 'head', 'tiara', 'top_head', 'earring', 'helmet', 'skin'
 ]
 
+// Categories that must always keep something equipped, so their slot shows no unequip button —
+// mirrors Unity's IsUnequippable gate (BackpackGridController: not body_shape/eyes/eyebrows/mouth).
+const REQUIRED_CATEGORIES = new Set(['body_shape', 'eyes', 'eyebrows', 'mouth'])
+
 function CategoryTile({
   cat,
   active,
   equipped,
-  onClick
+  onClick,
+  onUnequip
 }: {
   cat: string
   active: boolean
   equipped?: Wearable
   onClick: () => void
+  /** Present only when the slot holds a removable equipped item — renders the hover unequip button. */
+  onUnequip?: () => void
 }): React.JSX.Element {
   const [failed, setFailed] = useState(false)
   return (
@@ -72,6 +79,17 @@ function CategoryTile({
         <img className={styles.catThumb} src={equipped.thumbnail} alt="" onError={() => setFailed(true)} />
       ) : (
         <span className={styles.catGlyph}><CategoryIcon category={cat} /></span>
+      )}
+      {onUnequip != null && (
+        <span
+          className={styles.catUnequip}
+          role="button"
+          aria-label={`Unequip ${humanize(cat)}`}
+          title="Unequip"
+          onClick={(e) => { e.stopPropagation(); onUnequip() }}
+        >
+          ✕
+        </span>
       )}
     </button>
   )
@@ -316,8 +334,10 @@ export function BackpackPage({
   const select = (w: Wearable): void => {
     setSelected(w)
   }
+  // Clicking a category filters the grid to it; clicking the already-selected one again clears the
+  // filter back to "all" (deselect) — matches Unity's OnSlotButtonPressed toggle.
   const pick = (c: string): void => {
-    setCat(c)
+    setCat((prev) => (prev === c ? 'all' : c))
     setPage(0)
   }
   // Select a saved outfit — live-preview its wearables on the avatar without persisting.
@@ -428,9 +448,19 @@ export function BackpackPage({
               ) : (
               <div className={styles.catalog}>
                 <div className={styles.catColumn}>
-                  {categories.map((c) => (
-                    <CategoryTile key={c} cat={c} active={cat === c} equipped={equippedByCat.get(c)} onClick={() => pick(c)} />
-                  ))}
+                  {categories.map((c) => {
+                    const eq = equippedByCat.get(c)
+                    return (
+                      <CategoryTile
+                        key={c}
+                        cat={c}
+                        active={cat === c}
+                        equipped={eq}
+                        onClick={() => pick(c)}
+                        onUnequip={eq != null && !REQUIRED_CATEGORIES.has(c) ? () => toggleEquip(eq) : undefined}
+                      />
+                    )
+                  })}
                 </div>
                 <div className={styles.gridArea}>
                   <div className={styles.chips}>

--- a/react-web/src/features/backpack/BackpackPage.tsx
+++ b/react-web/src/features/backpack/BackpackPage.tsx
@@ -311,11 +311,10 @@ export function BackpackPage({
     backpack.equip(next)
     backpack.preview(null)
   }
-  // Selecting an item (card click) — show it in the detail panel and preview it on the avatar
-  // WITHOUT persisting. Closing the Backpack (or equipping) clears this.
+  // Selecting an item (card click) — show it in the detail panel only. It is NOT equipped, and the
+  // avatar is left untouched; equipping is an explicit action (the card's EQUIP pill or a double-click).
   const select = (w: Wearable): void => {
     setSelected(w)
-    backpack.preview(w.equipped ? null : equipSetWith(w))
   }
   const pick = (c: string): void => {
     setCat(c)
@@ -459,6 +458,7 @@ export function BackpackPage({
                           count={w.count}
                           categoryIcon={<CategoryIcon category={w.category} size={15} />}
                           onClick={() => select(w)}
+                          onDoubleClick={() => toggleEquip(w)}
                           onEquip={() => toggleEquip(w)}
                         />
                       ))}

--- a/react-web/src/features/backpack/BackpackPage.tsx
+++ b/react-web/src/features/backpack/BackpackPage.tsx
@@ -29,6 +29,18 @@ function humanize(s: string): string {
   return s.replace(/[_-]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
+const PAGE_BUTTONS = 5
+
+// A sliding window of consecutive page numbers (mirrors bevy-ui-scene's pagination-util): the
+// current page stays centered once past the first half, and the window clamps at both ends so it
+// never runs off. All indices 0-based.
+export function pageWindow(current: number, count: number): number[] {
+  const size = Math.min(PAGE_BUTTONS, count)
+  const half = Math.floor(PAGE_BUTTONS / 2)
+  const start = current > half ? Math.min(current - half, count - size) : 0
+  return Array.from({ length: size }, (_, i) => start + i)
+}
+
 // Ordered like Unity's NftCategoryIcons (body parts grouped head→body→accessories).
 const CATEGORY_ORDER = [
   'body_shape', 'hair', 'eyebrows', 'eyes', 'mouth', 'facial_hair',
@@ -205,16 +217,12 @@ export function BackpackPage({
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
   const [collectiblesOnly, setCollectiblesOnly] = useState(false)
 
-  // Categories present in the wearable list (plus any equipped item's category), ordered like Unity.
-  const categories = useMemo(() => {
-    const present = new Set(backpack.list.map((w) => w.category))
-    for (const w of backpack.equipped) present.add(w.category)
-    return CATEGORY_ORDER.filter((c) => present.has(c))
-  }, [backpack.list, backpack.equipped])
+  // Fixed body-part slots. With a server-paginated grid we don't hold the full catalog, so the
+  // category column is the canonical Unity ordering rather than "categories present in the page".
+  const categories = CATEGORY_ORDER
 
-  // Equipped item shown in each category slot. Prefer the catalog list (so equip/unequip from the
-  // grid reflects optimistically), then fill from the decoupled equipped set for items that aren't
-  // on the catalog page at all — otherwise their slot would render empty.
+  // Equipped item shown in each category slot. Prefer the current page (so equip/unequip reflects
+  // optimistically), then fill from the decoupled equipped set for items not on this page.
   const equippedByCat = useMemo(() => {
     const m = new Map<string, Wearable>()
     for (const w of backpack.list) if (w.equipped && !m.has(w.category)) m.set(w.category, w)
@@ -222,28 +230,34 @@ export function BackpackPage({
     return m
   }, [backpack.list, backpack.equipped])
 
-  const items = useMemo(() => {
-    const dir = sortDir === 'asc' ? 1 : -1
-    return backpack.list
-      .filter(
-        (w) =>
-          (cat === 'all' || w.category === cat) &&
-          (!query || (w.name ?? '').toLowerCase().includes(query.toLowerCase())) &&
-          (!collectiblesOnly || (w.rarity ?? 'base') !== 'base')
-      )
-      .sort((a, b) =>
-        sortBy === 'name'
-          ? dir * (a.name ?? '').localeCompare(b.name ?? '')
-          : dir * ((RARITY_RANK[a.rarity ?? 'base'] ?? 0) - (RARITY_RANK[b.rarity ?? 'base'] ?? 0))
-      )
-  }, [backpack.list, cat, query, collectiblesOnly, sortBy, sortDir])
-  // Back to page 1 whenever the result set changes.
+  // Debounce the search box before hitting the server.
+  const [searchDebounced, setSearchDebounced] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => setSearchDebounced(query), 300)
+    return () => clearTimeout(t)
+  }, [query])
+  // Any filter change resets to the first page.
   useEffect(() => {
     setPage(0)
-  }, [cat, query, collectiblesOnly, sortBy, sortDir])
-  const pageCount = Math.max(1, Math.ceil(items.length / PAGE_SIZE))
+  }, [cat, searchDebounced, collectiblesOnly, sortBy, sortDir])
+  // Fetch the current catalog page from the catalyst (wearables tab). Filters/sort are applied
+  // server-side; the session drops stale responses via a request id.
+  useEffect(() => {
+    if (!backpack.open || tab !== 'wearables') return
+    backpack.query({
+      page,
+      pageSize: PAGE_SIZE,
+      category: cat === 'all' ? undefined : cat,
+      search: searchDebounced || undefined,
+      orderBy: sortBy,
+      direction: sortDir,
+      collectiblesOnly
+    })
+  }, [backpack.open, tab, page, cat, searchDebounced, sortBy, sortDir, collectiblesOnly, backpack.query])
+
+  const pageCount = Math.max(1, Math.ceil(backpack.total / PAGE_SIZE))
   const safePage = Math.min(page, pageCount - 1)
-  const pageItems = items.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE)
+  const pageItems = backpack.list
 
   // Emotes share the same search / sort / collectibles filter as wearables (no category — emotes
   // aren't grouped by body part). The wheel slot list on the left is unaffected.
@@ -283,15 +297,16 @@ export function BackpackPage({
 
   if (!backpack.open) return null
 
-  // The equipped set if `w` were on (same-category item swapped out).
+  // The full equipped set = the decoupled equipped list (NOT the current page — the rest of the
+  // outfit lives on other pages). The equipped set if `w` were on (same-category item swapped out).
   const equipSetWith = (w: Wearable): string[] =>
-    [...backpack.list.filter((x) => x.equipped && x.category !== w.category).map((x) => x.urn), w.urn]
+    [...backpack.equipped.filter((x) => x.category !== w.category).map((x) => x.urn), w.urn]
 
   // Explicit equip/unequip (the hover pill) — persists to the profile, then drops the preview
   // override so the avatar follows the (now updated) profile.
   const toggleEquip = (w: Wearable): void => {
     const next = w.equipped
-      ? backpack.list.filter((x) => x.equipped && x.urn !== w.urn).map((x) => x.urn)
+      ? backpack.equipped.filter((x) => x.urn !== w.urn).map((x) => x.urn)
       : equipSetWith(w)
     backpack.equip(next)
     backpack.preview(null)
@@ -430,7 +445,7 @@ export function BackpackPage({
                     )}
                   </div>
                   {pageItems.length === 0 ? (
-                    <div className={styles.empty}>No wearables.</div>
+                    <div className={styles.empty}>{backpack.loading ? 'Loading…' : 'No wearables.'}</div>
                   ) : (
                     <div className={styles.grid}>
                       {pageItems.map((w) => (
@@ -449,15 +464,24 @@ export function BackpackPage({
                       ))}
                     </div>
                   )}
+                  {/* Server-paginated → potentially hundreds of pages: a sliding window of
+                      consecutive page numbers (bevy-ui-scene style). The arrows WRAP — prev on the
+                      first page jumps to the last, next on the last wraps to the first. */}
                   {pageCount > 1 && (
                     <div className={styles.pager}>
-                      <button type="button" className={styles.pageArrow} disabled={safePage === 0} onClick={() => setPage(safePage - 1)}>‹</button>
-                      {Array.from({ length: pageCount }, (_, i) => (
-                        <button key={i} type="button" className={`${styles.pageNum} ${i === safePage ? styles.pageNumActive : ''}`.trim()} onClick={() => setPage(i)}>
-                          {i + 1}
+                      <button type="button" className={styles.pageArrow} aria-label="Previous page" onClick={() => setPage(safePage === 0 ? pageCount - 1 : safePage - 1)}>‹</button>
+                      {pageWindow(safePage, pageCount).map((p) => (
+                        <button
+                          key={p}
+                          type="button"
+                          className={`${styles.pageNum} ${p === safePage ? styles.pageNumActive : ''}`.trim()}
+                          aria-current={p === safePage ? 'page' : undefined}
+                          onClick={() => setPage(p)}
+                        >
+                          {p + 1}
                         </button>
                       ))}
-                      <button type="button" className={styles.pageArrow} disabled={safePage >= pageCount - 1} onClick={() => setPage(safePage + 1)}>›</button>
+                      <button type="button" className={styles.pageArrow} aria-label="Next page" onClick={() => setPage(safePage >= pageCount - 1 ? 0 : safePage + 1)}>›</button>
                     </div>
                   )}
                 </div>

--- a/react-web/src/features/backpack/BackpackPage.tsx
+++ b/react-web/src/features/backpack/BackpackPage.tsx
@@ -125,12 +125,14 @@ function DetailPanel({ item }: { item: Wearable | Emote | null }): React.JSX.Ele
 }
 
 // One Saved-Outfits slot: an empty "save current look" tile, or a saved outfit showing a
-// composite of its wearable thumbnails with Equip / Delete actions. Clicking a saved slot
-// live-previews it on the avatar (the left preview column); Equip persists it.
+// composite of its wearable thumbnails with Equip / Delete actions. Clicking a saved slot selects
+// it (shows its wearables in the detail panel) without touching the avatar; Equip or a double-click
+// persists it. A dot marks the outfit that matches the current look (like an equipped wearable).
 function OutfitSlotCard({
   index,
   outfit,
   selected,
+  equipped,
   onSelect,
   onSave,
   onEquip,
@@ -139,6 +141,7 @@ function OutfitSlotCard({
   index: number
   outfit: Outfit | null
   selected: boolean
+  equipped: boolean
   onSelect: () => void
   onSave: () => void
   onEquip: () => void
@@ -153,18 +156,34 @@ function OutfitSlotCard({
     )
   }
   return (
-    <div className={`${styles.outfitCard} ${selected ? styles.outfitCardSel : ''}`.trim()}>
-      <button type="button" className={styles.outfitThumbs} onClick={onSelect} aria-label={`Preview Outfit ${index + 1}`}>
+    <div className={`${styles.outfitCard} ${selected ? styles.outfitCardSel : ''} ${equipped ? styles.outfitEquipped : ''}`.trim()}>
+      <button type="button" className={styles.outfitThumbs} onClick={onSelect} onDoubleClick={onEquip} aria-label={`Outfit ${index + 1}`}>
         {outfit.wearables.slice(0, 4).map((u) => (
           <span key={u} className={styles.outfitThumb}><CatalystImg urn={u} /></span>
         ))}
       </button>
+      {equipped && <span className={styles.outfitDot} aria-hidden="true" />}
       <div className={styles.outfitActions}>
         <button type="button" className={styles.outfitEquip} onClick={onEquip}>EQUIP</button>
         <button type="button" className={styles.outfitDelete} onClick={onDelete} aria-label={`Delete Outfit ${index + 1}`} title="Delete outfit">✕</button>
       </div>
       <span className={styles.outfitLabel}>Outfit {index + 1}</span>
     </div>
+  )
+}
+
+// Right-panel detail for a selected saved outfit: all its wearable thumbnails (the composite card
+// shows only the first four).
+function OutfitDetailPanel({ outfit, index }: { outfit: Outfit; index: number }): React.JSX.Element {
+  return (
+    <aside className={styles.detail}>
+      <div className={styles.detailName}>Outfit {index + 1}</div>
+      <div className={styles.outfitDetailGrid}>
+        {outfit.wearables.map((u) => (
+          <span key={u} className={styles.outfitDetailThumb}><CatalystImg urn={u} /></span>
+        ))}
+      </div>
+    </aside>
   )
 }
 
@@ -221,7 +240,7 @@ export function BackpackPage({
 }): React.JSX.Element | null {
   const [tab, setTab] = useState<'wearables' | 'emotes'>(initialTab)
   const [section, setSection] = useState<'categories' | 'outfits'>('categories')
-  // The saved-outfit slot currently live-previewed on the avatar (null = none).
+  // The saved-outfit slot currently selected (shown in the detail panel; null = none).
   const [outfitSlot, setOutfitSlot] = useState<number | null>(null)
   const [cat, setCat] = useState('all')
   const [query, setQuery] = useState('')
@@ -296,22 +315,20 @@ export function BackpackPage({
     if (backpack.open) setTab(initialTab)
   }, [backpack.open, initialTab])
 
-  // When the Backpack closes, drop any unequipped preview so the avatar reverts to the
-  // actual profile (selecting an item must never persist).
+  // When the Backpack closes, drop any unequipped preview and clear the selection so a reopen
+  // starts clean (selecting an item must never persist).
   useEffect(() => {
     if (!backpack.open) {
       setSelected(null)
+      setOutfitSlot(null)
       backpack.preview(null)
     }
   }, [backpack.open, backpack.preview])
 
-  // Leaving the Outfits section reverts any outfit live-preview back to the profile.
+  // Leaving the Outfits section clears the selected outfit (and its detail panel).
   useEffect(() => {
-    if (section !== 'outfits' && outfitSlot !== null) {
-      setOutfitSlot(null)
-      backpack.preview(null)
-    }
-  }, [section, outfitSlot, backpack.preview])
+    if (section !== 'outfits' && outfitSlot !== null) setOutfitSlot(null)
+  }, [section, outfitSlot])
 
   if (!backpack.open) return null
 
@@ -340,13 +357,25 @@ export function BackpackPage({
     setCat((prev) => (prev === c ? 'all' : c))
     setPage(0)
   }
-  // Select a saved outfit — live-preview its wearables on the avatar without persisting.
-  // (Body-shape/colour preview lands with Phase 2; Equip already applies them.)
-  const selectOutfit = (slot: number, outfit: Outfit): void => {
+  // Select a saved outfit — show its wearables in the detail panel. Like selecting a wearable, this
+  // never touches the avatar (the preview keeps showing the current look); equip via EQUIP or a
+  // double-click.
+  const selectOutfit = (slot: number): void => {
     setOutfitSlot(slot)
     setSelected(null)
-    backpack.preview(outfit.wearables)
   }
+  // An outfit matches the current look when its wearable set equals the equipped set. The equipped
+  // set holds bare item urns; an outfit may carry token/deployed urns, so compare with the same
+  // item-urn matcher used for equipping (u === urn or u startsWith `${urn}:`).
+  const outfitMatchesEquipped = (outfit: Outfit): boolean => {
+    const eq = backpack.equipped
+    if (eq.length === 0 || outfit.wearables.length !== eq.length) return false
+    return eq.every((w) => outfit.wearables.some((u) => u === w.urn || u.startsWith(`${w.urn}:`)))
+  }
+  const selectedOutfit =
+    section === 'outfits' && outfitSlot !== null
+      ? backpack.outfits.find((o) => o.slot === outfitSlot)?.outfit ?? null
+      : null
 
   const p = profile.data
   return (
@@ -433,12 +462,13 @@ export function BackpackPage({
                           index={i}
                           outfit={saved}
                           selected={outfitSlot === i}
-                          onSelect={() => { if (saved) selectOutfit(i, saved) }}
+                          equipped={saved != null && outfitMatchesEquipped(saved)}
+                          onSelect={() => { if (saved) selectOutfit(i) }}
                           onSave={() => backpack.saveOutfit(i)}
-                          onEquip={() => { backpack.equipOutfit(i); setOutfitSlot(null); backpack.preview(null) }}
+                          onEquip={() => backpack.equipOutfit(i)}
                           onDelete={() => {
                             backpack.deleteOutfit(i)
-                            if (outfitSlot === i) { setOutfitSlot(null); backpack.preview(null) }
+                            if (outfitSlot === i) setOutfitSlot(null)
                           }}
                         />
                       )
@@ -569,8 +599,13 @@ export function BackpackPage({
             )}
           </div>
 
-          {/* Right: selected-item detail. */}
-          <DetailPanel item={selected} />
+          {/* Right: selected-item detail — an outfit's wearables in the Outfits section, else the
+              selected wearable/emote. */}
+          {selectedOutfit != null ? (
+            <OutfitDetailPanel outfit={selectedOutfit} index={outfitSlot as number} />
+          ) : (
+            <DetailPanel item={section === 'outfits' ? null : selected} />
+          )}
           </div>
         </div>
       </div>

--- a/react-web/src/features/backpack/BackpackPage.tsx
+++ b/react-web/src/features/backpack/BackpackPage.tsx
@@ -205,17 +205,22 @@ export function BackpackPage({
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
   const [collectiblesOnly, setCollectiblesOnly] = useState(false)
 
-  // Categories present in the wearable list, ordered like Unity.
+  // Categories present in the wearable list (plus any equipped item's category), ordered like Unity.
   const categories = useMemo(() => {
     const present = new Set(backpack.list.map((w) => w.category))
+    for (const w of backpack.equipped) present.add(w.category)
     return CATEGORY_ORDER.filter((c) => present.has(c))
-  }, [backpack.list])
+  }, [backpack.list, backpack.equipped])
 
+  // Equipped item shown in each category slot. Prefer the catalog list (so equip/unequip from the
+  // grid reflects optimistically), then fill from the decoupled equipped set for items that aren't
+  // on the catalog page at all — otherwise their slot would render empty.
   const equippedByCat = useMemo(() => {
     const m = new Map<string, Wearable>()
     for (const w of backpack.list) if (w.equipped && !m.has(w.category)) m.set(w.category, w)
+    for (const w of backpack.equipped) if (!m.has(w.category)) m.set(w.category, w)
     return m
-  }, [backpack.list])
+  }, [backpack.list, backpack.equipped])
 
   const items = useMemo(() => {
     const dir = sortDir === 'asc' ? 1 : -1

--- a/react-web/src/features/backpack/BackpackPage.tsx
+++ b/react-web/src/features/backpack/BackpackPage.tsx
@@ -5,13 +5,13 @@
 // of fetchWearablesPage; equipping goes back through setAvatar.
 
 import { useEffect, useMemo, useState } from 'react'
-import { EmptyState, WearableCard, type Rarity } from '../../design'
+import { WearableCard, type Rarity } from '../../design'
 import { catalystThumbUrl, rarityColor } from '../../lib/identity'
 import { CatalystImg } from '../../components/CatalystImg'
 import { CategoryIcon } from './categoryIcons'
 import { EngineViewport } from '../engine/EngineViewport'
 import { MainMenuShell } from '../menu/MainMenuShell'
-import type { Emote, Wearable } from '../../engine/protocol'
+import type { Emote, Outfit, Wearable } from '../../engine/protocol'
 import type { BackpackState, EmotesState, ProfileState } from '../session/useEngineSession'
 import styles from './BackpackPage.module.css'
 
@@ -94,6 +94,50 @@ function DetailPanel({ item }: { item: Wearable | Emote | null }): React.JSX.Ele
   )
 }
 
+// One Saved-Outfits slot: an empty "save current look" tile, or a saved outfit showing a
+// composite of its wearable thumbnails with Equip / Delete actions. Clicking a saved slot
+// live-previews it on the avatar (the left preview column); Equip persists it.
+function OutfitSlotCard({
+  index,
+  outfit,
+  selected,
+  onSelect,
+  onSave,
+  onEquip,
+  onDelete
+}: {
+  index: number
+  outfit: Outfit | null
+  selected: boolean
+  onSelect: () => void
+  onSave: () => void
+  onEquip: () => void
+  onDelete: () => void
+}): React.JSX.Element {
+  if (!outfit) {
+    return (
+      <button type="button" className={styles.outfitEmpty} onClick={onSave} title="Save current look">
+        <span className={styles.outfitPlus} aria-hidden="true">+</span>
+        <span className={styles.outfitEmptyLabel}>Save Outfit</span>
+      </button>
+    )
+  }
+  return (
+    <div className={`${styles.outfitCard} ${selected ? styles.outfitCardSel : ''}`.trim()}>
+      <button type="button" className={styles.outfitThumbs} onClick={onSelect} aria-label={`Preview Outfit ${index + 1}`}>
+        {outfit.wearables.slice(0, 4).map((u) => (
+          <span key={u} className={styles.outfitThumb}><CatalystImg urn={u} /></span>
+        ))}
+      </button>
+      <div className={styles.outfitActions}>
+        <button type="button" className={styles.outfitEquip} onClick={onEquip}>EQUIP</button>
+        <button type="button" className={styles.outfitDelete} onClick={onDelete} aria-label={`Delete Outfit ${index + 1}`} title="Delete outfit">✕</button>
+      </div>
+      <span className={styles.outfitLabel}>Outfit {index + 1}</span>
+    </div>
+  )
+}
+
 function FilterIcon(): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" width="16" height="16" fill="none" aria-hidden="true">
@@ -147,6 +191,8 @@ export function BackpackPage({
 }): React.JSX.Element | null {
   const [tab, setTab] = useState<'wearables' | 'emotes'>(initialTab)
   const [section, setSection] = useState<'categories' | 'outfits'>('categories')
+  // The saved-outfit slot currently live-previewed on the avatar (null = none).
+  const [outfitSlot, setOutfitSlot] = useState<number | null>(null)
   const [cat, setCat] = useState('all')
   const [query, setQuery] = useState('')
   const [page, setPage] = useState(0)
@@ -222,6 +268,14 @@ export function BackpackPage({
     }
   }, [backpack.open, backpack.preview])
 
+  // Leaving the Outfits section reverts any outfit live-preview back to the profile.
+  useEffect(() => {
+    if (section !== 'outfits' && outfitSlot !== null) {
+      setOutfitSlot(null)
+      backpack.preview(null)
+    }
+  }, [section, outfitSlot, backpack.preview])
+
   if (!backpack.open) return null
 
   // The equipped set if `w` were on (same-category item swapped out).
@@ -246,6 +300,13 @@ export function BackpackPage({
   const pick = (c: string): void => {
     setCat(c)
     setPage(0)
+  }
+  // Select a saved outfit — live-preview its wearables on the avatar without persisting.
+  // (Body-shape/colour preview lands with Phase 2; Equip already applies them.)
+  const selectOutfit = (slot: number, outfit: Outfit): void => {
+    setOutfitSlot(slot)
+    setSelected(null)
+    backpack.preview(outfit.wearables)
   }
 
   const p = profile.data
@@ -324,12 +385,26 @@ export function BackpackPage({
             {tab === 'wearables' ? (
               section === 'outfits' ? (
                 <div className={styles.outfits}>
-                  <EmptyState
-                    variant="inline"
-                    icon={<BookmarkIcon size={34} />}
-                    title="No saved outfits yet"
-                    subtitle="Saving and loading outfits isn’t available in this explorer yet."
-                  />
+                  <div className={styles.outfitGrid}>
+                    {Array.from({ length: backpack.outfitSlots }, (_, i) => {
+                      const saved = backpack.outfits.find((o) => o.slot === i)?.outfit ?? null
+                      return (
+                        <OutfitSlotCard
+                          key={i}
+                          index={i}
+                          outfit={saved}
+                          selected={outfitSlot === i}
+                          onSelect={() => { if (saved) selectOutfit(i, saved) }}
+                          onSave={() => backpack.saveOutfit(i)}
+                          onEquip={() => { backpack.equipOutfit(i); setOutfitSlot(null); backpack.preview(null) }}
+                          onDelete={() => {
+                            backpack.deleteOutfit(i)
+                            if (outfitSlot === i) { setOutfitSlot(null); backpack.preview(null) }
+                          }}
+                        />
+                      )
+                    })}
+                  </div>
                 </div>
               ) : (
               <div className={styles.catalog}>

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -36,8 +36,26 @@ import type {
   Wearable
 } from '../../engine/protocol'
 
+/** A server-side catalog page request (backpack grid). Filters/sort are applied by the catalyst. */
+export interface CatalogQuery {
+  page: number
+  pageSize: number
+  category?: string
+  search?: string
+  orderBy?: 'rarity' | 'name'
+  direction?: 'asc' | 'desc'
+  collectiblesOnly?: boolean
+}
+
 export interface BackpackState {
+  /** The current catalog page (server-side paginated; drives the grid). */
   list: Wearable[]
+  /** Total matching items for the active filters (drives the pager). */
+  total: number
+  /** True while a catalog page is in flight. */
+  loading: boolean
+  /** Request a catalog page (page + filters); the newest response wins (stale ones are dropped). */
+  query: (q: CatalogQuery) => void
   equipped: Wearable[]
   open: boolean
   toggle: () => void
@@ -416,8 +434,14 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   const [emotes, setEmotes] = useState<Emote[]>([])
   const [emotesOpen, setEmotesOpen] = useState(false)
   const [mic, setMic] = useState({ enabled: false, available: false })
-  const [wearables, setWearables] = useState<Wearable[]>([])
+  const [catalogItems, setCatalogItems] = useState<Wearable[]>([])
+  const [catalogTotal, setCatalogTotal] = useState(0)
+  const [catalogLoading, setCatalogLoading] = useState(false)
+  const catalogReqId = useRef(0)
   const [equippedWearables, setEquippedWearables] = useState<Wearable[]>([])
+  // Mirror of catalogItems for equipWearables' optimistic equipped-set rebuild (avoids stale closure).
+  const catalogItemsRef = useRef<Wearable[]>([])
+  useEffect(() => { catalogItemsRef.current = catalogItems }, [catalogItems])
   const [outfits, setOutfits] = useState<OutfitsMetadata>({ outfits: [], namesForExtraSlots: [] })
   const [backpackOpen, setBackpackOpen] = useState(false)
   const [communities, setCommunities] = useState<Community[]>([])
@@ -535,8 +559,15 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           setMic({ enabled: msg.enabled, available: msg.available })
           break
         case 'wearables':
-          setWearables(msg.wearables)
           setEquippedWearables(msg.equipped)
+          break
+        case 'catalogPage':
+          // Only the newest request's page wins — drop stale responses (fast page/filter changes).
+          if (msg.catalog === 'wearables' && msg.requestId === catalogReqId.current) {
+            setCatalogItems(msg.items)
+            setCatalogTotal(msg.total)
+            setCatalogLoading(false)
+          }
           break
         case 'outfits':
           setOutfits(msg.metadata)
@@ -993,12 +1024,31 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   }, [submitted, destinationPicked, pickDestination])
   const equipWearables = useCallback((urns: string[]) => {
     driverRef.current?.send({ kind: 'equip', urns })
-    // Optimistically reflect the new equipped set so the button flips to "Unequip" immediately —
-    // the engine deploy + wearables re-emit lags, and a failed deploy never re-emits at all.
-    setWearables((list) => list.map((w) => ({ ...w, equipped: urns.some((u) => u === w.urn || u.startsWith(`${w.urn}:`)) })))
+    // Optimistically reflect the new equipped set so the button flips to "Unequip" immediately AND the
+    // equipped set stays authoritative for the next equip — the engine deploy + wearables re-emit lags,
+    // and a failed deploy never re-emits at all. `urns` is the full next set (see BackpackPage), so
+    // rebuild `equippedWearables` from it (resolving each urn against the catalog ∪ current equipped),
+    // mirroring bevy-ui-scene's local-store-is-source-of-truth model. Otherwise a stale equipped set
+    // makes each subsequent equip drop the previously-equipped items from the deploy.
+    const matches = (u: string, urn: string): boolean => u === urn || u.startsWith(`${urn}:`)
+    setCatalogItems((list) => list.map((w) => ({ ...w, equipped: urns.some((u) => matches(u, w.urn)) })))
+    setEquippedWearables((prev) => {
+      const pool = new Map<string, Wearable>([...catalogItemsRef.current, ...prev].map((w) => [w.urn, w]))
+      return urns
+        .map((u): Wearable | null => {
+          const w = pool.get(u) ?? [...pool.values()].find((x) => u.startsWith(`${x.urn}:`))
+          return w != null ? { ...w, equipped: true } : null
+        })
+        .filter((w): w is Wearable => w != null)
+    })
   }, [])
   const previewWearables = useCallback((urns: string[] | null) => {
     driverRef.current?.send({ kind: 'previewAvatar', urns })
+  }, [])
+  const queryCatalog = useCallback((q: CatalogQuery) => {
+    catalogReqId.current += 1
+    setCatalogLoading(true)
+    driverRef.current?.send({ kind: 'catalogQuery', catalog: 'wearables', requestId: catalogReqId.current, ...q })
   }, [])
   const saveOutfit = useCallback((slot: number) => {
     driverRef.current?.send({ kind: 'saveOutfit', slot })
@@ -1304,7 +1354,8 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     },
     emotes: { list: emotes, open: emotesOpen, toggle: toggleEmotes, play: playEmote, equip: equipEmote },
     backpack: {
-      list: wearables, equipped: equippedWearables, open: backpackOpen, toggle: toggleBackpack, equip: equipWearables, preview: previewWearables,
+      list: catalogItems, total: catalogTotal, loading: catalogLoading, query: queryCatalog,
+      equipped: equippedWearables, open: backpackOpen, toggle: toggleBackpack, equip: equipWearables, preview: previewWearables,
       outfits: outfits.outfits, outfitSlots: Math.min(10, 5 + outfits.namesForExtraSlots.length),
       saveOutfit, deleteOutfit, equipOutfit
     },

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -443,6 +443,9 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   const catalogItemsRef = useRef<Wearable[]>([])
   useEffect(() => { catalogItemsRef.current = catalogItems }, [catalogItems])
   const [outfits, setOutfits] = useState<OutfitsMetadata>({ outfits: [], namesForExtraSlots: [] })
+  // Mirror of outfits for equipOutfit's optimistic equipped-set rebuild (avoids stale closure).
+  const outfitsRef = useRef<OutfitsMetadata>({ outfits: [], namesForExtraSlots: [] })
+  useEffect(() => { outfitsRef.current = outfits }, [outfits])
   const [backpackOpen, setBackpackOpen] = useState(false)
   const [communities, setCommunities] = useState<Community[]>([])
   const [communitiesOpen, setCommunitiesOpen] = useState(false)
@@ -1022,14 +1025,13 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     urlDestination.current = null
     pickDestination(dest)
   }, [submitted, destinationPicked, pickDestination])
-  const equipWearables = useCallback((urns: string[]) => {
-    driverRef.current?.send({ kind: 'equip', urns })
-    // Optimistically reflect the new equipped set so the button flips to "Unequip" immediately AND the
-    // equipped set stays authoritative for the next equip — the engine deploy + wearables re-emit lags,
-    // and a failed deploy never re-emits at all. `urns` is the full next set (see BackpackPage), so
-    // rebuild `equippedWearables` from it (resolving each urn against the catalog ∪ current equipped),
-    // mirroring bevy-ui-scene's local-store-is-source-of-truth model. Otherwise a stale equipped set
-    // makes each subsequent equip drop the previously-equipped items from the deploy.
+  // Optimistically reflect a new equipped set so the button flips to "Unequip" immediately AND the
+  // equipped set stays authoritative for the next equip — the engine deploy + wearables re-emit lags,
+  // and a failed deploy never re-emits at all. `urns` is the full next set (see BackpackPage), so
+  // rebuild `equippedWearables` from it (resolving each urn against the catalog ∪ current equipped),
+  // mirroring bevy-ui-scene's local-store-is-source-of-truth model. Otherwise a stale equipped set
+  // makes each subsequent equip drop the previously-equipped items from the deploy.
+  const applyEquippedOptimistic = useCallback((urns: string[]) => {
     const matches = (u: string, urn: string): boolean => u === urn || u.startsWith(`${urn}:`)
     setCatalogItems((list) => list.map((w) => ({ ...w, equipped: urns.some((u) => matches(u, w.urn)) })))
     setEquippedWearables((prev) => {
@@ -1042,6 +1044,10 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
         .filter((w): w is Wearable => w != null)
     })
   }, [])
+  const equipWearables = useCallback((urns: string[]) => {
+    driverRef.current?.send({ kind: 'equip', urns })
+    applyEquippedOptimistic(urns)
+  }, [applyEquippedOptimistic])
   const previewWearables = useCallback((urns: string[] | null) => {
     driverRef.current?.send({ kind: 'previewAvatar', urns })
   }, [])
@@ -1058,7 +1064,12 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   }, [])
   const equipOutfit = useCallback((slot: number) => {
     driverRef.current?.send({ kind: 'equipOutfit', slot })
-  }, [])
+    // The bridge's equipOutfit deploys via setAvatar but never re-emits `wearables`, and the session
+    // fetches wearables only once — so rebuild the equipped set here from the outfit's wearables, else
+    // it stays stale and the next single-item equip (equipSetWith) drops the outfit's other wearables.
+    const found = outfitsRef.current.outfits.find((o) => o.slot === slot)
+    if (found != null) applyEquippedOptimistic(found.outfit.wearables.map(String))
+  }, [applyEquippedOptimistic])
   const createCommunity = useCallback(
     (input: { name: string; description: string; privacy: 'public' | 'private'; discoverable: boolean }) => {
       driverRef.current?.send({ kind: 'createCommunity', ...input })

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -38,6 +38,7 @@ import type {
 
 export interface BackpackState {
   list: Wearable[]
+  equipped: Wearable[]
   open: boolean
   toggle: () => void
   /** Persist a full equipped set to the profile (the explicit Equip action). */
@@ -416,6 +417,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   const [emotesOpen, setEmotesOpen] = useState(false)
   const [mic, setMic] = useState({ enabled: false, available: false })
   const [wearables, setWearables] = useState<Wearable[]>([])
+  const [equippedWearables, setEquippedWearables] = useState<Wearable[]>([])
   const [outfits, setOutfits] = useState<OutfitsMetadata>({ outfits: [], namesForExtraSlots: [] })
   const [backpackOpen, setBackpackOpen] = useState(false)
   const [communities, setCommunities] = useState<Community[]>([])
@@ -534,6 +536,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           break
         case 'wearables':
           setWearables(msg.wearables)
+          setEquippedWearables(msg.equipped)
           break
         case 'outfits':
           setOutfits(msg.metadata)
@@ -1301,7 +1304,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     },
     emotes: { list: emotes, open: emotesOpen, toggle: toggleEmotes, play: playEmote, equip: equipEmote },
     backpack: {
-      list: wearables, open: backpackOpen, toggle: toggleBackpack, equip: equipWearables, preview: previewWearables,
+      list: wearables, equipped: equippedWearables, open: backpackOpen, toggle: toggleBackpack, equip: equipWearables, preview: previewWearables,
       outfits: outfits.outfits, outfitSlots: Math.min(10, 5 + outfits.namesForExtraSlots.length),
       saveOutfit, deleteOutfit, equipOutfit
     },

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -787,6 +787,12 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   // The full-screen main menu — mirrors App's `pageOpen`.
   const menuPageOpen =
     settingsOpen || backpackOpen || communitiesOpen || mapOpen || placesOpen || galleryOpen
+  // Opening any full-screen menu frees the mouse: on web the camera-look IS the browser pointer lock,
+  // so releasing it lets the cursor drive the menu (the engine self-heals camera-look on
+  // `!document.pointerLockElement`, same as requestFocusChat). No-op on native (no DOM pointer lock).
+  useEffect(() => {
+    if (menuPageOpen) document.exitPointerLock?.()
+  }, [menuPageOpen])
   // What takes the screen from the chat, for requestFocusChat: the main menu, the emote wheel, and
   // the two modals App renders above everything (permission prompt, fatal error).
   chatCoveredRef.current =

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -25,6 +25,8 @@ import type {
   HoverAction,
   NavAction,
   NearbyMember,
+  OutfitSlot,
+  OutfitsMetadata,
   PermissionLevelChoice,
   PermissionRequestMessage,
   ProximityTip,
@@ -42,6 +44,16 @@ export interface BackpackState {
   equip: (urns: string[]) => void
   /** Preview a set on the avatar without persisting (selecting); null reverts to the profile. */
   preview: (urns: string[] | null) => void
+  /** Saved outfits (Outfits tab), by slot index. */
+  outfits: OutfitSlot[]
+  /** Number of outfit slots available (5 free + 1 per owned DCL name, capped at 10). */
+  outfitSlots: number
+  /** Save the current look into a slot. */
+  saveOutfit: (slot: number) => void
+  /** Delete a saved outfit slot. */
+  deleteOutfit: (slot: number) => void
+  /** Equip a saved outfit (applies its body shape, colors and wearables). */
+  equipOutfit: (slot: number) => void
 }
 
 export interface CommunitiesState {
@@ -404,6 +416,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   const [emotesOpen, setEmotesOpen] = useState(false)
   const [mic, setMic] = useState({ enabled: false, available: false })
   const [wearables, setWearables] = useState<Wearable[]>([])
+  const [outfits, setOutfits] = useState<OutfitsMetadata>({ outfits: [], namesForExtraSlots: [] })
   const [backpackOpen, setBackpackOpen] = useState(false)
   const [communities, setCommunities] = useState<Community[]>([])
   const [communitiesOpen, setCommunitiesOpen] = useState(false)
@@ -521,6 +534,9 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           break
         case 'wearables':
           setWearables(msg.wearables)
+          break
+        case 'outfits':
+          setOutfits(msg.metadata)
           break
         case 'communities':
           setCommunities(msg.communities)
@@ -700,7 +716,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   // re-emit fresh data through the relay, so we never need to re-pull on reopen. Avoids
   // hammering the catalyst every time a menu is reopened.
   const ensure = useCallback(
-    (kind: 'getSettings' | 'getProfile' | 'getEmotes' | 'getWearables' | 'getCommunities' | 'getGallery') => {
+    (kind: 'getSettings' | 'getProfile' | 'getEmotes' | 'getWearables' | 'getOutfits' | 'getCommunities' | 'getGallery') => {
       if (fetchedRef.current.has(kind)) return
       fetchedRef.current.add(kind)
       driverRef.current?.send({ kind })
@@ -764,6 +780,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       exclusive(setBackpackOpen, () => {
         ensure('getWearables')
         ensure('getEmotes') // Backpack's Emotes tab reuses the emotes list.
+        ensure('getOutfits') // Backpack's Outfits tab.
       }),
     [exclusive, ensure]
   )
@@ -979,6 +996,15 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   }, [])
   const previewWearables = useCallback((urns: string[] | null) => {
     driverRef.current?.send({ kind: 'previewAvatar', urns })
+  }, [])
+  const saveOutfit = useCallback((slot: number) => {
+    driverRef.current?.send({ kind: 'saveOutfit', slot })
+  }, [])
+  const deleteOutfit = useCallback((slot: number) => {
+    driverRef.current?.send({ kind: 'deleteOutfit', slot })
+  }, [])
+  const equipOutfit = useCallback((slot: number) => {
+    driverRef.current?.send({ kind: 'equipOutfit', slot })
   }, [])
   const createCommunity = useCallback(
     (input: { name: string; description: string; privacy: 'public' | 'private'; discoverable: boolean }) => {
@@ -1274,7 +1300,11 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       markAllRead: markNotificationsRead
     },
     emotes: { list: emotes, open: emotesOpen, toggle: toggleEmotes, play: playEmote, equip: equipEmote },
-    backpack: { list: wearables, open: backpackOpen, toggle: toggleBackpack, equip: equipWearables, preview: previewWearables },
+    backpack: {
+      list: wearables, open: backpackOpen, toggle: toggleBackpack, equip: equipWearables, preview: previewWearables,
+      outfits: outfits.outfits, outfitSlots: Math.min(10, 5 + outfits.namesForExtraSlots.length),
+      saveOutfit, deleteOutfit, equipOutfit
+    },
     communities: { list: communities, open: communitiesOpen, toggle: toggleCommunities, create: createCommunity, join: joinCommunity, leave: leaveCommunity, detail: communityDetail, loadDetail: loadCommunityDetail },
     map: { x: mapParcel.x, y: mapParcel.y, open: mapOpen, toggle: toggleMap, teleport, changeRealm },
     places: { open: placesOpen, toggle: togglePlaces },

--- a/react-web/src/test/backpack.clicks.test.tsx
+++ b/react-web/src/test/backpack.clicks.test.tsx
@@ -55,6 +55,27 @@ describe('backpack page clicks', () => {
     expect(vi.mocked(backpack.preview)).toHaveBeenCalledWith(null)
   })
 
+  it('clicking the selected category again clears the filter back to all', async () => {
+    const query = vi.fn()
+    renderBackpack({ query })
+    const hatCategory = screen.getByRole('button', { name: 'Hat' })
+    await userEvent.click(hatCategory)
+    expect(query).toHaveBeenLastCalledWith(expect.objectContaining({ category: 'hat' }))
+    await userEvent.click(hatCategory)
+    expect(query).toHaveBeenLastCalledWith(expect.objectContaining({ category: undefined }))
+  })
+
+  it('an equipped removable category slot has a hover unequip button that unequips it', async () => {
+    const backpack = renderBackpack({ list: [], equipped: [wearable({ category: 'hat', equipped: true })] })
+    await userEvent.click(screen.getByRole('button', { name: 'Unequip Hat' }))
+    expect(vi.mocked(backpack.equip)).toHaveBeenCalledWith([])
+  })
+
+  it('a required category (eyes) shows no unequip button even when equipped', () => {
+    renderBackpack({ list: [], equipped: [wearable({ urn: 'urn:eyes', category: 'eyes', equipped: true })] })
+    expect(screen.queryByRole('button', { name: 'Unequip Eyes' })).toBeNull()
+  })
+
   it('switching to the Emotes tab shows the equipped emotes', async () => {
     renderBackpack()
     await userEvent.click(screen.getByRole('button', { name: 'Emotes' }))

--- a/react-web/src/test/backpack.clicks.test.tsx
+++ b/react-web/src/test/backpack.clicks.test.tsx
@@ -31,10 +31,21 @@ function renderBackpack(over: Partial<BackpackState> = {}): BackpackState {
 }
 
 describe('backpack page clicks', () => {
-  it('clicking a wearable card previews it (no persist)', async () => {
+  it('clicking a wearable card selects it (shows detail; does not equip or preview)', async () => {
     const backpack = renderBackpack()
+    expect(screen.getByText('No item selected')).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: 'Cool Hat' }))
-    expect(vi.mocked(backpack.preview)).toHaveBeenCalledWith(['urn:hat'])
+    // The detail panel now shows the item (its name renders as visible text there); the avatar is
+    // left untouched — nothing is previewed or equipped.
+    expect(screen.getByText('Cool Hat')).toBeInTheDocument()
+    expect(vi.mocked(backpack.preview)).not.toHaveBeenCalled()
+    expect(vi.mocked(backpack.equip)).not.toHaveBeenCalled()
+  })
+
+  it('double-clicking a wearable card equips it', async () => {
+    const backpack = renderBackpack()
+    await userEvent.dblClick(screen.getByRole('button', { name: 'Cool Hat' }))
+    expect(vi.mocked(backpack.equip)).toHaveBeenCalledWith(['urn:hat'])
   })
 
   it('EQUIP persists the set and drops the preview', async () => {

--- a/react-web/src/test/backpack.clicks.test.tsx
+++ b/react-web/src/test/backpack.clicks.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BackpackPage } from '../features/backpack/BackpackPage'
-import type { Wearable } from '../engine/protocol'
+import type { Outfit, OutfitSlot, Wearable } from '../engine/protocol'
 import type { BackpackState } from '../features/session/useEngineSession'
 import { fakeSession } from './harness'
 
@@ -14,6 +14,12 @@ const wearable = (over: Partial<Wearable> = {}): Wearable => ({
   equipped: false,
   ...over
 })
+
+const outfitSlot = (slot: number, wearables: string[]): OutfitSlot => {
+  const grey = { r: 0.5, g: 0.5, b: 0.5 }
+  const outfit: Outfit = { bodyShape: '', eyes: { color: grey }, hair: { color: grey }, skin: { color: grey }, wearables, forceRender: [] }
+  return { slot, outfit }
+}
 
 function renderBackpack(over: Partial<BackpackState> = {}): BackpackState {
   const backpack: BackpackState = { ...fakeSession().backpack, open: true, list: [wearable()], equip: vi.fn(), preview: vi.fn(), ...over }
@@ -74,6 +80,38 @@ describe('backpack page clicks', () => {
   it('a required category (eyes) shows no unequip button even when equipped', () => {
     renderBackpack({ list: [], equipped: [wearable({ urn: 'urn:eyes', category: 'eyes', equipped: true })] })
     expect(screen.queryByRole('button', { name: 'Unequip Eyes' })).toBeNull()
+  })
+
+  it('outfits: the outfit matching the current look is marked equipped', async () => {
+    renderBackpack({
+      list: [],
+      equipped: [wearable({ urn: 'urn:hat', category: 'hat' }), wearable({ urn: 'urn:shirt', category: 'upper_body' })],
+      outfits: [outfitSlot(0, ['urn:hat', 'urn:shirt']), outfitSlot(1, ['urn:other'])]
+    })
+    await userEvent.click(screen.getByRole('button', { name: /saved outfits/i }))
+    // Only slot 0 (Outfit 1) equals the equipped set → exactly one equipped dot.
+    expect(document.querySelectorAll('[class*="outfitDot"]')).toHaveLength(1)
+  })
+
+  it('outfits: selecting shows the outfit wearables in the detail panel without equipping or previewing', async () => {
+    const backpack = renderBackpack({
+      list: [],
+      equipped: [],
+      outfits: [outfitSlot(0, ['urn:hat', 'urn:shirt', 'urn:pants'])]
+    })
+    await userEvent.click(screen.getByRole('button', { name: /saved outfits/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Outfit 1' }))
+    // The detail panel shows every wearable of the outfit (the card composite shows only four).
+    expect(document.querySelectorAll('[class*="outfitDetailGrid"] img')).toHaveLength(3)
+    expect(vi.mocked(backpack.equipOutfit)).not.toHaveBeenCalled()
+    expect(vi.mocked(backpack.preview)).not.toHaveBeenCalled()
+  })
+
+  it('outfits: double-clicking an outfit equips it', async () => {
+    const backpack = renderBackpack({ list: [], equipped: [], outfits: [outfitSlot(0, ['urn:hat'])] })
+    await userEvent.click(screen.getByRole('button', { name: /saved outfits/i }))
+    await userEvent.dblClick(screen.getByRole('button', { name: 'Outfit 1' }))
+    expect(vi.mocked(backpack.equipOutfit)).toHaveBeenCalledWith(0)
   })
 
   it('switching to the Emotes tab shows the equipped emotes', async () => {

--- a/react-web/src/test/harness.tsx
+++ b/react-web/src/test/harness.tsx
@@ -158,7 +158,7 @@ export function fakeSession(): EngineSession {
     requestUserProfile: vi.fn(),
     notifications: { list: [], unread: 0, open: false, toggle: vi.fn(), markAllRead: vi.fn() },
     emotes: { list: [], open: false, toggle: vi.fn(), play: vi.fn(), equip: vi.fn() },
-    backpack: { list: [], equipped: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn(), outfits: [], outfitSlots: 5, saveOutfit: vi.fn(), deleteOutfit: vi.fn(), equipOutfit: vi.fn() },
+    backpack: { list: [], total: 0, loading: false, query: vi.fn(), equipped: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn(), outfits: [], outfitSlots: 5, saveOutfit: vi.fn(), deleteOutfit: vi.fn(), equipOutfit: vi.fn() },
     communities: { list: [], open: false, toggle: vi.fn(), create: vi.fn(), join: vi.fn(), leave: vi.fn(), detail: null, loadDetail: vi.fn() },
     map: { x: 0, y: 0, open: false, toggle: vi.fn(), teleport: vi.fn(), changeRealm: vi.fn() },
     places: { open: false, toggle: vi.fn() },

--- a/react-web/src/test/harness.tsx
+++ b/react-web/src/test/harness.tsx
@@ -158,7 +158,7 @@ export function fakeSession(): EngineSession {
     requestUserProfile: vi.fn(),
     notifications: { list: [], unread: 0, open: false, toggle: vi.fn(), markAllRead: vi.fn() },
     emotes: { list: [], open: false, toggle: vi.fn(), play: vi.fn(), equip: vi.fn() },
-    backpack: { list: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn(), outfits: [], outfitSlots: 5, saveOutfit: vi.fn(), deleteOutfit: vi.fn(), equipOutfit: vi.fn() },
+    backpack: { list: [], equipped: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn(), outfits: [], outfitSlots: 5, saveOutfit: vi.fn(), deleteOutfit: vi.fn(), equipOutfit: vi.fn() },
     communities: { list: [], open: false, toggle: vi.fn(), create: vi.fn(), join: vi.fn(), leave: vi.fn(), detail: null, loadDetail: vi.fn() },
     map: { x: 0, y: 0, open: false, toggle: vi.fn(), teleport: vi.fn(), changeRealm: vi.fn() },
     places: { open: false, toggle: vi.fn() },

--- a/react-web/src/test/harness.tsx
+++ b/react-web/src/test/harness.tsx
@@ -158,7 +158,7 @@ export function fakeSession(): EngineSession {
     requestUserProfile: vi.fn(),
     notifications: { list: [], unread: 0, open: false, toggle: vi.fn(), markAllRead: vi.fn() },
     emotes: { list: [], open: false, toggle: vi.fn(), play: vi.fn(), equip: vi.fn() },
-    backpack: { list: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn() },
+    backpack: { list: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn(), outfits: [], outfitSlots: 5, saveOutfit: vi.fn(), deleteOutfit: vi.fn(), equipOutfit: vi.fn() },
     communities: { list: [], open: false, toggle: vi.fn(), create: vi.fn(), join: vi.fn(), leave: vi.fn(), detail: null, loadDetail: vi.fn() },
     map: { x: 0, y: 0, open: false, toggle: vi.fn(), teleport: vi.fn(), changeRealm: vi.fn() },
     places: { open: false, toggle: vi.fn() },

--- a/react-web/src/test/pageWindow.test.ts
+++ b/react-web/src/test/pageWindow.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { pageWindow } from '../features/backpack/BackpackPage'
+
+// pageWindow is a sliding window of up to 5 consecutive 0-based page indices (bevy-ui-scene style);
+// the UI shows each +1. The current page stays centered once past the first half, clamped at ends.
+describe('pageWindow (sliding window pager)', () => {
+  it('shows every page when there are 5 or fewer', () => {
+    expect(pageWindow(0, 1)).toEqual([0])
+    expect(pageWindow(2, 5)).toEqual([0, 1, 2, 3, 4])
+    expect(pageWindow(3, 4)).toEqual([0, 1, 2, 3])
+  })
+
+  it('keeps the window anchored at the start for the first pages (1 2 3 4 5)', () => {
+    expect(pageWindow(0, 20)).toEqual([0, 1, 2, 3, 4]) // page 1
+    expect(pageWindow(1, 20)).toEqual([0, 1, 2, 3, 4]) // page 2
+    expect(pageWindow(2, 20)).toEqual([0, 1, 2, 3, 4]) // page 3
+  })
+
+  it('centers the current page in the middle (… slides)', () => {
+    expect(pageWindow(3, 20)).toEqual([1, 2, 3, 4, 5]) // page 4 → centered
+    expect(pageWindow(9, 20)).toEqual([7, 8, 9, 10, 11]) // page 10 → centered
+  })
+
+  it('clamps the window at the end for the last pages (16 17 18 19 20)', () => {
+    expect(pageWindow(18, 20)).toEqual([15, 16, 17, 18, 19]) // page 19
+    expect(pageWindow(19, 20)).toEqual([15, 16, 17, 18, 19]) // page 20
+  })
+})

--- a/react-web/src/test/wearables.test.tsx
+++ b/react-web/src/test/wearables.test.tsx
@@ -91,4 +91,53 @@ describe('wearables domain', () => {
     // Categories survive the rebuild, so the per-category slots stay correct.
     expect(h.session().backpack.equipped.map((w) => w.category)).toEqual(['hat', 'feet', 'lower_body'])
   })
+
+  // Regression: equipping a saved outfit deploys via setAvatar and (like every equip) draws no
+  // wearables re-emit, so the session must rebuild `backpack.equipped` from the outfit itself. Before
+  // the fix it stayed stale and the next single-item equip (equipSetWith) dropped the outfit's other
+  // wearables. (The mock masks this by re-emitting; this test never re-emits.)
+  it('equipping a saved outfit rebuilds the equipped set so a later equip keeps the outfit', async () => {
+    const shirt = { ...wearable('urn:shirt'), category: 'upper_body' }
+    const pants = { ...wearable('urn:pants'), category: 'lower_body' }
+    const hat = { ...wearable('urn:hat'), category: 'hat' }
+
+    const h = renderSession()
+    await enterAsGuest(h)
+    // Catalog pool holds every wearable the outfit + later equip resolve against.
+    act(() => h.session().backpack.query({ page: 0, pageSize: 16 }))
+    const q = h.driver.last('catalogQuery') as { requestId: number }
+    h.driver.emit({ kind: 'catalogPage', catalog: 'wearables', items: [shirt, pants, hat], total: 3, requestId: q.requestId })
+    // A saved outfit at slot 0 with two wearables.
+    h.driver.emit({
+      kind: 'outfits',
+      metadata: {
+        outfits: [
+          {
+            slot: 0,
+            outfit: {
+              bodyShape: 'urn:body',
+              eyes: { color: { r: 0, g: 0, b: 0 } },
+              hair: { color: { r: 0, g: 0, b: 0 } },
+              skin: { color: { r: 0, g: 0, b: 0 } },
+              wearables: ['urn:shirt', 'urn:pants'],
+              forceRender: []
+            }
+          }
+        ],
+        namesForExtraSlots: []
+      }
+    })
+
+    // Equip the outfit — deploys via equipOutfit; no wearables re-emit follows.
+    act(() => h.session().backpack.equipOutfit(0))
+    expect(h.driver.last('equipOutfit')).toEqual({ kind: 'equipOutfit', slot: 0 })
+    expect(h.session().backpack.equipped.map((w) => w.urn)).toEqual(['urn:shirt', 'urn:pants'])
+
+    // Now equip a hat (a new category) — before the fix this deployed just [hat], dropping the outfit.
+    const equipSetWith = (equipped: Wearable[], w: Wearable): string[] =>
+      [...equipped.filter((x) => x.category !== w.category).map((x) => x.urn), w.urn]
+    act(() => h.session().backpack.equip(equipSetWith(h.session().backpack.equipped, hat)))
+    expect(h.driver.last('equip')).toEqual({ kind: 'equip', urns: ['urn:shirt', 'urn:pants', 'urn:hat'] })
+    expect(h.session().backpack.equipped.map((w) => w.urn)).toEqual(['urn:shirt', 'urn:pants', 'urn:hat'])
+  })
 })

--- a/react-web/src/test/wearables.test.tsx
+++ b/react-web/src/test/wearables.test.tsx
@@ -24,8 +24,10 @@ describe('wearables domain', () => {
   it('wearables stream populates the catalog', async () => {
     const h = renderSession()
     await enterAsGuest(h)
-    h.driver.emit({ kind: 'wearables', wearables: [wearable('urn:hat'), wearable('urn:hair', true)] })
+    h.driver.emit({ kind: 'wearables', wearables: [wearable('urn:hat'), wearable('urn:hair', true)], equipped: [wearable('urn:hair', true)] })
     expect(h.session().backpack.list).toHaveLength(2)
+    // Equipped set is decoupled from the catalog list (drives the per-category slots).
+    expect(h.session().backpack.equipped.map((w) => w.urn)).toEqual(['urn:hair'])
   })
 
   it('preview posts previewAvatar; null clears it', async () => {
@@ -40,7 +42,7 @@ describe('wearables domain', () => {
   it('equip posts the full set and optimistically flips equipped', async () => {
     const h = renderSession()
     await enterAsGuest(h)
-    h.driver.emit({ kind: 'wearables', wearables: [wearable('urn:hat')] })
+    h.driver.emit({ kind: 'wearables', wearables: [wearable('urn:hat')], equipped: [] })
     act(() => h.session().backpack.equip(['urn:hat']))
     expect(h.driver.last('equip')).toEqual({ kind: 'equip', urns: ['urn:hat'] })
     expect(h.session().backpack.list.find((w) => w.urn === 'urn:hat')?.equipped).toBe(true)

--- a/react-web/src/test/wearables.test.tsx
+++ b/react-web/src/test/wearables.test.tsx
@@ -21,13 +21,22 @@ describe('wearables domain', () => {
     expect(h.driver.sentOf('getEmotes')).toHaveLength(1)
   })
 
-  it('wearables stream populates the catalog', async () => {
+  it('catalogPage populates the grid; the wearables stream carries the equipped set', async () => {
     const h = renderSession()
     await enterAsGuest(h)
-    h.driver.emit({ kind: 'wearables', wearables: [wearable('urn:hat'), wearable('urn:hair', true)], equipped: [wearable('urn:hair', true)] })
+    // Grid is server-paginated: query, then the matching page populates the list + total.
+    act(() => h.session().backpack.query({ page: 0, pageSize: 16 }))
+    const q = h.driver.last('catalogQuery') as { requestId: number }
+    expect(q).toMatchObject({ kind: 'catalogQuery', catalog: 'wearables', page: 0 })
+    h.driver.emit({ kind: 'catalogPage', catalog: 'wearables', items: [wearable('urn:hat'), wearable('urn:hair', true)], total: 42, requestId: q.requestId })
     expect(h.session().backpack.list).toHaveLength(2)
-    // Equipped set is decoupled from the catalog list (drives the per-category slots).
-    expect(h.session().backpack.equipped.map((w) => w.urn)).toEqual(['urn:hair'])
+    expect(h.session().backpack.total).toBe(42)
+    // A stale (older requestId) page is ignored.
+    h.driver.emit({ kind: 'catalogPage', catalog: 'wearables', items: [], total: 0, requestId: q.requestId - 1 })
+    expect(h.session().backpack.list).toHaveLength(2)
+    // Equipped set is decoupled from the grid (drives the per-category slots).
+    h.driver.emit({ kind: 'wearables', equipped: [wearable('urn:mask', true)] })
+    expect(h.session().backpack.equipped.map((w) => w.urn)).toEqual(['urn:mask'])
   })
 
   it('preview posts previewAvatar; null clears it', async () => {
@@ -42,9 +51,44 @@ describe('wearables domain', () => {
   it('equip posts the full set and optimistically flips equipped', async () => {
     const h = renderSession()
     await enterAsGuest(h)
-    h.driver.emit({ kind: 'wearables', wearables: [wearable('urn:hat')], equipped: [] })
+    act(() => h.session().backpack.query({ page: 0, pageSize: 16 }))
+    const q = h.driver.last('catalogQuery') as { requestId: number }
+    h.driver.emit({ kind: 'catalogPage', catalog: 'wearables', items: [wearable('urn:hat')], total: 1, requestId: q.requestId })
     act(() => h.session().backpack.equip(['urn:hat']))
     expect(h.driver.last('equip')).toEqual({ kind: 'equip', urns: ['urn:hat'] })
+    // Optimistic flip on the current page.
     expect(h.session().backpack.list.find((w) => w.urn === 'urn:hat')?.equipped).toBe(true)
+  })
+
+  // Regression: the real bridge emits `wearables` only once (at load) — it never re-emits after an
+  // equip deploy. So `backpack.equipped` must stay authoritative from the optimistic rebuild, or each
+  // subsequent equip (built via equipSetWith from the equipped set) drops the previously-equipped
+  // items. (The mock masks this by re-emitting; this test never re-emits.)
+  it('sequential cross-category equips accumulate without a wearables re-emit', async () => {
+    // Mirrors BackpackPage's equipSetWith: keep every equipped item of a different category, add w.
+    const equipSetWith = (equipped: Wearable[], w: Wearable): string[] =>
+      [...equipped.filter((x) => x.category !== w.category).map((x) => x.urn), w.urn]
+    const hat = { ...wearable('urn:hat', true), category: 'hat' }
+    const shoes = { ...wearable('urn:shoes'), category: 'feet' }
+    const pants = { ...wearable('urn:pants'), category: 'lower_body' }
+
+    const h = renderSession()
+    await enterAsGuest(h)
+    // Initial equipped set (the one-and-only wearables emit) and a catalog page holding the pool.
+    h.driver.emit({ kind: 'wearables', equipped: [hat] })
+    act(() => h.session().backpack.query({ page: 0, pageSize: 16 }))
+    const q = h.driver.last('catalogQuery') as { requestId: number }
+    h.driver.emit({ kind: 'catalogPage', catalog: 'wearables', items: [shoes, pants], total: 2, requestId: q.requestId })
+
+    // Equip shoes (different category) — no re-emit follows.
+    act(() => h.session().backpack.equip(equipSetWith(h.session().backpack.equipped, shoes)))
+    expect(h.session().backpack.equipped.map((w) => w.urn)).toEqual(['urn:hat', 'urn:shoes'])
+
+    // Equip pants (a third category) — before the fix this deployed [hat, pants], dropping shoes.
+    act(() => h.session().backpack.equip(equipSetWith(h.session().backpack.equipped, pants)))
+    expect(h.driver.last('equip')).toEqual({ kind: 'equip', urns: ['urn:hat', 'urn:shoes', 'urn:pants'] })
+    expect(h.session().backpack.equipped.map((w) => w.urn)).toEqual(['urn:hat', 'urn:shoes', 'urn:pants'])
+    // Categories survive the rebuild, so the per-category slots stay correct.
+    expect(h.session().backpack.equipped.map((w) => w.category)).toEqual(['hat', 'feet', 'lower_body'])
   })
 })


### PR DESCRIPTION
### What
Builds out the react-web Backpack across nine commits:

- **Saved Outfits tab** wired end to end (load, save, delete, equip, live preview) — was a stub.
- **Outfits interaction model now matches wearables**: selecting an outfit populates the detail panel with *every* wearable thumbnail (the composite card shows only four) and no longer live-previews on the avatar; equipping is explicit via the **EQUIP** pill or a **double-click**. The outfit matching the current look is marked like an equipped wearable (accent ring + dot).
- **Equipping a saved outfit rebuilds the session equipped set** so category slots and later single-item equips stay correct.
- **Equipped set decoupled from the catalog grid**, so every occupied category slot renders its thumbnail even when the item is off the current catalog page.
- **Server-side catalog pagination** behind a generic `catalogQuery`, replacing the single 200-item page + client-side paging.
- **Explicit equip UX** in Categories: selecting a card only populates the detail panel; category slots get a hover unequip (✕) and click-to-deselect toggle.
- **collections-v1 equipped resolve fix**: strip `:tokenId` from v1 urns too, so v1 collectibles land in their slot.
- **Pointer lock released when a full-screen menu opens** (communities, places, map, backpack, gallery, settings), freeing the mouse to operate the menu.

### Why
- Users owning >200 wearables could never browse past the first 200 (client-side paging over a single page).
- Category slots for equipped items outside that page (mask/eyewear/lower_body) rendered empty.
- Equipped v1 collectibles kept their tokenId and got no category, leaving the slot blank until the category was selected.
- Outfits tab was non-functional (empty state only), and once implemented, click-to-preview + a stale equipped set caused wrong deploys (equipping an outfit then a single item dropped the outfit's other wearables).
- Click-to-equip made it easy to change the avatar accidentally; the Unity model is explicit equip + slot toggle/unequip, consistent between wearables and outfits.
- Opening a menu while pointer-locked left the mouse driving the camera behind the menu.

### How
- **protocol.ts**: `catalogQuery`/`catalogPage`; `WearablesMessage.equipped` (decoupled equipped set); Outfit types + `getOutfits`/`saveOutfit`/`deleteOutfit`/`equipOutfit`; `setAvatar` extended with `base`.
- **bridge**: `domains/catalog.ts` (dispatch by catalog kind) and `domains/outfits.ts` (localStorage-first, else catalyst `/outfits/:address`; equip via `setAvatar`); `wearables.ts` gains `fetchWearablesPage` and resolves equipped urns independently, accumulating the item→token map across pages.
- **session** (`useEngineSession`): paginated grid state with a request id to drop out-of-order responses; equip optimistic on the current page; `equipOutfit` rebuilds the equipped set from the outfit's own wearables (shared `applyEquippedOptimistic`, via an `outfitsRef` to avoid a stale closure); a `useEffect` releases pointer lock when any full-screen menu opens (mirrors `requestFocusChat`).
- **UI** (`BackpackPage`): server-side filters/sort/debounced search; sliding 5-page pager with wrapping arrows; outfit slot grid; `OutfitDetailPanel` (all wearable thumbnails); equipped-marker (`outfitMatchesEquipped` compares wearable sets with the same item-urn matcher used for equipping).
- **mock** (`mockBridge`): exercises the off-catalog equipped path and `?mock=1` outfits; `saveOutfit` captures the full current look so a saved slot equals the equipped set and shows the marker.

### Verification
- Typecheck clean (react-web app + bridge-scene).
- Unit tests: **257 pass** — adds an equip-outfit regression test (`wearables.test.tsx`) and three outfit-interaction tests (`backpack.clicks.test.tsx`); `backpack.clicks`, `wearables`, `pageWindow` updated.
- Browser-verified in `?mock=1`: selecting an outfit shows all its thumbnails with no avatar change; double-click equips; a saved current-look outfit shows the equipped ring + dot. No console errors.
- Visual baselines unchanged.

### Known limitations
- Outfits Phase 1 only: local persistence. Signed catalyst deploy + base-color preview are Phase 2.
- The outfit equipped-marker compares wearable sets only (the decoupled equipped set carries no body-shape/color data).
- Pointer-lock release is the web path (`document.exitPointerLock`); native (no DOM pointer lock) is a no-op and unaffected.
- Emotes catalog still on the old path — `catalogQuery` is generic and ready, wearables migrated, emotes TODO.
- No tier-1.5 visual baseline yet for the Saved Outfits section (deferred per MVP priority).
