### PR TITLE
ui: scene-UI perf (material dedup caches, retry backoff, dead-system removal)

### DIFF
--- a/crates/scene_runner/src/update_world/scene_ui/mod.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/mod.rs
@@ -19,7 +19,7 @@ use bevy_console::ConsoleCommand;
 use bevy_dui::{DuiCommandsExt, DuiProps, DuiRegistry};
 use console::DoAddConsoleCommand;
 use scene_material::SceneMaterial;
-use ui_background::{set_ui_background, UiBackground};
+use ui_background::{set_ui_background, StretchUvKey, UiBackground};
 use ui_dropdown::{set_ui_dropdown, UiDropdown};
 use ui_input::{set_ui_input, UiInput};
 use ui_pointer::set_ui_pointer_events;
@@ -32,6 +32,7 @@ use crate::{
     ContainerEntity, ContainingScene, InteractableArea, SceneEntity, SceneSets,
 };
 use common::{
+    asset_cache::{clean_asset_cache, AssetCache},
     rpc::{RpcCall, RpcUiFocusAction},
     structs::{AppConfig, PrimaryPlayerRes, PrimaryUser, ZOrder},
     util::{DespawnWith, ModifyComponentExt},
@@ -54,6 +55,7 @@ use ui_core::{
     scrollable::{
         ScrollDirection, ScrollPosition, ScrollTarget, ScrollTargetEvent, Scrollable, StartPosition,
     },
+    stretch_uvs_image::StretchUvMaterial,
     ui_actions::{DataChanged, On, UiActionSet, UiCaller},
 };
 
@@ -451,6 +453,11 @@ impl Plugin for SceneUiPlugin {
 
         app.init_resource::<HiddenSceneUis>();
         app.init_resource::<SceneCanvasAtlases>();
+        app.init_resource::<AssetCache<StretchUvKey, StretchUvMaterial>>();
+        app.add_systems(
+            Update,
+            clean_asset_cache::<StretchUvKey, StretchUvMaterial>.after(set_ui_background),
+        );
 
         app.add_systems(Update, init_scene_ui_root.in_set(SceneSets::PostInit));
         app.add_systems(

--- a/crates/scene_runner/src/update_world/scene_ui/mod.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/mod.rs
@@ -480,7 +480,6 @@ impl Plugin for SceneUiPlugin {
                     set_ui_dropdown,
                     set_ui_pointer_events,
                 ),
-                fully_update_target_camera_system,
                 set_ui_focus,
                 manage_scene_ui_interact,
             )
@@ -1437,66 +1436,6 @@ fn layout_scene_ui(
                 warn!("scroll to target `{target}` not found");
             }
         }
-    }
-}
-
-pub fn fully_update_target_camera_system(
-    mut commands: Commands,
-    root_nodes_query: Query<
-        (Entity, Option<&UiTargetCamera>),
-        (With<ComputedNode>, Without<ChildOf>),
-    >,
-    children_query: Query<&Children, With<ComputedNode>>,
-) {
-    // Track updated entities to prevent redundant updates, as `Commands` changes are deferred,
-    // and updates done for changed_children_query can overlap with itself or with root_node_query
-    let mut updated_entities = HashSet::new();
-
-    for (root_node, target_camera) in &root_nodes_query {
-        update_children_target_camera(
-            root_node,
-            target_camera,
-            &children_query,
-            &mut commands,
-            &mut updated_entities,
-        );
-    }
-}
-
-fn update_children_target_camera(
-    entity: Entity,
-    camera_to_set: Option<&UiTargetCamera>,
-    children_query: &Query<&Children, With<ComputedNode>>,
-    commands: &mut Commands,
-    updated_entities: &mut HashSet<Entity>,
-) {
-    let Ok(children) = children_query.get(entity) else {
-        return;
-    };
-
-    for &child in children {
-        // Skip if the child has already been updated
-        if updated_entities.contains(&child) {
-            continue;
-        }
-
-        match camera_to_set {
-            Some(camera) => {
-                commands.entity(child).try_insert(camera.clone());
-            }
-            None => {
-                commands.entity(child).remove::<UiTargetCamera>();
-            }
-        }
-        updated_entities.insert(child);
-
-        update_children_target_camera(
-            child,
-            camera_to_set,
-            children_query,
-            commands,
-            updated_entities,
-        );
     }
 }
 

