### PR TITLE
ipfs: opt-in per-scene content packs (single-fetch scene delivery, streaming)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,6 +3628,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-fs",
+ "web-sys",
  "web-time",
  "wgpu",
  "world_ui",
@@ -6275,7 +6276,10 @@ dependencies = [
  "url",
  "urlencoding",
  "urn",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-fs",
+ "web-sys",
  "web-time",
 ]
 
@@ -8384,6 +8388,7 @@ dependencies = [
  "async-compat",
  "async-tungstenite",
  "bevy",
+ "bytes",
  "directories",
  "futures-lite",
  "futures-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,7 @@ serde_bytes = "0.11"
 web-sys = { version = "0.3", features = [
   "Performance",
   "Window",
+  "Location",
   "Document",
   "Element",
   "HtmlCanvasElement",
@@ -328,6 +329,7 @@ console_error_panic_hook = "0.1.7"
 log = "0.4"
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true }
 once_cell = { workspace = true }
 web-fs = { workspace = true }
 

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -458,6 +458,9 @@ pub struct AppConfig {
     pub inputs: InputMapSerialized,
     pub point_at_marker_visibility: PointAtMarkerVisibility,
     pub camera_smoothing: CameraSmoothing,
+    // base url of a scene content-pack server; None (the default) disables
+    // scene packs entirely and every content request goes to /contents
+    pub scene_packs_url: Option<String>,
     // field-level default (0) so configs saved before this field existed read as outdated,
     // rather than taking the current generation from the container-level default
     #[serde(default)]
@@ -499,6 +502,7 @@ impl Default for AppConfig {
             inputs: Default::default(),
             point_at_marker_visibility: Default::default(),
             camera_smoothing: Default::default(),
+            scene_packs_url: None,
             settings_generation: SETTINGS_GENERATION,
         }
     }

--- a/crates/ipfs/Cargo.toml
+++ b/crates/ipfs/Cargo.toml
@@ -38,3 +38,6 @@ futures-io = "0.3"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-fs = { workspace = true }
 futures-lite = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true }

--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -566,6 +566,15 @@ impl IpfsPath {
         Ok(self.ipfs_type.context_free_hash()?.map(ToOwned::to_owned))
     }
 
+    // the scene hash whose content pack (if any) can serve this request
+    pub fn scene_context_hash(&self) -> Option<&str> {
+        match &self.ipfs_type {
+            IpfsType::ContentFile { content_hash, .. } => Some(content_hash),
+            IpfsType::SceneContent { scene_hash, .. } => Some(scene_hash),
+            _ => None,
+        }
+    }
+
     pub fn should_cache(&self, hash: &str) -> bool {
         !hash.starts_with("b64-")
         //        true // TODO only if hash is some and is not b64-

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "ipfs_debug")]
 mod ipfs_debug;
 pub mod ipfs_path;
