### PR TITLE
web: stream-compile the engine wasm and keep the code cache

### DIFF
--- a/deploy/web/engine/engine.js
+++ b/deploy/web/engine/engine.js
@@ -29,13 +29,15 @@ function workerCrashHandler(name) {
  * Fetches a URL with download progress tracking.
  * @param {string} url - URL to fetch
  * @param {function} onProgress - Callback with percentage (0-100)
- * @param {number|null} expectedSize - Expected uncompressed size in bytes (fallback when Content-Length is missing due to content-encoding)
+ * @param {number|null} expectedSize - Expected decoded size in bytes. Preferred over
+ *   Content-Length, which under CDN compression counts compressed bytes while the body
+ *   reader yields decoded bytes.
  * @returns {Promise<ArrayBuffer>}
  */
 async function fetchWithProgress(url, onProgress, expectedSize) {
   const response = await fetch(url);
   const contentLength = response.headers.get('Content-Length');
-  const total = contentLength ? parseInt(contentLength, 10) : expectedSize;
+  const total = expectedSize || (contentLength ? parseInt(contentLength, 10) : null);
 
   if (!total || !response.body) {
     // Fallback if no size info available or no streaming support
@@ -69,6 +71,71 @@ async function fetchWithProgress(url, onProgress, expectedSize) {
 }
 
 /**
+ * Downloads and compiles the engine WASM.
+ *
+ * Compiles with WebAssembly.compileStreaming on the live network response, so
+ * compilation overlaps the download and — because the response keeps its URL
+ * identity — the browser may persist the compiled module in its code cache and
+ * skip the compile on repeat visits. The progress callback is fed from a clone
+ * of the response; wrapping a byte-counting stream in a synthesized Response
+ * instead would discard the URL identity and with it the code cache.
+ *
+ * @param {string} url - WASM URL
+ * @param {number|null} expectedSize - Expected decoded size in bytes (from the manifest)
+ * @param {function} onProgress - Callback with percentage (0-100)
+ * @param {function} onDownloaded - Called once the last byte has arrived, before the compile tail
+ * @returns {Promise<WebAssembly.Module>}
+ */
+async function compileWasmWithProgress(url, expectedSize, onProgress, onDownloaded) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`WASM fetch failed: ${response.status} ${response.statusText}`);
+  }
+
+  const contentLength = response.headers.get('Content-Length');
+  const total = expectedSize || (contentLength ? parseInt(contentLength, 10) : null);
+
+  if (typeof WebAssembly.compileStreaming === 'function' && response.body) {
+    let cancelProgress = () => {};
+    let progressTask = Promise.resolve();
+    if (total) {
+      const reader = response.clone().body.getReader();
+      cancelProgress = () => reader.cancel().catch(() => {});
+      progressTask = (async () => {
+        let received = 0;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          received += value.length;
+          onProgress(Math.min((received / total) * 100, 100));
+        }
+      })().catch(() => {});
+    }
+
+    try {
+      const module = await WebAssembly.compileStreaming(response);
+      await progressTask;
+      onProgress(100);
+      onDownloaded();
+      return module;
+    } catch (e) {
+      // typically a server not sending Content-Type: application/wasm — refetch
+      // (usually straight from the HTTP cache) and compile from a buffer instead
+      cancelProgress();
+      console.warn('[Main JS] compileStreaming failed, falling back to buffered compile', e);
+    }
+  } else {
+    try {
+      response.body?.cancel();
+    } catch (e) { /* body already consumed or locked */ }
+  }
+
+  const buffer = await fetchWithProgress(url, onProgress, total);
+  onDownloaded();
+  return WebAssembly.compile(buffer);
+}
+
+/**
  * Initializes the WASM engine, shared memory, and worker threads.
  * @returns {Promise<void>}
  */
@@ -88,18 +155,20 @@ export async function initEngine() {
     console.warn("Could not load manifest.json, progress may not be accurate", e);
   }
 
-  // Step 1: Download WASM with progress
+  // Steps 1+2: Download and compile WASM. Compilation streams alongside the download,
+  // so the 'compile' step only covers the tail left after the last byte arrives.
   setLoadingStepActive('download');
-  const wasmBytes = await fetchWithProgress(wasmUrl, (percent) => {
-    setLoadingStepProgress('download', percent);
-  }, expectedWasmSize);
-  setLoadingStepCompleted('download');
-
-  // Step 2: Compile WASM
-  setLoadingStepActive('compile');
   console.time("compileTime")
