### PR TITLE
fix: render out-of-bounds geometry in the editor & preview

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1276,6 +1276,11 @@ pub struct PreviewMode {
     pub preview_parcel: Option<IVec2>,
 }
 
+/// Render out-of-bounds geometry (dithered) instead of culling it. Set at startup;
+/// read by scene_material's show-outside-bounds observer.
+#[derive(Debug, Resource, Default)]
+pub struct ShowOutOfBounds(pub bool);
+
 // resource into which systems can add debug info
 #[derive(Resource, Default, Debug)]
 pub struct DebugInfo {

--- a/crates/scene_material/src/lib.rs
+++ b/crates/scene_material/src/lib.rs
@@ -8,7 +8,10 @@ use bevy::{
     },
 };
 use boimp::bake::{ImposterBakeMaterialExtension, ImposterBakeMaterialPlugin};
-use common::{structs::PreviewMode, util::InvertedScaleExt};
+use common::{
+    structs::{PreviewMode, ShowOutOfBounds},
+    util::InvertedScaleExt,
+};
 
 pub type SceneMaterial = ExtendedMaterial<SceneBound>;
 
@@ -313,6 +316,8 @@ impl Plugin for SceneBoundPlugin {
         }
 
         app.init_resource::<InvertedMaterials>();
+        // Default false; the app entry overrides it.
+        app.init_resource::<ShowOutOfBounds>();
 
         app.add_observer(new_material);
         app.add_systems(
@@ -330,9 +335,10 @@ impl Plugin for SceneBoundPlugin {
 fn update_show_outside_bounds(
     trigger: Trigger<OnInsert, MeshMaterial3d<SceneMaterial>>,
     mut meshes: Query<&mut MeshTag, With<MeshMaterial3d<SceneMaterial>>>,
-    preview: Res<PreviewMode>,
+    show_oob: Res<ShowOutOfBounds>,
 ) {
-    if !preview.is_preview {
+    // Tag the mesh to render out-of-bounds instead of being culled.
+    if !show_oob.0 {
         return;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ use common::{
     sets::SetupSets,
     structs::{
         AppConfig, AvatarDynamicState, HeadSync, PointAtSync, PreviewMode, PrimaryCamera,
-        PrimaryCameraRes, PrimaryPlayerRes, SceneImposterBake, SceneLoadDistance, StartupScene,
-        StartupScenes, Version, GROUND_RENDERLAYER,
+        PrimaryCameraRes, PrimaryPlayerRes, SceneImposterBake, SceneLoadDistance, ShowOutOfBounds,
+        StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
     },
     util::UtilsPlugin,
 };
@@ -177,6 +177,17 @@ pub struct DecentralandArguments {
     pub loading_scene: bool,
 }
 
+/// Whether a realm URL points at the local machine (localhost / loopback IP).
+fn is_loopback_realm(realm: &str) -> bool {
+    let after_scheme = realm.split("://").last().unwrap_or(realm);
+    let host = after_scheme
+        .split(['/', ':'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
+}
+
 impl DecentralandApp {
     /// Creates an [`App`] with [`LogPlugin`] so that logs
     /// work from the start
@@ -219,6 +230,10 @@ impl DecentralandApp {
         info!("Bevy-Explorer version {}", version);
 
         let boot_server = map_realm_name(decentraland_app_config.boot_server());
+        // Show out-of-bounds geometry in preview + on a loopback realm (editor /
+        // local dev), never on a public realm. Computed before boot_server moves.
+        let show_out_of_bounds =
+            decentraland_app_config.arguments.is_preview || is_loopback_realm(&boot_server);
 
         // Resources
         app.insert_resource(Version(version))
@@ -258,6 +273,7 @@ impl DecentralandApp {
                 is_preview: decentraland_app_config.arguments.is_preview,
                 preview_parcel: None,
             })
+            .insert_resource(ShowOutOfBounds(show_out_of_bounds))
             .insert_resource(SceneLoadDistance {
                 load: if decentraland_app_config.arguments.is_preview {
                     1.0


### PR DESCRIPTION
<img width="891" height="551" alt="Screenshot 2026-07-24 at 12 43 52 PM" src="https://github.com/user-attachments/assets/25cee790-01bd-420d-8f61-3d21f97de650" />
