### PR TITLE
security: refuse eth signing on the authoritative server

### DIFF
--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -1656,6 +1656,7 @@ pub fn handle_eth_async(
     scenes: Query<&RendererSceneContext>,
     wallet: Res<Wallet>,
     time: Res<Time>,
+    is_server: Res<IsServer>,
     mut tasks: Local<
         Vec<(
             RpcResultSender<Result<serde_json::Value, String>>,
@@ -1672,6 +1673,14 @@ pub fn handle_eth_async(
         } => Some((body, scene, response)),
         _ => None,
     }) {
+        // The engine wallet is AUTHORITATIVE_SERVER_KEY on a server; never sign for a scene.
+        if is_server.0 {
+            response.send(Err(
+                "eth signing is not available on the authoritative server".to_owned(),
+            ));
+            continue;
+        }
+
         let last_action_time = scenes
             .get(*scene)
             .ok()


### PR DESCRIPTION
`handle_eth_async` signs with the wallet the process holds. On the authoritative server that is `AUTHORITATIVE_SERVER_KEY`, and there is no `is_server` check on this path — the file gates `is_server` in several other places but not here, so a scene running server-side can reach the signing path.

Refuse eth signing when running as a server.

+9/-0. `cargo check --workspace` clean on this base. No tests.