+mod scene_pack;
+
+pub use scene_pack::ScenePack;
 
 use std::{
     borrow::Cow,
@@ -458,6 +461,9 @@ pub struct IpfsIoPlugin {
     pub starting_realm: Option<String>,
     pub content_server_override: Option<String>,
     pub num_slots: usize,
+    // base url for opt-in single-fetch scene content packs; None (the default
+    // config value) disables the feature entirely
+    pub scene_packs_url: Option<String>,
 }
 
 impl Plugin for IpfsIoPlugin {
@@ -498,6 +504,7 @@ impl Plugin for IpfsIoPlugin {
             cache_root,
             HashMap::default(),
             self.num_slots,
+            self.scene_packs_url.clone(),
             #[cfg(feature = "ipfs_debug")]
             debug_overlay_sender,
         );
@@ -730,6 +737,7 @@ pub struct IpfsIo {
     #[cfg(not(target_arch = "wasm32"))]
     allowed_file_roots: std::sync::RwLock<Vec<PathBuf>>,
     client: reqwest::Client,
+    scene_packs: scene_pack::ScenePackRegistry,
     #[cfg(feature = "ipfs_debug")]
     debug_overlay_sender: tokio::sync::mpsc::UnboundedSender<IpfsDebug>,
 }
@@ -741,6 +749,7 @@ impl IpfsIo {
         default_fs_path: Option<PathBuf>,
         static_paths: HashMap<&'static str, &'static str>,
         num_slots: usize,
+        scene_packs_url: Option<String>,
         #[cfg(feature = "ipfs_debug")] debug_overlay_sender: tokio::sync::mpsc::UnboundedSender<
             IpfsDebug,
         >,
@@ -760,6 +769,7 @@ impl IpfsIo {
             request_slots: tokio::sync::Semaphore::new(num_slots),
             reqno: default(),
             static_files: static_paths,
+            scene_packs: scene_pack::ScenePackRegistry::new(scene_packs_url),
             #[cfg(not(target_arch = "wasm32"))]
             allowed_file_roots: Default::default(),
             client: reqwest::Client::builder()
@@ -1554,6 +1564,16 @@ impl AssetReader for IpfsIo {
             }
 
             let hash = ipfs_path.hash(&*self.context.read().await);
+
+            // serve scene content from a resident scene pack when one is loaded;
+            // any miss or pack failure falls through to the regular fetch path
+            if let (Some(scene_hash), Some(cid)) = (ipfs_path.scene_context_hash(), hash.as_deref())
+            {
+                if let Some(slice) = self.scene_pack_read(scene_hash, cid).await {
+                    ipfs_io_read_state.send_cached(slice.as_ref().len());
+                    return Ok(Box::new(AsyncCursor::new(slice)));
+                }
+            }
 
             if let Some(cache_path) = self.cache_path() {
                 if let Some(hash) = &hash {

--- a/crates/ipfs/src/scene_pack.rs
+++ b/crates/ipfs/src/scene_pack.rs
@@ -1,0 +1,867 @@
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+    Arc,
+};
+
+use anyhow::anyhow;
+use bevy::{platform::collections::HashMap, prelude::*, tasks::IoTaskPool};
+use common::util::TaskCompat;
+use multihash_codetable::MultihashDigest;
+use platform::AsyncRwLock;
+use serde::Deserialize;
+use web_time::Instant;
+
+use crate::IpfsIo;
+
+mod stream;
+use stream::StreamingBuf;
+
+#[cfg(test)]
+mod harden;
+#[cfg(test)]
+mod testkit;
+
+pub const PACK_MAGIC: &[u8; 8] = b"DCLBVPK\0";
+pub const PACK_VERSION: u32 = 1;
+pub const PACK_PROFILE: &str = "bv4";
+const MAX_INDEX_LEN: usize = 16 * 1024 * 1024;
+
+#[cfg(target_arch = "wasm32")]
+const PACK_RESIDENT_BUDGET: u64 = 128 * 1024 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+const PACK_RESIDENT_BUDGET: u64 = 512 * 1024 * 1024;
+
+#[derive(Deserialize)]
+struct PackIndex {
+    v: u32,
+    profile: String,
+    entity: String,
+    payload: u64,
+    files: Vec<PackIndexEntry>,
+}
+
+#[derive(Deserialize)]
+struct PackIndexEntry {
+    path: String,
+    cid: String,
+    off: u64,
+    len: u64,
+    kind: String,
+    c: u8,
+    sha256: String,
+}
+
+struct PackEntry {
+    path: String,
+    off: u64,
+    len: u64,
+    sha256: [u8; 32],
+    verified: AtomicU64,
+}
+
+enum PackData {
+    Streaming(StreamingBuf),
+    Resident(Arc<Vec<u8>>),
+    #[cfg(not(target_arch = "wasm32"))]
+    File(std::path::PathBuf),
+    Evicted,
+}
+
+pub struct ScenePack {
+    url: String,
+    entity: String,
+    size: u64,
+    payload_base: u64,
+    prefix_end: u64,
+    entries: Vec<PackEntry>,
+    by_cid: HashMap<String, usize>,
+    by_path: HashMap<String, usize>,
+    data: AsyncRwLock<PackData>,
+    refetch: tokio::sync::Mutex<()>,
+    last_use: AtomicU64,
+    available: AtomicU64,
+    waiting: AtomicUsize,
+    last_read: AtomicU64,
+    /// materialization counter: bumped before each refetch installs data, so a
+    /// verify racing an eviction can never stamp `verified` for bytes it did
+    /// not hash (entry.verified stores the generation it was verified against)
+    generation: AtomicU64,
+    created: Instant,
+}
+
+pub(crate) enum PackState {
+    Fetching(tokio::sync::watch::Receiver<()>),
+    Ready(Arc<ScenePack>),
+    Failed,
+}
+
+pub(crate) struct ScenePackRegistry {
+    base_url: Option<String>,
+    packs: AsyncRwLock<HashMap<String, PackState>>,
+    use_counter: AtomicU64,
+}
+
+impl ScenePackRegistry {
+    pub fn new(base_url: Option<String>) -> Self {
+        Self {
+            base_url: base_url
+                .map(|b| b.trim_end_matches('/').to_owned())
+                .filter(|b| !b.is_empty()),
+            packs: AsyncRwLock::new(HashMap::default()),
+            use_counter: AtomicU64::new(0),
+        }
+    }
+
+    fn bump_use(&self) -> u64 {
+        self.use_counter.fetch_add(1, Ordering::Relaxed) + 1
+    }
+}
+
+fn decode_sha256(hex: &str) -> Result<[u8; 32], anyhow::Error> {
+    anyhow::ensure!(hex.len() == 64 && hex.is_ascii(), "bad sha256 encoding");
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16)?;
+    }
+    Ok(out)
+}
+
+impl ScenePack {
+    pub(crate) fn index_end(bytes: &[u8]) -> Result<Option<usize>, anyhow::Error> {
+        if bytes.len() < 16 {
+            return Ok(None);
+        }
+        anyhow::ensure!(&bytes[0..8] == PACK_MAGIC, "bad magic");
+        let version = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        anyhow::ensure!(version == PACK_VERSION, "unsupported version {version}");
+        let index_len = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+        anyhow::ensure!(index_len <= MAX_INDEX_LEN, "index too large");
+        Ok(Some(16 + index_len))
+    }
+
+    pub(crate) fn parse_index(
+        url: String,
+        entity: &str,
+        bytes: &[u8],
+    ) -> Result<Self, anyhow::Error> {
+        let index_end = Self::index_end(bytes)?
+            .filter(|end| *end <= bytes.len())
+            .ok_or_else(|| anyhow!("index out of bounds"))?;
+        let index: PackIndex = serde_json::from_slice(&bytes[16..index_end])?;
+        anyhow::ensure!(index.v == PACK_VERSION, "index version mismatch");
+        anyhow::ensure!(
+            index.profile == PACK_PROFILE,
+            "unexpected profile {}",
+            index.profile
+        );
+        anyhow::ensure!(index.entity == entity, "entity mismatch");
+        let payload_base = index_end.div_ceil(16) * 16;
+
+        let mut entries = Vec::with_capacity(index.files.len());
+        let mut by_cid = HashMap::default();
+        let mut by_path = HashMap::default();
+        let mut next_off = 0u64;
+        let mut prefix_end = 0u64;
+        for file in &index.files {
+            let end = file
+                .off
+                .checked_add(file.len)
+                .ok_or_else(|| anyhow!("entry range overflow: {}", file.path))?;
+            anyhow::ensure!(end <= index.payload, "entry out of bounds: {}", file.path);
+            anyhow::ensure!(file.off % 16 == 0, "entry misaligned: {}", file.path);
+            anyhow::ensure!(
+                matches!(file.kind.as_str(), "glb" | "img" | "raw"),
+                "unknown entry kind: {}",
+                file.kind
+            );
+            anyhow::ensure!(file.c <= 3, "bad entry class: {}", file.path);
+            if file.c <= 1 {
+                prefix_end = prefix_end.max(end);
+            }
+            let idx = entries.len();
+            match by_cid.get(&file.cid) {
+                Some(prev) => {
+                    let prev: &PackEntry = &entries[*prev];
+                    anyhow::ensure!(
+                        prev.off == file.off && prev.len == file.len,
+                        "cid dedup mismatch: {}",
+                        file.cid
+                    );
+                }
+                None => {
+                    anyhow::ensure!(
+                        file.off >= next_off,
+                        "blobs unsorted or overlapping: {}",
+                        file.path
+                    );
+                    next_off = end;
+                    by_cid.insert(file.cid.clone(), idx);
+                }
+            }
+            anyhow::ensure!(
+                by_path.insert(file.path.clone(), idx).is_none(),
+                "duplicate path: {}",
+                file.path
+            );
+            entries.push(PackEntry {
+                path: file.path.clone(),
+                off: file.off,
+                len: file.len,
+                sha256: decode_sha256(&file.sha256)?,
+                verified: AtomicU64::new(0),
+            });
+        }
+
+        Ok(Self {
+            url,
+            entity: entity.to_owned(),
+            size: payload_base as u64 + index.payload,
+            payload_base: payload_base as u64,
+            prefix_end,
+            entries,
+            by_cid,
+            by_path,
+            data: AsyncRwLock::new(PackData::Evicted),
+            refetch: tokio::sync::Mutex::new(()),
+            last_use: AtomicU64::new(0),
+            available: AtomicU64::new(0),
+            waiting: AtomicUsize::new(0),
+            last_read: AtomicU64::new(0),
+            generation: AtomicU64::new(1),
+            created: Instant::now(),
+        })
+    }
+
+    pub fn parse(url: String, entity: &str, bytes: &[u8]) -> Result<Self, anyhow::Error> {
+        anyhow::ensure!(bytes.len() >= 16, "pack too short");
+        let pack = Self::parse_index(url, entity, bytes)?;
+        anyhow::ensure!(bytes.len() as u64 == pack.size, "payload length mismatch");
+        pack.available.store(pack.payload(), Ordering::Relaxed);
+        Ok(pack)
+    }
+
+    pub fn entry_by_cid(&self, cid: &str) -> Option<usize> {
+        self.by_cid.get(cid).copied()
+    }
+
+    pub fn entry_by_path(&self, path: &str) -> Option<usize> {
+        self.by_path.get(path).copied()
+    }
+
+    fn entry_range(&self, idx: usize) -> (usize, usize) {
+        let entry = &self.entries[idx];
+        let start = (self.payload_base + entry.off) as usize;
+        (start, start + entry.len as usize)
+    }
+
+    fn payload(&self) -> u64 {
+        self.size - self.payload_base
+    }
+
+    fn note_read(&self) {
+        self.last_read
+            .store(self.created.elapsed().as_millis() as u64, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone)]
+pub struct ArcSlice {
+    data: Arc<Vec<u8>>,
+    start: usize,
+    end: usize,
+}
+
+impl AsRef<[u8]> for ArcSlice {
+    fn as_ref(&self) -> &[u8] {
+        &self.data[self.start..self.end]
+    }
+}
+
+pub enum PackSlice {
+    Mem(ArcSlice),
+    Owned(Vec<u8>),
+}
+
+impl AsRef<[u8]> for PackSlice {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            PackSlice::Mem(slice) => slice.as_ref(),
+            PackSlice::Owned(bytes) => bytes,
+        }
+    }
+}
+
+impl IpfsIo {
+    pub fn prefetch_scene_pack(self: &Arc<Self>, scene_hash: &str) {
+        let Some(base) = self.scene_packs.base_url.clone() else {
+            return;
+        };
+        if self
+            .context
+            .blocking_read()
+            .modifiers
+            .get(scene_hash)
+            .is_some_and(|modifier| modifier.base_url.is_some())
+        {
+            return;
+        }
+        let (sender, receiver) = tokio::sync::watch::channel(());
+        {
+            let mut packs = self.scene_packs.packs.blocking_write();
+            if packs.contains_key(scene_hash) {
+                return;
+            }
+            packs.insert(scene_hash.to_owned(), PackState::Fetching(receiver));
+        }
+        let io = self.clone();
+        let scene_hash = scene_hash.to_owned();
+        IoTaskPool::get()
+            .spawn_compat(async move {
+                io.run_pack_stream(&base, &scene_hash, sender).await;
+                io.enforce_pack_budget().await;
+            })
+            .detach();
+    }
+
+    pub fn release_scene_pack(&self, scene_hash: &str) {
+        self.scene_packs.packs.blocking_write().remove(scene_hash);
+    }
+
+    pub(crate) async fn scene_pack_read(&self, scene_hash: &str, cid: &str) -> Option<PackSlice> {
+        self.scene_packs.base_url.as_ref()?;
+        let mut waited = false;
+        loop {
+            let waiter = {
+                let packs = self.scene_packs.packs.read().await;
+                match packs.get(scene_hash)? {
+                    PackState::Failed => return None,
+                    PackState::Ready(pack) => {
+                        let pack = pack.clone();
+                        drop(packs);
+                        return self.serve_pack_entry(scene_hash, &pack, cid).await;
+                    }
+                    PackState::Fetching(_) if waited => return None,
+                    PackState::Fetching(receiver) => receiver.clone(),
+                }
+            };
+            let mut waiter = waiter;
+            let _ = waiter.changed().await;
+            waited = true;
+        }
+    }
+
+    async fn serve_pack_entry(
+        &self,
+        scene_hash: &str,
+        pack: &Arc<ScenePack>,
+        cid: &str,
+    ) -> Option<PackSlice> {
+        pack.note_read();
+        let idx = pack.entry_by_cid(cid)?;
+        pack.last_use
+            .store(self.scene_packs.bump_use(), Ordering::Relaxed);
+        let gen_before = pack.generation.load(Ordering::SeqCst);
+        let slice = match self.pack_entry_bytes(pack, idx).await {
+            Ok(Some(slice)) => slice,
+            Ok(None) => return None,
+            Err(e) => {
+                warn!("scene pack read failed for {scene_hash}: {e}");
+                self.fail_scene_pack(scene_hash, &pack.url).await;
+                return None;
+            }
+        };
+        // the slice's generation is pinned only when the counter did not move
+        // across the read; otherwise re-verify and leave the stamp alone
+        let generation = pack.generation.load(Ordering::SeqCst);
+        let entry = &pack.entries[idx];
+        if gen_before != generation || entry.verified.load(Ordering::SeqCst) != generation {
+            let digest = multihash_codetable::Code::Sha2_256.digest(slice.as_ref());
+            if digest.digest() != entry.sha256 {
+                warn!(
+                    "scene pack entry `{}` failed verification, disabling pack for {scene_hash}",
+                    entry.path
+                );
+                self.fail_scene_pack(scene_hash, &pack.url).await;
+                return None;
+            }
+            if gen_before == generation {
+                entry.verified.store(generation, Ordering::SeqCst);
+            }
+        }
+        Some(slice)
+    }
+
+    async fn fail_scene_pack(&self, scene_hash: &str, url: &str) {
+        if let Some(state) = self.scene_packs.packs.write().await.get_mut(scene_hash) {
+            *state = PackState::Failed;
+        }
+        purge_pack_sw_cache(url).await;
+    }
+
+    async fn enforce_pack_budget(&self) {
+        let packs: Vec<Arc<ScenePack>> = self
+            .scene_packs
+            .packs
+            .read()
+            .await
+            .values()
+            .filter_map(|state| match state {
+                PackState::Ready(pack) => Some(pack.clone()),
+                _ => None,
+            })
+            .collect();
+        evict_packs_to_budget(packs, PACK_RESIDENT_BUDGET).await;
+    }
+}
+
+async fn evict_packs_to_budget(packs: Vec<Arc<ScenePack>>, budget: u64) {
+    let mut resident = Vec::new();
+    for pack in packs {
+        let len = match &*pack.data.read().await {
+            PackData::Resident(bytes) => bytes.len() as u64,
+            _ => continue,
+        };
+        resident.push((pack.last_use.load(Ordering::Relaxed), len, pack));
+    }
+    let mut total: u64 = resident.iter().map(|(_, len, _)| *len).sum();
+    resident.sort_by_key(|(last_use, ..)| *last_use);
+    let mut candidates = resident.iter();
+    while total > budget && candidates.len() > 1 {
+        let (_, len, pack) = candidates.next().unwrap();
+        *pack.data.write().await = PackData::Evicted;
+        total -= len;
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn purge_pack_sw_cache(pack_url: &str) {
+    use wasm_bindgen::JsCast;
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Ok(caches) = window.caches() else {
+        return;
+    };
+    let Ok(cache) = wasm_bindgen_futures::JsFuture::from(caches.open("ipfs-path-cache-v1")).await
+    else {
+        return;
+    };
+    let cache: web_sys::Cache = cache.unchecked_into();
+    let key = url::Url::parse(pack_url)
+        .map(|u| u.path().to_owned())
+        .unwrap_or_else(|_| pack_url.to_owned());
+    let _ = wasm_bindgen_futures::JsFuture::from(cache.delete_with_str(&key)).await;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn purge_pack_sw_cache(_pack_url: &str) {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    pub(crate) fn sha_hex(bytes: &[u8]) -> String {
+        multihash_codetable::Code::Sha2_256
+            .digest(bytes)
+            .digest()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
+    pub(crate) fn align16(len: usize) -> usize {
+        len.div_ceil(16) * 16
+    }
+
+    pub(crate) fn class_for(path: &str) -> u8 {
+        match path.rsplit('.').next().unwrap_or("") {
+            "js" | "json" | "crdt" | "wasm" => 0,
+            "glb" | "gltf" | "bin" => 1,
+            "mp3" | "wav" | "flac" | "aac" | "oga" | "opus" => 3,
+            _ => 2,
+        }
+    }
+
+    pub(crate) fn build_pack(entity: &str, files: &[(&str, &str, &[u8])]) -> Vec<u8> {
+        let mut blob_class: std::collections::HashMap<&str, u8> = Default::default();
+        let mut blob_min_path: std::collections::HashMap<&str, &str> = Default::default();
+        for (path, cid, _) in files {
+            let class = class_for(path);
+            blob_class
+                .entry(cid)
+                .and_modify(|c| *c = (*c).min(class))
+                .or_insert(class);
+            blob_min_path
+                .entry(cid)
+                .and_modify(|p| *p = (*p).min(path))
+                .or_insert(path);
+        }
+        let mut sorted = files.to_vec();
+        sorted.sort_by_key(|(path, cid, bytes)| {
+            (
+                blob_class[cid],
+                bytes.len(),
+                blob_min_path[cid].to_owned(),
+                path.to_owned(),
+            )
+        });
+
+        let mut blob_offsets: std::collections::HashMap<&str, (u64, u64)> = Default::default();
+        let mut blobs = Vec::new();
+        let mut off = 0u64;
+        for (_, cid, bytes) in &sorted {
+            if !blob_offsets.contains_key(cid) {
+                blob_offsets.insert(cid, (off, bytes.len() as u64));
+                blobs.push(*bytes);
+                off += align16(bytes.len()) as u64;
+            }
+        }
+        let payload = blobs
+            .last()
+            .map(|last| off - align16(last.len()) as u64 + last.len() as u64)
+            .unwrap_or(0);
+
+        let file_entries = sorted
+            .iter()
+            .map(|(path, cid, bytes)| {
+                let (off, len) = blob_offsets[cid];
+                format!(
+                    r#"{{"path":"{path}","cid":"{cid}","off":{off},"len":{len},"kind":"raw","c":{},"sha256":"{}"}}"#,
+                    blob_class[cid],
+                    sha_hex(bytes)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let index = format!(
+            r#"{{"v":1,"profile":"bv4","entity":"{entity}","payload":{payload},"files":[{file_entries}]}}"#
+        );
+
+        let mut out = Vec::new();
+        out.extend_from_slice(PACK_MAGIC);
+        out.extend_from_slice(&PACK_VERSION.to_le_bytes());
+        out.extend_from_slice(&(index.len() as u32).to_le_bytes());
+        out.extend_from_slice(index.as_bytes());
+        out.resize(align16(out.len()), 0);
+        for bytes in &blobs {
+            let aligned = align16(out.len());
+            out.resize(aligned, 0);
+            out.extend_from_slice(bytes);
+        }
+        out
+    }
+
+    fn fixture() -> (String, Vec<u8>) {
+        let files: &[(&str, &str, &[u8])] = &[
+            ("models/thing.glb", "bafyglb", b"glb bytes here padded"),
+            ("scene.json", "bafyjson", b"{}"),
+            ("textures/a.png", "bafypng", b"png bytes"),
+            ("textures/a_copy.png", "bafypng", b"png bytes"),
+        ];
+        ("entity1".to_owned(), build_pack("entity1", files))
+    }
+
+    #[test]
+    fn parses_valid_pack() {
+        let (entity, bytes) = fixture();
+        let pack = ScenePack::parse("http://x/p.pack".into(), &entity, &bytes).unwrap();
+        assert_eq!(pack.entries.len(), 4);
+        assert_eq!(pack.by_cid.len(), 3);
+        assert_eq!(pack.size, bytes.len() as u64);
+        let glb = pack.entry_by_cid("bafyglb").unwrap();
+        assert_eq!(pack.entry_by_path("models/thing.glb"), Some(glb));
+        let (start, end) = pack.entry_range(glb);
+        assert_eq!(&bytes[start..end], b"glb bytes here padded");
+        assert_eq!(
+            pack.prefix_end,
+            pack.entries[glb].off + pack.entries[glb].len
+        );
+        let a = pack.entry_by_path("textures/a.png").unwrap();
+        let b = pack.entry_by_path("textures/a_copy.png").unwrap();
+        assert_eq!(pack.entry_range(a), pack.entry_range(b));
+        assert!(pack.entries[a].off > pack.entries[glb].off, "demand order");
+    }
+
+    #[test]
+    fn rejects_corrupt_packs() {
+        let (entity, bytes) = fixture();
+        let parse = |bytes: &[u8]| ScenePack::parse("u".into(), &entity, bytes);
+
+        assert!(parse(&bytes[0..12]).is_err());
+
+        let mut bad_magic = bytes.clone();
+        bad_magic[0] = b'X';
+        assert!(parse(&bad_magic).is_err());
+
+        let mut bad_version = bytes.clone();
+        bad_version[8] = 9;
+        assert!(parse(&bad_version).is_err());
+
+        let mut oversize_index = bytes.clone();
+        oversize_index[12..16].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(parse(&oversize_index).is_err());
+
+        let truncated_payload = &bytes[0..bytes.len() - 1];
+        assert!(parse(truncated_payload).is_err());
+
+        assert!(ScenePack::parse("u".into(), "other-entity", &bytes).is_err());
+
+        let patch_index = |from: &str, to: &str| {
+            assert_eq!(from.len(), to.len());
+            let index_len = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+            let index = std::str::from_utf8(&bytes[16..16 + index_len]).unwrap();
+            let pos = index
+                .find(from)
+                .unwrap_or_else(|| panic!("fixture drifted: `{from}` not found"));
+            let mut patched = bytes.clone();
+            patched[16 + pos..16 + pos + to.len()].copy_from_slice(to.as_bytes());
+            patched
+        };
+        assert!(parse(&patch_index(r#""off":16"#, r#""off":17"#)).is_err());
+        assert!(parse(&patch_index(r#""off":48"#, r#""off":16"#)).is_err());
+        assert!(parse(&patch_index(r#""off":48"#, r#""off":96"#)).is_err());
+        assert!(parse(&patch_index(r#""c":2"#, r#""c":9"#)).is_err());
+        assert!(parse(&patch_index(r#""c":0,"#, r#"      "#)).is_err());
+        assert!(parse(&patch_index(r#""profile":"bv4""#, r#""profile":"bv3""#)).is_err());
+
+        let glb_sha = sha_hex(b"glb bytes here padded");
+        let bad_sha = format!("zz{}", &glb_sha[2..]);
+        assert!(parse(&patch_index(&glb_sha, &bad_sha)).is_err());
+    }
+
+    #[test]
+    fn slice_reader_matches_vec_reader() {
+        use crate::AsyncCursor;
+        use bevy::asset::io::{AsyncSeekForwardExt, Reader, VecReader};
+
+        let (entity, bytes) = fixture();
+        let pack = ScenePack::parse("u".into(), &entity, &bytes).unwrap();
+        let idx = pack.entry_by_path("models/thing.glb").unwrap();
+        let (start, end) = pack.entry_range(idx);
+
+        async_std::task::block_on(async {
+            let slice = PackSlice::Mem(ArcSlice {
+                data: Arc::new(bytes.clone()),
+                start,
+                end,
+            });
+            let mut cursor = AsyncCursor::new(slice);
+            let mut via_pack = Vec::new();
+            Reader::read_to_end(&mut cursor, &mut via_pack)
+                .await
+                .unwrap();
+
+            let mut vec_reader = VecReader::new(bytes[start..end].to_vec());
+            let mut via_vec = Vec::new();
+            Reader::read_to_end(&mut vec_reader, &mut via_vec)
+                .await
+                .unwrap();
+            assert_eq!(via_pack, via_vec);
+
+            let slice = PackSlice::Mem(ArcSlice {
+                data: Arc::new(bytes.clone()),
+                start,
+                end,
+            });
+            let mut cursor = AsyncCursor::new(slice);
+            cursor.seek_forward(4).await.unwrap();
+            let mut tail = Vec::new();
+            Reader::read_to_end(&mut cursor, &mut tail).await.unwrap();
+            assert_eq!(tail, via_vec[4..].to_vec());
+        });
+    }
+
+    #[test]
+    fn evicts_least_recently_used_within_budget() {
+        let (entity, bytes) = fixture();
+        async_std::task::block_on(async {
+            let mut packs = Vec::new();
+            for last_use in 1..=3u64 {
+                let pack = Arc::new(ScenePack::parse("u".into(), &entity, &bytes).unwrap());
+                *pack.data.write().await = PackData::Resident(Arc::new(bytes.clone()));
+                pack.last_use.store(last_use, Ordering::Relaxed);
+                packs.push(pack);
+            }
+            evict_packs_to_budget(packs.clone(), packs[0].size).await;
+
+            assert!(matches!(&*packs[0].data.read().await, PackData::Evicted));
+            assert!(matches!(&*packs[1].data.read().await, PackData::Evicted));
+            assert!(matches!(
+                &*packs[2].data.read().await,
+                PackData::Resident(_)
+            ));
+
+            evict_packs_to_budget(vec![packs[2].clone()], 1).await;
+            assert!(matches!(
+                &*packs[2].data.read().await,
+                PackData::Resident(_)
+            ));
+
+            *packs[0].data.write().await = PackData::Resident(Arc::new(bytes.clone()));
+            assert!(matches!(
+                &*packs[0].data.read().await,
+                PackData::Resident(_)
+            ));
+        });
+    }
+
+    pub(crate) fn test_io() -> IpfsIo {
+        IpfsIo::new(
+            false,
+            Box::new(bevy::asset::io::memory::MemoryAssetReader {
+                root: Default::default(),
+            }),
+            None,
+            HashMap::default(),
+            4,
+            Some("http://localhost:1".to_owned()),
+            #[cfg(feature = "ipfs_debug")]
+            tokio::sync::mpsc::unbounded_channel().0,
+        )
+    }
+
+    pub(crate) async fn run_fetch(io: &IpfsIo, base: &str, entity: &str) {
+        let (sender, receiver) = tokio::sync::watch::channel(());
+        io.scene_packs
+            .packs
+            .write()
+            .await
+            .insert(entity.to_owned(), PackState::Fetching(receiver));
+        io.run_pack_stream(base, entity, sender).await;
+    }
+
+    fn serve_bytes(routes: Vec<(String, Option<Vec<u8>>)>) -> String {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let path = request.split_whitespace().nth(1).unwrap_or("");
+                let response = match routes
+                    .iter()
+                    .find(|(route, _)| route == path)
+                    .and_then(|(_, body)| body.as_ref())
+                {
+                    Some(body) => {
+                        let mut response = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        )
+                        .into_bytes();
+                        response.extend_from_slice(body);
+                        response
+                    }
+                    None => {
+                        b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                            .to_vec()
+                    }
+                };
+                let _ = stream.write_all(&response);
+            }
+        });
+        base
+    }
+
+    #[test]
+    fn fetch_rejects_absent_and_corrupt_packs() {
+        let (entity, bytes) = fixture();
+        let mut truncated = build_pack("bad-entity", &[("a.bin", "bafya", b"raw bytes")]);
+        truncated.pop();
+        let base = serve_bytes(vec![
+            (
+                format!("/bvwebgpu/{PACK_PROFILE}/{entity}.pack"),
+                Some(bytes.clone()),
+            ),
+            (
+                format!("/bvwebgpu/{PACK_PROFILE}/bad-entity.pack"),
+                Some(truncated),
+            ),
+            (
+                format!("/bvwebgpu/{PACK_PROFILE}/wrong-entity.pack"),
+                Some(bytes),
+            ),
+        ]);
+        let io = test_io();
+
+        async_std::task::block_on(platform::compat(async {
+            run_fetch(&io, &base, "absent-entity").await;
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get("absent-entity"),
+                Some(PackState::Failed)
+            ));
+
+            run_fetch(&io, &base, "wrong-entity").await;
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get("wrong-entity"),
+                Some(PackState::Failed)
+            ));
+
+            run_fetch(&io, &base, "bad-entity").await;
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get("bad-entity"),
+                Some(PackState::Ready(_))
+            ));
+            assert!(io.scene_pack_read("bad-entity", "bafya").await.is_none());
+
+            run_fetch(&io, &base, &entity).await;
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Ready(_))
+            ));
+            let served = io.scene_pack_read(&entity, "bafyglb").await.unwrap();
+            assert_eq!(served.as_ref(), b"glb bytes here padded");
+        }));
+    }
+
+    #[test]
+    fn serves_verified_entries_and_fails_on_corruption() {
+        let (entity, bytes) = fixture();
+        let pack = Arc::new(ScenePack::parse("u".into(), &entity, &bytes).unwrap());
+        let io = test_io();
+
+        async_std::task::block_on(platform::compat(async {
+            *pack.data.write().await = PackData::Resident(Arc::new(bytes.clone()));
+            io.scene_packs
+                .packs
+                .write()
+                .await
+                .insert(entity.clone(), PackState::Ready(pack.clone()));
+
+            let served = io.scene_pack_read(&entity, "bafyglb").await.unwrap();
+            assert_eq!(served.as_ref(), b"glb bytes here padded");
+            assert!(io.scene_pack_read(&entity, "missing-cid").await.is_none());
+
+            let mut corrupt = bytes.clone();
+            let idx = pack.entry_by_cid("bafyjson").unwrap();
+            let (start, _) = pack.entry_range(idx);
+            corrupt[start] ^= 0xff;
+            *pack.data.write().await = PackData::Resident(Arc::new(corrupt));
+            assert!(io.scene_pack_read(&entity, "bafyjson").await.is_none());
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Failed)
+            ));
+
+            io.release_scene_pack(&entity);
+            assert!(io.scene_pack_read(&entity, "bafyglb").await.is_none());
+
+            let unreachable = Arc::new(
+                ScenePack::parse("http://localhost:1/p.pack".into(), &entity, &bytes).unwrap(),
+            );
+            io.scene_packs
+                .packs
+                .write()
+                .await
+                .insert(entity.clone(), PackState::Ready(unreachable));
+            assert!(io.scene_pack_read(&entity, "bafyglb").await.is_none());
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Failed)
+            ));
+        }));
+    }
+}

--- a/crates/ipfs/src/scene_pack/harden.rs
+++ b/crates/ipfs/src/scene_pack/harden.rs
@@ -1,0 +1,497 @@
+use std::sync::{atomic::Ordering, Arc};
+use std::time::Duration;
+
+use super::{
+    test::{build_pack, run_fetch, test_io},
+    testkit::{
+        full, idle_env, is_streaming, pack_route, ready_pack, serve_scripted, spawn_fetch,
+        stream_fixture, wire_start, Gate, Script,
+    },
+    PackData, PackState, ScenePack,
+};
+
+#[test]
+fn dribbles_prime_chunks_across_header_boundaries() {
+    let _env = idle_env("5");
+    let (entity, bytes) = stream_fixture();
+    let (base, _) = serve_scripted(pack_route(&entity), bytes.clone(), vec![full(7)]);
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        run_fetch(&io, &base, &entity).await;
+        let pack = ready_pack(&io, &entity).await;
+        assert!(matches!(&*pack.data.read().await, PackData::Resident(_)));
+        assert_eq!(pack.available.load(Ordering::Relaxed), pack.payload());
+        for (cid, len) in [("bafyjson", 2), ("bafyglb", 100), ("bafymp3", 4096)] {
+            let served = io.scene_pack_read(&entity, cid).await.unwrap();
+            assert_eq!(served.as_ref().len(), len);
+        }
+    }));
+}
+
+#[test]
+fn dribbles_1k_chunks_serving_prefix_before_large_tail() {
+    let _env = idle_env("5");
+    let mp3: Vec<u8> = (0..65536usize).map(|i| (i * 7 % 256) as u8).collect();
+    let files: &[(&str, &str, &[u8])] = &[
+        ("scene.json", "bafyjson", b"{}"),
+        ("models/big.glb", "bafyglb", b"glb bytes for the dribble"),
+        ("sounds/huge.mp3", "bafymp3", &mp3),
+    ];
+    let entity = "dribble-entity".to_owned();
+    let bytes = build_pack(&entity, files);
+    let hold = wire_start(&bytes, &entity, "bafymp3");
+    let gate = Gate::new();
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![Script {
+            hold_at: Some((hold, gate.clone())),
+            ..full(1024)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        let served = io.scene_pack_read(&entity, "bafyjson").await.unwrap();
+        assert_eq!(served.as_ref(), b"{}");
+        let pack = ready_pack(&io, &entity).await;
+        assert!(is_streaming(&pack).await, "tail held: must still stream");
+        gate.open();
+        driver.await;
+        assert_eq!(pack.available.load(Ordering::Relaxed), pack.payload());
+        let tail = io.scene_pack_read(&entity, "bafymp3").await.unwrap();
+        assert_eq!(tail.as_ref(), &mp3[..]);
+    }));
+}
+
+#[test]
+fn no_abort_during_index_fetch() {
+    let _env = idle_env("0.2");
+    let (entity, bytes) = stream_fixture();
+    let gate = Gate::new();
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![Script {
+            hold_at: Some((20, gate.clone())),
+            ..full(512)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        async_std::task::sleep(Duration::from_millis(1000)).await;
+        assert!(
+            matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Fetching(_))
+            ),
+            "idle abort must not fire before the index is parsed"
+        );
+        gate.open();
+        assert!(
+            platform::with_timeout(Duration::from_secs(15), driver)
+                .await
+                .is_ok(),
+            "driver never finished"
+        );
+        let pack = ready_pack(&io, &entity).await;
+        assert!(pack.available.load(Ordering::Relaxed) >= pack.prefix_end);
+        let served = io.scene_pack_read(&entity, "bafyjson").await.unwrap();
+        assert_eq!(served.as_ref(), b"{}");
+    }));
+}
+
+#[test]
+fn abort_mid_entry_keeps_prefix_and_misses_partial_tail() {
+    let _env = idle_env("0.2");
+    let (entity, bytes) = stream_fixture();
+    let hold = wire_start(&bytes, &entity, "bafymp3") + 100;
+    let gate = Gate::new();
+    let (base, broken) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![Script {
+            hold_at: Some((hold, gate.clone())),
+            ..full(512)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        let pack = ready_pack(&io, &entity).await;
+        assert!(
+            platform::with_timeout(Duration::from_secs(15), driver)
+                .await
+                .is_ok(),
+            "driver did not abort"
+        );
+        let mp3 = {
+            let idx = pack.entry_by_cid("bafymp3").unwrap();
+            (pack.entries[idx].off, pack.entries[idx].len)
+        };
+        let available = pack.available.load(Ordering::Relaxed);
+        assert!(
+            available > mp3.0 && available < mp3.0 + mp3.1,
+            "abort must have cut mid-entry: {available} vs {mp3:?}"
+        );
+        let start = web_time::Instant::now();
+        assert!(io.scene_pack_read(&entity, "bafymp3").await.is_none());
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "partial-entry miss must not wait"
+        );
+        assert_eq!(
+            io.scene_pack_read(&entity, "bafyjson")
+                .await
+                .unwrap()
+                .as_ref(),
+            b"{}"
+        );
+        assert_eq!(
+            io.scene_pack_read(&entity, "bafyglb")
+                .await
+                .unwrap()
+                .as_ref()
+                .len(),
+            100
+        );
+        gate.open();
+        for _ in 0..100 {
+            if broken.load(Ordering::SeqCst) {
+                break;
+            }
+            async_std::task::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(broken.load(Ordering::SeqCst), "server never saw the abort");
+    }));
+}
+
+#[test]
+fn streamed_garbage_header_fails_pack() {
+    let _env = idle_env("5");
+    let entity = "garbage-entity".to_owned();
+    let (base, _) = serve_scripted(pack_route(&entity), vec![0xAB; 64], vec![full(16)]);
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        run_fetch(&io, &base, &entity).await;
+        assert!(matches!(
+            io.scene_packs.packs.read().await.get(&entity),
+            Some(PackState::Failed)
+        ));
+        assert!(io.scene_pack_read(&entity, "bafyjson").await.is_none());
+    }));
+}
+
+#[test]
+fn streamed_corrupt_index_json_fails_pack() {
+    let _env = idle_env("5");
+    let (entity, mut bytes) = stream_fixture();
+    bytes[20] ^= 0xff;
+    let (base, _) = serve_scripted(pack_route(&entity), bytes, vec![full(64)]);
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        run_fetch(&io, &base, &entity).await;
+        assert!(matches!(
+            io.scene_packs.packs.read().await.get(&entity),
+            Some(PackState::Failed)
+        ));
+        assert!(io.scene_pack_read(&entity, "bafyjson").await.is_none());
+    }));
+}
+
+#[test]
+fn streamed_surplus_bytes_fail_pack() {
+    let _env = idle_env("5");
+    let (entity, bytes) = stream_fixture();
+    let mut surplus = bytes.clone();
+    surplus.extend_from_slice(&[0xEE; 64]);
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes,
+        vec![Script {
+            body: Some(surplus),
+            ..full(512)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        run_fetch(&io, &base, &entity).await;
+        assert!(matches!(
+            io.scene_packs.packs.read().await.get(&entity),
+            Some(PackState::Failed)
+        ));
+        assert!(io.scene_pack_read(&entity, "bafyjson").await.is_none());
+    }));
+}
+
+#[test]
+fn double_read_of_pending_entry_both_resolve() {
+    let _env = idle_env("5");
+    let (entity, bytes) = stream_fixture();
+    let hold = wire_start(&bytes, &entity, "bafymp3");
+    let gate = Gate::new();
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![Script {
+            hold_at: Some((hold, gate.clone())),
+            ..full(512)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        let readers: Vec<_> = (0..2)
+            .map(|_| {
+                let io = io.clone();
+                let entity = entity.clone();
+                async_std::task::spawn(platform::compat(async move {
+                    io.scene_pack_read(&entity, "bafymp3").await
+                }))
+            })
+            .collect();
+        async_std::task::sleep(Duration::from_millis(500)).await;
+        let pack = ready_pack(&io, &entity).await;
+        assert!(is_streaming(&pack).await);
+        assert_eq!(
+            pack.waiting.load(Ordering::SeqCst),
+            2,
+            "both reads must be registered as pending"
+        );
+        gate.open();
+        for reader in readers {
+            let tail = platform::with_timeout(Duration::from_secs(15), reader)
+                .await
+                .ok()
+                .expect("pending read deadlocked")
+                .unwrap();
+            assert_eq!(tail.as_ref().len(), 4096);
+        }
+        driver.await;
+        assert_eq!(pack.waiting.load(Ordering::SeqCst), 0);
+    }));
+}
+
+#[test]
+fn evicted_mid_stream_pending_readers_recover_via_rematerialize() {
+    let _env = idle_env("5");
+    let (entity, bytes) = stream_fixture();
+    let hold = wire_start(&bytes, &entity, "bafymp3");
+    let gate = Gate::new();
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![
+            Script {
+                hold_at: Some((hold, gate.clone())),
+                ..full(512)
+            },
+            full(512),
+        ],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        let pack = ready_pack(&io, &entity).await;
+        let spawn_reader = |io: &Arc<crate::IpfsIo>, entity: &str| {
+            let io = io.clone();
+            let entity = entity.to_owned();
+            async_std::task::spawn(platform::compat(async move {
+                io.scene_pack_read(&entity, "bafymp3").await
+            }))
+        };
+        let waiter = spawn_reader(&io, &entity);
+        async_std::task::sleep(Duration::from_millis(300)).await;
+        *pack.data.write().await = PackData::Evicted;
+        let late = spawn_reader(&io, &entity);
+        async_std::task::sleep(Duration::from_millis(200)).await;
+        gate.open();
+        for reader in [waiter, late] {
+            let tail = platform::with_timeout(Duration::from_secs(20), reader)
+                .await
+                .ok()
+                .expect("reader deadlocked across eviction")
+                .unwrap();
+            assert_eq!(tail.as_ref().len(), 4096);
+        }
+        platform::with_timeout(Duration::from_secs(15), driver)
+            .await
+            .ok()
+            .expect("stale driver never exited");
+        assert!(matches!(&*pack.data.read().await, PackData::Resident(_)));
+        assert_eq!(pack.available.load(Ordering::Relaxed), pack.payload());
+        assert_eq!(pack.waiting.load(Ordering::SeqCst), 0);
+    }));
+}
+
+#[test]
+fn stale_driver_error_leaves_new_fetch_alone() {
+    let _env = idle_env("5");
+    let (entity, bytes) = stream_fixture();
+    let gate = Gate::new();
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![Script {
+            hold_at: Some((20, gate.clone())),
+            truncate_at: Some(21),
+            ..full(512)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        async_std::task::sleep(Duration::from_millis(300)).await;
+        let (_tx2, rx2) = tokio::sync::watch::channel(());
+        io.scene_packs
+            .packs
+            .write()
+            .await
+            .insert(entity.clone(), PackState::Fetching(rx2.clone()));
+        gate.open();
+        platform::with_timeout(Duration::from_secs(15), driver)
+            .await
+            .ok()
+            .expect("stale driver never exited");
+        match io.scene_packs.packs.read().await.get(&entity) {
+            Some(PackState::Fetching(rx)) => {
+                assert!(rx.same_channel(&rx2), "slot swapped to a foreign channel")
+            }
+            other => panic!(
+                "stale driver clobbered the fresh fetch: {:?}",
+                other.map(|s| match s {
+                    PackState::Fetching(_) => "fetching",
+                    PackState::Ready(_) => "ready",
+                    PackState::Failed => "failed",
+                })
+            ),
+        }
+    }));
+}
+
+#[test]
+fn stale_driver_success_leaves_new_fetch_alone() {
+    let _env = idle_env("5");
+    let (entity, bytes) = stream_fixture();
+    let gate = Gate::new();
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![Script {
+            hold_at: Some((20, gate.clone())),
+            ..full(512)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        async_std::task::sleep(Duration::from_millis(300)).await;
+        let (_tx2, rx2) = tokio::sync::watch::channel(());
+        io.scene_packs
+            .packs
+            .write()
+            .await
+            .insert(entity.clone(), PackState::Fetching(rx2.clone()));
+        gate.open();
+        platform::with_timeout(Duration::from_secs(15), driver)
+            .await
+            .ok()
+            .expect("stale driver never exited");
+        assert!(
+            matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Fetching(rx)) if rx.same_channel(&rx2)
+            ),
+            "stale driver must not flip a slot it does not own"
+        );
+    }));
+}
+
+#[test]
+fn zero_length_entry_serves_during_and_after_stream() {
+    let _env = idle_env("5");
+    let glb: Vec<u8> = (0..64u8).collect();
+    let (entity, bytes, index_end) = (1..17)
+        .find_map(|i| {
+            let entity = format!("zlen-{}", "x".repeat(i));
+            let files: &[(&str, &str, &[u8])] = &[
+                ("empty.bin", "bafyempty", b""),
+                ("models/pad.glb", "bafyglb", &glb),
+            ];
+            let bytes = build_pack(&entity, files);
+            let end = ScenePack::index_end(&bytes).unwrap().unwrap();
+            (end % 16 != 0).then_some((entity, bytes, end))
+        })
+        .unwrap();
+    let gate = Gate::new();
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![Script {
+            hold_at: Some((index_end, gate.clone())),
+            ..full(512)
+        }],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        let driver = spawn_fetch(&io, &base, &entity).await;
+        let pack = ready_pack(&io, &entity).await;
+        assert!(
+            pack.payload_base > index_end as u64,
+            "fixture must leave a padding gap after the index"
+        );
+        assert!(is_streaming(&pack).await);
+        let empty = platform::with_timeout(
+            Duration::from_secs(2),
+            io.scene_pack_read(&entity, "bafyempty"),
+        )
+        .await
+        .ok()
+        .expect("zero-length read must not wait")
+        .unwrap();
+        assert_eq!(empty.as_ref().len(), 0);
+        gate.open();
+        driver.await;
+        let served = io.scene_pack_read(&entity, "bafyglb").await.unwrap();
+        assert_eq!(served.as_ref(), &glb[..]);
+        let empty = io.scene_pack_read(&entity, "bafyempty").await.unwrap();
+        assert_eq!(empty.as_ref().len(), 0);
+    }));
+}
+
+#[test]
+fn corrupt_rematerialization_is_reverified_and_failed() {
+    let _env = idle_env("5");
+    let (entity, bytes) = stream_fixture();
+    let mut corrupt = bytes.clone();
+    let mp3_wire = wire_start(&bytes, &entity, "bafymp3");
+    corrupt[mp3_wire] ^= 0xff;
+    let (base, _) = serve_scripted(
+        pack_route(&entity),
+        bytes.clone(),
+        vec![
+            full(512),
+            Script {
+                body: Some(corrupt),
+                ..full(512)
+            },
+        ],
+    );
+    let io = Arc::new(test_io());
+    async_std::task::block_on(platform::compat(async {
+        run_fetch(&io, &base, &entity).await;
+        let pack = ready_pack(&io, &entity).await;
+        let served = io.scene_pack_read(&entity, "bafymp3").await.unwrap();
+        assert_eq!(served.as_ref().len(), 4096);
+        *pack.data.write().await = PackData::Evicted;
+        assert!(
+            io.scene_pack_read(&entity, "bafymp3").await.is_none(),
+            "refetched corruption must not ride an earlier verification"
+        );
+        assert!(matches!(
+            io.scene_packs.packs.read().await.get(&entity),
+            Some(PackState::Failed)
+        ));
+    }));
+}

