### PR TITLE
fix: scene entity table is one slot short, so entity id 65535 out of bounds

### DIFF
--- a/crates/dcl/src/interface/crdt_context.rs
+++ b/crates/dcl/src/interface/crdt_context.rs
@@ -8,9 +8,6 @@ use dcl_component::SceneEntityId;
 
 type LiveTable = Vec<(u16, bool)>;
 
-/// both 0 and 65535 are valid indexes
-const LIVE_TABLE_LEN: usize = u16::MAX as usize + 1;
-
 #[derive(Serialize, Deserialize)]
 pub struct CrdtContext {
     pub scene_id: SceneId,
@@ -29,7 +26,7 @@ pub struct CrdtContext {
 }
 
 fn default_live_entities() -> LiveTable {
-    vec![(0, false); LIVE_TABLE_LEN]
+    vec![(0, false); SceneEntityId::LIVE_TABLE_LEN]
 }
 
 fn default_last_new() -> u16 {
@@ -58,6 +55,7 @@ impl CrdtContext {
     }
 
     fn entity_entry(&self, id: u16) -> &(u16, bool) {
+        // SAFETY: live_entities has LIVE_TABLE_LEN (u16::MAX + 1) entries, so any u16 index is in bounds
         unsafe { self.live_entities.get_unchecked(id as usize) }
     }
 

--- a/crates/dcl/src/interface/crdt_context.rs
+++ b/crates/dcl/src/interface/crdt_context.rs
@@ -8,6 +8,9 @@ use dcl_component::SceneEntityId;
 
 type LiveTable = Vec<(u16, bool)>;
 
+/// both 0 and 65535 are valid indexes
+const LIVE_TABLE_LEN: usize = u16::MAX as usize + 1;
+
 #[derive(Serialize, Deserialize)]
 pub struct CrdtContext {
     pub scene_id: SceneId,
@@ -26,7 +29,7 @@ pub struct CrdtContext {
 }
 
 fn default_live_entities() -> LiveTable {
-    vec![(0, false); u16::MAX as usize]
+    vec![(0, false); LIVE_TABLE_LEN]
 }
 
 fn default_last_new() -> u16 {
@@ -55,7 +58,6 @@ impl CrdtContext {
     }
 
     fn entity_entry(&self, id: u16) -> &(u16, bool) {
-        // SAFETY: live entities has u16::MAX members
         unsafe { self.live_entities.get_unchecked(id as usize) }
     }
 

--- a/crates/dcl/src/interface/mod.rs
+++ b/crates/dcl/src/interface/mod.rs
@@ -440,3 +440,28 @@ impl CrdtStore {
         });
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // a peer sending 65535 as an id should not crash us
+    #[test]
+    fn max_entity_id_is_within_the_live_table() {
+        let max = SceneEntityId {
+            id: u16::MAX,
+            generation: 0,
+        };
+        let mut context = CrdtContext::new(
+            crate::SceneId::DUMMY,
+            Default::default(),
+            Default::default(),
+            false,
+            false,
+        );
+
+        assert!(context.init(max));
+        context.kill(max);
+        assert!(context.is_dead(max));
+    }
+}

--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -106,6 +106,9 @@ impl SceneEntityId {
 
     pub const FOREIGN_PLAYER_RANGE: RangeInclusive<u16> = 6..=405;
 
+    /// size for a table indexed by `id`: both 0 and 65535 are valid indexes
+    pub const LIVE_TABLE_LEN: usize = u16::MAX as usize + 1;
+
     pub fn as_proto_u32(&self) -> Option<u32> {
         Some(self.id as u32 | ((self.generation as u32) << 16))
     }

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -119,6 +119,9 @@ pub const FROZEN_BLOCK: &str = "frozen";
 
 pub const SCENE_LOG_BUFFER_SIZE: usize = 100;
 
+/// both 0 and 65535 are valid indexes
+const LIVE_TABLE_LEN: usize = u16::MAX as usize + 1;
+
 // A scene tick that has been in-flight (sent to the scene, no response yet) for longer than this
 // is treated as "not responding": handle_out_of_world stops holding the player behind the loading
 // screen, and the loading UI surfaces a countdown to this timeout.
@@ -164,7 +167,7 @@ impl RendererSceneContext {
             death_row: Default::default(),
             outbound_born: Default::default(),
             outbound_died: Default::default(),
-            live_entities: vec![(0, None); u16::MAX as usize],
+            live_entities: vec![(0, None); LIVE_TABLE_LEN],
             unparented_entities: HashSet::new(),
             hierarchy_changed: false,
             last_sent: 0.0,
@@ -195,12 +198,10 @@ impl RendererSceneContext {
     }
 
     fn entity_entry(&self, id: u16) -> &(u16, Option<Entity>) {
-        // SAFETY: live entities has u16::MAX members
         unsafe { self.live_entities.get_unchecked(id as usize) }
     }
 
     fn entity_entry_mut(&mut self, id: u16) -> &mut (u16, Option<Entity>) {
-        // SAFETY: live entities has u16::MAX members
         unsafe { self.live_entities.get_unchecked_mut(id as usize) }
     }
 

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -119,9 +119,6 @@ pub const FROZEN_BLOCK: &str = "frozen";
 
 pub const SCENE_LOG_BUFFER_SIZE: usize = 100;
 
-/// both 0 and 65535 are valid indexes
-const LIVE_TABLE_LEN: usize = u16::MAX as usize + 1;
-
 // A scene tick that has been in-flight (sent to the scene, no response yet) for longer than this
 // is treated as "not responding": handle_out_of_world stops holding the player behind the loading
 // screen, and the loading UI surfaces a countdown to this timeout.
@@ -167,7 +164,7 @@ impl RendererSceneContext {
             death_row: Default::default(),
             outbound_born: Default::default(),
             outbound_died: Default::default(),
-            live_entities: vec![(0, None); LIVE_TABLE_LEN],
+            live_entities: vec![(0, None); SceneEntityId::LIVE_TABLE_LEN],
             unparented_entities: HashSet::new(),
             hierarchy_changed: false,
             last_sent: 0.0,
@@ -198,10 +195,12 @@ impl RendererSceneContext {
     }
 
     fn entity_entry(&self, id: u16) -> &(u16, Option<Entity>) {
+        // SAFETY: live_entities has LIVE_TABLE_LEN (u16::MAX + 1) entries, so any u16 index is in bounds
         unsafe { self.live_entities.get_unchecked(id as usize) }
     }
 
     fn entity_entry_mut(&mut self, id: u16) -> &mut (u16, Option<Entity>) {
+        // SAFETY: live_entities has LIVE_TABLE_LEN (u16::MAX + 1) entries, so any u16 index is in bounds
         unsafe { self.live_entities.get_unchecked_mut(id as usize) }
     }
 


### PR DESCRIPTION
`CrdtContext::live_entities` and `RendererSceneContext::live_entities` are sized `u16::MAX` (65535 slots, valid indices 0..=65534) but are indexed by `SceneEntityId::id`, a `u16` ranging over 0..=65535.

Scene entity ids arrive unvalidated: `SceneEntityId::from_reader` reads the id as a raw `u16`, so any CRDT message stream -- a scene's `crdt_send_to_renderer` batch, or a `main.crdt` fetched from the content server -- can name entity 65535 and index one past the end.