### PR TITLE
fix/ui/05-emote-hotkeys: emotes — number keys play the wheel slot

### DIFF
--- a/react-web/bridge-scene/src/domains/emotes.ts
+++ b/react-web/bridge-scene/src/domains/emotes.ts
@@ -25,6 +25,16 @@ function itemUrn(urn: string): string {
 }
 const isBase = (urn: string): boolean => BASE_EMOTES.includes(itemUrn(urn))
 
+// The 10 wheel slots to show for a profile: its equipped emotes positionally, or — when the wheel is
+// entirely empty (a fresh profile) — the base emotes in order (slot i = BASE_EMOTES[i]). The bevy
+// runtime doesn't seed the defaults into getPlayer().emotes (bevy-ui-scene hits the same empty array),
+// so the HUD fills them here, mirroring Unity's SelfProfile empty-wheel fill: it's all-or-nothing, so
+// once any slot is equipped the remaining empties stay empty.
+function equippedSlots(emotes: readonly unknown[] | undefined): string[] {
+  const slots = Array.from({ length: SLOT_COUNT }, (_, i) => String((emotes ?? [])[i] ?? ''))
+  return slots.every((u) => u === '') ? [...BASE_EMOTES] : slots
+}
+
 // Title-case a base-emote id ("raisehand" → "Raise Hand"); custom emotes use the catalog name.
 function baseEmoteName(urn: string): string {
   const i = urn.indexOf('base-emotes:')
@@ -99,7 +109,9 @@ export function registerEmotes(ctx: Ctx): void {
     const me = getPlayer()
     if (me == null) return
     if (!isBase(msg.urn) && tokenUrnByItem.size === 0) await getOwned(await catalystBase(), me.userId).catch(() => [])
-    const slots = Array.from({ length: SLOT_COUNT }, (_, i) => String((me.emotes ?? [])[i] ?? ''))
+    // Seed from the effective slots (base defaults when the wheel is empty) so equipping into a fresh
+    // profile persists the defaults alongside the new one, instead of blanking the other 9 slots.
+    const slots = equippedSlots(me.emotes)
     slots[msg.slot] = equipUrn(msg.urn)
     BevyApi.setAvatar({
       equip: { wearableUrns: (me.wearables ?? []).map(String), emoteUrns: slots, forceRender: [] }
@@ -112,9 +124,9 @@ export function registerEmotes(ctx: Ctx): void {
     const player = getPlayer()
     const base = await catalystBase()
 
-    // equipped array index = wheel slot; map item-urn → slot.
+    // equipped array index = wheel slot; map item-urn → slot (base defaults when the wheel is empty).
     const slotByItem = new Map<string, number>()
-    ;(player?.emotes ?? []).map(String).forEach((urn, slot) => {
+    equippedSlots(player?.emotes).forEach((urn, slot) => {
       if (urn !== '') slotByItem.set(itemUrn(urn), slot)
     })
 

--- a/react-web/bridge-scene/src/domains/emotes.ts
+++ b/react-web/bridge-scene/src/domains/emotes.ts
@@ -11,9 +11,19 @@ import type { Ctx } from '../bridge'
 import type { Emote } from '../../../src/engine/protocol'
 
 const SLOT_COUNT = 10 // the emote wheel has 10 slots
+const BASE_EMOTE_PREFIX = 'urn:decentraland:off-chain:base-emotes:'
 const BASE_EMOTES = ['handsair', 'wave', 'fistpump', 'dance', 'raisehand', 'clap', 'money', 'kiss', 'headexplode', 'shrug'].map(
-  (n) => `urn:decentraland:off-chain:base-emotes:${n}`
+  (n) => `${BASE_EMOTE_PREFIX}${n}`
 )
+
+// getPlayer().emotes stores base emotes by SHORT name ("handsair"), not the full off-chain urn:
+// the engine strips base emotes to their short form when it writes the profile (see the explorer's
+// system_ui/src/profile.rs, and avatar/src/lib.rs which feeds emote_urns back verbatim). The catalog
+// + BASE_EMOTES use the full urn, so expand bare short names or equipped base emotes never match a
+// slot and the wheel renders empty.
+function fullEmoteUrn(urn: string): string {
+  return urn !== '' && !urn.includes(':') ? `${BASE_EMOTE_PREFIX}${urn}` : urn
+}
 
 // Equipped/owned emote urns can carry an NFT token id:
 //   urn:decentraland:matic:collections-v2:<contract>:<itemId>[:<tokenId>]
@@ -125,9 +135,10 @@ export function registerEmotes(ctx: Ctx): void {
     const base = await catalystBase()
 
     // equipped array index = wheel slot; map item-urn → slot (base defaults when the wheel is empty).
+    // Normalize short base-emote names to the full urn so equipped base emotes match a slot.
     const slotByItem = new Map<string, number>()
     equippedSlots(player?.emotes).forEach((urn, slot) => {
-      if (urn !== '') slotByItem.set(itemUrn(urn), slot)
+      if (urn !== '') slotByItem.set(itemUrn(fullEmoteUrn(urn)), slot)
     })
 
     // base emotes are always available to everyone

--- a/react-web/src/features/emotes/EmotesWheel.tsx
+++ b/react-web/src/features/emotes/EmotesWheel.tsx
@@ -84,9 +84,7 @@ export function EmotesWheel({
             Customise [E]
           </button>
           <div className={styles.hint}>
-            Hold [B+num] to run an emote
-            <br />
-            while the wheel is closed
+            Press [B+num] to run an emote
           </div>
         </div>
       </div>

--- a/react-web/src/lib/useMenuShortcuts.ts
+++ b/react-web/src/lib/useMenuShortcuts.ts
@@ -33,8 +33,8 @@ export function useMenuShortcuts(session: EngineSession): void {
   sessionRef.current = session
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent): void => {
-      // Plain letters only — leave chords (Ctrl/Cmd/Alt) and keystrokes in text fields alone.
+    const keyDownHandler = (e: KeyboardEvent): void => {
+      // Plain keys only — leave chords (Ctrl/Cmd/Alt) and keystrokes in text fields alone.
       if (e.ctrlKey || e.metaKey || e.altKey || e.repeat) return
       const target = e.target as HTMLElement | null
       const tag = target?.tagName
@@ -43,6 +43,19 @@ export function useMenuShortcuts(session: EngineSession): void {
 
       const s = sessionRef.current
       if (s.phase !== 'world') return
+
+      // Quick emotes: while the wheel is open, a number key (0–9) plays that slot's emote (which also
+      // closes the wheel). With the wheel closed a number does nothing — this covers both "hold B, tap
+      // a number" and "tap B, then a number", since either way B has opened the wheel first. Handled
+      // here (not off the engine's QuickEmote action) so it fires while the HUD holds keyboard focus.
+      if (s.emotes.open && /^[0-9]$/.test(e.key)) {
+        e.preventDefault()
+        e.stopPropagation()
+        const emote = s.emotes.list.find((em) => em.slot === Number(e.key))
+        if (emote) s.emotes.play(emote.urn)
+        return
+      }
+
       const toggle = SHORTCUTS[e.key.toLowerCase()]
       if (!toggle) return
       e.preventDefault()
@@ -52,7 +65,7 @@ export function useMenuShortcuts(session: EngineSession): void {
 
     // Same-document engine (no iframe): the canvas shares this window, so one capture-phase
     // listener sees keys wherever focus is.
-    window.addEventListener('keydown', handler, true)
-    return () => window.removeEventListener('keydown', handler, true)
+    window.addEventListener('keydown', keyDownHandler, true)
+    return () => window.removeEventListener('keydown', keyDownHandler, true)
   }, [])
 }

--- a/react-web/src/test/menuShortcuts.test.ts
+++ b/react-web/src/test/menuShortcuts.test.ts
@@ -52,4 +52,25 @@ describe('useMenuShortcuts', () => {
     press('m')
     expect(session.map.toggle).not.toHaveBeenCalled()
   })
+
+  it('quick emotes: a number plays that slot, but only while the wheel is open', () => {
+    const emote = { slot: 3, urn: 'urn:emote:three', name: 'Three' }
+
+    // Wheel closed → a number does nothing.
+    const closed = fakeSession()
+    closed.emotes.list = [emote]
+    const { unmount } = renderHook(() => useMenuShortcuts(closed))
+    press('3')
+    expect(closed.emotes.play).not.toHaveBeenCalled()
+    unmount()
+
+    // Wheel open → the number plays that slot's emote; an empty slot (7) is a no-op.
+    const open = fakeSession()
+    open.emotes = { ...open.emotes, open: true, list: [emote] }
+    renderHook(() => useMenuShortcuts(open))
+    press('3')
+    press('7')
+    expect(open.emotes.play).toHaveBeenCalledTimes(1)
+    expect(open.emotes.play).toHaveBeenCalledWith('urn:emote:three')
+  })
 })


### PR DESCRIPTION
## What

- Emote hotkeys: while the wheel is open, number keys 0-9 now play the emote in that slot (and close the wheel). A number with the wheel closed does nothing. Covers both gestures:
  - `b + number` (hold B, which opens the wheel, then press a number)
  - `b , number` (tap B to open the wheel, then press a number)
- Empty-wheel defaults: a fresh profile (no equipped emotes) now renders the 10 base emotes instead of an empty wheel, and equipping into a fresh profile keeps the other defaults instead of blanking the remaining 9 slots. Base-emote short names are normalized to their full off-chain urn so equipped base emotes match a slot (the engine stores them by short name; the catalog keys on the full urn).
- Updated the wheel hint text to match the tap-B-then-number behavior ("Press [B+num] to run an emote").

## Why / approach

The hotkey handling lives in the HUD's capture-phase `window` keydown listener (`useMenuShortcuts`, renamed `handler` to `keyDownHandler`), next to the existing letter shortcuts. It does not go through the engine's `QuickEmote` system action on purpose: that action only fires while the engine canvas holds keyboard focus, so it never arrived once the HUD (or the open wheel) took focus. A DOM window listener sees the key regardless of focus, which is exactly what the B shortcut already relies on.

Gating on "wheel open" is enough for both gestures, since B opens the wheel first in either case. Keystrokes aimed at text fields (e.g. the chat input) are still ignored.

The empty-wheel fill mirrors Unity's SelfProfile behavior: the bevy runtime does not seed the default emotes into `getPlayer().emotes`, so the HUD fills them (slot i = base emote i) when every slot is empty. It is all-or-nothing, so once any slot is equipped the remaining empties stay empty.

## Tests

- New unit test in `menuShortcuts.test.ts`: a number plays that slot only while the wheel is open; a bare number is a no-op; an empty slot is a no-op.
- Full react-web suite: 258/258 passing. Typecheck clean (react-web and bridge-scene).
- Verified in the browser with `?mock=1`: B opens the wheel, a number plays and closes it, a number with the wheel closed does nothing, no console errors.

## Note

Stacked on #991 (`fix/ui/04-outfits`); base is that branch, so this PR's diff is the emote hotkey commit plus the empty-wheel default-fill fixes and the hint-text change. Retarget to `main` once #991 merges.