--- a/crates/ipfs/src/scene_pack/harden.rs
+++ b/crates/ipfs/src/scene_pack/harden.rs
@@ -12,7 +12,10 @@ use super::{
 
 #[test]
 fn dribbles_prime_chunks_across_header_boundaries() {
-    let _env = idle_env("5");
+    // completeness across prime chunk boundaries, not idle-abort: the 2ms-per-chunk
+    // server can outlast any finite idle window on a slow runner and abort the
+    // read-less stream mid-payload, so keep the abort timer off here
+    let _env = idle_env("0");
     let (entity, bytes) = stream_fixture();
     let (base, _) = serve_scripted(pack_route(&entity), bytes.clone(), vec![full(7)]);
     let io = Arc::new(test_io());

--- a/crates/ipfs/src/scene_pack/stream.rs
+++ b/crates/ipfs/src/scene_pack/stream.rs
@@ -1,0 +1,836 @@
+use std::sync::{atomic::Ordering, Arc};
+
+use anyhow::anyhow;
+use bevy::prelude::*;
+use web_time::Duration;
+
+use crate::IpfsIo;
+
+use super::{
+    purge_pack_sw_cache, ArcSlice, PackData, PackSlice, PackState, ScenePack, PACK_PROFILE,
+};
+
+const PACK_IDLE_ABORT_SECS: f32 = 5.0;
+const DRIVE_TICK: Duration = Duration::from_secs(1);
+const STALL_TICKS: u32 = 10;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum Phase {
+    Streaming,
+    Complete,
+    Aborted,
+    Failed,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct StreamProgress {
+    received: u64,
+    phase: Phase,
+}
+
+pub(super) struct StreamingBuf {
+    buf: Vec<u8>,
+    progress: tokio::sync::watch::Receiver<StreamProgress>,
+}
+
+struct WaitingGuard<'a>(&'a ScenePack);
+
+impl<'a> WaitingGuard<'a> {
+    fn new(pack: &'a ScenePack) -> Self {
+        pack.waiting.fetch_add(1, Ordering::SeqCst);
+        Self(pack)
+    }
+}
+
+impl Drop for WaitingGuard<'_> {
+    fn drop(&mut self) {
+        self.0.waiting.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn configured_idle_abort() -> Option<Duration> {
+    let secs = idle_abort_override().unwrap_or(PACK_IDLE_ABORT_SECS);
+    (secs > 0.0).then(|| Duration::from_secs_f32(secs))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn idle_abort_override() -> Option<f32> {
+    let search = web_sys::window()?.location().search().ok()?;
+    search
+        .trim_start_matches('?')
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("packs_idle="))
+        .and_then(|v| v.parse().ok())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn idle_abort_override() -> Option<f32> {
+    std::env::var("SCENE_PACK_IDLE_ABORT_SECS")
+        .ok()?
+        .parse()
+        .ok()
+}
+
+fn payload_received(pack: &ScenePack, wire_len: usize) -> u64 {
+    (wire_len as u64)
+        .saturating_sub(pack.payload_base)
+        .min(pack.payload())
+}
+
+fn should_abort(pack: &ScenePack, idle_abort: Option<Duration>) -> bool {
+    let Some(idle) = idle_abort else {
+        return false;
+    };
+    if pack.waiting.load(Ordering::SeqCst) != 0 {
+        return false;
+    }
+    if pack.available.load(Ordering::Relaxed) < pack.prefix_end {
+        return false;
+    }
+    let now_ms = pack.created.elapsed().as_millis() as u64;
+    now_ms.saturating_sub(pack.last_read.load(Ordering::Relaxed)) > idle.as_millis() as u64
+}
+
+fn fetch_error<E: std::fmt::Display>(e: platform::FetchError<E>) -> anyhow::Error {
+    match e {
+        platform::FetchError::Headers => anyhow!("timed out awaiting headers"),
+        platform::FetchError::Send(e) => anyhow!("{e}"),
+        platform::FetchError::Status(s) => anyhow!("status {s}"),
+        platform::FetchError::Stalled => anyhow!("stalled"),
+        platform::FetchError::Body(e) => anyhow!(e),
+    }
+}
+
+enum OpenError {
+    Fetch(anyhow::Error),
+    Parse(anyhow::Error),
+}
+
+enum Outcome {
+    Complete,
+    Aborted,
+    Failed(anyhow::Error),
+    Surplus,
+}
+
+impl IpfsIo {
+    pub(super) async fn run_pack_stream(
+        &self,
+        base: &str,
+        scene_hash: &str,
+        fetching: tokio::sync::watch::Sender<()>,
+    ) {
+        let url = format!("{base}/bvwebgpu/{PACK_PROFILE}/{scene_hash}.pack");
+        // a release + re-prefetch installs a fresh Fetching slot; a stale driver
+        // must never resolve a slot it does not own
+        let own_slot = fetching.subscribe();
+        let (stream, pack, buf) = match self.open_pack_stream(&url, scene_hash).await {
+            Ok(opened) => opened,
+            Err(e) => {
+                match e {
+                    OpenError::Fetch(e) => info!("scene pack unavailable for {scene_hash}: {e}"),
+                    OpenError::Parse(e) => warn!("invalid scene pack for {scene_hash}: {e}"),
+                }
+                purge_pack_sw_cache(&url).await;
+                let mut packs = self.scene_packs.packs.write().await;
+                if matches!(packs.get(scene_hash), Some(PackState::Fetching(rx)) if rx.same_channel(&own_slot))
+                {
+                    packs.insert(scene_hash.to_owned(), PackState::Failed);
+                }
+                return;
+            }
+        };
+        let total = buf.len();
+        let received = payload_received(&pack, total);
+        let (progress_tx, progress_rx) = tokio::sync::watch::channel(StreamProgress {
+            received,
+            phase: Phase::Streaming,
+        });
+        pack.available.store(received, Ordering::Relaxed);
+        *pack.data.write().await = PackData::Streaming(StreamingBuf {
+            buf,
+            progress: progress_rx,
+        });
+        pack.last_use
+            .store(self.scene_packs.bump_use(), Ordering::Relaxed);
+        {
+            let mut packs = self.scene_packs.packs.write().await;
+            if !matches!(packs.get(scene_hash), Some(PackState::Fetching(rx)) if rx.same_channel(&own_slot))
+            {
+                return;
+            }
+            packs.insert(scene_hash.to_owned(), PackState::Ready(pack.clone()));
+        }
+        drop(fetching);
+        info!(
+            "scene pack ready for {}: {} files, {} bytes",
+            pack.entity,
+            pack.entries.len(),
+            pack.size
+        );
+        self.drive_pack_stream(&pack, stream, progress_tx, total)
+            .await;
+    }
+
+    async fn open_pack_stream(
+        &self,
+        url: &str,
+        entity: &str,
+    ) -> Result<(platform::FetchStream, Arc<ScenePack>, Vec<u8>), OpenError> {
+        let request = self
+            .client
+            .get(url)
+            .header("X-IPFS", "true")
+            .build()
+            .map_err(|e| OpenError::Fetch(anyhow!(e)))?;
+        let mut stream = platform::fetch_stream(
+            self.client.execute(request),
+            Duration::from_secs(30),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|e| OpenError::Fetch(fetch_error(e)))?;
+
+        let mut buf = Vec::new();
+        let index_end = loop {
+            match ScenePack::index_end(&buf).map_err(OpenError::Parse)? {
+                Some(end) if buf.len() >= end => break end,
+                _ => {}
+            }
+            match stream.next_chunk().await {
+                Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+                Ok(None) => return Err(OpenError::Parse(anyhow!("truncated before index"))),
+                Err(e) => return Err(OpenError::Fetch(fetch_error(e))),
+            }
+        };
+        let pack = ScenePack::parse_index(url.to_owned(), entity, &buf[..index_end])
+            .map_err(OpenError::Parse)?;
+        if buf.len() as u64 > pack.size {
+            return Err(OpenError::Parse(anyhow!("payload length mismatch")));
+        }
+        Ok((stream, Arc::new(pack), buf))
+    }
+
+    async fn drive_pack_stream(
+        &self,
+        pack: &Arc<ScenePack>,
+        mut stream: platform::FetchStream,
+        progress: tokio::sync::watch::Sender<StreamProgress>,
+        mut total: usize,
+    ) {
+        let idle_abort = configured_idle_abort();
+        // a forced eviction + rematerialize can install a fresh buffer while
+        // this driver still runs; only the materialization it created may be
+        // appended to or finalized
+        let own = progress.subscribe();
+        let mut stall_ticks = 0u32;
+        let outcome = loop {
+            if total as u64 == pack.size {
+                break Outcome::Complete;
+            }
+            if should_abort(pack, idle_abort) {
+                break Outcome::Aborted;
+            }
+            match platform::with_timeout(DRIVE_TICK, stream.next_chunk()).await {
+                Err(platform::Elapsed) => {
+                    stall_ticks += 1;
+                    if stall_ticks >= STALL_TICKS {
+                        break Outcome::Failed(anyhow!("stalled"));
+                    }
+                }
+                Ok(Ok(Some(chunk))) => {
+                    stall_ticks = 0;
+                    let mut data = pack.data.write().await;
+                    let PackData::Streaming(live) = &mut *data else {
+                        return;
+                    };
+                    if !live.progress.same_channel(&own) {
+                        return;
+                    }
+                    live.buf.extend_from_slice(&chunk);
+                    total = live.buf.len();
+                    if total as u64 > pack.size {
+                        break Outcome::Surplus;
+                    }
+                    let received = payload_received(pack, total);
+                    pack.available.store(received, Ordering::Relaxed);
+                    drop(data);
+                    progress.send_modify(|p| p.received = received);
+                }
+                Ok(Ok(None)) => {
+                    break if total as u64 == pack.size {
+                        Outcome::Complete
+                    } else {
+                        Outcome::Failed(anyhow!("closed early"))
+                    };
+                }
+                Ok(Err(e)) => break Outcome::Failed(fetch_error(e)),
+            }
+        };
+        drop(stream);
+        match outcome {
+            Outcome::Complete => {
+                self.finalize_stream_data(pack, true, &own).await;
+                progress.send_modify(|p| p.phase = Phase::Complete);
+                info!(
+                    "scene pack stream complete for {}: {}/{} bytes",
+                    pack.entity, total, pack.size
+                );
+            }
+            Outcome::Aborted => {
+                self.finalize_stream_data(pack, false, &own).await;
+                progress.send_modify(|p| p.phase = Phase::Aborted);
+                info!(
+                    "scene pack stream aborted for {}: {}/{} bytes",
+                    pack.entity, total, pack.size
+                );
+            }
+            Outcome::Failed(e) => {
+                self.finalize_stream_data(pack, false, &own).await;
+                progress.send_modify(|p| p.phase = Phase::Failed);
+                warn!(
+                    "scene pack stream failed for {}: {e} ({}/{} bytes)",
+                    pack.entity, total, pack.size
+                );
+            }
+            Outcome::Surplus => {
+                self.finalize_stream_data(pack, false, &own).await;
+                progress.send_modify(|p| p.phase = Phase::Failed);
+                warn!(
+                    "scene pack stream overran for {}: {}/{} bytes",
+                    pack.entity, total, pack.size
+                );
+                self.fail_scene_pack(&pack.entity, &pack.url).await;
+            }
+        }
+    }
+
+    async fn finalize_stream_data(
+        &self,
+        pack: &Arc<ScenePack>,
+        complete: bool,
+        own: &tokio::sync::watch::Receiver<StreamProgress>,
+    ) {
+        let mut data = pack.data.write().await;
+        let PackData::Streaming(live) = &mut *data else {
+            return;
+        };
+        if !live.progress.same_channel(own) {
+            return;
+        }
+        let mut body = std::mem::take(&mut live.buf);
+        pack.available
+            .store(payload_received(pack, body.len()), Ordering::Relaxed);
+        *data = if complete {
+            self.completed_pack_data(pack, body)
+        } else {
+            // partial packs live on under the LRU budget, which accounts len();
+            // drop the growth slack so capacity matches what is accounted
+            body.shrink_to_fit();
+            PackData::Resident(Arc::new(body))
+        };
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn completed_pack_data(&self, pack: &ScenePack, body: Vec<u8>) -> PackData {
+        if let Some(cache_path) = self.cache_path() {
+            let tmp = cache_path.join(format!("{}.bvpack.part", pack.entity));
+            let path = cache_path.join(format!("{}.bvpack", pack.entity));
+            if std::fs::write(&tmp, &body)
+                .and_then(|_| std::fs::rename(&tmp, &path))
+                .is_ok()
+            {
+                return PackData::File(path);
+            }
+        }
+        PackData::Resident(Arc::new(body))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn completed_pack_data(&self, _pack: &ScenePack, body: Vec<u8>) -> PackData {
+        PackData::Resident(Arc::new(body))
+    }
+
+    pub(super) async fn rematerialize_pack(
+        &self,
+        pack: &Arc<ScenePack>,
+    ) -> Result<(), anyhow::Error> {
+        let guard = pack.refetch.lock().await;
+        if !matches!(&*pack.data.read().await, PackData::Evicted) {
+            return Ok(());
+        }
+        let request = self
+            .client
+            .get(&pack.url)
+            .header("X-IPFS", "true")
+            .build()?;
+        let mut stream = platform::fetch_stream(
+            self.client.execute(request),
+            Duration::from_secs(30),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(fetch_error)?;
+        let mut buf = Vec::new();
+        loop {
+            match ScenePack::index_end(&buf)? {
+                Some(end) if buf.len() >= end => {
+                    anyhow::ensure!(
+                        (end.div_ceil(16) * 16) as u64 == pack.payload_base,
+                        "refetched pack layout changed"
+                    );
+                    break;
+                }
+                _ => {}
+            }
+            match stream.next_chunk().await {
+                Ok(Some(chunk)) => {
+                    buf.extend_from_slice(&chunk);
+                    anyhow::ensure!(buf.len() as u64 <= pack.size, "refetched pack size changed");
+                }
+                Ok(None) => anyhow::bail!("truncated before index"),
+                Err(e) => return Err(fetch_error(e)),
+            }
+        }
+        pack.generation.fetch_add(1, Ordering::SeqCst);
+        let total = buf.len();
+        let received = payload_received(pack, total);
+        let (progress_tx, progress_rx) = tokio::sync::watch::channel(StreamProgress {
+            received,
+            phase: Phase::Streaming,
+        });
+        pack.available.store(received, Ordering::Relaxed);
+        *pack.data.write().await = PackData::Streaming(StreamingBuf {
+            buf,
+            progress: progress_rx,
+        });
+        pack.last_use
+            .store(self.scene_packs.bump_use(), Ordering::Relaxed);
+        drop(guard);
+        self.drive_pack_stream(pack, stream, progress_tx, total)
+            .await;
+        self.enforce_pack_budget().await;
+        Ok(())
+    }
+
+    pub(super) async fn pack_entry_bytes(
+        &self,
+        pack: &Arc<ScenePack>,
+        idx: usize,
+    ) -> Result<Option<PackSlice>, anyhow::Error> {
+        let (start, end) = pack.entry_range(idx);
+        // zero-length entries need no payload bytes; the buffer may end before
+        // payload_base, so indexing it at `start` would be out of bounds
+        if start == end {
+            return Ok(Some(PackSlice::Owned(Vec::new())));
+        }
+        let entry_end = {
+            let entry = &pack.entries[idx];
+            entry.off + entry.len
+        };
+        let mut wait_guard = None;
+        let mut sender_gone = false;
+        loop {
+            let waiter = {
+                let data = pack.data.read().await;
+                match &*data {
+                    PackData::Resident(bytes) => {
+                        return Ok((entry_end <= pack.available.load(Ordering::Relaxed)).then(
+                            || {
+                                PackSlice::Mem(ArcSlice {
+                                    data: bytes.clone(),
+                                    start,
+                                    end,
+                                })
+                            },
+                        ));
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    PackData::File(path) => {
+                        use std::io::{Read, Seek, SeekFrom};
+                        let path = path.clone();
+                        drop(data);
+                        let mut file = std::fs::File::open(&path)?;
+                        file.seek(SeekFrom::Start(start as u64))?;
+                        let mut buf = vec![0u8; end - start];
+                        file.read_exact(&mut buf)?;
+                        return Ok(Some(PackSlice::Owned(buf)));
+                    }
+                    PackData::Streaming(live) => {
+                        if entry_end <= pack.available.load(Ordering::Relaxed) {
+                            return Ok(Some(PackSlice::Owned(live.buf[start..end].to_vec())));
+                        }
+                        if live.progress.borrow().phase != Phase::Streaming || sender_gone {
+                            return Ok(None);
+                        }
+                        Some(live.progress.clone())
+                    }
+                    PackData::Evicted => None,
+                }
+            };
+            if wait_guard.is_none() {
+                wait_guard = Some(WaitingGuard::new(pack));
+            }
+            match waiter {
+                Some(mut receiver) => {
+                    receiver.borrow_and_update();
+                    if entry_end <= pack.available.load(Ordering::Relaxed) {
+                        continue;
+                    }
+                    if receiver.borrow().phase != Phase::Streaming {
+                        continue;
+                    }
+                    if receiver.changed().await.is_err() {
+                        sender_gone = true;
+                    }
+                }
+                None => {
+                    sender_gone = false;
+                    self.rematerialize_pack(pack).await?;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::scene_pack::{
+        test::{build_pack, run_fetch, test_io},
+        testkit::{
+            full, idle_env, is_streaming, pack_route, ready_pack, serve_scripted, spawn_fetch,
+            stream_fixture, wire_start, Gate, Script,
+        },
+        PackSlice, PackState,
+    };
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    #[test]
+    fn streams_serve_before_complete() {
+        let _env = idle_env("5");
+        let (entity, bytes) = stream_fixture();
+        let hold = wire_start(&bytes, &entity, "bafymp3");
+        let gate = Gate::new();
+        let (base, _) = serve_scripted(
+            pack_route(&entity),
+            bytes.clone(),
+            vec![Script {
+                hold_at: Some((hold, gate.clone())),
+                ..full(512)
+            }],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            let driver = spawn_fetch(&io, &base, &entity).await;
+            let served = io.scene_pack_read(&entity, "bafyjson").await.unwrap();
+            assert_eq!(served.as_ref(), b"{}");
+            let pack = ready_pack(&io, &entity).await;
+            assert!(is_streaming(&pack).await, "tail held: still streaming");
+            gate.open();
+            driver.await;
+            assert!(matches!(&*pack.data.read().await, PackData::Resident(_)));
+            assert_eq!(pack.available.load(Ordering::Relaxed), pack.payload());
+            let tail = io.scene_pack_read(&entity, "bafymp3").await.unwrap();
+            assert_eq!(tail.as_ref().len(), 4096);
+        }));
+    }
+
+    #[test]
+    fn aborts_when_idle_after_prefix() {
+        let _env = idle_env("0.2");
+        let (entity, bytes) = stream_fixture();
+        let hold = wire_start(&bytes, &entity, "bafymp3");
+        let gate = Gate::new();
+        let (base, broken) = serve_scripted(
+            pack_route(&entity),
+            bytes.clone(),
+            vec![Script {
+                hold_at: Some((hold, gate.clone())),
+                ..full(512)
+            }],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            let driver = spawn_fetch(&io, &base, &entity).await;
+            let pack = ready_pack(&io, &entity).await;
+            assert!(
+                platform::with_timeout(Duration::from_secs(15), driver)
+                    .await
+                    .is_ok(),
+                "driver did not abort"
+            );
+            assert!(matches!(&*pack.data.read().await, PackData::Resident(_)));
+            let available = pack.available.load(Ordering::Relaxed);
+            assert!(available >= pack.prefix_end && available < pack.payload());
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Ready(_))
+            ));
+            let start = web_time::Instant::now();
+            assert!(io.scene_pack_read(&entity, "bafymp3").await.is_none());
+            assert!(
+                start.elapsed() < Duration::from_millis(500),
+                "tail miss must not wait"
+            );
+            assert_eq!(
+                io.scene_pack_read(&entity, "bafyjson")
+                    .await
+                    .unwrap()
+                    .as_ref(),
+                b"{}"
+            );
+            gate.open();
+            for _ in 0..100 {
+                if broken.load(Ordering::SeqCst) {
+                    break;
+                }
+                async_std::task::sleep(Duration::from_millis(50)).await;
+            }
+            assert!(
+                broken.load(Ordering::SeqCst),
+                "server never saw the closed connection"
+            );
+        }));
+    }
+
+    #[test]
+    fn pending_tail_read_blocks_abort() {
+        let _env = idle_env("0.2");
+        let (entity, bytes) = stream_fixture();
+        let hold = wire_start(&bytes, &entity, "bafymp3");
+        let gate = Gate::new();
+        let (base, _) = serve_scripted(
+            pack_route(&entity),
+            bytes.clone(),
+            vec![Script {
+                hold_at: Some((hold, gate.clone())),
+                ..full(512)
+            }],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            let driver = spawn_fetch(&io, &base, &entity).await;
+            let io2 = io.clone();
+            let ent = entity.clone();
+            let reader = async_std::task::spawn(platform::compat(async move {
+                io2.scene_pack_read(&ent, "bafymp3").await
+            }));
+            async_std::task::sleep(Duration::from_millis(2500)).await;
+            let pack = ready_pack(&io, &entity).await;
+            assert!(
+                is_streaming(&pack).await,
+                "pending read must hold the stream open"
+            );
+            gate.open();
+            let tail = reader.await.unwrap();
+            assert_eq!(tail.as_ref().len(), 4096);
+            driver.await;
+        }));
+    }
+
+    #[test]
+    fn no_abort_before_prefix_delivered() {
+        let _env = idle_env("0.2");
+        let glb: Vec<u8> = (0..200u8).map(|i| i.wrapping_mul(3)).collect();
+        let files: &[(&str, &str, &[u8])] = &[
+            ("scene.json", "bafyjson", b"{}"),
+            ("models/big.glb", "bafyglb", &glb),
+        ];
+        let entity = "prefix-entity".to_owned();
+        let bytes = build_pack(&entity, files);
+        let hold = wire_start(&bytes, &entity, "bafyglb") + 10;
+        let gate = Gate::new();
+        let (base, _) = serve_scripted(
+            pack_route(&entity),
+            bytes.clone(),
+            vec![Script {
+                hold_at: Some((hold, gate.clone())),
+                ..full(512)
+            }],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            let driver = spawn_fetch(&io, &base, &entity).await;
+            let pack = ready_pack(&io, &entity).await;
+            async_std::task::sleep(Duration::from_millis(2500)).await;
+            assert!(
+                is_streaming(&pack).await,
+                "must not abort before the prefix"
+            );
+            gate.open();
+            driver.await;
+            assert_eq!(pack.available.load(Ordering::Relaxed), pack.payload());
+            let served = io.scene_pack_read(&entity, "bafyglb").await.unwrap();
+            assert_eq!(served.as_ref(), &glb[..]);
+        }));
+    }
+
+    #[test]
+    fn truncation_keeps_delivered_entries() {
+        let _env = idle_env("5");
+        let (entity, bytes) = stream_fixture();
+        let cut = wire_start(&bytes, &entity, "bafymp3") + 100;
+        let (base, _) = serve_scripted(
+            pack_route(&entity),
+            bytes.clone(),
+            vec![Script {
+                truncate_at: Some(cut),
+                ..full(512)
+            }],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            run_fetch(&io, &base, &entity).await;
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Ready(_))
+            ));
+            let pack = ready_pack(&io, &entity).await;
+            assert!(matches!(&*pack.data.read().await, PackData::Resident(_)));
+            assert!(pack.available.load(Ordering::Relaxed) < pack.payload());
+            assert!(io.scene_pack_read(&entity, "bafymp3").await.is_none());
+            assert_eq!(
+                io.scene_pack_read(&entity, "bafyjson")
+                    .await
+                    .unwrap()
+                    .as_ref(),
+                b"{}"
+            );
+        }));
+    }
+
+    #[test]
+    fn index_truncation_fails_pack() {
+        let _env = idle_env("5");
+        let (entity, bytes) = stream_fixture();
+        let (base, _) = serve_scripted(
+            pack_route(&entity),
+            bytes,
+            vec![Script {
+                truncate_at: Some(20),
+                ..full(8)
+            }],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            run_fetch(&io, &base, &entity).await;
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Failed)
+            ));
+            assert!(io.scene_pack_read(&entity, "bafyjson").await.is_none());
+        }));
+    }
+
+    #[test]
+    fn streamed_sha_corruption_fails_pack() {
+        let _env = idle_env("5");
+        let (entity, mut bytes) = stream_fixture();
+        let json_start = wire_start(&bytes, &entity, "bafyjson");
+        bytes[json_start] ^= 0xff;
+        let (base, _) = serve_scripted(pack_route(&entity), bytes, vec![full(512)]);
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            run_fetch(&io, &base, &entity).await;
+            assert!(io.scene_pack_read(&entity, "bafyjson").await.is_none());
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Failed)
+            ));
+        }));
+    }
+
+    #[test]
+    fn complete_stream_finalizes_zero_copy() {
+        let _env = idle_env("5");
+        let (entity, bytes) = stream_fixture();
+        let (base, _) = serve_scripted(pack_route(&entity), bytes, vec![full(512)]);
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            run_fetch(&io, &base, &entity).await;
+            let a = io.scene_pack_read(&entity, "bafyjson").await.unwrap();
+            let b = io.scene_pack_read(&entity, "bafyjson").await.unwrap();
+            match (&a, &b) {
+                (PackSlice::Mem(x), PackSlice::Mem(y)) => {
+                    assert!(Arc::ptr_eq(&x.data, &y.data));
+                }
+                _ => panic!("expected shared resident slices"),
+            }
+        }));
+    }
+
+    #[test]
+    fn evict_and_rematerialize_restores_then_partial_keeps() {
+        let _env = idle_env("5");
+        let (entity, bytes) = stream_fixture();
+        let cut = wire_start(&bytes, &entity, "bafymp3") + 100;
+        let (base, _) = serve_scripted(
+            pack_route(&entity),
+            bytes.clone(),
+            vec![
+                full(512),
+                full(512),
+                Script {
+                    truncate_at: Some(cut),
+                    ..full(512)
+                },
+            ],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            run_fetch(&io, &base, &entity).await;
+            let pack = ready_pack(&io, &entity).await;
+
+            *pack.data.write().await = PackData::Evicted;
+            let tail = io.scene_pack_read(&entity, "bafymp3").await.unwrap();
+            assert_eq!(tail.as_ref().len(), 4096);
+            assert_eq!(pack.available.load(Ordering::Relaxed), pack.payload());
+
+            *pack.data.write().await = PackData::Evicted;
+            assert!(io.scene_pack_read(&entity, "bafymp3").await.is_none());
+            assert!(matches!(
+                io.scene_packs.packs.read().await.get(&entity),
+                Some(PackState::Ready(_))
+            ));
+            assert!(pack.available.load(Ordering::Relaxed) < pack.payload());
+            assert_eq!(
+                io.scene_pack_read(&entity, "bafyjson")
+                    .await
+                    .unwrap()
+                    .as_ref(),
+                b"{}"
+            );
+        }));
+    }
+
+    #[test]
+    fn idle_zero_disables_abort() {
+        let _env = idle_env("0");
+        let (entity, bytes) = stream_fixture();
+        let hold = wire_start(&bytes, &entity, "bafymp3");
+        let gate = Gate::new();
+        let (base, _) = serve_scripted(
+            pack_route(&entity),
+            bytes.clone(),
+            vec![Script {
+                hold_at: Some((hold, gate.clone())),
+                ..full(512)
+            }],
+        );
+        let io = Arc::new(test_io());
+        async_std::task::block_on(platform::compat(async {
+            let driver = spawn_fetch(&io, &base, &entity).await;
+            let pack = ready_pack(&io, &entity).await;
+            async_std::task::sleep(Duration::from_millis(2500)).await;
+            assert!(
+                is_streaming(&pack).await,
+                "abort disabled: stream must stay open"
+            );
+            gate.open();
+            driver.await;
+            assert_eq!(pack.available.load(Ordering::Relaxed), pack.payload());
+        }));
+    }
+}

