### PR TITLE
crdt: opt-in byte-equality dedup for LWW component updates

### DIFF
--- a/crates/dcl/src/crdt/lww.rs
+++ b/crates/dcl/src/crdt/lww.rs
@@ -12,6 +12,12 @@ pub struct LWWEntry {
     pub data: Vec<u8>,
 }
 
+impl LWWEntry {
+    fn value_matches(&self, is_some: bool, data: &[u8]) -> bool {
+        self.is_some == is_some && self.data.as_slice() == data
+    }
+}
+
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct CrdtLWWState {
     pub last_write: HashMap<SceneEntityId, LWWEntry>,
@@ -81,14 +87,13 @@ impl CrdtLWWState {
                 let entry = o.into_mut();
                 let update = match mode {
                     UpdateMode::Force => true,
-                    UpdateMode::ForceIfDifferent => {
-                        entry.is_some != maybe_new_data.is_some()
-                            || entry.data.as_slice()
-                                != maybe_new_data
-                                    .as_ref()
-                                    .map(|r| r.as_slice())
-                                    .unwrap_or_default()
-                    }
+                    UpdateMode::ForceIfDifferent => !entry.value_matches(
+                        maybe_new_data.is_some(),
+                        maybe_new_data
+                            .as_ref()
+                            .map(|r| r.as_slice())
+                            .unwrap_or_default(),
+                    ),
                     UpdateMode::Normal => {
                         Self::check_update(entry, new_timestamp, maybe_new_data.as_deref())
                     }
@@ -168,6 +173,29 @@ impl CrdtLWWState {
 
     pub fn update_lww_timestamp(&mut self, entity: SceneEntityId, timestamp: SceneCrdtTimestamp) {
         self.last_write.entry(entity).or_default().timestamp = timestamp;
+    }
+
+    // merge a delta into this state, marking entities as updated only when the
+    // payload actually changed. identical payloads still advance the timestamp
+    // so future conflict checks behave as if the write had been applied.
+    pub fn merge_dedup(&mut self, delta: CrdtLWWState) {
+        for (entity, entry) in delta.last_write {
+            match self.last_write.entry(entity) {
+                Entry::Occupied(mut o) => {
+                    let prev = o.get_mut();
+                    if prev.value_matches(entry.is_some, &entry.data) {
+                        prev.timestamp = entry.timestamp;
+                    } else {
+                        *prev = entry;
+                        self.updates.insert(entity);
+                    }
+                }
+                Entry::Vacant(v) => {
+                    v.insert(entry);
+                    self.updates.insert(entity);
+                }
+            }
+        }
     }
 }
 
@@ -420,5 +448,94 @@ mod test {
         assert!(state.try_update(entity, newer_timestamp, Some(&mut reader)));
 
         assert_entry_eq(state, entity, newer_timestamp, Some(Vec::<u8>::default()));
+    }
+
+    fn lww_entry(timestamp: u32, data: Option<&[u8]>) -> LWWEntry {
+        LWWEntry {
+            timestamp: SceneCrdtTimestamp(timestamp),
+            is_some: data.is_some(),
+            data: data.unwrap_or_default().to_vec(),
+        }
+    }
+
+    fn lww_state(entity: SceneEntityId, entry: LWWEntry) -> CrdtLWWState {
+        let mut state = CrdtLWWState::default();
+        state.last_write.insert(entity, entry);
+        state
+    }
+
+    const MERGE_ENTITY: SceneEntityId = SceneEntityId {
+        id: 0,
+        generation: 0,
+    };
+
+    #[test]
+    fn merge_dedup_identical_resend_advances_timestamp_without_update_mark() {
+        let mut state = lww_state(MERGE_ENTITY, lww_entry(1, Some(&[1, 2, 3])));
+        state.merge_dedup(lww_state(MERGE_ENTITY, lww_entry(5, Some(&[1, 2, 3]))));
+
+        assert!(state.updates.is_empty());
+        let entry = state.last_write.get(&MERGE_ENTITY).unwrap();
+        assert_eq!(entry.timestamp, SceneCrdtTimestamp(5));
+        assert!(entry.is_some);
+        assert_eq!(entry.data, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn merge_dedup_tombstone_resend_advances_timestamp_without_update_mark() {
+        let mut state = lww_state(MERGE_ENTITY, lww_entry(1, None));
+        state.merge_dedup(lww_state(MERGE_ENTITY, lww_entry(4, None)));
+
+        assert!(state.updates.is_empty());
+        let entry = state.last_write.get(&MERGE_ENTITY).unwrap();
+        assert_eq!(entry.timestamp, SceneCrdtTimestamp(4));
+        assert!(!entry.is_some);
+    }
+
+    #[test]
+    fn merge_dedup_some_to_none_marks_update() {
+        let mut state = lww_state(MERGE_ENTITY, lww_entry(1, Some(&[])));
+        state.merge_dedup(lww_state(MERGE_ENTITY, lww_entry(3, None)));
+
+        assert!(state.updates.contains(&MERGE_ENTITY));
+        let entry = state.last_write.get(&MERGE_ENTITY).unwrap();
+        assert_eq!(entry.timestamp, SceneCrdtTimestamp(3));
+        assert!(!entry.is_some);
+    }
+
+    #[test]
+    fn merge_dedup_none_to_some_marks_update() {
+        let mut state = lww_state(MERGE_ENTITY, lww_entry(1, None));
+        state.merge_dedup(lww_state(MERGE_ENTITY, lww_entry(2, Some(&[7]))));
+
+        assert!(state.updates.contains(&MERGE_ENTITY));
+        let entry = state.last_write.get(&MERGE_ENTITY).unwrap();
+        assert_eq!(entry.timestamp, SceneCrdtTimestamp(2));
+        assert!(entry.is_some);
+        assert_eq!(entry.data, vec![7]);
+    }
+
+    #[test]
+    fn merge_dedup_changed_data_marks_update() {
+        let mut state = lww_state(MERGE_ENTITY, lww_entry(1, Some(&[1])));
+        state.merge_dedup(lww_state(MERGE_ENTITY, lww_entry(2, Some(&[2]))));
+
+        assert!(state.updates.contains(&MERGE_ENTITY));
+        let entry = state.last_write.get(&MERGE_ENTITY).unwrap();
+        assert_eq!(entry.timestamp, SceneCrdtTimestamp(2));
+        assert!(entry.is_some);
+        assert_eq!(entry.data, vec![2]);
+    }
+
+    #[test]
+    fn merge_dedup_vacant_insert_marks_update() {
+        let mut state = CrdtLWWState::default();
+        state.merge_dedup(lww_state(MERGE_ENTITY, lww_entry(1, Some(&[9]))));
+
+        assert!(state.updates.contains(&MERGE_ENTITY));
+        let entry = state.last_write.get(&MERGE_ENTITY).unwrap();
+        assert_eq!(entry.timestamp, SceneCrdtTimestamp(1));
+        assert!(entry.is_some);
+        assert_eq!(entry.data, vec![9]);
     }
 }

--- a/crates/scene_runner/src/update_world/mod.rs
+++ b/crates/scene_runner/src/update_world/mod.rs
@@ -97,6 +97,7 @@ pub trait CrdtInterface {
 
 pub struct CrdtLWWInterface<T: FromDclReader> {
     position: ComponentPosition,
+    dedup: bool,
     _marker: PhantomData<T>,
 }
 
@@ -111,10 +112,28 @@ impl<T: FromDclReader> CrdtInterface for CrdtLWWInterface<T> {
         type_map: &mut CrdtStore,
         commands: &mut EntityCommands,
     ) {
-        type_map
-            .lww
-            .remove(&component_id)
-            .map(|state| commands.try_insert(CrdtStateComponent::<CrdtLWWState, T>::new(state)));
+        let Some(state) = type_map.lww.remove(&component_id) else {
+            return;
+        };
+
+        if self.dedup {
+            // merge into the existing state so unchanged payloads can be recognised
+            commands.queue_handled(
+                move |mut entity: EntityWorldMut| {
+                    if let Some(mut existing) =
+                        entity.get_mut::<CrdtStateComponent<CrdtLWWState, T>>()
+                    {
+                        existing.state.merge_dedup(state);
+                    } else {
+                        entity.insert(CrdtStateComponent::<CrdtLWWState, T>::new(state));
+                    }
+                },
+                // the scene may have despawned; just drop the update
+                bevy::ecs::error::ignore,
+            );
+        } else {
+            commands.try_insert(CrdtStateComponent::<CrdtLWWState, T>::new(state));
+        }
     }
 }
 
@@ -219,6 +238,24 @@ pub trait AddCrdtInterfaceExt {
     ) where
         <C as TryFrom<D>>::Error: std::fmt::Display;
 
+    // as `add_crdt_lww_component`, but a resend with an unchanged payload only
+    // advances the crdt timestamp instead of re-applying the component. don't
+    // use for components where a resend is meaningful (e.g. tween restart).
+    fn add_crdt_lww_component_dedup<
+        D: FromDclReader
+            + std::fmt::Debug
+            + prost::Message
+            + Default
+            + serde::Serialize
+            + serde::de::DeserializeOwned,
+        C: Component + TryFrom<D>,
+    >(
+        &mut self,
+        id: SceneComponentId,
+        position: ComponentPosition,
+    ) where
+        <C as TryFrom<D>>::Error: std::fmt::Display;
+
     fn add_crdt_go_component<
         D: FromDclReader
             + std::fmt::Debug
@@ -234,22 +271,73 @@ pub trait AddCrdtInterfaceExt {
     );
 }
 
+fn register_crdt_lww_interface<D: FromDclReader>(
+    app: &mut App,
+    id: SceneComponentId,
+    position: ComponentPosition,
+    dedup: bool,
+) {
+    // store a writer
+    let existing = app.world_mut().resource_mut::<CrdtExtractors>().0.insert(
+        id,
+        Box::new(CrdtLWWInterface::<D> {
+            position,
+            dedup,
+            _marker: PhantomData,
+        }),
+    );
+
+    assert!(existing.is_none(), "duplicate registration for {id:?}");
+}
+
+fn register_crdt_lww_component<
+    D: FromDclReader
+        + std::fmt::Debug
+        + prost::Message
+        + Default
+        + serde::Serialize
+        + serde::de::DeserializeOwned,
+    C: Component + TryFrom<D>,
+    const DEDUP: bool,
+>(
+    app: &mut App,
+    id: SceneComponentId,
+    position: ComponentPosition,
+) where
+    <C as TryFrom<D>>::Error: std::fmt::Display,
+{
+    register_crdt_lww_interface::<D>(app, id, position, DEDUP);
+    // register in ComponentNameRegistry for inspection
+    let (inspect, write, default) = make_proto_closures::<D>();
+    app.world_mut()
+        .resource_mut::<ComponentNameRegistry>()
+        .register(
+            derive_component_name::<D>(),
+            id,
+            CrdtType::LWW(position),
+            inspect,
+            Some(write),
+            Some(default),
+        );
+    // add a system to process the update
+    app.world_mut()
+        .resource_mut::<SceneLoopSchedule>()
+        .schedule
+        .add_systems(process_crdt_lww_updates::<D, C, DEDUP>.in_set(SceneLoopSets::UpdateWorld));
+    // add a tracker system
+    app.add_systems(
+        PostUpdate,
+        track_components::<C, false>.run_if(|track: Res<TrackComponents>| track.0),
+    );
+}
+
 impl AddCrdtInterfaceExt for App {
     fn add_crdt_lww_interface<D: FromDclReader>(
         &mut self,
         id: SceneComponentId,
         position: ComponentPosition,
     ) {
-        // store a writer
-        let existing = self.world_mut().resource_mut::<CrdtExtractors>().0.insert(
-            id,
-            Box::new(CrdtLWWInterface::<D> {
-                position,
-                _marker: PhantomData,
-            }),
-        );
-
-        assert!(existing.is_none(), "duplicate registration for {id:?}");
+        register_crdt_lww_interface::<D>(self, id, position, false);
     }
 
     fn add_crdt_lww_component<
@@ -267,29 +355,25 @@ impl AddCrdtInterfaceExt for App {
     ) where
         <C as TryFrom<D>>::Error: std::fmt::Display,
     {
-        self.add_crdt_lww_interface::<D>(id, position);
-        // register in ComponentNameRegistry for inspection
-        let (inspect, write, default) = make_proto_closures::<D>();
-        self.world_mut()
-            .resource_mut::<ComponentNameRegistry>()
-            .register(
-                derive_component_name::<D>(),
-                id,
-                CrdtType::LWW(position),
-                inspect,
-                Some(write),
-                Some(default),
-            );
-        // add a system to process the update
-        self.world_mut()
-            .resource_mut::<SceneLoopSchedule>()
-            .schedule
-            .add_systems(process_crdt_lww_updates::<D, C>.in_set(SceneLoopSets::UpdateWorld));
-        // add a tracker system
-        self.add_systems(
-            PostUpdate,
-            track_components::<C, false>.run_if(|track: Res<TrackComponents>| track.0),
-        );
+        register_crdt_lww_component::<D, C, false>(self, id, position);
+    }
+
+    fn add_crdt_lww_component_dedup<
+        D: FromDclReader
+            + std::fmt::Debug
+            + prost::Message
+            + Default
+            + serde::Serialize
+            + serde::de::DeserializeOwned,
+        C: Component + TryFrom<D>,
+    >(
+        &mut self,
+        id: SceneComponentId,
+        position: ComponentPosition,
+    ) where
+        <C as TryFrom<D>>::Error: std::fmt::Display,
+    {
+        register_crdt_lww_component::<D, C, true>(self, id, position);
     }
 
     fn add_crdt_go_component<
@@ -340,6 +424,7 @@ impl AddCrdtInterfaceExt for App {
 pub(crate) fn process_crdt_lww_updates<
     D: FromDclReader + std::fmt::Debug,
     C: Component + TryFrom<D>,
+    const DEDUP: bool,
 >(
     mut commands: Commands,
     mut scenes: Query<(
@@ -353,16 +438,20 @@ pub(crate) fn process_crdt_lww_updates<
 {
     for (_root, scene_context, mut updates, deleted_entities) in scenes.iter_mut() {
         // avoid triggering change detection when there is nothing to do
-        if updates.last_write.is_empty() && deleted_entities.0.is_empty() {
+        if updates.updates.is_empty() && deleted_entities.0.is_empty() {
             continue;
         }
 
         // remove crdt state for dead entities
         for deleted in &deleted_entities.0 {
             updates.last_write.remove(deleted);
+            updates.updates.remove(deleted);
         }
 
-        for (scene_entity, entry) in std::mem::take(&mut updates.last_write) {
+        for scene_entity in std::mem::take(&mut updates.updates) {
+            let Some(entry) = updates.last_write.get(&scene_entity) else {
+                continue;
+            };
             let Some(entity) = scene_context.bevy_entity(scene_entity) else {
                 warn!(
                     "skipping {} update for missing entity {:?}",
@@ -405,6 +494,11 @@ pub(crate) fn process_crdt_lww_updates<
             } else {
                 commands.entity(entity).remove::<C>();
             }
+        }
+
+        // dedup interfaces keep last_write so unchanged resends can be recognised
+        if !DEDUP {
+            updates.last_write.clear();
         }
     }
 }

--- a/crates/scene_runner/src/update_world/scene_ui/mod.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/mod.rs
@@ -424,27 +424,29 @@ impl From<PbUiCanvas> for UiCanvas {
 
 impl Plugin for SceneUiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_crdt_lww_component::<PbUiTransform, UiTransform>(
+        // scene frameworks commonly resend unchanged ui state every frame; dedup
+        // registration avoids rebuilding the ui tree when nothing changed
+        app.add_crdt_lww_component_dedup::<PbUiTransform, UiTransform>(
             SceneComponentId::UI_TRANSFORM,
             ComponentPosition::EntityOnly,
         );
-        app.add_crdt_lww_component::<PbUiBackground, UiBackground>(
+        app.add_crdt_lww_component_dedup::<PbUiBackground, UiBackground>(
             SceneComponentId::UI_BACKGROUND,
             ComponentPosition::EntityOnly,
         );
-        app.add_crdt_lww_component::<PbUiText, UiText>(
+        app.add_crdt_lww_component_dedup::<PbUiText, UiText>(
             SceneComponentId::UI_TEXT,
             ComponentPosition::EntityOnly,
         );
-        app.add_crdt_lww_component::<PbUiInput, UiInput>(
+        app.add_crdt_lww_component_dedup::<PbUiInput, UiInput>(
             SceneComponentId::UI_INPUT,
             ComponentPosition::EntityOnly,
         );
-        app.add_crdt_lww_component::<PbUiDropdown, UiDropdown>(
+        app.add_crdt_lww_component_dedup::<PbUiDropdown, UiDropdown>(
             SceneComponentId::UI_DROPDOWN,
             ComponentPosition::EntityOnly,
         );
-        app.add_crdt_lww_component::<PbUiCanvas, UiCanvas>(
+        app.add_crdt_lww_component_dedup::<PbUiCanvas, UiCanvas>(
             SceneComponentId::UI_CANVAS,
             ComponentPosition::EntityOnly,
         );


### PR DESCRIPTION
# crdt: opt-in byte-equality dedup for LWW component updates

## What

Adds an opt-in dedup mode for LWW CRDT component registration. For components registered with the new `add_crdt_lww_component_dedup`, a scene write whose payload is byte-identical to the last applied value advances the CRDT timestamp but does not re-apply the component to the Bevy entity. The six scene UI components (`PbUiTransform`, `PbUiBackground`, `PbUiText`, `PbUiInput`, `PbUiDropdown`, `PbUiCanvas`) are switched to dedup registration; every other component is untouched.

## Why

The LWW layer treats any newer-timestamp write as a change even when the payload is unchanged, and script frameworks commonly re-send unchanged components every frame. For scene UI this is expensive: each re-applied `UiTransform`/`UiText`/etc. reinserts the Bevy component, retriggering change detection and forcing the UI systems to tear down and rebuild the scene's UI tree every frame even when nothing changed.

This change was measured as part of a combined engine performance pass (paired interleaved A/B runs, headed Chromium/WebGPU on a discrete NVIDIA GPU, Mann-Whitney gated): on a 17-scene benchmark realm orbit, cpu p50 -2.7% (p=.028) and wall p50 -6.9% (better in 7/7 rounds); with 32 synthetic avatars added, cpu p50 -9.2% (p=.029) and wall p50 -49.7% (62.6 ms -> 31.5 ms, p=.025). UI dedup is one of the changes in that pass; scenes that re-send large UI trees every frame benefit the most.

## How

- `CrdtLWWState::merge_dedup(delta)` merges a freshly-taken delta into retained state: a byte-identical payload (including matching some/none-ness) only advances the entry timestamp, while a changed payload or a new entity replaces the entry and marks it updated. A small `LWWEntry::value_matches` helper is shared with the existing `ForceIfDifferent` path.
- `CrdtLWWInterface` gains a `dedup` flag. Non-dedup interfaces replace the `CrdtStateComponent` wholesale, as before; dedup interfaces merge the delta into the existing component via a fallible entity command that is a no-op if the scene root has despawned.
- `process_crdt_lww_updates` drains the `updates` set rather than `last_write` (equivalent for non-dedup deltas, which carry exactly the updated entries), and retains `last_write` as comparison memory when dedup is enabled; non-dedup components clear it each pass, preserving the previous lifecycle.
- `AddCrdtInterfaceExt::add_crdt_lww_component_dedup` registers a component with dedup; `SceneUiPlugin` uses it for the six UI components.

## Default behavior

Opt-in per component. Components not registered with the dedup variant behave exactly as before: every accepted write is re-applied, so consumers that use a resend as a signal (e.g. `Tween` restart) are unaffected. For dedup components, an unchanged resend still advances the stored timestamp, so LWW conflict resolution and timestamp echoes are unchanged.

## Testing

- Six new unit tests on `merge_dedup` in `crates/dcl/src/crdt/lww.rs`: identical resend advances the timestamp without an update mark, tombstone resend likewise, some-to-none, none-to-some, changed payload, and vacant insert all mark updates.
- Existing LWW tests are unchanged and still pass.
- `cargo check --workspace` passes.

## Evidence

Independently verified reproduction pass on the branch tip against the base commit: mechanism-level A/B counts, a full workspace regression gate with triage, and a boot smoke.

**Method.** A 10,000-resend scenario compiled per side via a test-only commit (never part of this branch): one entity, a 64-byte payload, 10,000 `try_update` calls with timestamps 1..=10000 and byte-identical data; after each call a `take_updates`-style delta is applied to an engine-side state exactly as `CrdtLWWInterface::extract_onto` + `process_crdt_lww_updates` do (base and non-dedup: wholesale replace + drain; dedup: `merge_dedup` + drain `updates`). Marks counted = entries drained = component re-applications. Six runs per configuration.

**Results (exact counts, 6/6 runs identical).**

| side | path | updated-marks per 10,000 identical resends | final timestamp |
|---|---|---|---|
| base | plain (only path) | 10,000 | 10,000 |
| branch | non-dedup path | 10,000 | 10,000 |
| branch | dedup path | **1** (the first write only) | **10,000** (still advances) |

Every `try_update` at a newer timestamp was accepted on both sides (asserted) — LWW acceptance semantics are unchanged; dedup only suppresses the downstream updated-mark. The branch's non-dedup path is count-identical to base, matching the opt-in design: components not registered with the dedup variant stay on the old code path.

**Regression gate.** `cargo test --workspace --no-fail-fast` on the branch: the only real failure is `scene_runner test::cyclic_recovery`, which fails identically on the unmodified base commit (pre-existing). One run also reported 31 failing targets (one lib test binary plus 30 doctest targets) that all died before executing anything — "extern location for `common` does not exist"-class rlib errors from a shared local build directory being rebuilt concurrently by unrelated jobs. All 31 were re-run like-for-like on both base and branch: 31/31 pass on both sides, zero branch-only failures, and the 30 doctest targets contain zero actual doctests — build-infrastructure artifact races, not test failures. Net: no new failures.

**Boot smoke.** The release branch binary (identity verified by checksum immediately before the run) ran ~90 s against a local mirror of the scene-explorer-tests realm, headed on a discrete NVIDIA GPU, spawning at `52,-60`: two scenes started and ran — the **Raycast Unit Test** scene at `52,-52` (sdk7) and the realm's `0,0` urn scene, the identical set a base binary starts with the same flags — ticking for the whole run (frame count 2,785 at cutoff, per-second fps diagnostics throughout), clean scene-thread shutdown on SIGTERM, non-black screenshot of the rendered world showing the Raycast Unit Test scene card. Two non-fatal audio-thread panics (`snd_pcm_hw_params` I/O error) are environmental — the identical pair appears in base-binary runs on the same rig.
