### PR TITLE
fix: annotate loopback fetches for Chrome Local Network Access

### DIFF
--- a/react-web/src/lib/localNetworkFetch.test.ts
+++ b/react-web/src/lib/localNetworkFetch.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installLocalNetworkFetch, targetAddressSpaceOf, type LnaRequestInit } from './localNetworkFetch'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('targetAddressSpaceOf', () => {
+  it.each([
+    ['http://localhost:8000/about', 'loopback'],
+    ['http://127.0.0.1:1234/content', 'loopback'],
+    ['http://[::1]:8000/', 'loopback'],
+    ['http://10.0.0.5/x', 'local'],
+    ['http://192.168.1.10:2044/', 'local'],
+    ['http://172.16.0.1/', 'local'],
+    ['http://169.254.1.1/', 'local'],
+    ['http://gaming-rig.local/', 'local'],
+    ['http://172.32.0.1/', null], // outside 172.16/12 — public
+    ['https://decentraland.org/bevy-web/', null],
+    ['https://peer.decentraland.org/content', null]
+  ])('%s → %s', (url, expected) => {
+    expect(targetAddressSpaceOf(url)).toBe(expected)
+  })
+
+  it('resolves relative URLs against the page origin', () => {
+    // jsdom serves tests from http://localhost — relative is loopback here.
+    expect(targetAddressSpaceOf('/engine/pkg')).toBe('loopback')
+  })
+
+  it('returns null for unparseable input instead of throwing', () => {
+    expect(targetAddressSpaceOf('http://')).toBe(null)
+  })
+})
+
+describe('installLocalNetworkFetch', () => {
+  function install(): ReturnType<typeof vi.fn> {
+    const mock = vi.fn().mockResolvedValue(new Response())
+    vi.stubGlobal('fetch', mock)
+    installLocalNetworkFetch()
+    return mock
+  }
+
+  it('annotates loopback string URLs with targetAddressSpace', async () => {
+    const mock = install()
+    await window.fetch('http://127.0.0.1:8000/about')
+    expect(mock).toHaveBeenCalledWith('http://127.0.0.1:8000/about', { targetAddressSpace: 'loopback' })
+  })
+
+  it('annotates Request-object inputs via the init override', async () => {
+    const mock = install()
+    const req = new Request('http://localhost:2044/content/contents/x')
+    await window.fetch(req)
+    expect(mock).toHaveBeenCalledWith(req, { targetAddressSpace: 'loopback' })
+  })
+
+  it('preserves existing init options', async () => {
+    const mock = install()
+    await window.fetch('http://192.168.1.4:2044/about', { method: 'HEAD' })
+    expect(mock).toHaveBeenCalledWith('http://192.168.1.4:2044/about', {
+      method: 'HEAD',
+      targetAddressSpace: 'local'
+    })
+  })
+
+  it('leaves public URLs untouched', async () => {
+    const mock = install()
+    await window.fetch('https://peer.decentraland.org/about')
+    expect(mock).toHaveBeenCalledWith('https://peer.decentraland.org/about', undefined)
+  })
+
+  it('respects a caller-provided targetAddressSpace', async () => {
+    const mock = install()
+    const init: LnaRequestInit = { targetAddressSpace: 'local' }
+    await window.fetch('http://127.0.0.1:8000/about', init)
+    expect(mock).toHaveBeenCalledWith('http://127.0.0.1:8000/about', init)
+  })
+})

