### PR TITLE
security: reject URL-shaped readFile on the authoritative server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9222,6 +9222,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "ui_core",
+ "url",
  "urlencoding",
  "user_input",
  "wallet",

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -292,6 +292,19 @@ pub struct SceneDrivenAnimationFeedback {
 #[derive(Resource, Default)]
 pub struct IsServer(pub bool);
 
+static SERVER_MODE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Latch this process as an authoritative scene server. Irreversible by design;
+/// mirrors [`IsServer`] for code paths (e.g. the ipfs crate) that have no ECS access.
+pub fn set_server_mode() {
+    SERVER_MODE.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// True once [`set_server_mode`] has been called.
+pub fn server_mode() -> bool {
+    SERVER_MODE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 #[derive(Debug, Clone)]
 pub struct SceneDrivenAnimationFeedbackState {
     pub src: String,

--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -133,11 +133,18 @@ impl IpfsType {
                 .hash(file_path)
                 .map(|hash| format!("{base_url}{hash}"))
                 .or_else(|| {
-                    // try as a url directly
+                    // On an authoritative server a content-map miss must NOT fall through to
+                    // fetching the file_path as a raw URL: that turns any asset load of a
+                    // missing entry into a scene-controlled outbound request (SSRF). Clients
+                    // keep the URL fallthrough.
                     // TODO: check scene.json for allowed domains (include these in context like baseUrls)
-                    url::Url::try_from(file_path.as_str())
-                        .is_ok()
-                        .then_some(file_path.to_owned())
+                    if common::structs::server_mode() {
+                        None
+                    } else {
+                        url::Url::try_from(file_path.as_str())
+                            .is_ok()
+                            .then_some(file_path.to_owned())
+                    }
                 })
                 .ok_or_else(|| {
                     anyhow::anyhow!("file not found in content map: {file_path:?} in {scene_hash}")

--- a/crates/restricted_actions/Cargo.toml
+++ b/crates/restricted_actions/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { workspace = true }
 serde_json = { workspace = true }
 ethers-core = { workspace = true }
 urlencoding = { workspace = true }
+url = { workspace = true }
 opener = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -2048,16 +2048,16 @@ fn handle_sign_request(
     })
 }
 
-/// True when a readFile target is shaped like `<scheme>://…` — the form
-/// `IpfsType::url_target` treats as a directly-fetchable URL rather than a scene
+/// True when a readFile target parses as an absolute URL of ANY scheme — the form
+/// `IpfsType::url_target` can treat as a directly-fetchable URL rather than a scene
 /// content file. Used to block that fallthrough on the authoritative server.
+///
+/// `Url::parse` succeeds only for absolute URLs (a relative content path yields
+/// `RelativeUrlWithoutBase`), and it applies WHATWG normalisation, so it catches shapes a
+/// raw `://` scan missed: leading whitespace (` http://169.254.169.254`) and the slash-less
+/// `http:169.254.169.254` (normalised to `http://169.254.169.254/`).
 fn filename_looks_like_url(filename: &str) -> bool {
-    match filename.find("://") {
-        Some(idx) if idx > 0 => filename[..idx]
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.')),
-        _ => false,
-    }
+    url::Url::parse(filename.trim()).is_ok()
 }
 
 #[allow(clippy::type_complexity)]
@@ -2241,5 +2241,50 @@ pub fn process_startup_scenes(
 
     if tasks.is_empty() {
         *done = true;
+    }
+}
+
+#[cfg(test)]
+mod readfile_url_guard_tests {
+    use super::filename_looks_like_url;
+
+    #[test]
+    fn absolute_urls_of_any_scheme_are_url_shaped() {
+        for s in [
+            "http://169.254.169.254/latest/meta-data/",
+            "https://evil.example/x",
+            "ws://127.0.0.1:9000",
+            "file:///etc/passwd",
+            "ipfs+http://host/x",
+        ] {
+            assert!(
+                filename_looks_like_url(s),
+                "{s} must be refused on a server"
+            );
+        }
+    }
+
+    #[test]
+    fn the_shapes_a_substring_scan_missed_are_caught() {
+        assert!(filename_looks_like_url(" http://169.254.169.254"));
+        assert!(filename_looks_like_url("http:169.254.169.254"));
+        assert!(filename_looks_like_url("\thttps://evil.example\n"));
+    }
+
+    #[test]
+    fn ordinary_scene_content_paths_are_not_url_shaped() {
+        for s in [
+            "models/scene.glb",
+            "a/b://c",
+            "://nohost",
+            "plain.txt",
+            "./nested/thing.json",
+            "",
+        ] {
+            assert!(
+                !filename_looks_like_url(s),
+                "{s} is scene content and must still be readable"
+            );
+        }
     }
 }

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -102,6 +102,10 @@ fn parse_args() -> Args {
     let orchestrated = args.contains("--orchestrated");
     // orchestrated mode is always a server
     let server_mode = args.contains("--server-mode") || orchestrated;
+    // latch the process-global mirror of IsServer so ECS-less code (ipfs) sees server role
+    if server_mode {
+        common::structs::set_server_mode();
+    }
     let timeout: Option<f32> = args.value_from_str("--timeout").ok();
     let scene_threads: usize = args
         .value_from_str("--scene-threads")
@@ -431,7 +435,11 @@ fn main() {
             )
             .add_systems(
                 PostUpdate,
-                (emit_scene_status, emit_scene_stats, emit_failed_scene_status),
+                (
+                    emit_scene_status,
+                    emit_scene_stats,
+                    emit_failed_scene_status,
+                ),
             );
         ctl_emit(&serde_json::json!({"type": "starting", "realm": args.realm}));
     }


### PR DESCRIPTION
`filename_looks_like_url` on this branch scans for `://` and validates the scheme prefix. Two shapes get past it and reach `IpfsType::url_target`, which fetches the filename as a raw URL through a redirect-following client — from the process holding the authoritative key:

- `" http://169.254.169.254"` — a leading space makes the prefix check fail, so the guard returns false
- `"http:169.254.169.254"` — no `://` at all, but WHATWG parsing normalises it to `http://169.254.169.254/`

Parse the trimmed filename with `url::Url::parse` instead. It succeeds only for absolute URLs (a relative content path gives `RelativeUrlWithoutBase`) and applies the same normalisation an attacker would rely on.

Also closes the second path: on a server a content-map miss no longer falls through to fetching the path as a URL. Because the ipfs crate has no ECS access, `IsServer` is mirrored as a process-global latched at server boot. Clients keep both behaviours unchanged.

Three unit tests. Substituting this branch's current implementation back in fails `the_shapes_a_substring_scan_missed_are_caught` on `" http://169.254.169.254"`, so the bypass is demonstrated against the code as it stands rather than argued.
