### PR TITLE
render: gate fixed GPU costs (RTT cameras, sky compute, UI-only cameras)

### DIFF
--- a/crates/avatar/src/avatar_texture.rs
+++ b/crates/avatar/src/avatar_texture.rs
@@ -6,6 +6,7 @@ use bevy::{
     diagnostic::FrameCount,
     ecs::system::SystemParam,
     math::FloatOrd,
+    platform::collections::{HashMap, HashSet},
     prelude::*,
     render::{
         camera::RenderTarget,
@@ -39,7 +40,15 @@ impl Plugin for AvatarTexturePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LiveBooths>();
         app.add_systems(Startup, setup.in_set(SetupSets::Main));
-        app.add_systems(Update, (update_booth_image, snapshot, clean_booths));
+        app.add_systems(
+            Update,
+            (
+                update_booth_image,
+                update_booth_camera_activity,
+                snapshot,
+                clean_booths,
+            ),
+        );
     }
 }
 
@@ -305,6 +314,37 @@ fn update_booth_image(
                 height: (node_size.y as u32).max(16),
                 ..Default::default()
             };
+        }
+    }
+}
+
+// booth cameras render only while some ui node is actually displaying their output
+// (snapshots use their own transient cameras, so they are unaffected)
+fn update_booth_camera_activity(
+    consumers: Query<(&BoothInstance, &InheritedVisibility, &ComputedNode), With<BoothImage>>,
+    mut cameras: Query<&mut Camera>,
+    mut managed: Local<HashSet<Entity>>,
+    mut desired: Local<HashMap<Entity, bool>>,
+) {
+    desired.clear();
+    for camera in managed.iter() {
+        desired.insert(*camera, false);
+    }
+    for (instance, visibility, node) in consumers.iter() {
+        let shown = visibility.get() && node.size().cmpgt(Vec2::ZERO).all();
+        let entry = desired.entry(instance.camera).or_insert(false);
+        if shown {
+            *entry = true;
+        }
+    }
+    managed.clear();
+    for (camera_ent, active) in desired.iter() {
+        let Ok(mut camera) = cameras.get_mut(*camera_ent) else {
+            continue;
+        };
+        managed.insert(*camera_ent);
+        if camera.is_active != *active {
+            camera.is_active = *active;
         }
     }
 }

--- a/crates/avatar/src/avatar_texture.rs
+++ b/crates/avatar/src/avatar_texture.rs
@@ -345,7 +345,9 @@ fn update_booth_camera_activity(
             continue;
         };
         managed.insert(*camera_ent);
-        camera.map_unchanged(|c| &mut c.is_active).set_if_neq(*active);
+        camera
+            .map_unchanged(|c| &mut c.is_active)
+            .set_if_neq(*active);
     }
 }
 

