### PR TITLE
settings: avatar outline toggle

### DIFF
--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -117,7 +117,7 @@ impl Plugin for AvatarPlugin {
                 spawn_scenes,
                 process_avatar.after(update_render_avatar),
                 set_avatar_visibility,
-                retag_avatars_on_cel_shading_change,
+                retag_avatars_on_style_change,
             ),
         );
 
@@ -498,16 +498,16 @@ pub struct AvatarDefinition {
 #[derive(Component)]
 pub struct RetryRenderAvatar;
 
-// when the cel-shading setting is toggled, re-render every avatar so their
-// meshes are respawned with (or without) the toon mesh tag. the tag is set once
-// at mesh creation in process_avatar, so an in-place flip isn't enough.
-fn retag_avatars_on_cel_shading_change(
+// when an avatar style setting (cel shading, outline) is toggled, re-render every
+// avatar so their meshes are respawned with the right mesh tags. the tags are set
+// once at mesh creation in process_avatar, so an in-place flip isn't enough.
+fn retag_avatars_on_style_change(
     config: Res<AppConfig>,
-    mut prev: Local<Option<bool>>,
+    mut prev: Local<Option<(bool, bool)>>,
     avatars: Query<Entity, With<AvatarSelection>>,
     mut commands: Commands,
 ) {
-    let cur = config.graphics.cel_shading;
+    let cur = (config.graphics.cel_shading, config.graphics.avatar_outline);
     if *prev != Some(cur) {
         if prev.is_some() {
             for entity in &avatars {
@@ -1049,10 +1049,15 @@ fn process_avatar(
             Vec3::new(1.24, 2.42, 0.7) + root_gt.translation(),
         );
 
-        // cel-shade avatar meshes only when the setting is on; toggling it
-        // re-renders avatars (see retag_avatars_on_cel_shading_change)
+        // style avatar meshes per the current settings; toggling either
+        // re-renders avatars (see retag_avatars_on_style_change)
         let toon_tag = if config.graphics.cel_shading {
             SCENE_MATERIAL_TOON_MESH_TAG
+        } else {
+            0
+        };
+        let outline_tag = if config.graphics.avatar_outline {
+            SCENE_MATERIAL_OUTLINE_BLACK_MESH_TAG
         } else {
             0
         };
@@ -1196,7 +1201,7 @@ fn process_avatar(
                     commands.entity(scene_ent).try_insert((
                         MeshMaterial3d(instance_mat.clone()),
                         MeshTag(
-                            SCENE_MATERIAL_OUTLINE_BLACK_MESH_TAG
+                            outline_tag
                                 | (if def.disable_dither {
                                     SCENE_MATERIAL_NO_DITHERING_MESH_TAG
                                 } else {
@@ -1265,7 +1270,7 @@ fn process_avatar(
                             commands.entity(scene_ent).try_insert((
                                 MeshMaterial3d(material),
                                 MeshTag(
-                                    SCENE_MATERIAL_OUTLINE_BLACK_MESH_TAG
+                                    outline_tag
                                         | (if def.disable_dither {
                                             SCENE_MATERIAL_NO_DITHERING_MESH_TAG
                                         } else {
@@ -1488,7 +1493,7 @@ fn process_avatar(
                         commands.entity(scene_ent).try_insert((
                             MeshMaterial3d(instance_mat.clone()),
                             MeshTag(
-                                SCENE_MATERIAL_OUTLINE_BLACK_MESH_TAG
+                                outline_tag
                                     | (if def.disable_dither {
                                         SCENE_MATERIAL_NO_DITHERING_MESH_TAG
                                     } else {

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -592,6 +592,8 @@ pub struct GraphicsSettings {
     pub ambient_brightness: i32,
     /// cel-shade avatars (toon shading) instead of standard PBR
     pub cel_shading: bool,
+    /// draw the dark edge outline around avatars
+    pub avatar_outline: bool,
     pub gpu_bytes_per_frame: usize,
 }
 
@@ -615,6 +617,7 @@ impl Default for GraphicsSettings {
             oob: 2.0,
             ambient_brightness: 50,
             cel_shading: true,
+            avatar_outline: true,
             gpu_bytes_per_frame: 0,
         }
     }

--- a/crates/system_bridge/src/settings/avatar_outline_setting.rs
+++ b/crates/system_bridge/src/settings/avatar_outline_setting.rs
@@ -1,0 +1,51 @@
+use common::structs::AppConfig;
+
+use super::{AppSetting, EnumAppSetting};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AvatarOutlineSetting {
+    Off,
+    On,
+}
+
+impl EnumAppSetting for AvatarOutlineSetting {
+    fn variants() -> Vec<Self> {
+        vec![Self::Off, Self::On]
+    }
+
+    fn name(&self) -> String {
+        match self {
+            AvatarOutlineSetting::Off => "Off",
+            AvatarOutlineSetting::On => "On",
+        }
+        .to_owned()
+    }
+}
+
+impl AppSetting for AvatarOutlineSetting {
+    type Param = ();
+
+    fn title() -> String {
+        "Avatar Outline".to_owned()
+    }
+
+    fn description(&self) -> String {
+        "Dark edge outline around avatars.\n\nOn: avatars are drawn with an edge outline so they stand out from the world. Off: no outline is drawn, and the outline's per-pixel shading cost is skipped.".to_owned()
+    }
+
+    fn category() -> super::SettingCategory {
+        super::SettingCategory::Graphics
+    }
+
+    fn save(&self, config: &mut AppConfig) {
+        config.graphics.avatar_outline = matches!(self, AvatarOutlineSetting::On);
+    }
+
+    fn load(config: &AppConfig) -> Self {
+        if config.graphics.avatar_outline {
+            Self::On
+        } else {
+            Self::Off
+        }
+    }
+}

--- a/crates/system_bridge/src/settings/mod.rs
+++ b/crates/system_bridge/src/settings/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use ambient_brightness_setting::AmbientSetting;
 use anyhow::anyhow;
+use avatar_outline_setting::AvatarOutlineSetting;
 use bevy::{
     app::{Plugin, Update},
     ecs::{
@@ -51,6 +52,7 @@ use {js_sys::Function, wasm_bindgen::prelude::*, web_sys::Event};
 
 pub mod aa_settings;
 pub mod ambient_brightness_setting;
+pub mod avatar_outline_setting;
 pub mod bloom_settings;
 pub mod cache_size;
 pub mod camera_smoothing;
@@ -153,6 +155,7 @@ impl Plugin for SettingBridgePlugin {
         add_enum_setting::<SsaoSetting>(app, &mut settings, &mut schedule, &config);
         add_enum_setting::<OobSetting>(app, &mut settings, &mut schedule, &config);
         add_enum_setting::<CelShadingSetting>(app, &mut settings, &mut schedule, &config);
+        add_enum_setting::<AvatarOutlineSetting>(app, &mut settings, &mut schedule, &config);
         add_enum_setting::<AaSetting>(app, &mut settings, &mut schedule, &config);
         add_int_setting::<AmbientSetting>(app, &mut settings, &mut schedule, &config);
         if is_fullscreen_available() {

--- a/crates/system_ui/src/app_settings/mod.rs
+++ b/crates/system_ui/src/app_settings/mod.rs
@@ -25,6 +25,7 @@ use crate::profile::SettingsDialog;
 
 use system_bridge::settings::{
     ambient_brightness_setting::AmbientSetting,
+    avatar_outline_setting::AvatarOutlineSetting,
     cel_shading_setting::CelShadingSetting,
     constrain_ui::ConstrainUiSetting,
     frame_rate::FpsTargetSetting,
@@ -126,6 +127,7 @@ fn set_app_settings_content(
             spawn_enum_setting_template::<SsaoSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<OobSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<CelShadingSetting>(&mut commands, &dui, &config),
+            spawn_enum_setting_template::<AvatarOutlineSetting>(&mut commands, &dui, &config),
             spawn_enum_setting_template::<ConstrainUiSetting>(&mut commands, &dui, &config),
             commands
                 .spawn_template(


### PR DESCRIPTION
# settings: avatar outline toggle

## What

Add `graphics.avatar_outline` (default **on**) gating the black outline mesh tag that every avatar body part and wearable receives at mesh creation, and surface it in the settings UI next to "Avatar Cel Shading". The existing cel-shading retag system generalizes to `retag_avatars_on_style_change`, re-rendering avatars when either style toggle flips so the change applies live without a relog.

## Why

The avatar outline was unconditional. It is an aesthetic choice with a per-pixel shading cost in the bound-material effect, and it is the kind of choice players toggle: cel shading already has exactly this switch. The toggle also gives lower-end setups one more knob that removes per-pixel work across every avatar on screen.

Scope note: only the avatar (black) outline bit is gated. The hover-highlight (green) and collider-debug (red) outline bits are functional indicators and stay unconditional.

## Default behavior

`avatar_outline` defaults to `true` and the struct is `#[serde(default)]`, so existing `config.json` files and fresh installs render byte-identically to before this PR. Turning it off only skips the outline term for avatar-tagged meshes.

## Testing

- `cargo check` on `common`, `avatar`, `system_bridge`, `system_ui` passes; stable rustfmt clean on touched files.
- The setting round-trips through the same `EnumAppSetting` plumbing as cel shading (save writes the flag, load reads it, retag system observes the flip and re-renders via `RetryRenderAvatar` — the identical, already-exercised path).
