### PR TITLE
ipc: a lost sidecar fails the scene, not the whole app

### DIFF
--- a/crates/dcl_deno_ipc/src/lib.rs
+++ b/crates/dcl_deno_ipc/src/lib.rs
@@ -328,27 +328,30 @@ pub fn spawn_scene(
     let (main_sx, thread_rx) = tokio::sync::mpsc::unbounded_channel::<RendererResponse>();
 
     let ipc_out = NEW_SCENE_SENDER.read().unwrap();
-    let ipc_out = ipc_out.as_ref().unwrap();
+    let Some(ipc_out) = ipc_out.as_ref() else {
+        error!("scene {id:?} not started: ipc runtime is not initialized");
+        return main_sx;
+    };
 
-    ipc_out
-        .send(NewSceneCommand {
-            id: id.0.to_bits(),
-            info: NewSceneInfo {
-                initial_crdt_store,
-                scene_context,
-                scene_js: scene_js.0.to_string(),
-                crdt_component_interfaces,
-                storage_root,
-                inspect,
-                is_super,
-                scene_origin,
-            },
-            renderer_channel: thread_rx,
-            global_channel: global_update_receiver,
-            response_channel: renderer_sender,
-            system_api_sender: super_user,
-        })
-        .unwrap();
+    if let Err(e) = ipc_out.send(NewSceneCommand {
+        id: id.0.to_bits(),
+        info: NewSceneInfo {
+            initial_crdt_store,
+            scene_context,
+            scene_js: scene_js.0.to_string(),
+            crdt_component_interfaces,
+            storage_root,
+            inspect,
+            is_super,
+            scene_origin,
+        },
+        renderer_channel: thread_rx,
+        global_channel: global_update_receiver,
+        response_channel: renderer_sender,
+        system_api_sender: super_user,
+    }) {
+        error!("scene {id:?} not started: ipc channel closed ({e})");
+    }
 
     main_sx
 }


### PR DESCRIPTION
`spawn_scene` unwraps the send to the IPC out-task. Once the sidecar is gone that channel is closed, so the next scene load panics inside a bevy system and aborts the app. Sidecar loss then presents as a crash attributed to whatever scene happened to load next.

Log and return the sender instead. On the orchestrated server the runtime thread still drives `EXIT_ON_SIDECAR_LOSS`, so recovery is unchanged.

Not verified: that the existing broken-scene path then claims the scene. If nothing marks it broken it hangs quietly rather than crashing loudly, which may not be an improvement. Worth a second opinion.