--- a/crates/avatar/src/avatar_texture.rs
+++ b/crates/avatar/src/avatar_texture.rs
@@ -322,6 +322,8 @@ fn update_booth_image(
 // (snapshots use their own transient cameras, so they are unaffected)
 fn update_booth_camera_activity(
     consumers: Query<(&BoothInstance, &InheritedVisibility, &ComputedNode), With<BoothImage>>,
+    // shares `&mut Camera` with `update_texture_cameras`; the two touch disjoint camera
+    // entities so bevy just orders them (no marker exists to make the access disjoint)
     mut cameras: Query<&mut Camera>,
     mut managed: Local<HashSet<Entity>>,
     mut desired: Local<HashMap<Entity, bool>>,
@@ -339,13 +341,11 @@ fn update_booth_camera_activity(
     }
     managed.clear();
     for (camera_ent, active) in desired.iter() {
-        let Ok(mut camera) = cameras.get_mut(*camera_ent) else {
+        let Ok(camera) = cameras.get_mut(*camera_ent) else {
             continue;
         };
         managed.insert(*camera_ent);
-        if camera.is_active != *active {
-            camera.is_active = *active;
-        }
+        camera.map_unchanged(|c| &mut c.is_active).set_if_neq(*active);
     }
 }
 

--- a/crates/texture_camera/src/lib.rs
+++ b/crates/texture_camera/src/lib.rs
@@ -3,6 +3,7 @@ use std::f32::consts::FRAC_PI_4;
 use bevy::{
     app::{HierarchyPropagatePlugin, Propagate, PropagateSet, PropagateStop},
     asset::RenderAssetTransferPriority,
+    diagnostic::FrameCount,
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::{
@@ -199,6 +200,13 @@ fn update_directional_light_layers(
 #[derive(Component)]
 pub struct TextureCamEntity(Entity);
 
+// frame at which the camera was last (re)created, used to prioritise the most
+// recently requested cameras when a scene has more than the active limit
+#[derive(Component)]
+pub struct TextureCamRequest(u32);
+
+const MAX_ACTIVE_TEXTURE_CAMERAS_PER_SCENE: usize = 4;
+
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn update_texture_cameras(
     mut commands: Commands,
@@ -208,6 +216,7 @@ fn update_texture_cameras(
         &ContainerEntity,
         Option<&TextureCamEntity>,
         Option<&VideoTextureOutput>,
+        Option<&TextureCamRequest>,
     )>,
     removed: Query<(Entity, &TextureCamEntity), Without<TextureCamera>>,
     mut images: ResMut<Assets<Image>>,
@@ -220,11 +229,14 @@ fn update_texture_cameras(
     layers: Res<SceneLayerProperties>,
     mut layer_cache: ResMut<TextureLayersCache>,
     scene_distance: Res<SceneLoadDistance>,
+    frame: Res<FrameCount>,
 ) {
     let active_scenes = player
         .single()
         .map(|p| containing_scene.get_area(p, PLAYER_COLLIDER_RADIUS))
         .unwrap_or_default();
+
+    let mut existing_cams: HashMap<Entity, Vec<(u32, Entity)>> = HashMap::new();
 
     // remove cameras when TextureCam is removed
     for (ent, removed) in &removed {
@@ -235,7 +247,9 @@ fn update_texture_cameras(
     }
 
     // (re)create new/modified cams
-    for (ent, texture_cam, container, maybe_existing_camera, maybe_existing_image) in q.iter() {
+    for (ent, texture_cam, container, maybe_existing_camera, maybe_existing_image, maybe_request) in
+        q.iter()
+    {
         let layer_ix = layer_cache.get_layer(container.root, texture_cam.0.layer.unwrap_or(0));
         if texture_cam.is_changed() || layer_cache.changed_layers.contains(&layer_ix) {
             // remove previous camera if modified
@@ -383,24 +397,38 @@ fn update_texture_cameras(
             commands
                 .entity(ent)
                 .try_push_children(&[camera_id])
-                .try_insert((TextureCamEntity(camera_id), VideoTextureOutput(image)));
+                .try_insert((
+                    TextureCamEntity(camera_id),
+                    TextureCamRequest(frame.0),
+                    VideoTextureOutput(image),
+                ));
 
             new_cam_events.write(NewCameraEvent(camera_id));
         } else {
-            // set active for current scenes only
-            // TODO: limit / cycle
             let Some(existing) = maybe_existing_camera else {
                 warn!("missing TextureCameraEntity");
                 continue;
             };
 
-            let Ok(camera) = cameras.get_mut(existing.0) else {
+            existing_cams
+                .entry(container.root)
+                .or_default()
+                .push((maybe_request.map(|r| r.0).unwrap_or(0), existing.0));
+        }
+    }
+
+    // set active for current scenes only, limited to the most recently requested
+    // cameras per scene
+    for (root, mut cams) in existing_cams {
+        let scene_active = active_scenes.contains(&root);
+        cams.sort_unstable_by(|a, b| b.cmp(a));
+        for (ix, (_, cam_ent)) in cams.into_iter().enumerate() {
+            let Ok(camera) = cameras.get_mut(cam_ent) else {
                 warn!("missing camera entity for TextureCamera");
                 continue;
             };
 
-            let is_active = active_scenes.contains(&container.root);
-            // debug!("[{}] active: {}", container.container_id, is_active);
+            let is_active = scene_active && ix < MAX_ACTIVE_TEXTURE_CAMERAS_PER_SCENE;
             camera
                 .map_unchanged(|c| &mut c.is_active)
                 .set_if_neq(is_active);

--- a/crates/texture_camera/src/lib.rs
+++ b/crates/texture_camera/src/lib.rs
@@ -220,6 +220,8 @@ fn update_texture_cameras(
     )>,
     removed: Query<(Entity, &TextureCamEntity), Without<TextureCamera>>,
     mut images: ResMut<Assets<Image>>,
+    // shares `&mut Camera` with `update_booth_camera_activity`; the two touch disjoint
+    // camera entities so bevy just orders them (no marker exists to make the access disjoint)
     mut cameras: Query<&mut Camera>,
     containing_scene: ContainingScene,
     player: Query<Entity, With<PrimaryUser>>,
@@ -230,13 +232,14 @@ fn update_texture_cameras(
     mut layer_cache: ResMut<TextureLayersCache>,
     scene_distance: Res<SceneLoadDistance>,
     frame: Res<FrameCount>,
+    mut existing_cams: Local<HashMap<Entity, Vec<(u32, Entity)>>>,
 ) {
     let active_scenes = player
         .single()
         .map(|p| containing_scene.get_area(p, PLAYER_COLLIDER_RADIUS))
         .unwrap_or_default();
 
-    let mut existing_cams: HashMap<Entity, Vec<(u32, Entity)>> = HashMap::new();
+    existing_cams.clear();
 
     // remove cameras when TextureCam is removed
     for (ent, removed) in &removed {
@@ -419,11 +422,11 @@ fn update_texture_cameras(
 
     // set active for current scenes only, limited to the most recently requested
     // cameras per scene
-    for (root, mut cams) in existing_cams {
-        let scene_active = active_scenes.contains(&root);
+    for (root, cams) in existing_cams.iter_mut() {
+        let scene_active = active_scenes.contains(root);
         cams.sort_unstable_by(|a, b| b.cmp(a));
-        for (ix, (_, cam_ent)) in cams.into_iter().enumerate() {
-            let Ok(camera) = cameras.get_mut(cam_ent) else {
+        for (ix, (_, cam_ent)) in cams.iter().enumerate() {
+            let Ok(camera) = cameras.get_mut(*cam_ent) else {
                 warn!("missing camera entity for TextureCamera");
                 continue;
             };

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -27,8 +27,9 @@ use bevy_console::ConsoleCommand;
 use common::{
     sets::SetupSets,
     structs::{
-        AppConfig, DofConfig, FogSetting, PrimaryCamera, PrimaryCameraRes, PrimaryUser,
-        SceneGlobalLight, SceneLoadDistance, ShadowSetting, TimeOfDay, PRIMARY_AVATAR_LIGHT_LAYER,
+        AppConfig, DofConfig, FogSetting, GraphicsSettings, PrimaryCamera, PrimaryCameraRes,
+        PrimaryUser, SceneGlobalLight, SceneLoadDistance, ShadowSetting, TimeOfDay,
+        PRIMARY_AVATAR_LIGHT_LAYER,
     },
 };
 use console::DoAddConsoleCommand;
@@ -42,23 +43,40 @@ pub struct VisualsPlugin {
 
 impl Plugin for VisualsPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(DirectionalLightShadowMap { size: 4096 })
-            .init_resource::<SceneGlobalLight>()
-            .insert_resource(CloudCover {
-                cover: 0.35,
-                speed: 30.0,
-                density_cap: 0.8,
-                shadow: 0.05,
-                scale: 1.5,
-                steps: 44,
-                lacunarity: 2.0,
-            })
-            .add_plugins(WireframePlugin::default())
-            .add_plugins(DayNightPlugin)
-            .add_plugins(ShellTexturingPlugin)
-            .add_systems(Update, apply_global_light)
-            .add_systems(Update, update_dof)
-            .add_systems(Startup, setup.in_set(SetupSets::Main));
+        let shadow_map_size =
+            directional_shadow_map_size(&app.world().resource::<AppConfig>().graphics);
+
+        app.insert_resource(DirectionalLightShadowMap {
+            size: shadow_map_size,
+        })
+        .init_resource::<SceneGlobalLight>()
+        .init_resource::<BlendedGlobalLight>()
+        .insert_resource(CloudCover {
+            cover: 0.35,
+            speed: 30.0,
+            density_cap: 0.8,
+            shadow: 0.05,
+            scale: 1.5,
+            steps: 44,
+            lacunarity: 2.0,
+        })
+        .add_plugins(WireframePlugin::default())
+        .add_plugins(DayNightPlugin)
+        .add_plugins(ShellTexturingPlugin)
+        .add_systems(
+            Update,
+            (
+                apply_global_light,
+                update_atmosphere.run_if(sky_needs_update),
+            )
+                .chain(),
+        )
+        .add_systems(
+            Update,
+            update_shadow_map_size.run_if(resource_changed::<AppConfig>),
+        )
+        .add_systems(Update, update_dof)
+        .add_systems(Startup, setup.in_set(SetupSets::Main));
 
         app.insert_resource(AtmosphereSettings {
             resolution: 1024,
@@ -110,6 +128,30 @@ impl Plugin for VisualsPlugin {
 #[derive(Component)]
 struct DirectionalLightLayer(Layer);
 
+fn directional_shadow_map_size(graphics: &GraphicsSettings) -> usize {
+    // on web the shadow map is a significant part of the fixed frame cost; use a
+    // smaller map unless the user explicitly asks for high quality shadows
+    if cfg!(target_arch = "wasm32") && graphics.shadow_settings != ShadowSetting::High {
+        2048
+    } else {
+        4096
+    }
+}
+
+fn update_shadow_map_size(
+    config: Res<AppConfig>,
+    mut shadow_map: ResMut<DirectionalLightShadowMap>,
+) {
+    let size = directional_shadow_map_size(&config.graphics);
+    if shadow_map.size != size {
+        shadow_map.size = size;
+    }
+}
+
+/// the output of `apply_global_light`'s settle transition, consumed by `update_atmosphere`
+#[derive(Resource, Default)]
+struct BlendedGlobalLight(SceneGlobalLight);
+
 fn setup(
     mut commands: Commands,
     camera: Res<PrimaryCameraRes>,
@@ -147,13 +189,124 @@ fn setup(
 }
 
 static TRANSITION_TIME: f32 = 1.0;
+const SKY_UPDATE_INTERVAL: u32 = 8;
+const SKY_JUMP_BURST_FRAMES: u32 = 64;
+
+fn color_delta(a: Color, b: Color) -> f32 {
+    let a = a.to_srgba();
+    let b = b.to_srgba();
+    (a.red - b.red)
+        .abs()
+        .max((a.green - b.green).abs())
+        .max((a.blue - b.blue).abs())
+}
+
+// merely constructing the `AtmosphereMut` param marks the atmosphere resource changed,
+// which re-dispatches the sky compute pass, so `update_atmosphere` must not run every
+// frame. while the light drifts slowly (day/night cycle) an update every
+// SKY_UPDATE_INTERVAL frames is imperceptible under the dithered skybox; a real jump
+// (scene light override, teleport) triggers a full-rate burst so the sky snaps to the
+// new state instead of visibly stepping.
+fn sky_needs_update(
+    scene_global_light: Res<SceneGlobalLight>,
+    mut frames_since_update: Local<u32>,
+    mut burst_frames: Local<u32>,
+    mut last_applied: Local<Option<SceneGlobalLight>>,
+) -> bool {
+    let jumped = match last_applied.as_ref() {
+        None => true,
+        Some(prev) => {
+            prev.source != scene_global_light.source
+                || prev
+                    .dir_direction
+                    .angle_between(scene_global_light.dir_direction)
+                    > 0.02
+                || (prev.dir_illuminance - scene_global_light.dir_illuminance).abs()
+                    > prev.dir_illuminance.max(100.0) * 0.05
+                || color_delta(prev.dir_color, scene_global_light.dir_color) > 0.05
+                || color_delta(prev.ambient_color, scene_global_light.ambient_color) > 0.05
+                || (prev.ambient_brightness - scene_global_light.ambient_brightness).abs() > 0.1
+        }
+    };
+
+    if jumped {
+        *burst_frames = SKY_JUMP_BURST_FRAMES;
+    }
+
+    *frames_since_update += 1;
+    if *burst_frames > 0 || *frames_since_update >= SKY_UPDATE_INTERVAL {
+        *burst_frames = burst_frames.saturating_sub(1);
+        *frames_since_update = 0;
+        *last_applied = Some(scene_global_light.clone());
+        true
+    } else {
+        false
+    }
+}
+
+fn update_atmosphere(
+    mut atmosphere: AtmosphereMut<NishitaCloud>,
+    cloud: Res<CloudCover>,
+    blended: Res<BlendedGlobalLight>,
+    time_of_day: Res<TimeOfDay>,
+    time: Res<Time>,
+    mut cloud_dt: Local<f32>,
+    mut last_elapsed: Local<Option<f32>>,
+) {
+    // this system runs at a reduced rate, so track real elapsed time rather than
+    // using the frame delta
+    let elapsed = time.elapsed_secs();
+    let dt = elapsed - last_elapsed.unwrap_or(elapsed);
+    *last_elapsed = Some(elapsed);
+
+    let light = &blended.0;
+
+    // physically-simulated sky: rayleigh (hue) and mie (haze) are baked day-cycle
+    // curves keyed by time of day; the sun sets naturally (no floor), and a flat
+    // night colour (added in-shader) provides the night sky.
+    let day = (time_of_day.elapsed_secs() / (60.0 * 60.0 * 24.0)).rem_euclid(1.0);
+    atmosphere.sun_position = -light.dir_direction;
+    atmosphere.rayleigh_coefficient = atmosphere_params::RAYLEIGH.sample(day);
+    atmosphere.mie_coefficient = atmosphere_params::MIE.sample(day);
+    atmosphere.night_color = atmosphere_params::NIGHT_SKY;
+    // moon on its own low orbit: rises at dusk, peaks at MOON_PEAK_ELEV around
+    // midnight (well below the zenith, so it never sits overhead like the sun),
+    // sets at dawn. Anti-phase to the sun but on an independent arc, so it has
+    // no singularity at midnight (where the antisolar direction is undefined).
+    const MOON_PEAK_ELEV: f32 = 0.45; // radians (~26°)
+    let a = day * std::f32::consts::TAU + std::f32::consts::FRAC_PI_2;
+    let (sin_a, cos_a) = a.sin_cos();
+    let (sin_b, cos_b) = MOON_PEAK_ELEV.sin_cos();
+    atmosphere.moon_position = Vec3::new(cos_a, sin_a * sin_b, -sin_a * cos_b);
+    atmosphere.dir_light_intensity = light.dir_illuminance;
+    atmosphere.sun_color = light.dir_color.to_srgba().to_vec3();
+    atmosphere.tick += 1;
+
+    if atmosphere.cloudy != cloud.cover {
+        *cloud_dt = (*cloud_dt + dt * 20.0)
+            .min(80.0 * (atmosphere.cloudy - cloud.cover).abs())
+            .max(1.0);
+        atmosphere.cloudy += (cloud.cover - atmosphere.cloudy)
+            .clamp(-dt * 0.005 * *cloud_dt, dt * 0.005 * *cloud_dt);
+    } else {
+        *cloud_dt = f32::max(*cloud_dt - dt, cloud.speed);
+    }
+
+    atmosphere.time += dt * *cloud_dt;
+
+    // cloud look (live-tunable, baked later)
+    atmosphere.cloud_density_cap = cloud.density_cap;
+    atmosphere.cloud_shadow = cloud.shadow;
+    atmosphere.cloud_scale = cloud.scale;
+    atmosphere.cloud_steps = cloud.steps;
+    atmosphere.cloud_lacunarity = cloud.lacunarity;
+}
 
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn apply_global_light(
     mut commands: Commands,
     setting: Res<AppConfig>,
-    mut atmosphere: AtmosphereMut<NishitaCloud>,
-    cloud: Res<CloudCover>,
+    mut blended: ResMut<BlendedGlobalLight>,
     mut sun: Query<(
         Entity,
         &DirectionalLightLayer,
@@ -165,13 +318,44 @@ fn apply_global_light(
     mut cameras: Query<(Option<&PrimaryCamera>, Option<&mut DistanceFog>), With<Camera3d>>,
     scene_distance: Res<SceneLoadDistance>,
     scene_global_light: Res<SceneGlobalLight>,
-    time_of_day: Res<TimeOfDay>,
     mut prev: Local<(f32, SceneGlobalLight)>,
-    mut cloud_dt: Local<f32>,
     mut last_primary_distance: Local<f32>,
 ) {
     // the transition has settled once the previous output exactly matches the target
     let settled = prev.0 >= TRANSITION_TIME && prev.1 == *scene_global_light;
+
+    // skip the light/fog/ambient writes (which trigger change detection and re-extraction)
+    // when the light has settled and nothing else affecting them has changed
+    let primary_distance = cameras
+        .iter()
+        .find_map(|(maybe_primary, _)| maybe_primary.map(|camera| camera.distance))
+        .unwrap_or(0.0);
+    // a (re)inserted DistanceFog fires `is_added` and must be written even when the light has
+    // settled. reading the tick through the existing `&mut` access avoids the query conflict an
+    // `Added<DistanceFog>` filter would have with `cameras`; `is_added` (not `is_changed`) is used
+    // because our own per-frame fog writes set `changed`, which would otherwise never let the gate
+    // re-engage.
+    let fog_added = cameras
+        .iter_mut()
+        .any(|(_, fog)| fog.is_some_and(|fog| fog.is_added()));
+    // extra per-layer suns never cast shadows; re-disable if anything (e.g. the
+    // shadow console command) turned them back on
+    for (_, layer, _, mut light) in sun.iter_mut() {
+        if layer.0 != 0 && light.shadows_enabled {
+            light.shadows_enabled = false;
+        }
+    }
+    let skip_writes = settled
+        && !setting.is_changed()
+        && !scene_distance.is_changed()
+        && !fog_added
+        && *last_primary_distance == primary_distance;
+    *last_primary_distance = primary_distance;
+
+    if skip_writes {
+        prev.0 += time.delta_secs();
+        return;
+    }
 
     let next_light = if prev.0 >= TRANSITION_TIME && prev.1.source == scene_global_light.source {
         scene_global_light.clone()
@@ -205,75 +389,7 @@ fn apply_global_light(
 
     let rotation = Quat::from_rotation_arc(Vec3::NEG_Z, next_light.dir_direction);
 
-    // physically-simulated sky: rayleigh (hue) and mie (haze) are baked day-cycle
-    // curves keyed by time of day; the sun sets naturally (no floor), and a flat
-    // night colour (added in-shader) provides the night sky.
-    let day = (time_of_day.elapsed_secs() / (60.0 * 60.0 * 24.0)).rem_euclid(1.0);
-    atmosphere.sun_position = -next_light.dir_direction;
-    atmosphere.rayleigh_coefficient = atmosphere_params::RAYLEIGH.sample(day);
-    atmosphere.mie_coefficient = atmosphere_params::MIE.sample(day);
-    atmosphere.night_color = atmosphere_params::NIGHT_SKY;
-    // moon on its own low orbit: rises at dusk, peaks at MOON_PEAK_ELEV around
-    // midnight (well below the zenith, so it never sits overhead like the sun),
-    // sets at dawn. Anti-phase to the sun but on an independent arc, so it has
-    // no singularity at midnight (where the antisolar direction is undefined).
-    const MOON_PEAK_ELEV: f32 = 0.45; // radians (~26°)
-    let a = day * std::f32::consts::TAU + std::f32::consts::FRAC_PI_2;
-    let (sin_a, cos_a) = a.sin_cos();
-    let (sin_b, cos_b) = MOON_PEAK_ELEV.sin_cos();
-    atmosphere.moon_position = Vec3::new(cos_a, sin_a * sin_b, -sin_a * cos_b);
-    atmosphere.dir_light_intensity = next_light.dir_illuminance;
-    atmosphere.sun_color = next_light.dir_color.to_srgba().to_vec3();
-    atmosphere.tick += 1;
-
-    if atmosphere.cloudy != cloud.cover {
-        *cloud_dt = (*cloud_dt + time.delta_secs() * 20.0)
-            .min(80.0 * (atmosphere.cloudy - cloud.cover).abs())
-            .max(1.0);
-        atmosphere.cloudy += (cloud.cover - atmosphere.cloudy).clamp(
-            -time.delta_secs() * 0.005 * *cloud_dt,
-            time.delta_secs() * 0.005 * *cloud_dt,
-        );
-        // atmosphere.time += time.delta_secs() * 10.0;
-    } else {
-        *cloud_dt = f32::max(*cloud_dt - time.delta_secs(), cloud.speed);
-    }
-
-    atmosphere.time += time.delta_secs() * *cloud_dt;
-
-    // cloud look (live-tunable, baked later)
-    atmosphere.cloud_density_cap = cloud.density_cap;
-    atmosphere.cloud_shadow = cloud.shadow;
-    atmosphere.cloud_scale = cloud.scale;
-    atmosphere.cloud_steps = cloud.steps;
-    atmosphere.cloud_lacunarity = cloud.lacunarity;
-
-    // skip the light/fog/ambient writes (which trigger change detection and re-extraction)
-    // when the light has settled and nothing else affecting them has changed
-    let primary_distance = cameras
-        .iter()
-        .find_map(|(maybe_primary, _)| maybe_primary.map(|camera| camera.distance))
-        .unwrap_or(0.0);
-    // a (re)inserted DistanceFog fires `is_added` and must be written even when the light has
-    // settled. reading the tick through the existing `&mut` access avoids the query conflict an
-    // `Added<DistanceFog>` filter would have with `cameras`; `is_added` (not `is_changed`) is used
-    // because our own per-frame fog writes set `changed`, which would otherwise never let the gate
-    // re-engage.
-    let fog_added = cameras
-        .iter_mut()
-        .any(|(_, fog)| fog.is_some_and(|fog| fog.is_added()));
-    let skip_writes = settled
-        && !setting.is_changed()
-        && !scene_distance.is_changed()
-        && !fog_added
-        && *last_primary_distance == primary_distance;
-    *last_primary_distance = primary_distance;
-
-    if skip_writes {
-        prev.0 += time.delta_secs();
-        prev.1 = next_light;
-        return;
-    }
+    blended.0 = next_light.clone();
 
     let mut directional_layers = RenderLayers::none();
     for (entity, layer, mut light_trans, mut directional) in sun.iter_mut() {
@@ -298,30 +414,36 @@ fn apply_global_light(
             layer = layer.union(&PRIMARY_AVATAR_LIGHT_LAYER);
         }
 
-        let (shadows_enabled, cascade_shadow_config) = match setting.graphics.shadow_settings {
-            ShadowSetting::Off => (false, Default::default()),
-            ShadowSetting::Low => (
-                true,
-                CascadeShadowConfigBuilder {
-                    num_cascades: 1,
-                    minimum_distance: 0.1,
-                    maximum_distance: setting.graphics.shadow_distance,
-                    first_cascade_far_bound: setting.graphics.shadow_distance,
-                    overlap_proportion: 0.2,
-                }
-                .build(),
-            ),
-            ShadowSetting::High => (
-                true,
-                CascadeShadowConfigBuilder {
-                    num_cascades: 4,
-                    minimum_distance: 0.1,
-                    maximum_distance: setting.graphics.shadow_distance,
-                    first_cascade_far_bound: setting.graphics.shadow_distance / 15.0,
-                    overlap_proportion: 0.2,
-                }
-                .build(),
-            ),
+        // only the layer-0 sun casts shadows; each extra per-layer sun would otherwise
+        // add a full shadow cascade pass
+        let (shadows_enabled, cascade_shadow_config) = if new_layer != 0 {
+            (false, Default::default())
+        } else {
+            match setting.graphics.shadow_settings {
+                ShadowSetting::Off => (false, Default::default()),
+                ShadowSetting::Low => (
+                    true,
+                    CascadeShadowConfigBuilder {
+                        num_cascades: 1,
+                        minimum_distance: 0.1,
+                        maximum_distance: setting.graphics.shadow_distance,
+                        first_cascade_far_bound: setting.graphics.shadow_distance,
+                        overlap_proportion: 0.2,
+                    }
+                    .build(),
+                ),
+                ShadowSetting::High => (
+                    true,
+                    CascadeShadowConfigBuilder {
+                        num_cascades: 4,
+                        minimum_distance: 0.1,
+                        maximum_distance: setting.graphics.shadow_distance,
+                        first_cascade_far_bound: setting.graphics.shadow_distance / 15.0,
+                        overlap_proportion: 0.2,
+                    }
+                    .build(),
+                ),
+            }
         };
 
         commands.spawn((

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -128,13 +128,16 @@ impl Plugin for VisualsPlugin {
 #[derive(Component)]
 struct DirectionalLightLayer(Layer);
 
+const SHADOW_MAP_SIZE: usize = 4096;
+const WEB_SHADOW_MAP_SIZE: usize = 2048;
+
 fn directional_shadow_map_size(graphics: &GraphicsSettings) -> usize {
     // on web the shadow map is a significant part of the fixed frame cost; use a
     // smaller map unless the user explicitly asks for high quality shadows
     if cfg!(target_arch = "wasm32") && graphics.shadow_settings != ShadowSetting::High {
-        2048
+        WEB_SHADOW_MAP_SIZE
     } else {
-        4096
+        SHADOW_MAP_SIZE
     }
 }
 
@@ -191,6 +194,11 @@ fn setup(
 static TRANSITION_TIME: f32 = 1.0;
 const SKY_UPDATE_INTERVAL: u32 = 8;
 const SKY_JUMP_BURST_FRAMES: u32 = 64;
+const SKY_JUMP_DIRECTION_RADIANS: f32 = 0.02;
+const SKY_JUMP_ILLUMINANCE_FRACTION: f32 = 0.05;
+const SKY_JUMP_ILLUMINANCE_FLOOR: f32 = 100.0;
+const SKY_JUMP_COLOR_DELTA: f32 = 0.05;
+const SKY_JUMP_AMBIENT_DELTA: f32 = 0.1;
 
 fn color_delta(a: Color, b: Color) -> f32 {
     let a = a.to_srgba();
@@ -220,12 +228,15 @@ fn sky_needs_update(
                 || prev
                     .dir_direction
                     .angle_between(scene_global_light.dir_direction)
-                    > 0.02
+                    > SKY_JUMP_DIRECTION_RADIANS
                 || (prev.dir_illuminance - scene_global_light.dir_illuminance).abs()
-                    > prev.dir_illuminance.max(100.0) * 0.05
-                || color_delta(prev.dir_color, scene_global_light.dir_color) > 0.05
-                || color_delta(prev.ambient_color, scene_global_light.ambient_color) > 0.05
-                || (prev.ambient_brightness - scene_global_light.ambient_brightness).abs() > 0.1
+                    > prev.dir_illuminance.max(SKY_JUMP_ILLUMINANCE_FLOOR)
+                        * SKY_JUMP_ILLUMINANCE_FRACTION
+                || color_delta(prev.dir_color, scene_global_light.dir_color) > SKY_JUMP_COLOR_DELTA
+                || color_delta(prev.ambient_color, scene_global_light.ambient_color)
+                    > SKY_JUMP_COLOR_DELTA
+                || (prev.ambient_brightness - scene_global_light.ambient_brightness).abs()
+                    > SKY_JUMP_AMBIENT_DELTA
         }
     };
 

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -193,7 +193,6 @@ fn setup(
 
 static TRANSITION_TIME: f32 = 1.0;
 const SKY_UPDATE_INTERVAL: u32 = 8;
-const SKY_JUMP_BURST_FRAMES: u32 = 64;
 const SKY_JUMP_DIRECTION_RADIANS: f32 = 0.02;
 const SKY_JUMP_ILLUMINANCE_FRACTION: f32 = 0.05;
 const SKY_JUMP_ILLUMINANCE_FLOOR: f32 = 100.0;
@@ -217,8 +216,9 @@ fn color_delta(a: Color, b: Color) -> f32 {
 // new state instead of visibly stepping.
 fn sky_needs_update(
     scene_global_light: Res<SceneGlobalLight>,
+    time: Res<Time>,
     mut frames_since_update: Local<u32>,
-    mut burst_frames: Local<u32>,
+    mut burst_secs: Local<f32>,
     mut last_applied: Local<Option<SceneGlobalLight>>,
 ) -> bool {
     let jumped = match last_applied.as_ref() {
@@ -240,13 +240,16 @@ fn sky_needs_update(
         }
     };
 
+    // hold the sky at full update rate for the length of the light transition; time-based
+    // to match the time-based settle so it tracks the transition instead of stepping
     if jumped {
-        *burst_frames = SKY_JUMP_BURST_FRAMES;
+        *burst_secs = TRANSITION_TIME;
     }
+    let bursting = *burst_secs > 0.0;
+    *burst_secs = (*burst_secs - time.delta_secs()).max(0.0);
 
     *frames_since_update += 1;
-    if *burst_frames > 0 || *frames_since_update >= SKY_UPDATE_INTERVAL {
-        *burst_frames = burst_frames.saturating_sub(1);
+    if bursting || *frames_since_update >= SKY_UPDATE_INTERVAL {
         *frames_since_update = 0;
         *last_applied = Some(scene_global_light.clone());
         true

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -13,6 +13,7 @@ use bevy::{
             AsBindGroup, Extent3d, ShaderRef, TextureDimension, TextureFormat, TextureUsages,
         },
         renderer::RenderDevice,
+        view::RenderLayers,
     },
     transform::TransformSystem,
     ui::UiSystem,
@@ -130,6 +131,8 @@ pub fn spawn_world_ui_view(
         .spawn((
             WorldUiRenderTarget(image.clone()),
             Camera2d,
+            // this camera only renders ui; keep world entities out of its visibility pass
+            RenderLayers::none(),
             Camera {
                 target: RenderTarget::Image(image.clone().into()),
                 order: -1,


### PR DESCRIPTION
# render: gate fixed GPU costs (RTT cameras, sky compute, per-layer shadows)

## What

Cuts several GPU costs that were paid every frame regardless of whether anything on screen needed them:

- **Texture cameras** (`PbTextureCamera`): a scene could keep any number of RTT cameras active, each one a full render pass with its own whole-world visibility pass. Cameras in the current scenes are now capped at 4 active per scene, preferring the most recently requested (the existing `TODO: limit / cycle` in `update_texture_cameras`).
- **Photo booth cameras**: booth cameras spawned with `is_active: true` and stayed active for the life of the booth, so a backpack/emotes/profile avatar kept re-rendering even when no UI was showing it. They are now active only while some `BoothImage` UI node is visible with a non-zero layout size. Snapshots are unaffected (they use their own transient cameras).
- **World-UI RTT cameras** (text shapes, scene UI canvases): these `Camera2d`s only render UI, but with default `RenderLayers` each one still ran a whole-world visibility pass over layer-0 entities. They now spawn with `RenderLayers::none()`.
- **Sky compute**: `apply_global_light` took `AtmosphereMut<NishitaCloud>` every frame, and merely constructing that param marks the atmosphere resource changed — re-dispatching the `bevy_atmosphere` skybox compute every frame even with an unchanged sky. The atmosphere update is split into its own system that runs every 8 frames, with epsilon jump-detection on `SceneGlobalLight` and a 64-frame full-rate burst after a real jump.
- **Per-layer suns**: every extra per-render-layer directional light spawned with the same shadow settings as the primary sun, each adding a full shadow cascade pass for a light that only exists to illuminate an RTT layer. Extra suns are now shadowless, with a self-heal guard in case something (e.g. the `/shadows` console command) re-enables them.
- **Shadow map size**: the directional shadow map is sized from graphics settings instead of a hard-coded 4096: on web it drops to 2048 unless shadow quality is set to High, and resizes when the setting changes.

## Why

These are fixed per-frame costs: they scale with what content declares, not with what is visible, and they persist when the world is completely still. On WebGPU they were among the largest contributors to steady-state frame time.

This change shipped as part of an engine performance pass measured with paired interleaved A/B runs (headed Chromium/WebGPU on a discrete NVIDIA GPU, Mann-Whitney gated): on a 17-scene benchmark realm orbit, cpu p50 -2.7% (p=.028) and wall p50 -6.9% (7/7 rounds); with 32 synthetic avatars added, cpu p50 -9.2% (p=.029) and wall p50 -49.7% (62.6 ms -> 31.5 ms, p=.025).

## How

Three commits — the first two are independent of each other; the third only names the tuning constants the second introduced (`SKY_JUMP_*` thresholds, shadow map sizes):

**`gate rtt cameras on content and consumer activity`**

- `crates/texture_camera/src/lib.rs`: new `TextureCamRequest(u32)` component records the frame at which each camera was last (re)created. `update_texture_cameras` collects existing cameras per scene root, sorts by request recency, and `set_if_neq`s `is_active` so only the top `MAX_ACTIVE_TEXTURE_CAMERAS_PER_SCENE = 4` in an active scene render.
- `crates/avatar/src/avatar_texture.rs`: new `update_booth_camera_activity` system queries `(&BoothInstance, &InheritedVisibility, &ComputedNode)` on `BoothImage` nodes and drives each booth camera's `is_active` from consumer visibility. A `Local` set of managed cameras deactivates cameras whose last consumer disappeared.
- `crates/world_ui/src/lib.rs`: `spawn_world_ui_view` adds `RenderLayers::none()` to the camera (covers both text-shape views and the scene-UI canvas camera).

**`throttle sky compute updates and trim fixed shadow costs`**

- `crates/visuals/src/lib.rs`: the atmosphere writes move from `apply_global_light` into a new `update_atmosphere` system gated by a `sky_needs_update` run condition (pure `Local` state: frame counter, jump detection, burst countdown). A new `BlendedGlobalLight` resource carries the transition-blended light from `apply_global_light` to `update_atmosphere`; cloud animation uses real elapsed time between runs so cloud speed is unchanged.
- Same file: extra per-layer suns spawn with `shadows_enabled: false`, plus the self-heal loop; `DirectionalLightShadowMap` is initialized from `directional_shadow_map_size(&config.graphics)` and updated by a `resource_changed::<AppConfig>`-gated system.

## Default behavior

Visual output is unchanged at steady state. The sky is fully redrawn on every dispatch, so a throttled update is a complete (never partial) skybox; between updates the last skybox persists, and the dithered sky hides the 8-frame step during slow drift (day/night cycle). A real lighting jump (scene light override, teleport) triggers the full-rate burst, so the sky snaps within a frame of the jump being detected. Scenes with more than 4 texture cameras see the least recently requested ones freeze until re-requested (previously all rendered every frame); avatar booth output is pixel-identical whenever it is on screen.

## Testing

- `cargo check --workspace` clean on this branch.
- The same gating was soak-tested in a headed client on the tree this is ported from: texture-camera scenes render and video textures update; booth images render and drag-rotate while open, and their cameras deactivate when no UI shows them; text shapes and scene UI canvases render unchanged; the day/night sky drifts smoothly and snaps on scene light overrides; shadows are unchanged for the primary sun.
- The perf numbers above come from paired interleaved A/B runs of the containing performance pass on a 17-scene benchmark realm.

## Evidence

Independently verified instrumented A/B pass on this branch alone (not the fork series) against the base commit, audited against the raw artifacts with every count recomputed. (Gathered before the final constant-naming commit, which changes no values — `cargo check` re-run clean on the final tip.)

**Method.** Both sides carry a byte-identical instrumentation overlay counting, per frame in the main world, (a) atmosphere compute dispatches — via the atmosphere resource's change detection, which is exactly the mechanism that re-dispatches the `bevy_atmosphere` skybox compute — and (b) active render-to-texture cameras. These are deterministic main-world proxies for the GPU passes, identical on both sides, not GPU-side pass instrumentation. Two run families on a local mirror of the scene-explorer-tests realm, headed on a discrete NVIDIA GPU, checksum-verified binaries, fresh process per run: interleaved idle-window runs (60 s idle + 30 s moving, per-window counter deltas) and 6 interleaved wall rounds (32 synthetic avatars, 900 measured / 300 warmup frames, exact two-sided Mann-Whitney on per-round medians).

**Results — sky compute gating (confirmed, exact counts).**
- Base dispatches the atmosphere compute every frame, exactly: dispatches == frames in all 4 idle/move windows and all 6 wall rounds.
- The branch dispatches exactly 1 per 8 frames when lighting is static: observed 1/7.96–1/8.02 in all 4 windows, idle and moving alike.
- The full-rate burst fires exactly once per run: in every wall round the branch's dispatch total exceeds frames/8 by 56.1–56.9, and one 64-frame burst contributes exactly 64 − 64/8 = 56 — the boot-teleport lighting jump, followed by steady 1/8.

**Results — RTT camera gating (code-verified only).** The benchmark realm instantiates no photo booth and no scene texture cameras, so booth deactivation and the 4-per-scene cap could not fire at runtime. The counter shows exactly one active RTT camera per frame on both sides — the world-UI view camera, which this branch intentionally keeps active with `RenderLayers::none()` (its layers are emptied rather than the camera deactivated). The gating itself is verified in the diff: cap = 4 ordered by request recency, `RenderLayers::none()` on the world-UI camera bundle, booth `is_active` toggled by visible UI consumers.

**Wall/cpu (no claim made).** wall p50 +3.9% (p = 0.394), cpu p50 +16.9% (p = 0.310) — not significant in either direction. Two branch-side rounds coincided with unrelated workloads on the shared verification GPU, and the saved work (7/8 of one fullscreen compute dispatch) is below that rig's contention-shaped noise floor. The deterministic counters above are the verified signal.

**Regression gate.** `cargo test --workspace` in a private target dir: 80 suites ok, exactly one failure (`scene_runner test::cyclic_recovery`), identical to the pre-existing base baseline. No new failures.

**Boot smoke.** Plain branch binary, default config, 90 s: scenes start and tick (3,359 frames at cutoff), non-black screenshot, no fatal panic — only a known environmental audio-thread panic pair also present in base runs.

**Gaps (stated plainly).**
- The RTT gating half (booth cameras, per-scene cap) has zero runtime evidence in this pass — the benchmark realm has no RTT content. It is code-verified only.
- No scene in the benchmark realm changes lighting mid-run, so the burst was exercised only by the boot-teleport jump, not an interactive mid-run lighting change.
- The per-layer-sun shadow and shadow-map-size changes were not separately instrumented in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
