### PR TITLE
ipc: drop an unexpected ipc message instead of panicking the engine

### DIFF
--- a/crates/dcl_deno_ipc/src/lib.rs
+++ b/crates/dcl_deno_ipc/src/lib.rs
@@ -285,7 +285,8 @@ pub async fn renderer_ipc_in(mut stream: RecvHalf) {
             }),
             SceneToEngine::IpcMessage(id, ipc_message) => {
                 let IpcMessage::Closed = ipc_message else {
-                    panic!()
+                    warn!("ignoring unexpected ipc data message for channel {id}");
+                    continue;
                 };
 
                 ENGINE_IPC_CONTEXT.with(|ctx| {


### PR DESCRIPTION
Only `Closed` travels sidecar to engine; `Data` flows the other way. The reader asserts that with a bare `panic!()`, so a sidecar that ever sent `Data` would end the reader task — and under `EXIT_ON_SIDECAR_LOSS` that ends the engine process and every co-tenant scene.

Warn and continue. The channel registry is unchanged either way, so nothing downstream depends on the message having been `Closed`.

+2/-1. No test: the branch sits inside a large async match and I did not want to restructure it just to reach the arm.
