### PR TITLE
scene runner: watchdog for non-responding scene workers

### DIFF
--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -13,7 +13,7 @@ use crate::{
     interface::{crdt_context::CrdtContext, CrdtType},
     js::{
         AllocatorContext, CommunicatedWithRenderer, CrdtSentThisTick, CrdtStoreNextCheck,
-        FilteredCrdtStore, RendererStore, SceneResponseSender, SceneStatsFlush, ShuttingDown,
+        FilteredCrdtStore, KillFlag, RendererStore, SceneResponseSender, SceneStatsFlush,
     },
     AllocError, CrdtComponentInterfaces, CrdtStore, RendererResponse, RpcCalls, SceneElapsedTime,
     SceneLogMessage, SceneResourceCounters, SceneResponse,
@@ -89,7 +89,7 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
     // Once flagged for shutdown the scene is inert: ingest nothing further and emit no
     // frames, so a scene that ignores the unwind can't keep growing the store or pushing
     // frames at a scene the renderer has already marked broken.
-    if op_state.has::<ShuttingDown>() {
+    if op_state.borrow::<KillFlag>().killed() {
         return;
     }
 
@@ -106,7 +106,7 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
                 scene_id,
                 "scene sent more than one CRDT batch in a tick".to_owned(),
             ));
-        op_state.put(ShuttingDown);
+        op_state.borrow::<KillFlag>().kill();
         return;
     }
     op_state.put(CrdtSentThisTick);
@@ -127,7 +127,7 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
                 scene_id,
                 format!("scene exceeded the {MAX_CRDT_BATCH_BYTES}-byte CRDT batch limit"),
             ));
-        op_state.put(ShuttingDown);
+        op_state.borrow::<KillFlag>().kill();
         return;
     }
 
@@ -229,7 +229,7 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
                     scene_id,
                     format!("scene exceeded the {MAX_CRDT_STORE_BYTES}-byte CRDT store limit"),
                 ));