--- a/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use common::util::TryPushChildrenEx;
+use common::{asset_cache::AssetCache, util::TryPushChildrenEx};
 use dcl_component::proto_components::{
     common::{BorderRect, TextureUnion},
     sdk::components::{self, PbUiBackground},
@@ -96,6 +96,13 @@ pub struct RetryBackground;
 #[derive(Component)]
 pub struct UiMaterialSource(Entity);
 
+#[derive(PartialEq, Eq, Hash, Clone)]
+pub struct StretchUvKey {
+    image: AssetId<Image>,
+    uvs: [u32; 8],
+    color: [u32; 4],
+}
+
 pub fn set_ui_background(
     mut commands: Commands,
     backgrounds: Query<
@@ -114,6 +121,7 @@ pub fn set_ui_background(
     contexts: Query<&RendererSceneContext>,
     mut resolver: TextureResolver,
     mut stretch_uvs: ResMut<Assets<StretchUvMaterial>>,
+    mut cache: ResMut<AssetCache<StretchUvKey, StretchUvMaterial>>,
     sourced: Query<(
         Entity,
         Option<&MaterialNode<StretchUvMaterial>>,
@@ -223,36 +231,49 @@ pub fn set_ui_background(
                         UiBackgroundMarker,
                     ))
                     .id(),
-                BackgroundTextureMode::Stretch(ref uvs) => commands
-                    .commands()
-                    .spawn((
-                        Node {
-                            position_type: PositionType::Absolute,
-                            top: Val::Px(0.0),
-                            right: Val::Px(0.0),
-                            left: Val::Px(0.0),
-                            bottom: Val::Px(0.0),
-                            ..Default::default()
-                        },
-                        UiBackgroundMarker,
-                    ))
-                    .try_with_children(|c| {
-                        let mut inner = c.spawn((
-                            node,
-                            MaterialNode(stretch_uvs.add(StretchUvMaterial {
-                                image: image.image.clone(),
-                                uvs: *uvs,
-                                color: image_color.to_linear().to_vec4(),
-                            })),
-                        ));
-                        if let Some(source) = image.source_entity {
-                            inner.try_insert(UiMaterialSource(source));
-                        }
-                        if let Some(radius) = border_radius {
-                            inner.try_insert(*radius);
-                        }
-                    })
-                    .id(),
+                BackgroundTextureMode::Stretch(ref uvs) => {
+                    let color = image_color.to_linear().to_vec4();
+                    let mut uv_bits = [0u32; 8];
+                    for (bits, uv) in uv_bits
+                        .iter_mut()
+                        .zip(uvs.iter().flat_map(|v| v.to_array()))
+                    {
+                        *bits = uv.to_bits();
+                    }
+                    let key = StretchUvKey {
+                        image: image.image.id(),
+                        uvs: uv_bits,
+                        color: color.to_array().map(f32::to_bits),
+                    };
+                    let material = cache.get_or_add(key, &mut stretch_uvs, || StretchUvMaterial {
+                        image: image.image.clone(),
+                        uvs: *uvs,
+                        color,
+                    });
+                    commands
+                        .commands()
+                        .spawn((
+                            Node {
+                                position_type: PositionType::Absolute,
+                                top: Val::Px(0.0),
+                                right: Val::Px(0.0),
+                                left: Val::Px(0.0),
+                                bottom: Val::Px(0.0),
+                                ..Default::default()
+                            },
+                            UiBackgroundMarker,
+                        ))
+                        .try_with_children(|c| {
+                            let mut inner = c.spawn((node, MaterialNode(material)));
+                            if let Some(source) = image.source_entity {
+                                inner.try_insert(UiMaterialSource(source));
+                            }
+                            if let Some(radius) = border_radius {
+                                inner.try_insert(*radius);
+                            }
+                        })
+                        .id()
+                }
                 BackgroundTextureMode::Center => commands
                     .commands()
                     .spawn((

--- a/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_background.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{diagnostic::FrameCount, prelude::*};
 use common::{asset_cache::AssetCache, util::TryPushChildrenEx};
 use dcl_component::proto_components::{
     common::{BorderRect, TextureUnion},
@@ -91,10 +91,17 @@ impl From<PbUiBackground> for UiBackground {
 pub struct UiBackgroundMarker;
 
 #[derive(Component)]
-pub struct RetryBackground;
+pub struct RetryBackground {
+    since_frame: u32,
+}
+
+const RETRY_BACKGROUND_INTERVAL: u32 = 10;
 
 #[derive(Component)]
-pub struct UiMaterialSource(Entity);
+pub struct UiMaterialSource {
+    source: Entity,
+    owner: Entity,
+}
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct StretchUvKey {
@@ -106,7 +113,13 @@ pub struct StretchUvKey {
 pub fn set_ui_background(
     mut commands: Commands,
     backgrounds: Query<
-        (Entity, &SceneEntity, &UiBackground, &UiLink),
+        (
+            Entity,
+            &SceneEntity,
+            Ref<UiBackground>,
+            Ref<UiLink>,
+            Option<&RetryBackground>,
+        ),
         Or<(
             Changed<UiBackground>,
             Changed<UiLink>,
@@ -122,11 +135,9 @@ pub fn set_ui_background(
     mut resolver: TextureResolver,
     mut stretch_uvs: ResMut<Assets<StretchUvMaterial>>,
     mut cache: ResMut<AssetCache<StretchUvKey, StretchUvMaterial>>,
-    sourced: Query<(
-        Entity,
-        Option<&MaterialNode<StretchUvMaterial>>,
-        &UiMaterialSource,
-    )>,
+    frame: Res<FrameCount>,
+    sourced: Query<&UiMaterialSource>,
+    retried: Query<Has<RetryBackground>>,
 ) {
     for ent in removed.read() {
         let Ok(link) = links.get(ent) else {
@@ -146,7 +157,17 @@ pub fn set_ui_background(
         }
     }
 
-    for (ent, scene_ent, background, link) in backgrounds.iter() {
+    for (ent, scene_ent, background, link, maybe_retry) in backgrounds.iter() {
+        // waiting on a texture source; only despawn/respawn the node every few frames
+        if let Some(retry) = maybe_retry {
+            if !background.is_changed()
+                && !link.is_changed()
+                && frame.0.wrapping_sub(retry.since_frame) < RETRY_BACKGROUND_INTERVAL
+            {
+                continue;
+            }
+        }
+
         if let Ok(children) = children.get(link.ui_entity) {
             for child in children.iter().filter(|c| prev_backgrounds.get(*c).is_ok()) {
                 if let Ok(mut commands) = commands.get_entity(child) {
@@ -161,7 +182,7 @@ pub fn set_ui_background(
             continue;
         };
 
-        debug!("[{}] set background {:?}", scene_ent.id, background);
+        debug!("[{}] set background {:?}", scene_ent.id, &*background);
 
         if let Some(texture) = background.texture.as_ref() {
             let Ok(ctx) = contexts.get(scene_ent.root) else {
@@ -177,7 +198,9 @@ pub fn set_ui_background(
             let image = match image {
                 Some(Ok(t)) => t,
                 Some(Err(TextureResolveError::SourceNotReady)) => {
-                    commands.commands().entity(ent).try_insert(RetryBackground);
+                    commands.commands().entity(ent).try_insert(RetryBackground {
+                        since_frame: frame.0,
+                    });
                     continue;
                 }
                 None | Some(Err(TextureResolveError::NoTexture)) => {
@@ -266,7 +289,7 @@ pub fn set_ui_background(
                         .try_with_children(|c| {
                             let mut inner = c.spawn((node, MaterialNode(material)));
                             if let Some(source) = image.source_entity {
-                                inner.try_insert(UiMaterialSource(source));
+                                inner.try_insert(UiMaterialSource { source, owner: ent });
                             }
                             if let Some(radius) = border_radius {
                                 inner.try_insert(*radius);
@@ -304,7 +327,7 @@ pub fn set_ui_background(
                             let mut inner = c
                                 .spawn((node, ImageNode::new(image.image).with_color(image_color)));
                             if let Some(source) = image.source_entity {
-                                inner.try_insert(UiMaterialSource(source));
+                                inner.try_insert(UiMaterialSource { source, owner: ent });
                             }
                             if let Some(radius) = border_radius {
                                 inner.try_insert(*radius);
@@ -323,9 +346,15 @@ pub fn set_ui_background(
         }
     }
 
-    for (ent, _maybe_stretch, source) in sourced.iter() {
-        if commands.get_entity(source.0).is_err() {
-            commands.entity(ent).try_insert(RetryBackground);
+    // rebuild the owner when its texture-source entity disappears
+    for source in sourced.iter() {
+        let Ok(has_retry) = retried.get(source.owner) else {
+            continue;
+        };
+        if !has_retry && commands.get_entity(source.source).is_err() {
+            commands.entity(source.owner).try_insert(RetryBackground {
+                since_frame: frame.0,
+            });
         }
     }
 }

--- a/crates/scene_runner/src/update_world/text_shape.rs
+++ b/crates/scene_runner/src/update_world/text_shape.rs
@@ -640,7 +640,6 @@ fn apply_text_extras(
         Ref<TextLayout>,
         &ComputedTextBlock,
         &ComputedNode,
-        Option<&UiTargetCamera>,
         &ComputedNodeTarget,
     )>,
     changed_spans: Query<
@@ -715,17 +714,8 @@ fn apply_text_extras(
         .map(|c| c.parent())
         .collect::<HashSet<_>>();
 
-    for (
-        entity,
-        children,
-        parent,
-        gt,
-        layout,
-        computed_text,
-        computed_node,
-        maybe_camera,
-        node_target,
-    ) in text.iter()
+    for (entity, children, parent, gt, layout, computed_text, computed_node, node_target) in
+        text.iter()
     {
         let mut requires_update = layout.is_changed();
         requires_update |= changed.contains(&entity);
@@ -784,8 +774,8 @@ fn apply_text_extras(
                 TextExtraMarker,
             ));
 
-            if let Some(target_camera) = maybe_camera.as_ref() {
-                cmds.try_insert(UiTargetCamera(target_camera.0));
+            if let Some(camera) = node_target.camera() {
+                cmds.try_insert(UiTargetCamera(camera));
             }
 
             cmds.id()

--- a/crates/ui_core/src/combo_box.rs
+++ b/crates/ui_core/src/combo_box.rs
@@ -80,7 +80,7 @@ fn setup(mut dui: ResMut<DuiRegistry>) {
 
 #[derive(SystemParam)]
 pub struct TargetCameraHelper<'w, 's> {
-    target_camera: Query<'w, 's, &'static UiTargetCamera>,
+    target_camera: Query<'w, 's, &'static ComputedNodeTarget>,
     cameras: Query<'w, 's, &'static Camera>,
     all_windows: Query<'w, 's, &'static Window>,
     primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
@@ -95,10 +95,14 @@ pub struct TargetCameraProps {
 
 impl TargetCameraHelper<'_, '_> {
     fn get_props(&self, e: Entity) -> Option<TargetCameraProps> {
-        let target_camera = self.target_camera.get(e).ok().cloned();
-        let (window_ref, texture_ref) = match &target_camera {
-            Some(target) => {
-                let camera = self.cameras.get(target.0).ok()?;
+        let camera = self
+            .target_camera
+            .get(e)
+            .ok()
+            .and_then(ComputedNodeTarget::camera);
+        let (window_ref, texture_ref) = match camera {
+            Some(camera) => {
+                let camera = self.cameras.get(camera).ok()?;
 
                 match &camera.target {
                     RenderTarget::Window(window_ref) => (Some(*window_ref), None),
@@ -121,8 +125,9 @@ impl TargetCameraHelper<'_, '_> {
             window?.size().as_uvec2()
         };
 
+        // only pin popups to texture-target cameras; window targets use the default camera
         Some(TargetCameraProps {
-            target_camera,
+            target_camera: texture_ref.and(camera).map(UiTargetCamera),
             size,
             scale_factor,
         })

--- a/crates/ui_core/src/nine_slice.rs
+++ b/crates/ui_core/src/nine_slice.rs
@@ -6,7 +6,7 @@ use bevy::{
 };
 use bevy_dui::{DuiContext, DuiProps, DuiRegistry, DuiTemplate, NodeMap};
 use bevy_ecss::StyleSheetAsset;
-// use common::util::TryInsertEx;
+use common::asset_cache::{clean_asset_cache, AssetCache};
 
 /// specify a background image using 9-slice scaling
 /// https://en.wikipedia.org/wiki/9-slice_scaling
@@ -42,12 +42,32 @@ impl Plugin for Ui9SlicePlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup);
         app.add_plugins(UiMaterialPlugin::<NineSliceMaterial>::default());
-        app.add_systems(PostUpdate, update_slices.after(UiSystem::Layout));
+        app.init_resource::<AssetCache<NineSliceKey, NineSliceMaterial>>();
+        app.add_systems(
+            PostUpdate,
+            (
+                update_slices.after(UiSystem::Layout),
+                clean_asset_cache::<NineSliceKey, NineSliceMaterial>.after(update_slices),
+            ),
+        );
     }
 }
 
 #[derive(Component)]
 struct Retry9Slice;
+
+#[derive(PartialEq, Eq, Hash, Clone)]
+struct NineSliceKey {
+    image: AssetId<Image>,
+    bounds: [u32; 4],
+    surface: [u32; 2],
+    color: [u32; 4],
+}
+
+// quantize to whole pixels so equal-sized nodes share a material
+fn whole_pixel_size(node: &ComputedNode) -> Vec2 {
+    node.unrounded_size().round()
+}
 
 #[allow(clippy::type_complexity)]
 fn update_slices(
@@ -69,6 +89,7 @@ fn update_slices(
     >,
     mut removed: RemovedComponents<Ui9Slice>,
     mut mats: ResMut<Assets<NineSliceMaterial>>,
+    mut cache: ResMut<AssetCache<NineSliceKey, NineSliceMaterial>>,
 ) {
     // clean up removed slices
     for ent in removed.read() {
@@ -84,43 +105,59 @@ fn update_slices(
         };
         commands.entity(ent).remove::<Retry9Slice>();
 
-        let new_mat = NineSliceMaterial {
-            image: slice.image.clone(),
-            bounds: GpuSliceData {
-                bounds: Vec4::new(
-                    slice
-                        .center_region
-                        .left
-                        .resolve(image_size.x, Vec2::ZERO)
-                        .unwrap_or(0.0),
-                    slice
-                        .center_region
-                        .left
-                        .resolve(image_size.x, Vec2::ZERO)
-                        .unwrap_or(0.0),
-                    slice
-                        .center_region
-                        .left
-                        .resolve(image_size.x, Vec2::ZERO)
-                        .unwrap_or(0.0),
-                    slice
-                        .center_region
-                        .left
-                        .resolve(image_size.x, Vec2::ZERO)
-                        .unwrap_or(0.0),
-                ),
-                surface: node.unrounded_size().extend(0.0).extend(0.0),
-            },
-            color: slice.tint.unwrap_or(Color::WHITE).to_linear().to_vec4(),
+        let bounds = Vec4::new(
+            slice
+                .center_region
+                .left
+                .resolve(image_size.x, Vec2::ZERO)
+                .unwrap_or(0.0),
+            slice
+                .center_region
+                .left
+                .resolve(image_size.x, Vec2::ZERO)
+                .unwrap_or(0.0),
+            slice
+                .center_region
+                .left
+                .resolve(image_size.x, Vec2::ZERO)
+                .unwrap_or(0.0),
+            slice
+                .center_region
+                .left
+                .resolve(image_size.x, Vec2::ZERO)
+                .unwrap_or(0.0),
+        );
+        let surface = whole_pixel_size(node);
+        let color = slice.tint.unwrap_or(Color::WHITE).to_linear().to_vec4();
+
+        let key = NineSliceKey {
+            image: slice.image.id(),
+            bounds: bounds.to_array().map(f32::to_bits),
+            surface: surface.to_array().map(f32::to_bits),
+            color: color.to_array().map(f32::to_bits),
         };
 
-        if let Some(mat) = maybe_material.and_then(|h| mats.get_mut(h)) {
-            *mat = new_mat;
-        } else {
-            commands
-                .entity(ent)
-                .try_insert(MaterialNode(mats.add(new_mat)))
-                .remove::<BackgroundColor>();
+        let material = cache.get_or_add(key, &mut mats, || NineSliceMaterial {
+            image: slice.image.clone(),
+            bounds: GpuSliceData {
+                bounds,
+                surface: surface.extend(0.0).extend(0.0),
+            },
+            color,
+        });
+
+        // materials are shared, so swap handles instead of mutating in place
+        match maybe_material {
+            Some(existing) if existing.0.id() == material.id() => (),
+            Some(_) => {
+                commands.entity(ent).try_insert(MaterialNode(material));
+            }
+            None => {
+                commands
+                    .entity(ent)
+                    .try_insert(MaterialNode(material))
+                    .remove::<BackgroundColor>();
+            }
         }
     }
 }

--- a/crates/ui_core/src/scrollable.rs
+++ b/crates/ui_core/src/scrollable.rs
@@ -256,7 +256,7 @@ fn update_scrollables(
         Ref<GlobalTransform>,
         Ref<ComputedNode>,
         &Interaction,
-        Option<&UiTargetCamera>,
+        &ComputedNodeTarget,
     )>,
     mut bars: Query<
         (
@@ -267,7 +267,7 @@ fn update_scrollables(
             &Interaction,
             &ComputedNode,
             &GlobalTransform,
-            Option<&UiTargetCamera>,
+            &ComputedNodeTarget,
         ),
         (Without<Scrollable>, Without<Slider>),
     >,
@@ -331,9 +331,9 @@ fn update_scrollables(
 
     let window_cursor_position = window.cursor_position().unwrap_or(Vec2::NEG_ONE);
     let manual_cursor_positions: HashMap<_, _> = cursors.iter().collect();
-    let cursor_position = |camera: Option<&UiTargetCamera>| -> Option<Vec2> {
-        if let Some(camera) = camera {
-            if let Some(position) = manual_cursor_positions.get(&camera.0) {
+    let cursor_position = |camera: &ComputedNodeTarget| -> Option<Vec2> {
+        if let Some(camera) = camera.camera() {
+            if let Some(position) = manual_cursor_positions.get(&camera) {
                 return position.0;
             }
         }
@@ -359,7 +359,7 @@ fn update_scrollables(
         ref_transform,
         ref_node,
         interaction,
-        maybe_target_camera,
+        target_camera,
     ) in scrollables.iter_mut()
     {
         let Ok((child_node, mut style, _)) = nodes.get_mut(scroll_content.0) else {
@@ -367,7 +367,7 @@ fn update_scrollables(
             continue;
         };
 
-        let cursor_position = cursor_position(maybe_target_camera);
+        let cursor_position = cursor_position(target_camera);
 
         let child_size = child_node.size() / scale_factor;
         let parent_size = node.size() / scale_factor;
@@ -538,7 +538,7 @@ fn update_scrollables(
     }
 
     // bars
-    for (entity, bar, mut style, mut bounds, interaction, node, transform, maybe_target_camera) in
+    for (entity, bar, mut style, mut bounds, interaction, node, transform, target_camera) in
         bars.iter_mut()
     {
         let source = if bar.vertical {
@@ -575,7 +575,7 @@ fn update_scrollables(
             bounds.border_size = Val::Px(bar_width * 0.125);
         }
 
-        let Some(cursor_position) = cursor_position(maybe_target_camera) else {
+        let Some(cursor_position) = cursor_position(target_camera) else {
             continue;
         };
 


### PR DESCRIPTION
# perf: scene-ui material dedup, texture-source retry backoff, drop the per-frame target-camera walk

## What

Three independent scene-UI cost reductions:

1. **Material dedup.** Stretch-UV and nine-slice UI materials are deduplicated through a
   small generic `AssetCache` (new `common::asset_cache` module). Nodes with identical
   content (image + uvs + tint, and for nine-slice also bounds + surface size) now share
   one material asset instead of each allocating a fresh one.
2. **Retry backoff.** UI backgrounds waiting on a not-ready texture source retry on a
   10-frame backoff instead of despawning and respawning their node tree every single
   frame for as long as the source stays unready.
3. **Dead system removal.** `fully_update_target_camera_system` — a per-frame recursive
   walk of every UI tree that copied `UiTargetCamera` onto every descendant — is deleted.
   bevy 0.16 already propagates the root's target camera to all descendants as
   `ComputedNodeTarget`, so the walk only duplicated engine work. The in-repo consumers
   of the copied component (combo-box popups, scrollables, text extras) now read
   `ComputedNodeTarget` instead.

## Why

- UI materials batch by material asset id. Because every stretch-UV / nine-slice node got
  a unique asset, identical widgets (button rows, repeated frames, shared backgrounds)
  never batched and identical uniform data was re-uploaded per node. Sharing the assets
  restores batching for repeated widgets.
- The not-ready retry path was a permanent steady-state cost: scene content that binds a
  background to a source that never becomes ready (or whose source entity despawned) paid
  a despawn + respawn of the background subtree every frame, forever.
- The target-camera walk visited every UI node every frame and queued a `try_insert` (or
  `remove`) command per descendant — deferred commands and archetype moves that the
  engine's own `ComputedNodeTarget` propagation already makes redundant on 0.16.

These changes landed as part of an engine performance pass (paired interleaved A/B runs,
headed Chromium/WebGPU on a discrete NVIDIA GPU, Mann-Whitney gated) that measured, on a
17-scene benchmark realm orbit, cpu p50 −2.7% (p=.028) and wall p50 −6.9% (7/7 rounds)
for the pass as a whole. This PR is the scene-UI slice of that pass; each piece is a
mechanical reduction (fewer asset allocations, fewer queued commands, fewer per-frame
despawns) rather than a behavioral tradeoff.

## How

- `AssetCache<K, A>` maps a content key to an `AssetId<A>` and hands out strong handles
  via `Assets::get_strong_handle`; entries hold weak ids only, so dropping the last
  `MaterialNode` still frees the material, and a `clean_asset_cache::<K, A>` system prunes
  keys whose assets have been unloaded. One resource per (key, material) pair:
  `StretchUvKey → StretchUvMaterial` (registered by `SceneUiPlugin`) and
  `NineSliceKey → NineSliceMaterial` (registered by `Ui9SlicePlugin`).
- Keys hash the exact material inputs as bit patterns: `StretchUvKey` = image id + 8 uv
  floats + linear color; `NineSliceKey` = image id + resolved bounds + node surface size +
  tint. The nine-slice surface size is quantized to whole physical pixels so equal-sized
  nodes hit the same key. Nine-slice previously mutated its material asset in place on
  resize; with shared materials it now swaps the `MaterialNode` handle instead (a no-op
  when the cached id is unchanged).
- `RetryBackground` now records the frame the retry started; `set_ui_background` skips
  the rebuild until 10 frames have elapsed, unless the background or its `UiLink` actually
  changed (changes still apply immediately). `UiMaterialSource` also records the owning
  scene entity: when a texture-source entity despawns, the retry marker now goes on the
  owner — previously it was inserted on the spawned image node, which the rebuild query
  never matches, so that rebuild never actually fired.
- Walk removal: `TargetCameraHelper` (combo popups) and `update_scrollables` read
  `ComputedNodeTarget` and take the camera from `ComputedNodeTarget::camera()`;
  `apply_text_extras` pins its spawned marks with `UiTargetCamera(node_target.camera())`.
  Combo popups only pin an explicit `UiTargetCamera` for texture-target cameras; window
  targets fall back to the default UI camera exactly as an un-pinned root does.
- Pre-existing quirk deliberately left untouched: the nine-slice bounds resolve
  `center_region.left` for all four sides (copy-paste). This PR keeps that computation
  byte-for-byte to stay behavior-neutral; it deserves a separate fix.

## Default behavior

Always on, no flags. Rendered output is unchanged except for two intentional edges:

- the nine-slice `surface` uniform is rounded to whole physical pixels (≤ 0.5 px), which
  is what lets equal-sized nodes share a material;
- backgrounds whose texture source never becomes ready rebuild at 1/10 the previous rate
  (they render nothing during the wait either way), and backgrounds whose source entity
  died now correctly rebuild once the source situation changes.

## Testing

- `cargo check --workspace` passes on Linux.
- All in-repo readers of the walk-copied `UiTargetCamera` were migrated (combo_box,
  scrollable, text_shape); `automatic_testing` and the various root-node insertion sites
  only touch root nodes and are unaffected. The replacement relies on bevy 0.16's
  `update_ui_context_system`, which propagates the root's `UiTargetCamera` into every
  descendant's `ComputedNodeTarget` each frame.
- Recommended manual pass before merge: a scene using `UiCanvas` (scene UI rendered to a
  texture camera) exercising a dropdown, a scrollable, and text with extras — that is
  precisely the path the consumer migration covers.

## Evidence

Independently verified instrumented A/B pass on this branch alone against the base
commit, audited against the raw artifacts with every headline number recomputed.

**Method.** Both sides carry a byte-identical instrumentation overlay counting UI
material allocations (asset-added events for the stretch-UV / nine-slice / bounded-image
material types) and distinct material assets at exit. Two realms, headed on a discrete
NVIDIA GPU, checksum-verified binaries, fresh process per run, interleaved rounds:
(a) a standard 19-scene benchmark realm (wall/cpu secondary signal, 32 synthetic
avatars, 900 measured / 300 warmup frames), and (b) a purpose-built single-scene
UI-churn realm — 64 stretch-background nodes whose uvs are rewritten every 0.5 s cycling
4 variants, 4 static stretch nodes (the distinct-key floor), 32 nine-slice nodes sharing
one texture, and one background bound to a permanently not-ready video texture source to
drive the retry path.

**Results — material dedup (deterministic, exact).**
- Per-run UI material allocations on the churn realm: branch = exactly **6** in every
  round (the distinct-key count: 4 uv variants + 1 nine-slice + 1 system image);
  base = **293–357**, growing with elapsed churn ticks (~64 reallocations per 0.5 s
  rewrite). 49–59x fewer.
- With scene UI attached (player inside the scene, default UI): stretch materials at
  exit 91 → 26 (scene share 68 → 4), nine-slice 33 → 2 (scene share 32 → 1); total
  allocations over the run 3,845 → 167 (the branch's remainder is system-UI churn,
  which the cache dedups too).

**Results — retry backoff (mechanism visible in timestamps).** Dead-video-texture
rebuild attempts over the same settle window: 74 and 70 (base) vs 8 and 8 (branch).
Base attempts are ~25 ms apart — every frame at ~25 ms/frame; branch attempts are
~255 ms apart — every 10th frame, exactly the `RETRY_BACKGROUND_INTERVAL = 10` clamp.
End state identical on both sides.

**Results — target-camera walk removal is behavior-neutral.** Scene-UI screenshots show
identical layout (churn grid, statics, nine-slice row with correct slicing, HUD,
minimap); the diff mask localizes entirely to the uv-churn phase difference, the avatar
idle pose, and the live minimap. System-UI (login screen) full-frame RMSE vs base:
0.00087% — near byte-identical.

**Wall/cpu (honest negative).** No significant delta on either realm: standard realm
wall p50 +0.73% (p = 0.59), cpu p50 +0.56% (p = 0.94); churn realm wall p50 +0.94%
(p = 0.82). The rig's noise floor is ~1.5%; the value of this PR is the allocation and
retry collapse plus the removed per-frame walk, not a frame-time headline on these
scenes. Scene health: 0 broken and 0 zero-tick scenes on both sides in every round.

**Regression gate.** `cargo test --workspace`: 81 test targets, exactly one failure
(`scene_runner test::cyclic_recovery`), identical to the pre-existing base baseline.
No new failures.

**Boot smoke.** Plain branch binary vs plain base binary, default config, 90 s each:
same scene starts, near-identical pixels (RMSE 0.00087%), only a known environmental
audio-thread panic pair present identically on both sides.

**Gaps (stated plainly).**
- Wall/cpu was measured on a GPU shared with unrelated workloads; the deterministic
  counters are the primary signal.
- The tighter UI-panel crop comparison (RMSE 0.0022%) is not independently reproducible
  from the archived artifacts (crop coordinates unrecorded); the full-frame comparison
  above is.
