### PR TITLE
fix/ui/06-wgpu-crash-popup: engine-host — surface fatal wgpu error floods as a crash modal

### DIFF
--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -55,6 +55,22 @@ publish()
   const HANG_TICKS = 8 // ~16s with no corroborating error
   const ERROR_CONFIRM_TICKS = 2 // ~4s after a recorded error
 
+  // "Alive but rendering-dead" detector. The stall watchdog above only catches a FROZEN engine (the
+  // heartbeat stops). A render loop that keeps beating while every frame throws the SAME error — e.g. a
+  // wgpu pipeline/attachment mismatch that blanks the screen and spams the console — sails past it, so
+  // catch it by the flood: the identical engine-core console.error repeating FATAL_REPEATS times within
+  // FATAL_WINDOW_MS ⇒ runtime crash. Scene (UGC) console.error lives in the sandbox WORKER's own
+  // console and never reaches this main-thread patch, so this stream is engine-core only. Signatures are
+  // whitespace-normalized but otherwise EXACT (numbers/urls kept) so distinct errors — different assets,
+  // different coords — never pool into one false flood; only a truly identical per-frame error trips it.
+  const FATAL_REPEATS = 30
+  const FATAL_WINDOW_MS = 4000
+  // Engine-core errors that can repeat identically without being fatal — never trip the flood on these.
+  const BENIGN_REPEATS = ['Message too large']
+  // signature -> { count, since }. Per-signature counters (not a single last-seen key) so an identical
+  // per-frame error still floods even when the loop interleaves it with a second error each frame.
+  const floodCounts = new Map()
+
   const nowMs = () => (window.performance?.now ? performance.now() : Date.now())
   const errMessage = (err) => {
     if (!err) return 'Unknown error'
@@ -80,6 +96,7 @@ publish()
     missedTicks = 0
     recoverTicks = 0
     lastBeatCount = beatCount
+    floodCounts.clear()
     window.__bevyPanic = undefined
   }
   window.__rearmCrashWatchdog = rearm
@@ -90,6 +107,28 @@ publish()
   }
   window.reportEngineError = recordError
 
+  // Collapse whitespace only (keep numbers/urls) so "the same error" groups but distinct ones don't.
+  const signature = (msg) => String(msg).replace(/\s+/g, ' ').trim().slice(0, 300)
+
+  // Flood detector (see FATAL_REPEATS above): an identical engine-core error repeating every frame is a
+  // running-but-dead loop the stall watchdog can't see. Latched via `shown`; rearm() clears the counters.
+  function considerFatalRepeat(msg) {
+    if (shown) return
+    if (BENIGN_REPEATS.some((b) => msg.indexOf(b) !== -1)) return
+    const key = signature(msg)
+    const now = nowMs()
+    let e = floodCounts.get(key)
+    if (!e || now - e.since > FATAL_WINDOW_MS) {
+      e = { count: 0, since: now }
+      floodCounts.set(key, e)
+    }
+    if (++e.count >= FATAL_REPEATS) crash(msg, 'runtime')
+    // Bound memory: drop signatures whose window has lapsed once the map grows.
+    if (floodCounts.size > 64) {
+      for (const [k, v] of floodCounts) if (now - v.since > FATAL_WINDOW_MS) floodCounts.delete(k)
+    }
+  }
+
   // Capture Rust panic text: the wasm panic hook prints "panicked at …" via console.error, while
   // the throw that surfaces is a generic trap — stash the readable message for the host.
   const origConsoleError = console.error.bind(console)