-            op_state.put(ShuttingDown);
+            op_state.borrow::<KillFlag>().kill();
         } else {
             let headroom = (MAX_CRDT_STORE_BYTES - retained) as u64;
             op_state.put(CrdtStoreNextCheck(
@@ -250,9 +250,9 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
 
     // A scene flagged for shutdown must not park on the renderer channel — the renderer marks
     // it broken and never responds, which would leave the isolate resident until scene unload.
-    // Return an empty batch instead, so the tick unwinds to the scene loop, whose ShuttingDown
+    // Return an empty batch instead, so the tick unwinds to the scene loop, whose kill-flag
     // check tears the runtime down.
-    if op_state.borrow().has::<ShuttingDown>() {
+    if op_state.borrow().borrow::<KillFlag>().killed() {
         return Vec::new();
     }
 
@@ -439,7 +439,7 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
                 "{}: shutting down",
                 std::thread::current().name().unwrap_or("(webworker)")
             );
-            op_state.put(ShuttingDown);
+            op_state.borrow::<KillFlag>().kill();
             Default::default()
         }
         // GetCrdtSnapshot is handled before this match in the loop above.

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -60,8 +60,23 @@ mod response_channel {
 
 pub use response_channel::*;
 
-// marker to indicate shutdown has been triggered
-pub struct ShuttingDown;
+// signal that the scene should exit. set cooperatively by the ops (renderer channel
+// closed, contract-breach policy kills) or externally by the scene host (watchdog
+// kill, heap cap) — external setters pair it with v8 terminate_execution since the
+// scene may never run an op again. once set, the crdt ops go inert and the scene
+// loop tears the runtime down.
+#[derive(Clone, Default)]
+pub struct KillFlag(pub std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl KillFlag {
+    pub fn kill(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub fn killed(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
 
 pub struct RendererStore(pub CrdtStore);
 
@@ -165,6 +180,7 @@ pub fn init_state(
     global_update_receiver: tokio::sync::broadcast::Receiver<GlobalCrdtStateUpdate>,
     super_user: Option<tokio::sync::mpsc::UnboundedSender<SystemApi>>,
     scene_origin: bevy::prelude::Vec3,
+    kill_flag: KillFlag,
 ) {
     // Allocator context: a parallel CrdtContext used solely for entity allocation. It's populated
     // with every entity (recognized + filtered) on the send path, but the scene's authored entities
@@ -214,6 +230,7 @@ pub fn init_state(
     state.put(TimeOfDay { time: 0. });
     state.put(CameraFov::default());
     state.put(dcl_component::SceneOrigin(scene_origin));
+    state.put(kill_flag);
     if let Some(super_user) = super_user {
         state.put(SuperUserScene(super_user));
     }
@@ -483,6 +500,7 @@ mod scene_log_budget_tests {
         s.put(crate::CrdtComponentInterfaces::default());
         s.put(crate::RpcCalls::default());
         s.put(SceneStatsFlush(0.0));
+        s.put(KillFlag::default());
         s
     }
 
@@ -507,7 +525,7 @@ mod scene_log_budget_tests {
             other => panic!("expected Error, got {other:?}"),
         }
         assert!(
-            state.borrow().has::<ShuttingDown>(),
+            state.borrow().borrow::<KillFlag>().killed(),
             "oversized batch must flag the scene for shutdown"
         );
         assert!(
@@ -518,7 +536,7 @@ mod scene_log_budget_tests {
         // the follow-up recv must not park on the renderer channel (the renderer marks the
         // scene broken and never responds): it returns an empty batch immediately — the test
         // state holds no renderer channel at all, so reaching for it would panic — letting
-        // the tick unwind to the scene loop's ShuttingDown check.
+        // the tick unwind to the scene loop's kill-flag check.
         let batch = futures_lite::future::block_on(super::engine::op_crdt_recv_from_renderer(
             state.clone(),
         ));
@@ -607,7 +625,7 @@ mod scene_log_budget_tests {
             other => panic!("expected Error, got {other:?}"),
         }
         assert!(
-            state.borrow().has::<ShuttingDown>(),
+            state.borrow().borrow::<KillFlag>().killed(),
             "a second send in one tick must flag the scene for shutdown"
         );
     }
@@ -626,7 +644,7 @@ mod scene_log_budget_tests {
             // what the scene loop does at each tick boundary
             state.borrow_mut().try_take::<CrdtSentThisTick>();
         }
-        assert!(!state.borrow().has::<ShuttingDown>());
+        assert!(!state.borrow().borrow::<KillFlag>().killed());
     }
 
     // A normal batch flows through untouched: an Ok frame is produced and the scene is not
@@ -645,7 +663,7 @@ mod scene_log_budget_tests {
             other => panic!("expected Ok, got {other:?}"),
         }
         assert!(
-            !state.borrow().has::<ShuttingDown>(),
+            !state.borrow().borrow::<KillFlag>().killed(),
             "a normal batch must not shut the scene down"
         );
     }

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
 
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
-use bevy::log::{debug, error, info_span};
+use bevy::log::{debug, error, info_span, warn};
 use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
@@ -249,8 +249,9 @@ pub(crate) fn scene_thread(
 
     // store handle
     let vm_handle = runtime.v8_isolate().thread_safe_handle();
+    let kill_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let mut guard = VM_HANDLES.lock().unwrap();
-    guard.insert(scene_id, vm_handle);
+    guard.insert(scene_id, (vm_handle, kill_flag.clone()));
     drop(guard);
 
     let state = runtime.op_state();
@@ -393,6 +394,16 @@ pub(crate) fn scene_thread(
             .run_us += thread_cpu_us().saturating_sub(run_start);
 
         if state.borrow().try_borrow::<ShuttingDown>().is_some() {
+            rt.block_on(async move {
+                drop(runtime);
+            });
+            return;
+        }
+
+        // killed by the renderer (wedged or despawned): exit instead of running
+        // another tick, which would re-enter a deterministic wedge
+        if kill_flag.load(std::sync::atomic::Ordering::SeqCst) {
+            warn!("[{scene_id:?}] scene terminated by renderer; exiting");
             rt.block_on(async move {
                 drop(runtime);
             });

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -50,6 +50,7 @@ pub fn create_runtime(
     super_user: bool,
     storage_root: &str,
     preview: bool,
+    kill_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> (JsRuntime, Option<InspectorServer>) {
     // add fetch stack
     let net = deno_net::deno_net::init_ops_and_esm::<NP>(None, None);
@@ -189,6 +190,11 @@ pub fn create_runtime(
             if first_trip {
                 bevy::prelude::error!("scene exceeded its {MAX_SCENE_HEAP_BYTES}-byte heap cap; terminating the scene isolate");
             }
+            // termination alone only unwinds the current js: the heap stays rooted by the
+            // scene globals and the scene loop keeps ticking through uncaught errors, so it
+            // would re-trip this callback forever. the kill flag makes the loop exit, which
+            // drops the runtime and actually releases the heap.
+            kill_flag.store(true, std::sync::atomic::Ordering::SeqCst);
             terminate_handle.terminate_execution();
             if first_trip {
                 // one-time margin so the termination unwind can run rather than hard-aborting
@@ -244,12 +250,17 @@ pub(crate) fn scene_thread(
 ) {
     let scene_id = scene_context.scene_id;
     let preview = scene_context.preview;
-    let (mut runtime, inspector) =
-        create_runtime(inspect, super_user.is_some(), &storage_root, preview);
+    let kill_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (mut runtime, inspector) = create_runtime(
+        inspect,
+        super_user.is_some(),
+        &storage_root,
+        preview,
+        kill_flag.clone(),
+    );
 
     // store handle
     let vm_handle = runtime.v8_isolate().thread_safe_handle();
-    let kill_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let mut guard = VM_HANDLES.lock().unwrap();
     guard.insert(scene_id, (vm_handle, kill_flag.clone()));
     drop(guard);
@@ -637,7 +648,8 @@ mod tests {
     /// is evaluated (`op_require("~scene.js")` -> `evalContext`). A `throw` in the scene
     /// surfaces as `Err`.
     fn run_scene(is_server: bool, scene_js: &str) -> Result<(), String> {
-        let (mut runtime, _) = create_runtime(false, false, "test-scene-realm", false);
+        let (mut runtime, _) =
+            create_runtime(false, false, "test-scene-realm", false, Default::default());
         {
             let state = runtime.op_state();
             let mut state = state.borrow_mut();
@@ -721,7 +733,13 @@ mod tests {
     /// authoritative server the option must be refused outright.
     #[test]
     fn server_refuses_a_scene_supplied_proxy() {
-        let (mut runtime, _) = create_runtime(false, false, "test-custom-client", false);
+        let (mut runtime, _) = create_runtime(
+            false,
+            false,
+            "test-custom-client",
+            false,
+            Default::default(),
+        );
         runtime.op_state().borrow_mut().put(context(true));
         let err = runtime
             .execute_script(
@@ -739,7 +757,13 @@ mod tests {
     /// own outbound TLS.
     #[test]
     fn server_refuses_scene_supplied_ca_certs() {
-        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-ca", false);
+        let (mut runtime, _) = create_runtime(
+            false,
+            false,
+            "test-custom-client-ca",
+            false,
+            Default::default(),
+        );
         runtime.op_state().borrow_mut().put(context(true));
         let err = runtime
             .execute_script(
@@ -757,7 +781,13 @@ mod tests {
     /// this restriction is server-only.
     #[test]
     fn client_still_allows_custom_clients() {
-        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-clientmode", false);
+        let (mut runtime, _) = create_runtime(
+            false,
+            false,
+            "test-custom-client-clientmode",
+            false,
+            Default::default(),
+        );
         runtime.op_state().borrow_mut().put(context(false));
         runtime
             .execute_script(

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -1,13 +1,13 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
 
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
-use bevy::log::{debug, error, info_span, warn};
+use bevy::log::{debug, error, info_span};
 use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
     js::{
         engine::crdt_send_to_renderer, init_state, CommunicatedWithRenderer, CrdtSentThisTick,
-        SceneResponseSender, ShuttingDown, SuperUserScene,
+        KillFlag, SceneResponseSender, SuperUserScene,
     },
     RendererResponse, RpcCalls, SceneElapsedTime, SceneResourceCounters, SceneResponse,
 };
@@ -50,7 +50,7 @@ pub fn create_runtime(
     super_user: bool,
     storage_root: &str,
     preview: bool,
-    kill_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    kill_flag: KillFlag,
 ) -> (JsRuntime, Option<InspectorServer>) {
     // add fetch stack
     let net = deno_net::deno_net::init_ops_and_esm::<NP>(None, None);
@@ -194,7 +194,7 @@ pub fn create_runtime(
             // scene globals and the scene loop keeps ticking through uncaught errors, so it
             // would re-trip this callback forever. the kill flag makes the loop exit, which
             // drops the runtime and actually releases the heap.
-            kill_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            kill_flag.kill();
             terminate_handle.terminate_execution();
             if first_trip {
                 // one-time margin so the termination unwind can run rather than hard-aborting
@@ -250,7 +250,7 @@ pub(crate) fn scene_thread(
 ) {
     let scene_id = scene_context.scene_id;
     let preview = scene_context.preview;
-    let kill_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let kill_flag = KillFlag::default();
     let (mut runtime, inspector) = create_runtime(
         inspect,
         super_user.is_some(),
@@ -278,6 +278,7 @@ pub(crate) fn scene_thread(
         global_update_receiver,
         super_user,
         scene_origin,
+        kill_flag.clone(),
     );
 
     let span = info_span!("js startup").entered();
@@ -404,17 +405,12 @@ pub(crate) fn scene_thread(
             .borrow_mut::<SceneResourceCounters>()
             .run_us += thread_cpu_us().saturating_sub(run_start);
 
-        if state.borrow().try_borrow::<ShuttingDown>().is_some() {
-            rt.block_on(async move {
-                drop(runtime);
-            });
-            return;
-        }
-
-        // killed by the renderer (wedged or despawned): exit instead of running
-        // another tick, which would re-enter a deterministic wedge
-        if kill_flag.load(std::sync::atomic::Ordering::SeqCst) {
-            warn!("[{scene_id:?}] scene terminated by renderer; exiting");
+        // set cooperatively by the ops (renderer channel closed, policy kill) or
+        // externally with terminate_execution (watchdog kill, heap cap); either way
+        // exit instead of running another tick, which for a terminated scene would
+        // re-enter a deterministic wedge
+        if kill_flag.killed() {
+            debug!("[{scene_id:?}] scene loop exiting");
             rt.block_on(async move {
                 drop(runtime);
             });

--- a/crates/dcl_deno/src/lib.rs
+++ b/crates/dcl_deno/src/lib.rs
@@ -2,10 +2,7 @@ pub mod js;
 
 use std::{
     panic::{self, AssertUnwindSafe},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
-    },
+    sync::Mutex,
 };
 
 use bevy::{log::error, platform::collections::HashMap};
@@ -19,14 +16,13 @@ use ipfs::SceneJsFile;
 
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
-    js::SceneResponseSender,
+    js::{KillFlag, SceneResponseSender},
     RendererResponse, SceneId,
 };
 
 use crate::js::scene_thread;
 
-#[allow(clippy::type_complexity)]
-pub(crate) static VM_HANDLES: Lazy<Mutex<HashMap<SceneId, (IsolateHandle, Arc<AtomicBool>)>>> =
+pub(crate) static VM_HANDLES: Lazy<Mutex<HashMap<SceneId, (IsolateHandle, KillFlag)>>> =
     Lazy::new(Default::default);
 
 /// interrupt the scene's isolate even if it is stuck in a JS loop, so the scene
@@ -39,7 +35,7 @@ pub(crate) static VM_HANDLES: Lazy<Mutex<HashMap<SceneId, (IsolateHandle, Arc<At
 pub fn terminate_scene(scene_id: SceneId) {
     if let Some((handle, kill_flag)) = VM_HANDLES.lock().unwrap().get(&scene_id) {
         bevy::log::warn!("[{scene_id:?}] scene thread still running after kill; force-terminating");
-        kill_flag.store(true, Ordering::SeqCst);
+        kill_flag.kill();
         handle.terminate_execution();
     }
 }

--- a/crates/dcl_deno/src/lib.rs
+++ b/crates/dcl_deno/src/lib.rs
@@ -2,7 +2,10 @@ pub mod js;
 
 use std::{
     panic::{self, AssertUnwindSafe},
-    sync::Mutex,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 
 use bevy::{log::error, platform::collections::HashMap};
@@ -22,8 +25,24 @@ use dcl::{
 
 use crate::js::scene_thread;
 
-pub(crate) static VM_HANDLES: Lazy<Mutex<HashMap<SceneId, IsolateHandle>>> =
+#[allow(clippy::type_complexity)]
+pub(crate) static VM_HANDLES: Lazy<Mutex<HashMap<SceneId, (IsolateHandle, Arc<AtomicBool>)>>> =
     Lazy::new(Default::default);
+
+/// interrupt the scene's isolate even if it is stuck in a JS loop, so the scene
+/// thread unwinds and exits. no-op if the scene thread has already exited, or
+/// for a worker blocked inside a rust op (the termination takes effect when
+/// control returns to JS). the kill flag must be set as well as terminating:
+/// v8's termination request is consumed once the stack unwinds, and the scene
+/// loop doesn't exit on uncaught errors, so without the flag a deterministic
+/// wedge would just re-enter its loop on the next tick.
+pub fn terminate_scene(scene_id: SceneId) {
+    if let Some((handle, kill_flag)) = VM_HANDLES.lock().unwrap().get(&scene_id) {
+        bevy::log::warn!("[{scene_id:?}] scene thread still running after kill; force-terminating");
+        kill_flag.store(true, Ordering::SeqCst);
+        handle.terminate_execution();
+    }
+}
 
 /// must be called from main thread on linux before any isolates are created
 pub fn init_runtime() {
@@ -69,6 +88,8 @@ pub fn spawn_scene(
             if let Err(e) = thread_result {
                 error!("[{id:?}] caught scene thread panic: {e:?}");
             }
+
+            VM_HANDLES.lock().unwrap().remove(&id);
         })
         .unwrap();
 

--- a/crates/dcl_deno_ipc/src/main.rs
+++ b/crates/dcl_deno_ipc/src/main.rs
@@ -19,6 +19,10 @@ use std::{env, sync::Arc};
 use system_bridge::SystemApi;
 use tokio::io::AsyncReadExt;
 
+// how long a killed scene gets to exit cleanly (finish its in-flight tick after its
+// renderer channel closes) before its isolate is forcibly terminated
+const KILL_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(5);
+
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("info")))
@@ -139,6 +143,15 @@ async fn scene_ipc_in(
             }
             EngineToScene::KillScene(id) => {
                 renderer_senders.remove(&id);
+                // dropping the sender lets a healthy scene finish its current tick and
+                // exit cleanly; force-terminate only if the thread is still around after
+                // a grace period (wedged in js, or stuck awaiting something external)
+                tokio::spawn(async move {
+                    tokio::time::sleep(KILL_GRACE_PERIOD).await;
+                    dcl_deno::terminate_scene(dcl::SceneId(bevy::ecs::entity::Entity::from_bits(
+                        id,
+                    )));
+                });
             }
             EngineToScene::SceneUpdate(id, renderer_response) => {
                 let Some(sender) = renderer_senders.get(&id) else {

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -9,8 +9,7 @@ use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
     js::{
-        CommunicatedWithRenderer, CrdtSentThisTick, SceneResponseSender, ShuttingDown,
-        SuperUserScene,
+        CommunicatedWithRenderer, CrdtSentThisTick, KillFlag, SceneResponseSender, SuperUserScene,
     },
     RendererResponse, SceneElapsedTime,
 };
@@ -123,6 +122,7 @@ pub async fn wasm_init_scene() -> Result<WorkerContext, JsValue> {
         scene_initialization_data.global_update_receiver,
         scene_initialization_data.super_user,
         scene_initialization_data.scene_origin,
+        Default::default(),
     );
 
     local_storage::init(&context).await;
@@ -226,7 +226,7 @@ pub fn op_set_elapsed(state: &WorkerContext, elapsed: f32) {
 
 #[wasm_bindgen]
 pub fn op_continue_running(state: &WorkerContext) -> bool {
-    !state.state.borrow().has::<ShuttingDown>()
+    !state.state.borrow().borrow::<KillFlag>().killed()
 }
 
 #[wasm_bindgen]

--- a/crates/imposters/src/bake_scene.rs
+++ b/crates/imposters/src/bake_scene.rs
@@ -190,7 +190,7 @@ fn make_scene_oven(
         }
         let spawning_forever = tick.0 > start_tick.as_ref().unwrap().1 + 10000;
 
-        if context.tick_number < SCENE_BAKE_TICK && !context.broken && !spawning_forever {
+        if context.tick_number < SCENE_BAKE_TICK && !context.broken() && !spawning_forever {
             return;
         }
 
@@ -250,7 +250,7 @@ fn make_scene_oven(
         }
 
         context.blocked.insert("imposter_baking");
-        if context.in_flight && !context.broken && !spawning_forever {
+        if context.in_flight() && !spawning_forever {
             return;
         }
 

--- a/crates/imposters/src/render.rs
+++ b/crates/imposters/src/render.rs
@@ -283,7 +283,7 @@ pub fn spawn_imposters(
             if ctx.is_portable {
                 return None;
             }
-            if !ctx.broken && (ctx.tick_number <= 5 || !ctx.blocked.is_empty()) {
+            if !ctx.broken() && (ctx.tick_number <= 5 || !ctx.blocked.is_empty()) {
                 // not ready
                 return None;
             }

--- a/crates/restricted_actions/src/teleport.rs
+++ b/crates/restricted_actions/src/teleport.rs
@@ -156,10 +156,10 @@ pub fn handle_out_of_world(
         let frozen = context.blocked.contains(FROZEN_BLOCK);
         // A scene whose tick has been in-flight past the not-responding timeout is hung; stop
         // holding the player behind the loading screen and let them into the world.
-        let not_responding = context.in_flight
+        let not_responding = context.in_flight()
             && time.elapsed_secs() - context.last_sent > SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32();
         if !not_responding
-            && !context.broken
+            && !context.broken()
             && !frozen
             && (context.tick_number <= 5 || !context.blocked.is_empty())
         {

--- a/crates/restricted_actions/src/teleport.rs
+++ b/crates/restricted_actions/src/teleport.rs
@@ -11,7 +11,7 @@ use scene_runner::{
         LiveScenes, PointerResult, SceneHash, SceneLoading, ScenePointers, PARCEL_SIZE,
     },
     permissions::Permission,
-    renderer_context::{RendererSceneContext, FROZEN_BLOCK, SCENE_NOT_RESPONDING_TIMEOUT},
+    renderer_context::{RendererSceneContext, FROZEN_BLOCK},
     update_world::mesh_collider::SceneColliderData,
     OutOfWorld,
 };
@@ -78,7 +78,6 @@ pub fn teleport_player(
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn handle_out_of_world(
     mut commands: Commands,
-    time: Res<Time>,
     mut scenes: Query<
         (
             Option<&RendererSceneContext>,
@@ -154,19 +153,19 @@ pub fn handle_out_of_world(
         // tick or clears `blocked` to become "ready" on its own. FROZEN_BLOCK is only ever set by the
         // inspector's /freeze_scene + /tick_scene, so this only affects inspector-paused scenes.
         let frozen = context.blocked.contains(FROZEN_BLOCK);
-        // A scene whose tick has been in-flight past the not-responding timeout is hung; stop
-        // holding the player behind the loading screen and let them into the world.
-        let not_responding = context.in_flight()
-            && time.elapsed_secs() - context.last_sent > SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32();
-        if !not_responding
-            && !context.broken()
+        // A broken scene (hung past the not-responding timeout, errored, or unreachable) will
+        // never become ready; stop holding the player behind the loading screen and let them
+        // into the world. An inspected scene never gates the player at all: it's a debugging
+        // session, and it may sit at a breakpoint (or paused before its first tick) forever.
+        if !context.broken()
             && !frozen
+            && !context.inspected
             && (context.tick_number <= 5 || !context.blocked.is_empty())
         {
             debug!("scene not ready");
         } else {
-            if not_responding {
-                debug!("scene not responding, returning to world");
+            if context.broken() {
+                debug!("scene broken, returning to world");
             }
             debug!(
                 "ready, returning to world (set spawn here) tick: {}",

--- a/crates/scene_inspector/src/active_scene.rs
+++ b/crates/scene_inspector/src/active_scene.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use common::structs::PrimaryUser;
 use dcl::interface::CrdtStore;
 use dcl_component::{SceneComponentId, SceneEntityId};
-use scene_runner::{renderer_context::RendererSceneContext, ContainingScene, SceneThreadHandle};
+use scene_runner::{renderer_context::RendererSceneContext, ContainingScene};
 
 use crate::snapshot::{
     AllocCallback, PendingEntityAllocations, PendingSnapshotRequests, SnapshotCallback,
@@ -18,7 +18,6 @@ pub struct ActiveInspectionScene(pub Option<Entity>);
 pub struct SceneResolver<'w, 's> {
     pub active: Res<'w, ActiveInspectionScene>,
     pub scenes: Query<'w, 's, (Entity, &'static mut RendererSceneContext)>,
-    pub handles: Query<'w, 's, &'static SceneThreadHandle>,
     pub containing_scene: ContainingScene<'w, 's>,
     pub player: Query<'w, 's, Entity, With<PrimaryUser>>,
 }
@@ -67,13 +66,10 @@ impl SceneResolver<'_, '_> {
     where
         F: FnOnce(&CrdtStore) + Send + Sync + 'static,
     {
-        let entity = self.resolve_entity()?;
-        let handle = self
-            .handles
-            .get(entity)
-            .map_err(|_| "scene has no thread handle".to_string())?;
-        handle
-            .sender
+        let (entity, context) = self.resolve()?;
+        context
+            .sender()
+            .ok_or_else(|| "scene has no thread handle".to_string())?
             .send(dcl::RendererResponse::GetCrdtSnapshot)
             .map_err(|_| "failed to send snapshot request to scene".to_string())?;
         pending.push(entity, Box::new(callback) as SnapshotCallback);
@@ -94,13 +90,10 @@ impl SceneResolver<'_, '_> {
     where
         F: FnOnce(&[Result<SceneEntityId, dcl::AllocError>]) + Send + Sync + 'static,
     {
-        let entity = self.resolve_entity()?;
-        let handle = self
-            .handles
-            .get(entity)
-            .map_err(|_| "scene has no thread handle".to_string())?;
-        handle
-            .sender
+        let (entity, context) = self.resolve()?;
+        context
+            .sender()
+            .ok_or_else(|| "scene has no thread handle".to_string())?
             .send(dcl::RendererResponse::AllocateEntity {
                 component_id,
                 data,

--- a/crates/scene_inspector/src/read_commands.rs
+++ b/crates/scene_inspector/src/read_commands.rs
@@ -97,7 +97,7 @@ fn scene_stats_cmd(mut input: ConsoleCommand<SceneStatsCommand>, resolver: Scene
                 };
                 input.reply_ok(format!(
                     "scene: '{}'\nhash: {}\ntick: {}\nentities: {}\nstatus: {}\nbroken: {}\nin_flight: {}",
-                    ctx.title, ctx.hash, ctx.tick_number, entity_count, blocked, ctx.broken, ctx.in_flight,
+                    ctx.title, ctx.hash, ctx.tick_number, entity_count, blocked, ctx.broken(), ctx.in_flight(),
                 ));
             }
         }

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -44,7 +44,7 @@ use super::{update_world::CrdtExtractors, LoadSceneEvent, PrimaryUser, SceneSets
 use crate::{
     bounds_calc::scene_regions,
     parcel_to_vec3,
-    renderer_context::{RendererSceneContext, FROZEN_BLOCK},
+    renderer_context::{RendererSceneContext, SceneState, FROZEN_BLOCK},
     update_world::{visibility::VisibilityComponent, ComponentTracker},
     vec3_to_parcel, ContainerEntity, DeletedSceneEntities, OutOfWorld, SceneEntity,
     SceneThreadHandle,
@@ -712,16 +712,16 @@ pub(crate) fn initialize_scene(
             scene_origin,
         );
 
-        // mark context as in flight so we wait for initial RPC requests
-        context.in_flight = true;
         context.inspected = inspected;
         // set last_sent so the scene doesn't get extreme starvation priority
         // when it first becomes eligible after initialization completes
         context.last_sent = time.elapsed_secs();
+        // spawn in flight so we wait for initial RPC requests
+        context.state = SceneState::Live {
+            handle: SceneThreadHandle { sender: main_sx },
+            in_flight: true,
+        };
 
-        commands
-            .entity(root)
-            .try_insert((SceneThreadHandle { sender: main_sx },));
         commands.entity(root).remove::<SceneLoading>();
     }
 }
@@ -1630,7 +1630,7 @@ pub fn process_scene_lifecycle(
             }
         }
 
-        let still_loading = maybe_ctx.is_none_or(|ctx| ctx.tick_number <= 6 && !ctx.broken);
+        let still_loading = maybe_ctx.is_none_or(|ctx| ctx.tick_number <= 6 && !ctx.broken());
 
         // check if the current scene is still loading
         if let Some((current_hash, _)) = current_scene.as_ref() {
@@ -1754,7 +1754,7 @@ fn animate_ready_scene(
         // or paused by the inspector. Without the frozen case, a scene frozen before tick 5 has its
         // (already-spawned) main.crdt content stuck underground and looks empty until unfrozen.
         let frozen = ctx.blocked.contains(FROZEN_BLOCK);
-        if transform.translation.y < 0.0 && (ctx.tick_number >= 5 || ctx.broken || frozen) {
+        if transform.translation.y < 0.0 && (ctx.tick_number >= 5 || ctx.broken() || frozen) {
             if transform.translation.y == -1000.0 {
                 for child in children.map(|c| c.iter()).unwrap_or_default() {
                     if loading_quads.get(child).is_ok() {
@@ -1938,7 +1938,7 @@ pub fn handle_live_scene_info(
                 .map(|v| dcl_component::proto_components::common::Vector2::from(v.as_vec2()))
                 .collect(),
             is_portable: ctx.is_portable,
-            is_broken: ctx.broken,
+            is_broken: ctx.broken(),
             is_blocked: !ctx.blocked.is_empty(),
             is_super: maybe_super.is_some(),
             sdk_version: ctx.sdk_version.to_string(),

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -440,6 +440,29 @@ fn update_scene_priority(
         .map(|(e, gt)| (containing_scene.get(e), gt.translation()))
         .unwrap_or_default();
 
+    // mark scenes that have been in-flight past the timeout as broken and free their
+    // slot, so a wedged scene worker can't hold a scene thread forever
+    let elapsed = time.elapsed_secs();
+    for (ent, _, mut context, _) in scenes.iter_mut() {
+        if context.in_flight
+            && !context.broken
+            && !context.inspected
+            && elapsed - context.last_sent
+                > renderer_context::SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32()
+        {
+            warn!(
+                "scene {} ({} @ {}) has not responded for {:.0}s, marking broken",
+                context.hash,
+                context.title,
+                context.base,
+                elapsed - context.last_sent
+            );
+            context.broken = true;
+            context.in_flight = false;
+            updates.jobs_in_flight.remove(&ent);
+        }
+    }
+
     // check all in-flight scenes still exist
     let mut missing_in_flight = updates.jobs_in_flight.clone();
 
@@ -1092,47 +1115,57 @@ fn receive_scene_updates(
                         rpc_calls.len(),
                     );
                     if let Ok(mut context) = scenes.get_mut(*root) {
-                        context.tick_number = context.tick_number.wrapping_add(1);
-                        if context
-                            .refreeze_at_tick
-                            .is_some_and(|t| context.tick_number >= t)
-                        {
-                            context.blocked.insert(renderer_context::FROZEN_BLOCK);
-                            context.refreeze_at_tick = None;
-                        }
-                        context.last_update_dt = runtime.0 - context.total_runtime;
-                        context.total_runtime = runtime.0;
-                        context.last_update_frame = frame.0;
-                        context.in_flight = false;
-                        // extend (not assign) so renderer-side births (the inspector's /new_entity
-                        // adds the freshly-allocated ids straight to `nascent`) aren't clobbered by
-                        // the scene's reported births. `nascent` is drained every lifecycle pass, so
-                        // this matches assignment for scene-reported births.
-                        context.nascent.extend(census.born);
-                        // Merge externally-queued deaths (e.g. /delete_entity) with
-                        // scene-reported deaths, draining the old set so entries are
-                        // only processed once.
-                        let mut died = census.died;
-                        died.extend(std::mem::take(&mut context.death_row));
-                        context.death_row = died;
-                        for message in messages.into_iter() {
-                            context.log(message);
-                        }
-                        // Sync scene timestamps into crdt_store so renderer writes (e.g.
-                        // /set_component) use a base timestamp that wins over the scene's current.
-                        // Must happen before updates_to_entity drains `crdt`.
-                        context.crdt_store.sync_lww_timestamps_from(&crdt);
+                        if context.broken {
+                            // drop late replies from a scene already marked broken so they
+                            // can't un-break it; still fall through to free the job slot
+                            debug!("[{scene_id:?}] discarding update for broken scene");
+                        } else {
+                            context.tick_number = context.tick_number.wrapping_add(1);
+                            if context
+                                .refreeze_at_tick
+                                .is_some_and(|t| context.tick_number >= t)
+                            {
+                                context.blocked.insert(renderer_context::FROZEN_BLOCK);
+                                context.refreeze_at_tick = None;
+                            }
+                            context.last_update_dt = runtime.0 - context.total_runtime;
+                            context.total_runtime = runtime.0;
+                            context.last_update_frame = frame.0;
+                            context.in_flight = false;
+                            // extend (not assign) so renderer-side births (the inspector's /new_entity
+                            // adds the freshly-allocated ids straight to `nascent`) aren't clobbered by
+                            // the scene's reported births. `nascent` is drained every lifecycle pass, so
+                            // this matches assignment for scene-reported births.
+                            context.nascent.extend(census.born);
+                            // Merge externally-queued deaths (e.g. /delete_entity) with
+                            // scene-reported deaths, draining the old set so entries are
+                            // only processed once.
+                            let mut died = census.died;
+                            died.extend(std::mem::take(&mut context.death_row));
+                            context.death_row = died;
+                            for message in messages.into_iter() {
+                                context.log(message);
+                            }
+                            // Sync scene timestamps into crdt_store so renderer writes (e.g.
+                            // /set_component) use a base timestamp that wins over the scene's current.
+                            // Must happen before updates_to_entity drains `crdt`.
+                            context.crdt_store.sync_lww_timestamps_from(&crdt);
 
-                        let mut commands = commands.entity(*root);
-                        for (component_id, interface) in crdt_interfaces.0.iter() {
-                            interface.updates_to_entity(*component_id, &mut crdt, &mut commands);
-                        }
-                        // dcl_assert!(
-                        //     updates.jobs_in_flight.contains(root) || context.tick_number <= 2
-                        // );
+                            let mut commands = commands.entity(*root);
+                            for (component_id, interface) in crdt_interfaces.0.iter() {
+                                interface.updates_to_entity(
+                                    *component_id,
+                                    &mut crdt,
+                                    &mut commands,
+                                );
+                            }
+                            // dcl_assert!(
+                            //     updates.jobs_in_flight.contains(root) || context.tick_number <= 2
+                            // );
 
-                        for rpc_call in rpc_calls {
-                            rpc_call_events.write(rpc_call);
+                            for rpc_call in rpc_calls {
+                                rpc_call_events.write(rpc_call);
+                            }
                         }
                     } else {
                         debug!(

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -431,6 +431,7 @@ fn update_scene_priority(
     mut updates: ResMut<SceneUpdates>,
     time: Res<Time>,
     containing_scene: ContainingScene,
+    mut commands: Commands,
 ) {
     updates.eligible_jobs = 0;
     updates.frames += 1;
@@ -460,6 +461,9 @@ fn update_scene_priority(
             context.broken = true;
             context.in_flight = false;
             updates.jobs_in_flight.remove(&ent);
+            // dropping the thread handle closes the scene's renderer channel, which
+            // signals the scene host to terminate the worker's isolate
+            commands.entity(ent).try_remove::<SceneThreadHandle>();
         }
     }
 
@@ -793,6 +797,7 @@ fn send_scene_updates(
     preview_mode: Res<PreviewMode>,
     mut buf: Local<Vec<u8>>,
     mut realm_info_cache: Local<RealmInfoCache>,
+    mut commands: Commands,
 ) {
     let updates = &mut *updates;
     let buf = &mut *buf;
@@ -1027,7 +1032,7 @@ fn send_scene_updates(
             context.base
         );
         context.broken = true;
-        // TODO: clean up
+        commands.entity(ent).try_remove::<SceneThreadHandle>();
     } else {
         context.in_flight = true;
         context.last_sent = time.elapsed_secs();
@@ -1091,6 +1096,7 @@ fn receive_scene_updates(
                         if let Ok(mut context) = scenes.get_mut(*root) {
                             context.broken = true;
                             context.in_flight = false;
+                            commands.entity(*root).try_remove::<SceneThreadHandle>();
                             let timestamp = context.total_runtime as f64 + 1.0;
                             error!("[{scene_id:?} @ {}] error: {message}", context.tick_number);
                             context.log(SceneLogMessage {

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -56,7 +56,7 @@ use self::{
     initialize_scene::{
         LiveScenes, PointerResult, SceneLifecyclePlugin, SceneLoading, ScenePointers, PARCEL_SIZE,
     },
-    renderer_context::RendererSceneContext,
+    renderer_context::{RendererSceneContext, SceneState},
     update_scene::SceneInputPlugin,
     update_world::{CrdtExtractors, SceneOutputPlugin},
 };
@@ -111,7 +111,7 @@ impl SceneUpdates {
     }
 }
 
-#[derive(Component)]
+#[derive(Debug)]
 pub struct SceneThreadHandle {
     pub sender: tokio::sync::mpsc::UnboundedSender<RendererResponse>,
 }
@@ -431,7 +431,6 @@ fn update_scene_priority(
     mut updates: ResMut<SceneUpdates>,
     time: Res<Time>,
     containing_scene: ContainingScene,
-    mut commands: Commands,
 ) {
     updates.eligible_jobs = 0;
     updates.frames += 1;
@@ -445,8 +444,7 @@ fn update_scene_priority(
     // slot, so a wedged scene worker can't hold a scene thread forever
     let elapsed = time.elapsed_secs();
     for (ent, _, mut context, _) in scenes.iter_mut() {
-        if context.in_flight
-            && !context.broken
+        if context.in_flight()
             && !context.inspected
             && elapsed - context.last_sent
                 > renderer_context::SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32()
@@ -458,12 +456,10 @@ fn update_scene_priority(
                 context.base,
                 elapsed - context.last_sent
             );
-            context.broken = true;
-            context.in_flight = false;
-            updates.jobs_in_flight.remove(&ent);
             // dropping the thread handle closes the scene's renderer channel, which
             // signals the scene host to terminate the worker's isolate
-            commands.entity(ent).try_remove::<SceneThreadHandle>();
+            context.state = SceneState::Broken;
+            updates.jobs_in_flight.remove(&ent);
         }
     }
 
@@ -480,10 +476,10 @@ fn update_scene_priority(
         .iter_mut()
         .filter(|(ent, _, context, maybe_super)| {
             missing_in_flight.remove(ent);
-            let allow = !context.in_flight
-                && !context.broken
+            let allow = !context.in_flight()
+                && !context.broken()
                 && (context.blocked.is_empty() || maybe_super.is_some());
-            if context.in_flight {
+            if context.in_flight() {
                 skipped_in_flight += 1;
             }
             if !allow {
@@ -491,8 +487,8 @@ fn update_scene_priority(
                     "skipping {ent} (@{}) on {:?}",
                     context.base,
                     (
-                        context.in_flight,
-                        context.broken,
+                        context.in_flight(),
+                        context.broken(),
                         &context.blocked,
                         maybe_super.is_some()
                     )
@@ -514,11 +510,11 @@ fn update_scene_priority(
             };
             let not_yet_run = context.last_sent < time.elapsed_secs();
 
-            if !context.in_flight && !not_yet_run {
+            if !context.in_flight() && !not_yet_run {
                 skipped_already_sent += 1;
             }
 
-            (!context.in_flight && not_yet_run).then(|| {
+            (!context.in_flight() && not_yet_run).then(|| {
                 updates.eligible_jobs += 1;
                 let priority =
                     FloatOrd(context.priority / (time.elapsed_secs() - context.last_sent));
@@ -779,7 +775,6 @@ fn send_scene_updates(
     mut scenes: Query<(
         Entity,
         &mut RendererSceneContext,
-        &SceneThreadHandle,
         &GlobalTransform,
         Has<SuperUserScene>,
     )>,
@@ -797,7 +792,6 @@ fn send_scene_updates(
     preview_mode: Res<PreviewMode>,
     mut buf: Local<Vec<u8>>,
     mut realm_info_cache: Local<RealmInfoCache>,
-    mut commands: Commands,
 ) {
     let updates = &mut *updates;
     let buf = &mut *buf;
@@ -878,7 +872,12 @@ fn send_scene_updates(
 
     updates.scene_queue.pop_front();
 
-    let (_, mut context, handle, scene_transform, is_super) = scenes.get_mut(ent).unwrap();
+    let (_, mut context, scene_transform, is_super) = scenes.get_mut(ent).unwrap();
+
+    // only live scenes are queued, so this only fails if the scene broke this frame
+    let Some(sender) = context.sender().cloned() else {
+        return;
+    };
 
     // collect components
 
@@ -1023,7 +1022,7 @@ fn send_scene_updates(
         died: std::mem::take(&mut context.outbound_died),
     };
 
-    if let Err(e) = handle.sender.send(RendererResponse::Ok(
+    if let Err(e) = sender.send(RendererResponse::Ok(
         context.crdt_store.take_updates(),
         census,
     )) {
@@ -1031,10 +1030,9 @@ fn send_scene_updates(
             "failed to send updates to scene {ent:?} [{:?}]: {e:?}",
             context.base
         );
-        context.broken = true;
-        commands.entity(ent).try_remove::<SceneThreadHandle>();
+        context.state = SceneState::Broken;
     } else {
-        context.in_flight = true;
+        context.set_in_flight(true);
         context.last_sent = time.elapsed_secs();
         dcl_assert!(!updates.jobs_in_flight.contains(&ent));
         updates.jobs_in_flight.insert(ent);
@@ -1094,9 +1092,7 @@ fn receive_scene_updates(
                 SceneResponse::Error(scene_id, message) => {
                     if let Some(root) = updates.scene_ids.get(&scene_id) {
                         if let Ok(mut context) = scenes.get_mut(*root) {
-                            context.broken = true;
-                            context.in_flight = false;
-                            commands.entity(*root).try_remove::<SceneThreadHandle>();
+                            context.state = SceneState::Broken;
                             let timestamp = context.total_runtime as f64 + 1.0;
                             error!("[{scene_id:?} @ {}] error: {message}", context.tick_number);
                             context.log(SceneLogMessage {
@@ -1121,7 +1117,10 @@ fn receive_scene_updates(
                         rpc_calls.len(),
                     );
                     if let Ok(mut context) = scenes.get_mut(*root) {
-                        if context.broken {
+                        // this reply is the scene's in-flight tick coming back (a no-op for
+                        // broken scenes, whose state holds no in-flight bit)
+                        context.set_in_flight(false);
+                        if context.broken() {
                             // drop late replies from a scene already marked broken so they
                             // can't un-break it; still fall through to free the job slot
                             debug!("[{scene_id:?}] discarding update for broken scene");
@@ -1137,7 +1136,6 @@ fn receive_scene_updates(
                             context.last_update_dt = runtime.0 - context.total_runtime;
                             context.total_runtime = runtime.0;
                             context.last_update_frame = frame.0;
-                            context.in_flight = false;
                             // extend (not assign) so renderer-side births (the inspector's /new_entity
                             // adds the freshly-allocated ids straight to `nascent`) aren't clobbered by
                             // the scene's reported births. `nascent` is drained every lifecycle pass, so

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -6,7 +6,7 @@ use common::{
 };
 use dcl::{
     interface::{CrdtStore, CrdtType},
-    SceneId, SceneLogMessage, SceneResourceCounters,
+    RendererResponse, SceneId, SceneLogMessage, SceneResourceCounters,
 };
 use dcl_component::{DclReader, DclWriter, SceneComponentId, SceneEntityId, ToDclWriter};
 use scene_material::BoundRegion;
@@ -17,7 +17,7 @@ use crate::{
         mesh_collider::DisableCollisions,
         transform_and_parent::{ParentPositionSync, SceneProxyStage},
     },
-    ContainerEntity, SceneEntity, TargetParent,
+    ContainerEntity, SceneEntity, SceneThreadHandle, TargetParent,
 };
 
 // contains a list of (SceneEntityId.generation, bevy entity) indexed by SceneEntityId.id
@@ -29,6 +29,23 @@ use crate::{
 // or if they are required for hierarchy parenting
 // TODO - consider Vec<Option<page>>
 type LiveEntityTable = Vec<(u16, Option<Entity>)>;
+
+// scene worker lifecycle. `Broken` consumes the thread handle, so marking a scene broken
+// structurally drops the renderer channel, which signals the scene host to terminate the
+// worker (after a grace period for an in-flight tick to complete). `in_flight` (a tick has
+// been sent and not yet answered) lives inside `Live` since only a live scene can have a
+// tick outstanding — `Init` and `Broken` scenes are never in flight by construction.
+#[derive(Debug, Default)]
+pub enum SceneState {
+    // scene thread not yet spawned
+    #[default]
+    Init,
+    Live {
+        handle: SceneThreadHandle,
+        in_flight: bool,
+    },
+    Broken,
+}
 
 // mapping from script entity -> bevy entity
 // note - be careful with size as this struct is moved into/out of js runtimes
@@ -74,10 +91,9 @@ pub struct RendererSceneContext {
     pub last_sent_camera_transform: Option<Transform>,
     // time of last updates to bevy world from scene
     pub last_update_frame: u32,
-    // currently running?
-    pub in_flight: bool,
-    // currently broken (record and keep for debug purposes and to avoid spamming reloads)
-    pub broken: bool,
+    // scene worker state; broken scenes are recorded and kept for debug purposes and to
+    // avoid spamming reloads
+    pub state: SceneState,
 
     pub crdt_store: CrdtStore,
 
@@ -134,6 +150,34 @@ pub const SCENE_NOT_RESPONDING_DISPLAY_AFTER: std::time::Duration =
     std::time::Duration::from_secs(2);
 
 impl RendererSceneContext {
+    pub fn broken(&self) -> bool {
+        matches!(self.state, SceneState::Broken)
+    }
+
+    pub fn sender(&self) -> Option<&tokio::sync::mpsc::UnboundedSender<RendererResponse>> {
+        match &self.state {
+            SceneState::Live { handle, .. } => Some(&handle.sender),
+            _ => None,
+        }
+    }
+
+    pub fn in_flight(&self) -> bool {
+        matches!(
+            self.state,
+            SceneState::Live {
+                in_flight: true,
+                ..
+            }
+        )
+    }
+
+    // no-op unless the scene is live: `Init` and `Broken` scenes have no in-flight bit
+    pub fn set_in_flight(&mut self, value: bool) {
+        if let SceneState::Live { in_flight, .. } = &mut self.state {
+            *in_flight = value;
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         scene_id: SceneId,
@@ -175,8 +219,7 @@ impl RendererSceneContext {
             last_sent_player_transform: None,
             last_sent_camera_transform: None,
             last_update_frame: 0,
-            in_flight: false,
-            broken: false,
+            state: SceneState::Init,
             priority,
             crdt_store: Default::default(),
             initial_crdt: None,

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -123,8 +123,9 @@ pub const FROZEN_BLOCK: &str = "frozen";
 pub const SCENE_LOG_BUFFER_SIZE: usize = 100;
 
 // A scene tick that has been in-flight (sent to the scene, no response yet) for longer than this
-// is treated as "not responding": handle_out_of_world stops holding the player behind the loading
-// screen, and the loading UI surfaces a countdown to this timeout.
+// is treated as "not responding": update_scene_priority marks the scene broken and frees its
+// thread slot, handle_out_of_world stops holding the player behind the loading screen, and the
+// loading UI surfaces a countdown to this timeout.
 pub const SCENE_NOT_RESPONDING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 // Don't surface the "not responding" message until a tick has been in-flight at least this long,

--- a/crates/system_ui/src/oow.rs
+++ b/crates/system_ui/src/oow.rs
@@ -43,7 +43,7 @@ fn get_scene_loading_info(
     if let Some((context, _)) = scene {
         let in_flight_for = now - context.last_sent;
         if pending_assets.unwrap_or(0) == 0
-            && context.in_flight
+            && context.in_flight()
             && in_flight_for >= SCENE_NOT_RESPONDING_DISPLAY_AFTER.as_secs_f32()
         {
             let remaining = (SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32() - in_flight_for).max(0.0);

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -279,7 +279,7 @@ fn update_scene_load_state(
             if loading_scenes.get(scene).is_ok() {
                 "Loading"
             } else if let Ok(scene) = running_scenes.get(scene) {
-                if scene.broken {
+                if scene.broken() {
                     "Broken"
                 } else if !scene.blocked.is_empty() {
                     "Blocked"
@@ -294,15 +294,15 @@ fn update_scene_load_state(
         let loading = loading_scenes.iter().count();
         let running = running_scenes
             .iter()
-            .filter(|context| !context.broken && context.blocked.is_empty())
+            .filter(|context| !context.broken() && context.blocked.is_empty())
             .count();
         let blocked = running_scenes
             .iter()
-            .filter(|context| !context.broken && !context.blocked.is_empty())
+            .filter(|context| !context.broken() && !context.blocked.is_empty())
             .count();
         let broken = running_scenes
             .iter()
-            .filter(|context| context.broken)
+            .filter(|context| context.broken())
             .count();
         let transports = transports.iter().count();
         let players = players.iter().count() + 1;
@@ -490,7 +490,7 @@ fn update_minimap(
     let sdk = scene.map(|(context, _)| context.sdk_version).unwrap_or("");
     let state = scene
         .map(|(context, gltf_count)| {
-            if context.broken {
+            if context.broken() {
                 "Broken".to_owned()
             } else if !context.blocked.is_empty() {
                 format!("Loading [{}]", gltf_count.map(|c| c.0).unwrap_or_default())

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -588,7 +588,7 @@ fn supervisor(
     for ctx in scenes.iter() {
         count += 1;
         max_tick = max_tick.max(ctx.tick_number);
-        if ctx.broken {
+        if ctx.broken() {
             any_broken = true;
             error!("[headless] scene {} is broken", ctx.hash);
         }
@@ -949,7 +949,7 @@ fn drain_control_commands(
                 for ctx in scenes.iter() {
                     ctl_emit(&serde_json::json!({
                         "type": "scene-status", "scene": ctx.hash,
-                        "tick": ctx.tick_number, "broken": ctx.broken,
+                        "tick": ctx.tick_number, "broken": ctx.broken(),
                     }));
                 }
             }
@@ -1026,7 +1026,7 @@ fn emit_scene_status(
             live.insert(ctx.hash.clone());
             ctl_emit(&serde_json::json!({"type": "scene-live", "scene": ctx.hash}));
         }
-        if ctx.broken && !broken.contains(&ctx.hash) {
+        if ctx.broken() && !broken.contains(&ctx.hash) {
             broken.insert(ctx.hash.clone());
             ctl_emit(&serde_json::json!({"type": "scene-broken", "scene": ctx.hash}));
         }
@@ -1038,7 +1038,7 @@ fn emit_scene_status(
         for ctx in scenes.iter() {
             ctl_emit(&serde_json::json!({
                 "type": "scene-status", "scene": ctx.hash,
-                "tick": ctx.tick_number, "broken": ctx.broken,
+                "tick": ctx.tick_number, "broken": ctx.broken(),
             }));
         }
     }


### PR DESCRIPTION
# scene runner: watchdog for non-responding scene workers

## What

Enforce the existing `SCENE_NOT_RESPONDING_TIMEOUT` on the renderer side: a scene whose tick has been in flight longer than the timeout is marked `broken`, its `jobs_in_flight` slot is freed, and any reply that arrives after the mark is discarded so it cannot un-break the scene.

## Why

The timeout constant already exists and drives UI (the "not responding" countdown in the out-of-world overlay and the teleport checks), but nothing enforces it. If a scene worker wedges — an infinite loop in `onUpdate`, a runtime hang, a deadlocked worker thread — its `in_flight` flag stays set forever and its entity stays in `jobs_in_flight`. With the default `scene_threads = 4`, one wedged worker permanently consumes a quarter of scene tick throughput, and every other scene is silently throttled for the rest of the session. Two wedged workers halve it, and so on. The user sees nothing except the whole world gradually ticking slower.

Dropping late replies matters for the same reason: if a wedged worker eventually wakes up and flushes a stale `SceneResponse::Ok`, processing it would clear `in_flight` and apply a CRDT state the renderer has long moved past. The scene must stay broken once the watchdog has fired.

## How

- `update_scene_priority` (already the system that maintains `jobs_in_flight`) gets a pre-pass: any scene with `in_flight` set, not already broken, and `elapsed - last_sent > SCENE_NOT_RESPONDING_TIMEOUT` is marked broken with a `warn!`, its `in_flight` cleared, and its entity removed from `jobs_in_flight`. Scenes with an attached inspector are exempt, since a paused inspector session legitimately holds a tick open indefinitely.
- `receive_scene_updates` wraps the `SceneResponse::Ok` processing in a `context.broken` check: late replies from a watchdogged scene are logged at debug level and dropped — no tick increment, no CRDT application, no RPC dispatch. The job-completion bookkeeping after the match still runs, so the slot stays consistent either way.
- The comment on `SCENE_NOT_RESPONDING_TIMEOUT` is updated to describe the enforcement.

No new constants, no config, no protocol changes.

## Default behavior

On by default; there is nothing to configure. Healthy scenes are unaffected — the pre-pass only touches scenes that have already blown a 10 s tick deadline, which is far beyond anything a live scene does. Error handling for scenes that report failure (`SceneResponse::Error`) is unchanged; this covers the workers that never report anything at all. As a side effect, a scene broken via `SceneResponse::Error` that later flushes a stale `Ok` no longer has that reply applied.

## Testing

- `cargo check --workspace` passes.
- Manual: wedge a scene (infinite loop in `onUpdate`) and walk the world. Before this patch the wedged scene holds a `scene_threads` slot forever and neighboring scenes tick slower; with it, the scene is marked broken after 10 s (warn log), the slot is freed, and neighbors are unaffected. If the wedged worker later flushes a reply, it is discarded (debug log) and the scene stays broken.
- This logic has been running in a downstream fork of the engine under heavy automated scene load without regressions.

## Evidence

Independently verified A/B pass on this branch alone against the base commit, re-audited against the raw logs with all counts recomputed. (An earlier pair was invalid — both sides were identity-starved so the wedge scenes never spawned; it was diagnosed, archived, and fully redone.)

**Method.** A local mirror of the `scene-explorer-tests` realm (19 scenes) with two scenes replaced by wedged variants of their published `game.js`:

- WEDGE-INF = **NFT Shape Unit Test** at parcel `54,-68`: enters an infinite loop at its second tick, so its worker never answers again;
- WEDGE-SLOW = **Avatar Attach Unit Test** at parcel `52,-68`: busy-waits 25 s once at its second tick — a reply well past the 10 s timeout, to test that late replies do not un-break.

The 16 remaining healthy scene-explorer-tests scenes get a tail-appended tick logger (every 50th `onUpdate`). Both sides spawn at `52,-60` with `--distance 300 --threads 2` (2 scene-thread slots for 18 scenes), 150 s wall each, identical args and environment, deterministic guest identity on both sides, content cache purged before each run. The two binaries differ by exactly this branch's single commit (verified by patch identity). Signals are deterministic log counters; no perf claim is made.

**Results (exact counts, one 150 s run per side).**

| signal | base | branch |
|---|---|---|
| "marking broken" warns | 0 | 2 — both wedge scenes, both at "has not responded for 10s" |
| late-reply discards | 0 | 1 (WEDGE-SLOW's ~25 s-late reply) |
| WEDGE-SLOW after the late reply | reply accepted, scene keeps running | reply discarded, scene stays broken |
| healthy scenes (of 16) that ever ticked | 11 | 16 |
| scheduler skips on `broken` | 0 | 10,133 (wedges priced out of dispatch instead of holding slots) |

Starvation relief on the branch, by parcel (max tick counter, base → branch): `52,-60` 50 → 4,450 (**89x**), `52,-58` 100 → 3,200, `54,-60` 50 → 2,900, `54,-58` 100 → 2,000. On base, 5 of the 16 healthy scenes (`52,-64`, `52,-66`, `54,-62`, `54,-64`, `54,-66`) never ran a single tick in 150 s, and `52,-62` waited 146.9 s for its first tick vs 35.6 s on the branch.

Claim mapping: marked broken at the existing 10 s timeout — confirmed (both warns at 10 s); slot freed — confirmed (after the marks both slots serve healthy scenes and all 16 tick); base permanently loses a slot per wedged worker — confirmed (WEDGE-INF holds `in_flight` to end of run); late replies discarded without un-breaking — confirmed.

**Honest asymmetry.** The run driver began its camera orbit only on the branch side (on base the wedged realm never reached "ready", so the player stayed at spawn). Movement shuffles distance-based tick shares, but it cannot produce the sign-flips above (0 vs 2 marks, 0 vs 1 discard, accepted vs discarded late reply, 11 vs 16 scenes ticking) — those are decided in the first ~40 s while both sides are still at spawn.

**Regression gate.** `cargo test --workspace --no-fail-fast`: exactly one failing target (`scene_runner test::cyclic_recovery`), identical to the pre-existing base baseline. No new failures.

**Healthy-realm smoke.** Branch binary against the unmodified 19-scene scene-explorer-tests realm: 19/19 scenes started, 0 marked broken, ticks advancing on every scene (per-scene tick counts 36..1,802 at cutoff), 900 measured frames at wall p50 25.3 ms — the watchdog changes nothing on a healthy realm.

**Gaps (stated plainly).** The `--threads 2` identity across sides is enforced by the shared run script rather than echoed in the logs; base never exceeding 2 in-flight jobs and the serial first-tick staircase corroborate it. Two identical environmental audio-thread panics occur on each side (unrelated to scene scheduling).