--- a/react-web/src/lib/localNetworkFetch.ts
+++ b/react-web/src/lib/localNetworkFetch.ts
@@ -1,0 +1,47 @@
+// Chrome 142+ gates fetches that cross from a public site into the local network behind the
+// "Local Network Access" permission (developer.chrome.com/blog/local-network-access):
+// unannotated requests to loopback/private hosts are blocked outright. Annotating them with
+// `targetAddressSpace` lets Chrome raise its permission prompt ("Apps on device" in 145+) and
+// exempts the plain-http target from mixed-content blocking. The engine's wasm fetches
+// (reqwest → web-sys) resolve the global `fetch` at call time, so patching window.fetch covers
+// the engine and the HUD alike. The case that matters: a deployed build loading a
+// `sdk-commands start` preview realm (?preview=true&realm=http://127.0.0.1:PORT).
+//
+// Known gap: fetches issued from worker threads use the worker's own global fetch, which this
+// page-level patch can't reach — engine asset/realm fetches run on the main thread, so preview
+// is covered.
+
+type TargetAddressSpace = 'loopback' | 'local'
+
+export interface LnaRequestInit extends RequestInit {
+  targetAddressSpace?: TargetAddressSpace
+}
+
+const LOOPBACK = /^(localhost|127(\.\d{1,3}){3}|\[::1\])$/i
+// RFC1918 + link-local — Chrome's non-loopback "local" address space.
+const LOCAL = /^(10|192\.168|172\.(1[6-9]|2\d|3[01])|169\.254)(\.\d{1,3}){1,3}$/
+
+export function targetAddressSpaceOf(url: string): TargetAddressSpace | null {
+  let host: string
+  try {
+    host = new URL(url, location.href).hostname
+  } catch {
+    return null // unparseable — let fetch produce its own error
+  }
+  if (LOOPBACK.test(host)) return 'loopback'
+  if (LOCAL.test(host) || host.toLowerCase().endsWith('.local')) return 'local'
+  return null
+}
+
+export function installLocalNetworkFetch(): void {
+  const original = window.fetch.bind(window)
+  window.fetch = function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const url = input instanceof Request ? input.url : String(input)
+    const space = targetAddressSpaceOf(url)
+    if (space == null || (init != null && 'targetAddressSpace' in init)) {
+      return original(input, init)
+    }
+    const annotated: LnaRequestInit = { ...init, targetAddressSpace: space }
+    return original(input, annotated)
+  }
+}

--- a/react-web/src/main.tsx
+++ b/react-web/src/main.tsx
@@ -4,7 +4,12 @@ import '@fontsource-variable/inter/index.css' // self-hosted Inter (matches the 
 import { App } from './App'
 import { registerCoiServiceWorker } from './lib/coiServiceWorker'
 import { installCefNativeBridge } from './lib/cefNativeBridge'
+import { installLocalNetworkFetch } from './lib/localNetworkFetch'
 import './styles/global.css'
+
+// Before anything fetches: annotate loopback/local-network requests so Chrome's Local Network
+// Access permission (142+) prompts instead of silently blocking — preview realms live on localhost.
+installLocalNetworkFetch()
 
 // NATIVE (?native=1): bevy renders the 3D world *behind* this transparent webview, so the page must
 // be transparent (in web mode the engine canvas lives in this document at z-0, so the body


### PR DESCRIPTION
## Summary

Since Chrome 142, fetches from a public HTTPS site to loopback/private hosts are gated behind the **Local Network Access** permission ("Apps on device" in Chrome 145+). Unannotated requests are blocked outright — so `decentraland.org/bevy-web/?preview=true&realm=http://127.0.0.1:PORT` fails to reach the `sdk-commands start` preview server, often without the permission prompt ever appearing.

This adds `react-web/src/lib/localNetworkFetch.ts`, installed at page boot: a `window.fetch` wrapper that annotates requests to loopback (`localhost`, `127.0.0.0/8`, `[::1]`) and local-network (RFC1918, link-local, `.local`) hosts with `targetAddressSpace`, which makes Chrome raise its permission prompt and exempts the plain-http target from mixed-content blocking. The engine's wasm fetches (reqwest → web-sys) resolve the global `fetch` at call time, so the single page-level wrapper covers both the engine and the HUD. Reference: https://developer.chrome.com/blog/local-network-access

## What could break

- Any code relying on `window.fetch` being the native function (none in-repo; the wrapper delegates to the original and leaves public URLs completely untouched).
- Fetches issued from **worker threads** use the worker's own global fetch and are not covered — engine asset/realm fetches run on the main thread, so preview is covered. WebSockets (comms, hot-reload) are not yet LNA-gated by Chrome.
- `fetch(request, init)` with an init override re-constructs the request; only requests to loopback/local hosts take that path.

## How to test

1. `npm test` in `react-web/` (18 new tests in `localNetworkFetch.test.ts`; 275 total pass).
2. Manual: run `sdk-commands start --web` in a scene, open the deployed `decentraland.org/bevy-web` preview URL in Chrome 142+ with the site's "Apps on device" permission unset → Chrome should now show the permission prompt; after Allow, the scene loads.
3. Regression: normal (non-preview) world loading from public catalysts is unaffected.