### PR TITLE
deps: trim the image crate to the formats content actually uses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,7 +2210,7 @@ version = "0.1.1"
 source = "git+https://github.com/robtfm/boimp?branch=feat%2Fcomposite-bake-via-storage-texture#8abfcf6d0d2a9ec8beefbbc96822968379501d7c"
 dependencies = [
  "anyhow",
- "async-channel 2.5.0",
+ "async-channel 1.9.0",
  "bevy",
  "bytemuck",
  "crossbeam-channel",
@@ -2756,7 +2756,6 @@ dependencies = [
  "futures-util",
  "gloo-timers 0.3.0",
  "http 1.4.0",
- "image",
  "ipfs",
  "js-sys",
  "kira",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,20 @@ reqwest = { version = "0.12", default-features = false, features = [
 ] }
 kira = "0.9.6"
 zip = { version = "2", default-features = false }
-image = "0.25"
+# every image format observed in active catalyst content, plus png encode for
+# screenshots. drops the default avif *encoder* (rav1e, an AV1 encoder no client
+# path can invoke — avif decode is a non-default feature) and the unused
+# dds/exr/ff/hdr/pnm/qoi/tga decoders from the shipped code.
+image = { version = "0.25", default-features = false, features = [
+  "bmp",
+  "gif",
+  "ico",
+  "jpeg",
+  "png",
+  "rayon",
+  "tiff",
+  "webp",
+] }
 opener = { version = "0.8", git = "https://github.com/robtfm/opener" }
 chrono = { version = "0.4.31", features = ["serde"] }
 bevy_dui = { git = "https://github.com/robtfm/bevy_dui", branch = "0.16" }

--- a/crates/comms/Cargo.toml
+++ b/crates/comms/Cargo.toml
@@ -46,7 +46,6 @@ multipart = { version = "0.18.0", default-features = false, features = [
   "client",
   "lazy_static",
 ] }
-image = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 livekit = { git = "https://github.com/robtfm/client-sdk-rust", branch = "decentraland-webrtc", features = [


### PR DESCRIPTION
# deps: trim the image crate to the formats content actually uses

## What

Pin the workspace `image` dependency to an explicit format list instead of the crate's default feature set, and drop the unused `image` dependency from `comms`. Kept: `png`, `jpeg`, `gif`, `webp`, `bmp`, `ico`, `tiff` decode, `png` encode (screenshots), `rayon`. Dropped: the AVIF encoder (`ravif`/`rav1e` — a full AV1 encoder) and the `dds`/`exr`/`ff`/`hdr`/`pnm`/`qoi`/`tga` decoders.

**Pairs with robtfm/boimp#2** (one line: pin boimp's `image` dep to `png`) — boimp requests the full default set today, so cargo's feature unification re-adds everything this PR trims until that lands and the boimp rev is bumped. Standalone this PR is behavior-neutral and build-neutral; it prepares the workspace side.

## Why

The default feature set ships decoders — and one large encoder — that no client path can reach:

- `rav1e` is the `image` crate's AVIF **encode** backend. Nothing in the client encodes AVIF; AVIF **decode** is a separate non-default feature (`avif-native`), so `.avif` content files don't decode today either way.
- The kept list is data, not guesswork: a format census over every content file of every **active** (non-deleted) deployment on a fully synced catalyst content database. Present in active content: png (~5.5M files, dominated by profile snapshots), jpg/jpeg (~19K), ico (249), gif (72), webp (48), tiff (7), bmp (2). Not present: tga, pnm, qoi, ff, hdr, exr. (`.avif` appears 7 times and is undecodable before and after this change; `dds`/`ktx2` never route through the `image` crate.)
- The one sniffing decode site (`image_processing`'s `image::load_from_memory` over arbitrary content textures) therefore keeps decoding every format observed in the wild — this is deliberately **not** the aggressive png+jpeg-only trim.

## Measured (wasm web build, `--no-default-features --features livekit,social`, release)

Built A/B/stacked from the same tree, sizes checksummed:

| build | wasm bytes | brotli -q5 |
|---|---|---|
| base | 110,014,119 | 40,697,809 |
| this PR alone | 110,013,831 | 40,697,363 |
| this PR + boimp pin | 109,192,953 | 40,603,075 |

- **This PR alone is a no-op** (−288 bytes): boimp's default request keeps the union at full defaults — measured honestly, and why the boimp pairing is required.
- **Stacked: −821 KB raw wasm, −95 KB brotli wire.** The linker already dead-strips most of the unreachable encoder code, so the wire win is modest; the bigger wins are graph hygiene: `rav1e`, `ravif`, `exr`, `qoi` (and friends) leave the wasm dependency graph entirely (`cargo tree -i rav1e` → nothing), which cuts cold-build time (rav1e is one of the slowest crates in the graph) and shrinks the supply-chain surface.

## Default behavior

No behavior change. Every format observed in deployed content still decodes; screenshots still encode png. The only formats that stop decoding are formats with zero occurrences across active deployments.

## Testing

- `cargo check` on the workspace and touched crates passes; `cargo tree --target wasm32-unknown-unknown -i rav1e` / `-i exr` resolve to nothing with the boimp pin in place.
- wasm builds A/B/stacked compile clean (sizes above).
- Format census query and per-format counts reproduced in the PR discussion on request.