--- a/crates/ipfs/src/scene_pack/testkit.rs
+++ b/crates/ipfs/src/scene_pack/testkit.rs
@@ -1,0 +1,180 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Condvar, Mutex, MutexGuard, PoisonError,
+};
+use std::time::Duration;
+
+use crate::IpfsIo;
+
+use super::{test::build_pack, PackData, PackState, ScenePack};
+
+static IDLE_ENV: Mutex<()> = Mutex::new(());
+
+pub(crate) struct IdleEnv(#[allow(dead_code)] MutexGuard<'static, ()>);
+
+pub(crate) fn idle_env(value: &str) -> IdleEnv {
+    let guard = IDLE_ENV.lock().unwrap_or_else(PoisonError::into_inner);
+    std::env::set_var("SCENE_PACK_IDLE_ABORT_SECS", value);
+    IdleEnv(guard)
+}
+
+impl Drop for IdleEnv {
+    fn drop(&mut self) {
+        std::env::remove_var("SCENE_PACK_IDLE_ABORT_SECS");
+    }
+}
+
+pub(crate) struct Gate {
+    open: Mutex<bool>,
+    cv: Condvar,
+}
+
+impl Gate {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            open: Mutex::new(false),
+            cv: Condvar::new(),
+        })
+    }
+
+    pub(crate) fn open(&self) {
+        *self.open.lock().unwrap() = true;
+        self.cv.notify_all();
+    }
+
+    pub(crate) fn wait(&self) {
+        let mut open = self.open.lock().unwrap();
+        while !*open {
+            open = self.cv.wait(open).unwrap();
+        }
+    }
+}
+
+pub(crate) struct Script {
+    pub(crate) chunk: usize,
+    pub(crate) hold_at: Option<(usize, Arc<Gate>)>,
+    pub(crate) truncate_at: Option<usize>,
+    pub(crate) body: Option<Vec<u8>>,
+}
+
+pub(crate) fn full(chunk: usize) -> Script {
+    Script {
+        chunk,
+        hold_at: None,
+        truncate_at: None,
+        body: None,
+    }
+}
+
+pub(crate) fn serve_scripted(
+    path: String,
+    body: Vec<u8>,
+    scripts: Vec<Script>,
+) -> (String, Arc<AtomicBool>) {
+    use std::io::{Read, Write};
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let broken = Arc::new(AtomicBool::new(false));
+    let broken_flag = broken.clone();
+    std::thread::spawn(move || {
+        let mut scripts = scripts.into_iter();
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let Some(script) = scripts.next() else { break };
+            let body = script.body.as_ref().unwrap_or(&body);
+            let _ = stream.set_nodelay(true);
+            let mut buf = [0u8; 2048];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..n]);
+            if request.split_whitespace().nth(1) != Some(path.as_str()) {
+                continue;
+            }
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            if stream.write_all(header.as_bytes()).is_err() {
+                broken_flag.store(true, Ordering::SeqCst);
+                continue;
+            }
+            let end = script.truncate_at.unwrap_or(body.len()).min(body.len());
+            let mut sent = 0usize;
+            let mut held = false;
+            while sent < end {
+                let mut next = (sent + script.chunk).min(end);
+                if let Some((hold, gate)) = &script.hold_at {
+                    if !held && sent < *hold {
+                        next = next.min(*hold);
+                    }
+                    if !held && sent == *hold {
+                        gate.wait();
+                        held = true;
+                    }
+                }
+                if stream.write_all(&body[sent..next]).is_err() {
+                    broken_flag.store(true, Ordering::SeqCst);
+                    break;
+                }
+                sent = next;
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        }
+    });
+    (base, broken)
+}
+
+pub(crate) fn stream_fixture() -> (String, Vec<u8>) {
+    let glb: Vec<u8> = (0..100u8).collect();
+    let mp3: Vec<u8> = (0..4096usize).map(|i| (i % 251) as u8).collect();
+    let files: &[(&str, &str, &[u8])] = &[
+        ("scene.json", "bafyjson", b"{}"),
+        ("models/big.glb", "bafyglb", &glb),
+        ("sounds/tail.mp3", "bafymp3", &mp3),
+    ];
+    (
+        "stream-entity".to_owned(),
+        build_pack("stream-entity", files),
+    )
+}
+
+pub(crate) fn pack_route(entity: &str) -> String {
+    format!("/bvwebgpu/{}/{entity}.pack", super::PACK_PROFILE)
+}
+
+pub(crate) fn wire_start(bytes: &[u8], entity: &str, cid: &str) -> usize {
+    let pack = ScenePack::parse("u".into(), entity, bytes).unwrap();
+    pack.entry_range(pack.entry_by_cid(cid).unwrap()).0
+}
+
+pub(crate) async fn spawn_fetch(
+    io: &Arc<IpfsIo>,
+    base: &str,
+    entity: &str,
+) -> async_std::task::JoinHandle<()> {
+    let (sender, receiver) = tokio::sync::watch::channel(());
+    io.scene_packs
+        .packs
+        .write()
+        .await
+        .insert(entity.to_owned(), PackState::Fetching(receiver));
+    let io = io.clone();
+    let base = base.to_owned();
+    let entity = entity.to_owned();
+    async_std::task::spawn(platform::compat(async move {
+        io.run_pack_stream(&base, &entity, sender).await;
+    }))
+}
+
+pub(crate) async fn ready_pack(io: &IpfsIo, entity: &str) -> Arc<ScenePack> {
+    for _ in 0..500 {
+        if let Some(PackState::Ready(pack)) = io.scene_packs.packs.read().await.get(entity) {
+            return pack.clone();
+        }
+        async_std::task::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("pack never became ready");
+}
+
+pub(crate) async fn is_streaming(pack: &ScenePack) -> bool {
+    matches!(&*pack.data.read().await, PackData::Streaming(_))
+}

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 bevy = { workspace = true }
 anyhow = { workspace = true }
+bytes = "1"
 tungstenite = { workspace = true }
 futures-util = { workspace = true }
 futures-timer = { workspace = true }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -8,16 +8,16 @@ mod wasm;
 #[cfg(target_arch = "wasm32")]
 pub use wasm::*;
 
-use std::{future::Future, time::Duration};
+use std::{future::Future, pin::Pin, time::Duration};
 
 use futures_timer::Delay;
 use futures_util::{
     future::{select, Either},
-    pin_mut, StreamExt,
+    pin_mut, Stream, StreamExt,
 };
 
-/// Internal marker: the [`with_timeout`] timer fired before the future resolved.
-struct Elapsed;
+/// Marker: the [`with_timeout`] timer fired before the future resolved.
+pub struct Elapsed;
 
 /// Race `fut` against a `dur` timer, returning `Err(Elapsed)` if the timer wins.
 ///
@@ -25,7 +25,7 @@ struct Elapsed;
 /// — tokio is built without the `time` feature, and it wouldn't work on wasm
 /// anyway). `futures-timer` backs this with a native timer thread or wasm
 /// `setTimeout`.
-async fn with_timeout<F: Future>(dur: Duration, fut: F) -> Result<F::Output, Elapsed> {
+pub async fn with_timeout<F: Future>(dur: Duration, fut: F) -> Result<F::Output, Elapsed> {
     pin_mut!(fut);
     match select(fut, Delay::new(dur)).await {
         Either::Left((out, _)) => Ok(out),
@@ -55,6 +55,73 @@ pub enum FetchError<E> {
     Body(reqwest::Error),
 }
 
+impl FetchError<std::convert::Infallible> {
+    /// Re-type a body-phase error (which can never be `Send`) to any send error type.
+    pub fn widen<E>(self) -> FetchError<E> {
+        match self {
+            FetchError::Headers => FetchError::Headers,
+            FetchError::Send(never) => match never {},
+            FetchError::Status(status) => FetchError::Status(status),
+            FetchError::Stalled => FetchError::Stalled,
+            FetchError::Body(e) => FetchError::Body(e),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+type BytesStream = Pin<Box<dyn Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send>>;
+#[cfg(target_arch = "wasm32")]
+type BytesStream = Pin<Box<dyn Stream<Item = Result<bytes::Bytes, reqwest::Error>>>>;
+
+/// An in-flight response body being read incrementally.
+///
+/// Dropping a FetchStream aborts the transfer: reqwest's wasm AbortGuard lives
+/// exactly as long as the body stream, and native closes the connection.
+pub struct FetchStream {
+    pub headers: reqwest::header::HeaderMap,
+    stream: BytesStream,
+    idle_timeout: Duration,
+}
+
+/// Like [`fetch`], but hand back the body stream after the headers phase so the
+/// caller can consume chunks as they arrive (and abort by dropping).
+pub async fn fetch_stream<E>(
+    send: impl Future<Output = Result<reqwest::Response, E>>,
+    headers_timeout: Duration,
+    idle_timeout: Duration,
+) -> Result<FetchStream, FetchError<E>> {
+    let response = match with_timeout(headers_timeout, send).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(e)) => return Err(FetchError::Send(e)),
+        Err(Elapsed) => return Err(FetchError::Headers),
+    };
+
+    if !response.status().is_success() {
+        return Err(FetchError::Status(response.status()));
+    }
+
+    Ok(FetchStream {
+        headers: response.headers().clone(),
+        stream: Box::pin(response.bytes_stream()),
+        idle_timeout,
+    })
+}
+
+impl FetchStream {
+    /// Ok(Some(chunk)), Ok(None) at clean end, Err(Stalled) after idle_timeout
+    /// without a chunk, Err(Body) on transport error.
+    pub async fn next_chunk(
+        &mut self,
+    ) -> Result<Option<bytes::Bytes>, FetchError<std::convert::Infallible>> {
+        match with_timeout(self.idle_timeout, self.stream.next()).await {
+            Ok(Some(Ok(chunk))) => Ok(Some(chunk)),
+            Ok(Some(Err(e))) => Err(FetchError::Body(e)),
+            Ok(None) => Ok(None),
+            Err(Elapsed) => Err(FetchError::Stalled),
+        }
+    }
+}
+
 /// Drive an HTTP request with two independent timeouts, returning the response
 /// headers and fully-read body.
 ///
@@ -69,25 +136,18 @@ pub async fn fetch<E>(
     headers_timeout: Duration,
     idle_timeout: Duration,
 ) -> Result<FetchedResponse, FetchError<E>> {
-    let response = match with_timeout(headers_timeout, send).await {
-        Ok(Ok(response)) => response,
-        Ok(Err(e)) => return Err(FetchError::Send(e)),
-        Err(Elapsed) => return Err(FetchError::Headers),
-    };
-
-    if !response.status().is_success() {
-        return Err(FetchError::Status(response.status()));
-    }
-
-    let headers = response.headers().clone();
-    let mut stream = Box::pin(response.bytes_stream());
+    let mut stream = fetch_stream(send, headers_timeout, idle_timeout).await?;
     let mut body = Vec::new();
     loop {
-        match with_timeout(idle_timeout, stream.next()).await {
-            Ok(Some(Ok(chunk))) => body.extend_from_slice(&chunk),
-            Ok(Some(Err(e))) => return Err(FetchError::Body(e)),
-            Ok(None) => return Ok(FetchedResponse { headers, body }),
-            Err(Elapsed) => return Err(FetchError::Stalled),
+        match stream.next_chunk().await {
+            Ok(Some(chunk)) => body.extend_from_slice(&chunk),
+            Ok(None) => {
+                return Ok(FetchedResponse {
+                    headers: stream.headers,
+                    body,
+                })
+            }
+            Err(e) => return Err(e.widen()),
         }
     }
 }

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -226,6 +226,9 @@ pub(crate) fn load_scene_json(
             None,
             definition.metadata.as_ref().map(|v| v.to_string()),
         );
+        // start streaming the scene's content pack (if a pack server is configured)
+        // so asset reads can be served from it
+        ipfas.ipfs().prefetch_scene_pack(&definition.id);
 
         let crdt = definition.content.hash("main.crdt").map(|_| {
             ipfas
@@ -1515,6 +1518,7 @@ pub fn process_scene_lifecycle(
     imposter_scene: Res<CurrentImposterScene>,
     preview_mode: Res<PreviewMode>,
     mut current_scene_loading_res: ResMut<CurrentSceneLoading>,
+    ipfas: IpfsAssetServer,
 ) {
     let mut required_scene_ids: HashMap<(String, Option<String>), bool> = HashMap::new();
 
@@ -1640,6 +1644,7 @@ pub fn process_scene_lifecycle(
 
     for removed_hash in removed_hashes {
         live_scenes.scenes.remove(removed_hash);
+        ipfas.ipfs().release_scene_pack(removed_hash);
     }
 
     let mut defer_to_current_scene = false;

--- a/crates/scene_runner/src/test/mod.rs
+++ b/crates/scene_runner/src/test/mod.rs
@@ -94,6 +94,7 @@ impl PluginGroup for TestPlugins {
                 starting_realm: Default::default(),
                 num_slots: 8,
                 content_server_override: None,
+                scene_packs_url: None,
             })
             .add(AssetPlugin::default())
             .add(MeshPlugin)

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -215,6 +215,7 @@ fn main() {
                 content_server_override,
                 assets_root: Default::default(),
                 num_slots: final_config.max_concurrent_remotes,
+                scene_packs_url: None,
             }),
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ impl DecentralandAppConfig {
 pub struct DecentralandArguments {
     pub server: Option<String>,
     pub content_server_override: Option<String>,
+    pub scene_packs_url: Option<String>,
     pub location: Option<IVec2>,
     pub startup_scenes: Option<Vec<StartupScene>>,
     pub ui_scene: Option<String>,
@@ -536,6 +537,9 @@ fn update_app_config_from_arguments(
     arguments: &DecentralandArguments,
 ) {
     base_app_config.location.replace_if_some(arguments.location);
+    if arguments.scene_packs_url.is_some() {
+        base_app_config.scene_packs_url = arguments.scene_packs_url.clone();
+    }
 
     base_app_config
         .graphics
@@ -647,6 +651,7 @@ fn desktop_default_plugins(decentraland_app_config: &DecentralandAppConfig) -> P
                 .clone(),
             assets_root: Default::default(),
             num_slots: decentraland_app_config.app_config.max_concurrent_remotes,
+            scene_packs_url: decentraland_app_config.app_config.scene_packs_url.clone(),
         })
         .add_before::<IpfsIoPlugin>(NftReaderPlugin)
 }
@@ -682,6 +687,7 @@ fn wasm_default_plugins(decentraland_app_config: &DecentralandAppConfig) -> Plug
                 .clone(),
             assets_root: Default::default(),
             num_slots: decentraland_app_config.app_config.max_concurrent_remotes,
+            scene_packs_url: decentraland_app_config.app_config.scene_packs_url.clone(),
         })
         .add_before::<IpfsIoPlugin>(NftReaderPlugin)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
     let dcl_args = DecentralandArguments {
         server: args.value_from_str("--server").ok(),
         content_server_override: args.value_from_str("--content-server").ok(),
+        scene_packs_url: args.value_from_str("--scene-packs-url").ok(),
         location: args
             .value_from_str::<_, IVec2Arg>("--location")
             .ok()

--- a/src/web.rs
+++ b/src/web.rs
@@ -379,14 +379,42 @@ fn decentraland_app_config(
 }
 
 fn decentraland_serialized_app_config() -> AppConfig {
-    INIT_DATA.get().cloned().unwrap_or_else(|| AppConfig {
+    let mut config = INIT_DATA.get().cloned().unwrap_or_else(|| AppConfig {
         graphics: common::structs::GraphicsSettings {
             shadow_distance: 20.0,
             shadow_settings: common::structs::ShadowSetting::Low,
             ..Default::default()
         },
         ..Default::default()
-    })
+    });
+    // `?packs=<url>` overrides the configured scene-pack server ("off"/"0" disables)
+    if let Some(packs) = scene_packs_from_url() {
+        config.scene_packs_url = match packs.as_str() {
+            "off" | "0" => None,
+            _ => Some(packs),
+        };
+        info!("scene packs url override: {:?}", config.scene_packs_url);
+    }
+    // a root-relative pack url is resolved against the page origin
+    if let Some(packs) = config.scene_packs_url.as_mut() {
+        if packs.starts_with('/') {
+            if let Some(origin) = web_sys::window().and_then(|w| w.location().origin().ok()) {
+                *packs = format!("{origin}{packs}");
+            }
+        }
+    }
+    config
+}
+
+fn scene_packs_from_url() -> Option<String> {
+    let search = web_sys::window()?.location().search().ok()?;
+    search
+        .trim_start_matches('?')
+        .split('&')
+        .filter_map(|pair| pair.split_once('='))
+        .find(|(k, _)| *k == "packs")
+        .and_then(|(_, v)| urlencoding::decode(v).ok())
+        .map(|v| v.into_owned())
 }
 
 fn decentraland_app_arguments(
@@ -401,6 +429,7 @@ fn decentraland_app_arguments(
     DecentralandArguments {
         server: Some(server.to_owned()),
         content_server_override: None,
+        scene_packs_url: None,
         location: IVec2Arg::from_str(location)
             .map(|location_arg| location_arg.0)
             .ok(),


### PR DESCRIPTION
# ipfs: opt-in per-scene content packs

> **Depends on: https://github.com/decentraland/bevy-explorer/pull/1004 (`gltf: EXT_meshopt_compression support`) — hard prerequisite, land it first (or merge the two together).** Server-side producer: https://github.com/decentraland/abgen/pull/29. Current pack producers emit meshopt-compressed/quantized GLB variants inside packs; without `EXT_meshopt_compression` decode in this client, enabling packs against such a server is a rendering regression (verified: 1,486 mesh-load failures with this branch standalone vs a baseline-clean 12 with the meshopt PR merged — see Evidence). Also note the honest fallback caveat under Default behavior: pack entries the client cannot decode do **not** fall back to raw fetches; the pack-server contract must guarantee client-decodable content.

## What

Adds an opt-in fast path for scene content delivery: instead of issuing one `/contents/{cid}` GET per file (typically 8–43 requests per scene), the client fetches the whole scene as a single streamed pack and serves the scene's asset reads from it. Any miss or failure — no pack published, index invalid, hash mismatch, truncated transfer — falls through to the existing per-file fetch path, so a pack server can only ever add performance, never break loading.

The feature is **off by default**: with no pack server configured the new code is never reached and behavior is byte-for-byte unchanged.

The server side is a pack generator implemented in abgen — https://github.com/decentraland/abgen/pull/29. The container is a simple indexed concatenation (`DCLBVPK` magic, version 1, profile `bv4`): a 16-byte header, a JSON index (path, cid, offset, length, kind, priority class, sha256 per entry), then the 16-byte-aligned blobs, deduplicated by cid and ordered by demand priority (scene js/crdt first, then meshes, textures, and audio tails last).

## Why

Measured on a production scene fixture:

- Wire bytes: **245,732 B** as a single brotli-compressed pack fetch vs **2,375,218 B** for the raw multi-GET equivalent (~10x) — one stream compresses across files and dedupes shared blobs, where per-file GETs cannot.
- Round-trips: **8–43 requests collapse to 1** per scene, removing per-request latency, connection contention with other scenes, and per-request header overhead.
- Streaming: because packs are demand-ordered and entries become readable as soon as their prefix of the body has arrived, the first asset is usable **44 ms after headers** on a 1 MB/s link, vs **14.8 s** if the client had to wait for the whole body.
- Idle abort: on an audio-tail-heavy fixture, aborting the stream once the high-priority prefix is delivered and no reader is waiting cut wire bytes to **17% of the pack** — scenes only pay for what they actually read.

## How

- `crates/ipfs/src/scene_pack.rs` — pack registry and container handling. `ScenePackRegistry` lives on `IpfsIo`; per scene hash it tracks `Fetching` (readers wait on a watch channel), `Ready`, or `Failed` (readers immediately fall through). `ScenePack::parse_index` validates magic/version/profile/entity, entry bounds, 16-byte alignment, blob ordering, cid-dedup consistency, and per-entry sha256 encoding before any entry is served. Entries are sha256-verified on first serve (and re-verified after any re-materialization, tracked by a generation counter so a verify racing an eviction can never stamp bytes it did not hash). Resident pack bytes are bounded by an LRU byte budget (128 MiB wasm / 512 MiB native); evicted packs re-fetch on demand. Complete packs are spilled to the disk cache on native.
- `crates/ipfs/src/scene_pack/stream.rs` — the streaming driver. The index is parsed as soon as it arrives; the pack flips to `Ready` immediately and readers are woken as each entry's byte range is delivered, so early-priority entries are usable long before the body completes. Reads are zero-copy `Arc` slices once the pack is resident. If the delivered prefix covers all high-priority entries and no reader has waited for a configurable idle window, the transfer is aborted; the delivered prefix stays serveable and anything beyond it falls through to raw fetches.
- `crates/platform/src/lib.rs` — `fetch_stream`: the chunked counterpart of the existing `fetch`, sharing its headers-phase and body-idle timeouts, handing back the body stream so the caller can consume chunks as they arrive and abort by dropping.
- `crates/ipfs/src/lib.rs` — `AssetReader::read` consults the pack for any read carrying a scene context (a new `IpfsPath::scene_context_hash`) after hash resolution and before the disk-cache/remote path; `IpfsIoPlugin`/`IpfsIo::new` thread the configured base url through.
- `crates/scene_runner/src/initialize_scene.rs` — prefetch starts when the scene definition resolves (right after its collection is registered); the pack is released when the scene is despawned.
- Config plumbing: `AppConfig.scene_packs_url: Option<String>` (default `None`; the config struct is `#[serde(default)]` so existing saved configs deserialize unchanged), `--scene-packs-url` on native, and a `?packs=` URL override on web (`off`/`0` disables; a root-relative value resolves against the page origin). On web the pack request carries the same `X-IPFS` service-worker cache tag as raw content requests, and a failed pack purges its service-worker cache entry so a corrupt cached body cannot wedge the feature.

No new external dependencies (`bytes` was already in the graph via reqwest; it is now a direct dependency of `platform` for the chunk type).

## Default behavior

`scene_packs_url` defaults to `None` everywhere (native config, web config, CLI absent, no URL param): the registry is empty, `prefetch_scene_pack` returns immediately, and the asset-reader hook is a no-op — zero behavior change. When configured, any pack problem (404, bad index, sha mismatch, surplus bytes, stall) marks that scene's pack `Failed` and every read falls through to the normal `/contents` path.

**Fallback caveat (honest limitation).** The fallback fires on transport/integrity failures only. The client verifies the pack index's own sha256 of the stored bytes — not the entity's content cid — so a pack entry that is intact but not decodable by this client (e.g. a GLB variant requiring a codec the client lacks) passes every gate and is served with no raw fallback; a downstream loader failure never propagates back to the fetch layer. The pack-server contract must therefore guarantee client-decodable rewrites, or a future change must propagate content-level decode failures back to the fetch layer. This is exactly why the meshopt PR above is a hard prerequisite for today's pack producers.

## Testing

- 29 unit tests ported with the feature (`cargo test -p ipfs scene_pack`), covering: index parsing and rejection of corrupt/truncated/misaligned/mis-profiled packs; sha verification on serve and after re-materialization; LRU eviction and recovery; zero-copy resident serving; and a scripted local HTTP server driving the streaming edge cases — serve-before-complete, idle abort (and its suppression while the index or prefix is still arriving, or a reader is waiting), truncation keeping delivered entries, surplus bytes failing the pack, concurrent pending readers, eviction mid-stream, stale drivers not clobbering re-fetched slots, and zero-length entries.
- `cargo check --workspace` (native) and `cargo check --lib --target wasm32-unknown-unknown --no-default-features --features livekit,social` both pass.
- End-to-end behavior (single pack fetch, streaming first-use, fallthrough on failure) exercised against a pack-serving content mirror with headed Chromium/WebGPU on a 17-scene benchmark realm.

## Evidence

Independently verified A/B pass on this branch against the base commit, plus a stacked retest of this branch merged with the `EXT_meshopt_compression` PR (the merge is provably file-disjoint). Audited with all request and mesh-failure counters recomputed from the raw logs; all signals are exact deterministic counters — no perf delta is claimed.

**Method.** Genesis-city content served through a local logging proxy in front of a local content-server mirror and a local pack service (packs built from the same content, bv4 profile). 33 scenes spawn per run at a fixed location; fresh cache/config per run; every request's method/path/status/bytes logged; per-run gltf mesh-load failures counted from the client log (every raw-mode run sits at a stable 12-line / 3-source pre-existing baseline).

**Results — request replacement (exact; reproduced identically on the standalone and stacked binaries).** Packs on: exactly 32 pack GETs for the 32 realm entities — one per scene, no repeats — and **0** raw per-file content GETs, vs 327–337 raw GETs in every packs-off run. Under organic partial coverage (13 of 32 packs 404), all 155 raw GETs belong to scenes whose pack failed; zero raw GETs for any cid covered by a ready pack.

**Results — rendering (the hard dependency, isolated exactly).** This branch standalone, packs on: 1,486 gltf mesh-load failures (1,474 meshopt/quantization "unsupported extension" across 220 sources) and a near-empty world — the pack producer emits web-profile GLB variants requiring `EXT_meshopt_compression` + `KHR_mesh_quantization`. With the meshopt PR merged, same pack bytes, byte-identical request pattern: exactly the 12-line pre-existing baseline, 0 meshopt failures, dense world geometry matching every raw-mode screenshot. The regression is therefore entirely the missing decode capability, not a defect in the pack path — hence the dependency line at the top.

**Results — fallback and null (exact).** Dead pack endpoint: exactly 32 "scene pack unavailable" lines, one per scene, sticky, no retry storm; raw request set identical to base. Packs unset: zero pack-related requests; distinct raw request vocabulary identical to base (312 = 312 cids) and non-content requests exactly equal; multiset differences are retry-timing noise bounded by a control run.

**Honest caveats.**
- Content-level decode failures do not fall back (see Default behavior). Byte-proven: sampled pack GLB entries differ from the raw content bytes for the same cid, carry the meshopt marker, and still pass the pack's index-sha verification — served with no raw fallback.
- Wire bytes went UP in this scenario: 142 MB of packs vs 99.6 MB raw, because a pack carries the whole scene while raw mode fetches only what the runtime asks for. The measured win here is request count (359 → 32). The byte wins quoted under Why come from brotli-compressed, demand-ordered, idle-aborted transfers, which this whole-scene test did not exercise.
- The stacked (merged) branch got no separate workspace test run; both parents individually pass the regression gate at baseline (only the pre-existing `scene_runner test::cyclic_recovery` failure) and the merge is file-disjoint.
- Boot smoke (packs unset, default config) is behaviorally identical to base; no wall-clock perf numbers were taken.
