### PR TITLE
fix: web sandbox rejects scenes that redeclare injected globals

### DIFF
--- a/deploy/web/engine/sandbox_worker.js
+++ b/deploy/web/engine/sandbox_worker.js
@@ -202,7 +202,7 @@ async function runWithScope(code) {
     "globalThis",
     "module",
     "exports",
-    `${jsPreamble}\n\n${code}`
+    `${jsPreamble}\n\n;(function (globalThis, module, exports) {\n${code}\n}).call(globalThis, globalThis, module, exports);`
   );
 
   await defer(() => func.call(jsProxy, jsProxy, module, module.exports));


### PR DESCRIPTION
## Summary

Scenes that use `@colyseus/sdk` (e.g. Genesis Plaza's fishing game) never load in the web explorer:

```
[Sandbox Worker] Error during scene execution: SyntaxError: Identifier 'WebSocket' has already been declared
```

esbuild hoists the SDK's WebSocket binding to a top-level `var WebSocket` in the scene bundle. `runWithScope` prepends `const WebSocket = globalThis.WebSocket;` (allowlist preamble) into the same function body, and a `var` can't coexist with a same-named `const` in one scope — parse error before the scene runs. The same bundles load fine in the unity web kernel and native bevy.

Fix: evaluate the scene source in a nested function scope, so scene-level declarations of injected names shadow the preamble instead of colliding.

## What could break

- Isolation is unchanged: free identifiers still resolve to the preamble consts / proxy-bound `globalThis`; worker globals stay unreachable.
- A leading `"use strict"` in a bundle now actually applies to the scene code (it was inert behind the preamble before).

## How to test

1. Run a colyseus-using scene in preview (dev build, unminified): `npm run start -- --bevy-web` on Genesis-Plaza-2025 `fishing-game` branch.
2. Before: the SyntaxError above, scene never loads. After: scene loads and runs (verified: pond renders, colyseus transport constructs).