-  const compiledModule = await WebAssembly.compile(wasmBytes);
-  console.timeEnd("compileTime") // 70 ms
+  const compiledModule = await compileWasmWithProgress(
+    wasmUrl,
+    expectedWasmSize,
+    (percent) => setLoadingStepProgress('download', percent),
+    () => {
+      setLoadingStepCompleted('download');
+      setLoadingStepActive('compile');
+    }
+  );
+  console.timeEnd("compileTime")
   setLoadingStepCompleted('compile');
 
   const initialMemoryPages = 1280; // setting initial memory high causes malloc failures


### PR DESCRIPTION
# web: stream-compile the engine wasm and keep the code cache

## What

The web loader currently downloads the whole engine wasm into an ArrayBuffer (for the progress bar) and then calls `WebAssembly.compile(bytes)`. Switch it to `WebAssembly.compileStreaming` on the live network response, keeping the progress bar by counting bytes on `response.clone()`. The buffered path remains as an automatic fallback when `compileStreaming` is unavailable or rejects (e.g. a server not sending `Content-Type: application/wasm`).

## Why

Two independent wins, both forfeited by the buffer-then-compile shape:

1. **Download/compile overlap.** `compileStreaming` compiles chunks as they arrive, so on cold visits most of the compile wall disappears into the download wall instead of being paid after it.
2. **The persistent code cache.** Browsers key their compiled-wasm code cache to the response's URL identity. A buffer compile has no URL identity, so every visit pays the full compile. This is also why the progress bar must read a *clone* of the response rather than wrapping a byte-counting stream in a synthesized `Response` — a synthesized response has no URL and silently forfeits the cache (the same trap as serving wasm through a service worker's synthesized responses).

Also fixes the progress denominator: preferring the manifest's decoded size over `Content-Length`, which under CDN compression counts compressed bytes while the body reader yields decoded bytes — the old preference pins the bar at 100% at roughly the compression-ratio point of the download.

## How

- `compileWasmWithProgress(url, expectedSize, onProgress, onDownloaded)` — fetches once; hands the original response to `compileStreaming`; feeds progress from a clone's reader; `onDownloaded` fires when the last byte arrives so the loading UI can flip from "download" to "compile" for the tail. On rejection it cancels the progress reader and falls back to the old buffered path (refetch, typically straight from the HTTP cache).
- `fetchWithProgress` (the fallback) keeps its behavior with the denominator preference fixed the same way.
- The loading-step UI, weights, and worker handoff (`compiledModule` via `postMessage`) are unchanged — `compileStreaming` returns the same `WebAssembly.Module`.

## Default behavior

No configuration. Browsers without `compileStreaming` (or servers with a wrong MIME type) get exactly the old buffered behavior via the fallback.

## Evidence

Harness: the branch's two loader functions extracted verbatim (assertion-checked) into a test page, served with the real 110 MB release engine wasm under controlled header regimes (correct MIME / wrong MIME / brotli-encoded), driven headless with one persistent profile per mode, results posted back and archived. All runs compile to a module with the same import count (795) as a reference compile.

- **Streaming happy path (3 visits):** progress strictly monotonic 0→100, and `tDone == tDownloaded` in every visit — the compile tail after the last byte is zero; compilation fully overlapped the download. Buffered visits on the same artifact pay a ~65–70 ms compile after download completes.
- **Fallback (wrong MIME):** `compileStreaming` rejects, the loader logs the fallback warning, refetches, and still produces the module. No behavioral cliff.
- **Denominator fix (brotli-encoded response, deterministic):** old preference (Content-Length): the bar hits 100% at 90 ms of a 276 ms download — pinned at the compression-ratio point, exactly the reported misbehavior. New preference (manifest decoded size): 100% lands at download end (266 ms of 294 ms).

**Honest nulls:** on a localhost harness the download is ~250 ms and V8's lazy/baseline compilation keeps the eager compile wall at ~65 ms for this 110 MB module, so no wall-clock win is demonstrable here, and a persistent-cache compile-time drop across repeat visits was not observed at this compile cost. The structural wins stand regardless: compile overlaps real-network downloads instead of following them, the module becomes eligible for the browser's persistent code cache (URL-keyed; relevant to tier-up cost, and to engines with eager full compilation), and the loader stops holding the wasm bytes twice (~220 MB of transient chunk + assembled-buffer allocations for this artifact) on the boot path.

## Testing

- `node --check` on the module; full harness runs above.
- Manual: the loading bar renders identically (download progresses 0-100, compile flashes for the tail), and a `text/plain`-served wasm logs the fallback warning and still boots.