@@ -99,6 +138,17 @@ publish()
       if (typeof first === 'string' && first.indexOf('panicked at') !== -1) {
         window.__bevyPanic = { message: String(first), at: nowMs() }
         recordError(first, 'panic')
+      }
+      // Engine-core log lines arrive as a single formatted string (wasm __wbg_error → console.error).
+      // Feed them to the flood detector so a per-frame error storm (blank-screen render crash) becomes
+      // a runtime crash modal instead of an endless silent spam. Skip our OWN watchdog logging
+      // (recordError/crash re-enter this patch) so their constant prefixes can't self-trip the flood.
+      if (
+        typeof first === 'string' &&
+        first.indexOf('[engine error]') !== 0 &&
+        first.indexOf('[crash watchdog]') !== 0
+      ) {
+        considerFatalRepeat(first)
       }
     } catch (_) {}
     return origConsoleError.apply(console, arguments)

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -47,6 +47,11 @@ publish()
 // (window.__onEngineCrash) — React shows the error modal; there is no overlay here.
 ;(function () {
   let shown = false
+  // Set when the crash came from the FLOOD detector: there the heartbeat never stopped, so
+  // "frames resumed" is not evidence of recovery — only a host dismiss (__rearmCrashWatchdog)
+  // clears this latch. Without it the stall watchdog's auto-rearm would clear `shown` ~4s in,
+  // the still-running flood would re-trip, and the crash cycle would repeat forever.
+  let floodLatched = false
   let lastError = null
   let lastBeat = 0
   let beatsSeen = false
@@ -58,15 +63,19 @@ publish()
   // "Alive but rendering-dead" detector. The stall watchdog above only catches a FROZEN engine (the
   // heartbeat stops). A render loop that keeps beating while every frame throws the SAME error — e.g. a
   // wgpu pipeline/attachment mismatch that blanks the screen and spams the console — sails past it, so
-  // catch it by the flood: the identical engine-core console.error repeating FATAL_REPEATS times within
+  // catch it by the flood: the same fatal-class engine error repeating FATAL_REPEATS times within
   // FATAL_WINDOW_MS ⇒ runtime crash. Scene (UGC) console.error lives in the sandbox WORKER's own
   // console and never reaches this main-thread patch, so this stream is engine-core only. Signatures are
   // whitespace-normalized but otherwise EXACT (numbers/urls kept) so distinct errors — different assets,
   // different coords — never pool into one false flood; only a truly identical per-frame error trips it.
   const FATAL_REPEATS = 30
   const FATAL_WINDOW_MS = 4000
-  // Engine-core errors that can repeat identically without being fatal — never trip the flood on these.
-  const BENIGN_REPEATS = ['Message too large']
+  // Only these engine messages can trip the flood. A healthy session floods the console with benign
+  // ERROR lines at exactly this rate — a 404 asset retried per frame by bevy_asset, comms "channel
+  // closed" during startup — so an allowlist, not a denylist, is what keeps the modal off a working
+  // world. `captured wgpu error` is src/lib.rs's on_uncaptured_error handler: the device-level GPU
+  // fault that blanks the screen while the render loop keeps beating.
+  const FATAL_SIGNALS = ['captured wgpu error']
   // signature -> { count, since }. Per-signature counters (not a single last-seen key) so an identical
   // per-frame error still floods even when the loop interleaves it with a second error each frame.
   const floodCounts = new Map()
@@ -78,9 +87,10 @@ publish()
     return err.message || err.stack || String(err)
   }
 
-  function crash(err, source) {
+  function crash(err, source, latch) {
     if (shown) return
     shown = true
+    if (latch) floodLatched = true
     const msg = errMessage(err)
     console.error('[crash watchdog]', source || 'error', err)
     try {
@@ -91,6 +101,7 @@ publish()
   // Re-arm from a clean slate (host dismissed the modal, or frames resumed).
   function rearm() {
     shown = false
+    floodLatched = false
     lastError = null
     lastBeat = nowMs()
     missedTicks = 0
@@ -114,7 +125,7 @@ publish()
   // running-but-dead loop the stall watchdog can't see. Latched via `shown`; rearm() clears the counters.
   function considerFatalRepeat(msg) {
     if (shown) return
-    if (BENIGN_REPEATS.some((b) => msg.indexOf(b) !== -1)) return
+    if (!FATAL_SIGNALS.some((s) => msg.indexOf(s) !== -1)) return
     const key = signature(msg)
     const now = nowMs()
     let e = floodCounts.get(key)
@@ -122,15 +133,16 @@ publish()
       e = { count: 0, since: now }
       floodCounts.set(key, e)
     }
-    if (++e.count >= FATAL_REPEATS) crash(msg, 'runtime')
+    if (++e.count >= FATAL_REPEATS) crash(msg, 'runtime', true)
     // Bound memory: drop signatures whose window has lapsed once the map grows.
     if (floodCounts.size > 64) {
       for (const [k, v] of floodCounts) if (now - v.since > FATAL_WINDOW_MS) floodCounts.delete(k)
     }
   }
 
-  // Capture Rust panic text: the wasm panic hook prints "panicked at …" via console.error, while
-  // the throw that surfaces is a generic trap — stash the readable message for the host.
+  // Capture Rust panic text: the wasm panic hook prints "panicked at …" via console.error (the only
+  // engine path that uses that channel — wasm-bindgen's __wbg_error), while the throw that surfaces
+  // is a generic trap — stash the readable message for the host.
   const origConsoleError = console.error.bind(console)
   console.error = function () {
     try {
@@ -139,19 +151,22 @@ publish()
         window.__bevyPanic = { message: String(first), at: nowMs() }
         recordError(first, 'panic')
       }
-      // Engine-core log lines arrive as a single formatted string (wasm __wbg_error → console.error).
-      // Feed them to the flood detector so a per-frame error storm (blank-screen render crash) becomes
-      // a runtime crash modal instead of an endless silent spam. Skip our OWN watchdog logging
-      // (recordError/crash re-enter this patch) so their constant prefixes can't self-trip the flood.
-      if (
-        typeof first === 'string' &&
-        first.indexOf('[engine error]') !== 0 &&
-        first.indexOf('[crash watchdog]') !== 0
-      ) {
-        considerFatalRepeat(first)
-      }
     } catch (_) {}
     return origConsoleError.apply(console, arguments)
+  }
+
+  // Engine LOG lines — including every error!() — come through console.LOG, not console.error:
+  // bevy_log's wasm path (LogPlugin with no custom_layer) is tracing-wasm, whose only console
+  // binding is `log`. Each event is a 4-arg styled call whose first argument starts with the level
+  // ("%cERROR%c src/lib.rs:505 …"). So the flood detector has to listen here, or the wgpu storm this
+  // watchdog exists for never reaches it. FATAL_SIGNALS keeps the benign ERROR spam out.
+  const origConsoleLog = console.log.bind(console)
+  console.log = function () {
+    try {
+      const first = arguments[0]
+      if (typeof first === 'string') considerFatalRepeat(first)
+    } catch (_) {}
+    return origConsoleLog.apply(console, arguments)
   }
 
   window.__engineHeartbeat = () => {
@@ -174,7 +189,10 @@ publish()
     lastBeatCount = beatCount
 
     if (shown) {
-      // Frames back for two consecutive ticks → transient stall, re-arm.
+      // Frames back for two consecutive ticks → transient stall, re-arm. Never for a flood crash:
+      // there the frames never stopped (that's the whole point), so this would clear the latch and
+      // let the ongoing flood re-trip every few seconds. Only a host dismiss re-arms that one.
+      if (floodLatched) return
       recoverTicks = advanced ? recoverTicks + 1 : 0
       if (recoverTicks >= 2) rearm()
       return

--- a/react-web/docs/backlog.md
+++ b/react-web/docs/backlog.md
@@ -40,14 +40,41 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
    choice. **Duplicated identically** in both `PlaceCard.tsx` and `FeaturedCard.tsx` (the login-flow
    "Live Now"/"Featured Places" catalog, `LoadingAndLogin.tsx`), so fix both — or better, extract one
    shared glyph while fixing it (there's no `src/design/` icon for this yet).
+7. `[bug]` **Engine boot failure or hang leaves the user on the loading bar forever** — *blocks the app
+   completely, no error state; the "no infinite loading" delivery priority*. Every crash signal we have
+   needs the engine to have started: the watchdog tick in `deploy/web/engine/boot.js` returns early while
+   `beatsSeen` is false, so **before the first frame it is fully inert**. Two uncovered paths, both
+   ending on an endless loading bar with the error only in the console. (a) `initEngine()` **rejects**
+   (wasm download/compile fails, GPU cache init fails) → boot.js catches it and calls
+   `reportEngineError(e, 'boot')`, but that function only does `console.error` + stores `lastError`; it
+   never calls `crash()`, so `__onEngineCrash` never fires and no modal appears. (b) `initEngine()`
+   **hangs** (a worker never comes up, a fetch stalls) → `__bevyReadyToLaunch` stays false and the
+   readiness poll in `useEngineSession.ts` (`setInterval` every 200ms) has **no timeout or attempt cap**,
+   so it waits forever. Fix path: have the boot branch of `reportEngineError` raise a fatal (a `'boot'`
+   source alongside the existing `'launch'`/`'realm'`/`'runtime'`), and give the readiness poll a
+   no-progress deadline — watch `loadProgress`, and raise a fatal after ~30s **without advancement** (not
+   a wall-clock cap, or a slow connection on a legitimately long wasm download would false-trip).
 
 ## 🟡 Medium
 
-7. `[feature]` **Engine-panic / error capture → popup** — *new* (largely SHIPPED — `ErrorBoundary` +
+8. `[feature]` **Engine-panic / error capture → popup** — *new* (largely SHIPPED — `ErrorBoundary` +
    `EngineErrorModal` + crash watchdog landed on `fix/react-web-hud`). Kept as a tracking entry: engine
    WASM panics on launch (e.g. `can't init wasm queue`) and runtime crashes now surface a popup
    (message + copy details + reload/dismiss). (Old: `error-popup` + `error-popup-service`.)
-8. `[DS]` **`showDialog` / `showConfirm` (imperative dialog helpers)** — *mostly DONE (PR #915)*. Added
+   **Known gaps** (all are "engine alive, rendering dead" — the heartbeat keeps beating, so the stall
+   watchdog never fires; boot-time gaps are item 7). (a) **GPU device loss is handled nowhere** — nothing
+   in the repo awaits `device.lost` (not Rust, not the host JS, not react-web). A driver reset / GPU OOM /
+   the browser reclaiming the device gives a black canvas with a live page and **no console output at
+   all**, so the flood detector can't see it either. Cheapest real win here, and host-side only: await
+   `device.lost` where the device is created and route it to `__onEngineCrash`. (b) **The wgpu flood
+   detector needs ≥7.5 errors/sec** (30 within a tumbling 4s window), so the same fatal error at a low
+   framerate — 7fps gives 28 per window — never trips it. Now that the filter is the specific
+   `captured wgpu error` message rather than "any repeated error", the count no longer carries the
+   false-positive load and could drop to ~5. (c) Longer term both this and the flood sniffing are better
+   served by an **engine-side signal**: `on_uncaptured_error` in `src/lib.rs` already exists and could
+   call a JS callback directly instead of only `error!()` — exact, no console patching, no thresholds.
+   Needs a WASM rebuild, which is why the host-only detector shipped first.
+9. `[DS]` **`showDialog` / `showConfirm` (imperative dialog helpers)** — *mostly DONE (PR #915)*. Added
    `openPopup` + `showDialog` + `showConfirm` + `<PopupHost/>` in `src/design/popups.tsx` — an
    imperative, stackable popup layer backed by a **module-level store** (like the `hoverPos` store,
    read by the single `<PopupHost/>` via `useSyncExternalStore`), callable from anywhere without a
@@ -63,7 +90,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
    App-local state (`visitWorld`, `exitGuard.confirming`), so Enter still opens + focuses the chat
    behind them. Moving them onto `openPopup` fixes that for free; the alternative (wiring their state
    into the hook) is the reason not to bother.
-9. `[bug]` **`closeTopPopup` / `closeById` never run the popup's `onClose` → `showDialog` Promise leak** —
+10. `[bug]` **`closeTopPopup` / `closeById` never run the popup's `onClose` → `showDialog` Promise leak** —
    *correctness footgun, P2 pending PR #915 review*. `closeTopPopup()` (fired by the engine
    `Cancel`/Escape relay in `useEngineSession`) removes the top node with `closeById`, which only
    does `stack.filter + emit` — it never invokes that node's dismiss contract. So a
@@ -75,11 +102,11 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
    keydown reaches `Modal`). Fix: settle on removal — store the `close`/`onDismiss` per stack node and
    have `closeById` call it, so every close path (engine `Cancel`, backdrop click, per-node `close`)
    resolves the Promise exactly once.
-10. `[DS]` **`Badge` (standalone)** — *extract*. Badge logic is trapped inside `IconButton`; can't put a
+11. `[DS]` **`Badge` (standalone)** — *extract*. Badge logic is trapped inside `IconButton`; can't put a
     badge on a tab/avatar/chip without reimplementing. (Old: `notification-badge.tsx`.)
-11. `[DS]` **`Chip` / `Tag`** — *new*. "chip" is bespoke in ~11 files (map categories, count pills,
+12. `[DS]` **`Chip` / `Tag`** — *new*. "chip" is bespoke in ~11 files (map categories, count pills,
     status). (Old: `color-tag.tsx`.)
-12. `[DS]` **Consolidate modals onto `Modal`/`ModalShell`** — *cleanup*. ProfileCard, CommunityModal,
+13. `[DS]` **Consolidate modals onto `Modal`/`ModalShell`** — *cleanup*. ProfileCard, CommunityModal,
     CommunityCreateModal, WorldVisitModal roll their own portal/overlay and hardcode `z-index: 10001`.
     Unify backdrop / escape / focus-trap / z-layer.
     12b. `[bug]` **Suppress the world-hover tooltip while any overlay/scrim is open** — *mechanism, from
@@ -96,11 +123,11 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     the per-message `setHover([])`. Covers every popup, present/future, for free. *(Point 1 of the
     review — tooltip only returns after a 1px move on close — is expected native tooltip behavior and is
     not addressed by this; leave as-is.)*
-13. `[DS]` **`Radio` / `RadioGroup`** — *new*. Have Checkbox/Toggle/Select but no Radio; bespoke in
+14. `[DS]` **`Radio` / `RadioGroup`** — *new*. Have Checkbox/Toggle/Select but no Radio; bespoke in
     PermissionDialog. (Old: `radio-button.tsx`.)
-14. `[DS]` **`Skeleton`** — *new*. Only `Spinner` exists; no load placeholders for lists/cards.
+15. `[DS]` **`Skeleton`** — *new*. Only `Spinner` exists; no load placeholders for lists/cards.
     (Old: `loading-placeholder.tsx`.)
-15. `[bug]` **Passport "too far by camera" is confusing in third-person** — *behavior/UX, engine+bridge*.
+16. `[bug]` **Passport "too far by camera" is confusing in third-person** — *behavior/UX, engine+bridge*.
     Hovering a nearby avatar in third-person greys out "Show Profile" with "Get camera closer" even
     when your avatar is standing right next to them. Two causes combine: (1) the avatar pointer in
     `bridge-scene/src/domains/avatarPointer.ts` sets **no** distance fields, so it hits the SDK7
@@ -122,7 +149,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     interaction `camera_distance` player-focus-relative in third-person like Unity, fixing **all**
     SDK pointer events, not just passports. Analysis-only for now (2026-07-09) — user deferred the
     code change.
-16. `[feature]` **Passport — finish the sections (feature parity with unity-explorer / bevy-ui-scene)**
+17. `[feature]` **Passport — finish the sections (feature parity with unity-explorer / bevy-ui-scene)**
     — *feature parity*. The passport has OVERVIEW/BADGES/PHOTOS tabs but is missing sections the old
     scene renders (`bevy-ui-scene`: `ui-classes/main-hud/passport/passport-popup.tsx`). Gaps that
     **need new bridge/protocol data:** (a) **Equipped Wearables + Emotes** of the *viewed* avatar (grid:
@@ -136,7 +163,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     set. (f) Wire the **3D avatar preview** into the passport (machinery exists —
     `setEngineViewport('avatarPreview')`, used by the Backpack) instead of the 2D snapshot, + 3D badge
     preview on the Badges tab.
-17. `[feature]` **Notifications panel — bounded height, load-on-scroll, click-through to a detail
+18. `[feature]` **Notifications panel — bounded height, load-on-scroll, click-through to a detail
     popup** — *feature/bug*. `NotificationsPanel.tsx` fixes `.root` to `top: 16px; bottom: 16px`
     (`NotificationsPanel.module.css`), so the panel is always full-viewport-tall regardless of content —
     both `bevy-ui-scene` (`notifications-menu.tsx`, a fixed `menuHeight = fontSize * 30 * 1.1`) and
@@ -154,7 +181,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     building now, or should this wait on **stackable popups** — i.e. #12 (consolidate modals onto
     `Modal`/`ModalShell`) landing first, so a notification-detail popup doesn't become yet another bespoke
     overlay to migrate later. Leaning toward doing #12 first if both are picked up.
-18. `[arch]` **Pointer-lock / camera-look coordination across the HUD — the "right-click to move the
+19. `[arch]` **Pointer-lock / camera-look coordination across the HUD — the "right-click to move the
     camera again" confusion** — *behavior/parity, review + decision*. On web the engine's camera-look
     *is* the browser Pointer Lock (bevy `CursorGrabMode::Locked` → `requestPointerLock` on the iframe
     canvas; see `crates/user_input/src/camera.rs` `update_cursor_lock` +
@@ -190,7 +217,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     `PointerLock.isPointerLocked = false` on `CameraEntity` on menu open, the way `chat.ts` /
     `avatarPointer.ts` already do for their surfaces. Kept Medium: chat + click-to-open panels + web
     menus work today; only native menu-open cursor release is open.
-19. `[feature]` **Chat links: confirm popup before teleporting and before opening a URL** — *parity with
+20. `[feature]` **Chat links: confirm popup before teleporting and before opening a URL** — *parity with
     `bevy-ui-scene`, safety*. The **parsing** has parity: `chatText.tsx`'s `TOKEN_RE` linkifies the same
     four kinds as the old `LINK_TYPE` (`components/chat/chat-message/ChatMessage.tsx:43`) — url, world,
     location, mention — and react's single-pass regex is the better design (the old one composed four
@@ -208,7 +235,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
       you trust before proceeding." with the URL shown; CONTINUE → `openExternalUrl`.
     - **Worlds** (`boedo.dcl.eth`) — already confirmed via `WorldVisitModal` ✅.
     Build the two missing ones on `openPopup`/`showConfirm` rather than new App-local modals, and fold in
-    `WorldVisitModal` while there (see item 8 — it also fixes the Enter-focus hole). Related, same pass:
+    `WorldVisitModal` while there (see item 9 — it also fixes the Enter-focus hole). Related, same pass:
     (a) react linkifies `http://` too, where the old regex was `https://`-only — neither validates the
     scheme, the old one just incidentally kept `http`/`javascript:`/`data:` out of the click path, so
     make the scheme check explicit; (b) `PlacesPage` (`App.tsx:263`) changes realm with **no** confirm,
@@ -216,7 +243,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     one; (c) `chat.rich.test.tsx` covers url/location/mention clicks but never the `world` token or the
     `rel` attribute.
 
-20. `[arch]` **Unify avatar-equip authority — bridge re-emits `wearables` after every mutation (+
+21. `[arch]` **Unify avatar-equip authority — bridge re-emits `wearables` after every mutation (+
     mutation acks/errors)** — *hardening, from the fix/ui/04-outfits architecture review*. The equipped
     set runs two consistency models today: `equipOutfit` is **bridge-authoritative** (resolves the
     outfit by urn via `resolveEquippedSet` and re-emits `wearables` — the fix/ui/04-outfits fix), but
@@ -247,12 +274,12 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
 
 ## 🟢 Low / when a feature needs it
 
-21. `[DS]` **`Divider`** (bespoke in ~4 places · old `bottom-border`)
-22. `[DS]` **`Pagination`** (unused today · old `pagination/`)
-23. `[DS]` **`CopyButton`** (inline in ProfileCard · old `copy-button`)
-24. `[DS]` **`Username`** (name + verified · old `player-name-component`)
-25. `[DS]` `Button` `iconLeft`/`iconRight` props + `hoverIcon` (niche · old `ButtonComponent`)
-26. `[feature]` **Re-enable "Invite to Community" in `ProfileCard`** — *feature, parked until
+22. `[DS]` **`Divider`** (bespoke in ~4 places · old `bottom-border`)
+23. `[DS]` **`Pagination`** (unused today · old `pagination/`)
+24. `[DS]` **`CopyButton`** (inline in ProfileCard · old `copy-button`)
+25. `[DS]` **`Username`** (name + verified · old `player-name-component`)
+26. `[DS]` `Button` `iconLeft`/`iconRight` props + `hoverIcon` (niche · old `ButtonComponent`)
+27. `[feature]` **Re-enable "Invite to Community" in `ProfileCard`** — *feature, parked until
     communities work*. The row/submenu UI was removed from `ProfileCard` (PR #915 follow-up); the
     protocol messages, `session.communities.invitable`/`requestInvitable`/`invite`, and the bridge
     handlers all remain. When re-enabling: (1) the `/invites` response is `{data:[…]}` but `signed()`
@@ -263,7 +290,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     clear both `invitable` and the ref on logout/identity change; (3) surface invite errors to the user
     (the bridge currently swallows them with `console.error`); (4) build the submenu on the
     `ContextMenu` primitive instead of the removed bespoke `.submenu`/`.subRow` CSS.
-27. `[arch]` **HUD state: `useEngineSession` hook prop-drilled → consider Context / a store** —
+28. `[arch]` **HUD state: `useEngineSession` hook prop-drilled → consider Context / a store** —
     *architecture, low priority*. All HUD state lives in one `useEngineSession` hook at the top of
     `Hud`, prop-drilled down; the returned `session` is a fresh object every render, so the whole HUD
     re-renders on any change. Fine at current scale (engine round-trips are the bottleneck, not React
@@ -275,22 +302,22 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     state-lib-free). Also a test cost (harness passes props today; Context needs a provider wrapper).
     Recommendation: keep prop-drilling; add a single `SessionContext` only if drilling ergonomics annoy;
     memoized slices / store only if re-renders become a *measured* problem. **One concrete exception to
-    "renders aren't the bottleneck": item 37 — `proximity` is a per-frame (~60/s) re-render source while
+    "renders aren't the bottleneck": item 38 — `proximity` is a per-frame (~60/s) re-render source while
     near an interactable, not a user-action change.**
-28. `[arch]` **Deep-linkable / bookmarkable navigation — reflect location in the URL** — *architecture,
+29. `[arch]` **Deep-linkable / bookmarkable navigation — reflect location in the URL** — *architecture,
     low priority*. Entering a scene/world (and, ideally, opening HUD surfaces like the map/backpack)
     should be **parameterized in the URL** so the state is shareable and bookmarkable: reload/paste a
     URL and land in the same realm + coords. Scope to nail down: realm/world + parcel coords (e.g.
     `?realm=…&position=x,y` or a path), whether HUD panels also serialize, and wiring it to the picker
     (`pickDestination`) + `map.teleport`/`changeRealm` so URL ⇄ engine stay in sync (`popstate` → jump,
     jump → `pushState`). Deferred: needs a small router/URL-sync layer (project is router-free today).
-29. `[arch]` **Migrate inline `dt`-throttle timers to `bridge-scene/src/system-helpers.ts`** —
+30. `[arch]` **Migrate inline `dt`-throttle timers to `bridge-scene/src/system-helpers.ts`** —
     *cleanup*. The `throttleByDt` helper (added in PR #915 for `avatarPointer`) replaces a dt-accumulator
     that's re-implemented inline across most bridge domains (`chat`, `world`, `friends`, `project`,
     `nametags` — two timers there —, `avatarPreview`). Migrate them to the helper (and consider
     `singleFlight` / a named `pollSequential` wrapper where a polled async RPC could overlap). Pure
     cleanup, no behavior change; kept out of #915 to stay surgical.
-30. `[feature]` **Voice feedback — "who's speaking" indicator** — *feature parity, when voice chat is
+31. `[feature]` **Voice feedback — "who's speaking" indicator** — *feature parity, when voice chat is
     prioritized*. The old scene showed an **animated speaking indicator on each avatar nametag** while a
     nearby player talked (and used the local mic state for your own tag). Mechanism to port: the engine
     exposes a voice stream — `BevyApi.getVoiceStream()` yielding `{ sender_address, active }`
@@ -302,13 +329,13 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     nametags** (bridge scene) and/or the DOM **nearby-members list** (`chat.members`) — e.g. a pulsing
     mic ring. Depends on voice chat being wired end-to-end; today only the local `mic` toggle exists (no
     per-remote-speaker signal). Could yield a reusable `SpeakingIndicator` primitive.
-31. `[feature]` **Re-add "Report" to the profile card once a moderation/report endpoint exists** —
+32. `[feature]` **Re-add "Report" to the profile card once a moderation/report endpoint exists** —
     *feature, low priority*. Report was removed from `ProfileCard` in PR #915 because there's no backend —
     it was only a `console.log` stub, so shipping a dead action was worse than hiding it. When a report/
     moderation endpoint lands: re-add the `Report` row + `onBlock`-style `onReport` request prop
     (parent-owned confirm, same pattern as Block), the `ReportIcon` glyph, and wire the actual submit.
     (Old scene logged too — this is genuinely new backend work, not just UI.)
-32. `[feature]` **Passport / own-profile edit mode — no UI yet** — *feature, own-profile only; flagged by
+33. `[feature]` **Passport / own-profile edit mode — no UI yet** — *feature, own-profile only; flagged by
     Rob*. bevy-ui-scene lets you edit your own passport in place — About Me, the info-field dropdowns,
     links (add/remove, up to 5), and display name — then deploys the updated profile. react-web can
     *view* the profile (`ProfilePanel` = own profile, `ProfilePassport` = others) but has **no UI to
@@ -317,16 +344,16 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     wiring the profile deploy through the bridge/engine. Larger than the view-parity item (#16) — hence
     separate and lower priority than showing OTHER users' passports correctly. Reference the old client
     for the flow (`unity-explorer` `Explorer/Assets/DCL/UI/`, `bevy-ui-scene` profile screens).
-33. `[feature]` **Chat rate limiting** — *hardening, not in bevy-ui-scene*. unity-explorer's
+34. `[feature]` **Chat rate limiting** — *hardening, not in bevy-ui-scene*. unity-explorer's
     `MultiplayerChatMessagesBus` dedupes + rate-limits + buffers sends; react-web (like bevy-ui-scene)
     sends on every Enter with no client-side throttle. Only worth adding if spam becomes a real problem
     server-side rate limiting doesn't already cover.
-34. `[feature]` **DMs / private chat channels** — *net-new, not a port*. Neither `bevy-ui-scene` nor
+35. `[feature]` **DMs / private chat channels** — *net-new, not a port*. Neither `bevy-ui-scene` nor
     today's react-web have anything beyond the single "Nearby" channel; unity-explorer's
     `ChatChannelsPresenter`/`ChatChannelType.USER` is the only prior-art reference. Large scope (channel
     list UI, per-conversation history, member-list → "message" entry point) — flag for a dedicated design
     pass, not a drive-by addition.
-35. `[arch]` **SSO redirect on the login screen throws away the in-flight engine WASM download** —
+36. `[arch]` **SSO redirect on the login screen throws away the in-flight engine WASM download** —
     *boot perf, not blocking / not a direct bug*. On the login/loading screen the engine WASM is
     already downloading in the background while the sign-in buttons are live. "Start with account" /
     "Use different account" call `redirectToAuth()` → `location.replace('/auth/login?redirectTo=…')`
@@ -340,7 +367,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     a hidden **iframe** and read back the identity via `postMessage`/`storage` (auth site must allow
     being framed same-origin — verify its CSP/`X-Frame-Options`). Both are more moving parts than the
     current straight redirect, so only worth it if boot time on login is a measured concern.
-36. `[feature]` **Radial hover prompts — viewport clamping near screen edges** — *polish, non-blocking;
+37. `[feature]` **Radial hover prompts — viewport clamping near screen edges** — *polish, non-blocking;
     point to review*. When the free cursor is near a viewport edge, the fixed-offset radial slots
     (`HOVER_SLOTS` in `features/pointer/Pointer.tsx`) that point toward that edge run off-screen (cursor
     at the right edge → the right-middle prompt's label clips). No clamp today. Arguments for leaving it:
@@ -353,13 +380,13 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     `ProfileCard`, or flip slot sides near the edge. Review comment (note: it says "root is
     overflow: hidden" — there's no such rule, the clip is just the viewport edge):
     https://github.com/decentraland/bevy-explorer/pull/915#discussion_r3529180273
-37. `[arch]` **`proximity` pushes a full HUD re-render every frame while near an interactable** — *perf,
+38. `[arch]` **`proximity` pushes a full HUD re-render every frame while near an interactable** — *perf,
     when profiling confirms*. Unlike most session changes (user actions), the proximity domain is a
     **per-frame** source: `registerProximity`'s `ctx.push` reprojects each in-range entity world→screen
     and calls `ctx.send({ kind: 'proximity', tips })` **every frame with no dedupe**
     (`bridge-scene/src/domains/proximity.ts:52`) whenever ≥1 interactable is in range. Each message
     hits `setProximity(msg.tips)` with a fresh array (`useEngineSession.ts:416`), so `App` — and, per
-    item 27, the whole tree — re-renders ~60×/s. This is the concrete counterexample to item 27's
+    item 28, the whole tree — re-renders ~60×/s. This is the concrete counterexample to item 28's
     "engine round-trips are the bottleneck, not React renders." Cost is **conditional**: zero when
     nothing is in range (the `inRange.size === 0` early-out short-circuits the send), but scales with
     tree size, per-render cost (e.g. the `notifications.reduce` unread count runs every render), in-range
@@ -367,12 +394,12 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     steals main-thread from the same-origin engine iframe → world frame drops + battery drain near
     interactables. **Measure first** (React Profiler: proximity commit duration × 60) — <1ms is noise,
     5–10ms is a real 30–60% main-thread tax. Fix (pattern already in the repo): mirror the `hoverPos`
-    module store (item 8) — `<Pointer>` is the sole consumer, so move proximity off session state into a
+    module store (item 9) — `<Pointer>` is the sole consumer, so move proximity off session state into a
     store it reads via `useSyncExternalStore` (as it already does for `hoverPos`); then 60/s updates
     re-render only `<Pointer>`, not the tree. Optional bridge-side dedupe (skip `ctx.send` when `tips`
     is unchanged) zeroes the standing-still case but not the moving one (positions legitimately change
     each frame), so the store is the structural fix.
-38. `[bug]` **Chat name click shows the raw address for players who left nearby range** — *UX regression,
+39. `[bug]` **Chat name click shows the raw address for players who left nearby range** — *UX regression,
     P2 pending PR #915 review*. `Chat`/`FriendsPanel` now open the shared card via
     `openProfileCard(user.address, …)` (address only); the container re-resolves name/picture with
     `resolveIdentity` (nearby roster → friends/requests → fetched passports). For a **non-friend who
@@ -397,6 +424,6 @@ the old version-bump), `tokens.css`, and primitives the old lacks (`WearableCard
   as `openPopup`/`showDialog` + `<PopupHost/>` — a module store rendering JSX directly (no type map,
   no Redux store/dispatcher). `<PopupHost/>` is a top-level layer; the popups it renders use
   `ModalShell`, which is what portals to `document.body` (to escape the HUD `--ui-scale` transform).
-  See item 8.
+  See item 9.
 - The `friendshipStateVersion` + cached-snapshot + event-bus machinery — an artifact of the SDK7
   per-frame render model; React's targeted re-renders make it unnecessary.


### PR DESCRIPTION
## What

- Adds an **"alive but rendering-dead" flood detector** to `deploy/web/engine/boot.js` (host-integration JS): an identical engine-core `console.error` repeating **≥30× within 4s** now trips `crash(msg, 'runtime')` → the existing `EngineErrorModal`, instead of leaving the user on a silent black screen.
- **Latched** (fires once, not a stack of popups); **Dismiss** re-arms, so a persistent flood re-triggers.
- **Denylist** for benign identical repeats (sandbox `"Message too large"`).
- Host-side only (`boot.js`); **no WASM rebuild**.

## Why

During the **2026-07-17 playtesting session**, multiple users hit a **black screen / engine crash** with no error popup — just an endless console spam of a WebGPU validation error (`pbr_alpha_blend_mesh_pipeline` attachment mismatch on `main_opaque_pass_3d`). The user is stranded with no feedback and no recovery path.

No popup fired because the crash modal (`EngineErrorModal`) is fed by two signals, and the wgpu error is **neither**:

1. **Rust panic** — `boot.js` sniffs `console.error` for `"panicked at …"`.
2. **Heartbeat stall** — the watchdog fires `__onEngineCrash` only when frames **stop**.

The wgpu error takes a third path that only logs: `src/lib.rs` registers `wgpu_device().on_uncaptured_error(|e| error!("captured wgpu error: {e:?}"))` — logged and swallowed. Decisively, the **render loop keeps beating** (each frame re-sets the bad pipeline → black frame, but the heartbeat still ticks), so the stall watchdog sees a healthy engine and never fires. → endless spam + black screen + **no popup**.

The structural gap: the watchdog detects *"engine STOPPED"* but had no detector for *"engine RUNNING but rendering is dead"*.

## How

Reuses the same `console.error` patch that already sniffs panics:

- **Per-signature counters** (whitespace-normalized, otherwise **exact**) over a 4s window; ≥30 identical repeats ⇒ `crash(msg, 'runtime')` → the existing modal.
- Exact-signature keys so distinct errors (different assets/coords) never pool into a false flood; a per-signature Map so an identical per-frame error still floods even when interleaved with a second error.
- `rearm()` (modal dismissed, or frames resumed) clears the counters.
- Skips the watchdog's own `[engine error]` / `[crash watchdog]` logging so it can't self-trip. Scene (UGC) `console.error` runs in the sandbox worker's own console and never reaches this main-thread patch, so the stream stays engine-core.

## Testing

Verified **end-to-end against the real engine build** (react-web :5199, real engine, not `?mock=1`) via a synthetic trigger — spamming an identical `console.error` (incl. text sourced from a **real** `GPUValidationError`) 35× on the main thread:

- Flood → **"The world crashed"** runtime modal with the wgpu error text + Dismiss/Reload. ✅
- Fires **once** (latched), not a stack of popups. ✅
- **Dismiss** re-arms; a second flood re-triggers (matches persistent-error behaviour). ✅
- **Denylist**: 50× `"Message too large"` does **not** trigger. ✅
- A `throw` does **not** trigger it (different channel — uncaught exceptions don't hit the patched `console.error`). ✅
- Standalone unit test of the heuristic: 8/8 (fires on the flood incl. interleaved; never on denylist / distinct / slow-drip / sub-threshold; latches; re-arms).

## Notes / follow-ups

- This is the **error-surfacing** fix. The underlying pipeline attachment mismatch (the actual GPU bug) is separate and engine-side (needs a WASM rebuild).
- Confirmed workaround for the underlying bug: **Settings → Graphic Profile → change it**. Worth offering that as a recovery action in the modal later.
- Longer term, a cleaner engine-side signal (`device.lost` / a latched call from `on_uncaptured_error`) would beat string-sniffing logs.

Stacked on `fix/ui/05-emote-hotkeys` (base). Draft.
