### PR TITLE
scene sandbox: bound comms rate, size and bus queue

### DIFF
--- a/crates/common/src/rpc/stream_sender.rs
+++ b/crates/common/src/rpc/stream_sender.rs
@@ -1,8 +1,20 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
 
 use crate::rpc::*;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 use tokio_util::sync::CancellationToken;
+
+// In-flight counter for a bounded stream: the sender drops when full, the receiver decrements as it drains.
+#[derive(Debug)]
+struct QueueGaugeInner {
+    len: AtomicUsize,
+    cap: usize,
+}
+
+type QueueGauge = Arc<QueueGaugeInner>;
 
 #[derive(Clone)]
 pub enum LocalChannel<T> {
@@ -30,6 +42,7 @@ pub enum RpcStreamSender<T> {
     Local {
         channel: Arc<Mutex<LocalChannel<T>>>,
         cancel: CancellationToken,
+        gauge: Option<QueueGauge>,
     },
     Remote {
         id: u64,
@@ -48,15 +61,28 @@ impl<T> std::fmt::Debug for RpcStreamSender<T> {
 pub struct RpcStreamReceiver<T> {
     channel: tokio::sync::mpsc::UnboundedReceiver<T>,
     cancel: CancellationToken,
+    gauge: Option<QueueGauge>,
 }
 
 impl<T> RpcStreamReceiver<T> {
     pub fn try_recv(&mut self) -> Result<T, tokio::sync::mpsc::error::TryRecvError> {
-        self.channel.try_recv()
+        let result = self.channel.try_recv();
+        if result.is_ok() {
+            if let Some(gauge) = &self.gauge {
+                gauge.len.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+        result
     }
 
     pub async fn recv(&mut self) -> Option<T> {
-        self.channel.recv().await
+        let result = self.channel.recv().await;
+        if result.is_some() {
+            if let Some(gauge) = &self.gauge {
+                gauge.len.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+        result
     }
 }
 
@@ -77,20 +103,60 @@ impl<T: Serialize> RpcStreamSender<T> {
             Self::Local {
                 channel: Arc::new(Mutex::new(LocalChannel::Channel(sx))),
                 cancel: cancel.clone(),
+                gauge: None,
             },
             RpcStreamReceiver {
                 channel: rx,
                 cancel,
+                gauge: None,
+            },
+        )
+    }
+
+    // Caps in-flight items at `cap`; once full the sender drops further messages (fail closed).
+    pub fn bounded_channel(cap: usize) -> (Self, RpcStreamReceiver<T>) {
+        let (sx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        let gauge: QueueGauge = Arc::new(QueueGaugeInner {
+            len: AtomicUsize::new(0),
+            cap: cap.max(1),
+        });
+
+        (
+            Self::Local {
+                channel: Arc::new(Mutex::new(LocalChannel::Channel(sx))),
+                cancel: cancel.clone(),
+                gauge: Some(gauge.clone()),
+            },
+            RpcStreamReceiver {
+                channel: rx,
+                cancel,
+                gauge: Some(gauge),
             },
         )
     }
 
     pub fn send(&self, val: T) -> Result<(), tokio::sync::mpsc::error::SendError<T>> {
         match self {
-            RpcStreamSender::Local { channel, .. } => match &*channel.lock().unwrap() {
-                LocalChannel::Channel(unbounded_sender) => unbounded_sender.send(val),
-                LocalChannel::Serialized(_) => panic!(),
-            },
+            RpcStreamSender::Local { channel, gauge, .. } => {
+                if let Some(gauge) = gauge {
+                    if gauge.len.load(Ordering::Relaxed) >= gauge.cap {
+                        return Ok(());
+                    }
+                }
+                match &*channel.lock().unwrap() {
+                    LocalChannel::Channel(unbounded_sender) => {
+                        let result = unbounded_sender.send(val);
+                        if result.is_ok() {
+                            if let Some(gauge) = gauge {
+                                gauge.len.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        result
+                    }
+                    LocalChannel::Serialized(_) => panic!(),
+                }
+            }
             RpcStreamSender::Remote {
                 id,
                 router,
@@ -124,12 +190,22 @@ impl<T: Serialize> RpcStreamSender<T> {
 
 struct IpcStreamCallback<T: DeserializeOwned + Send + 'static> {
     sender: tokio::sync::mpsc::UnboundedSender<T>,
+    gauge: Option<QueueGauge>,
 }
 
 impl<T: DeserializeOwned + Send + 'static> IpcEndpoint for IpcStreamCallback<T> {
     fn send(&mut self, raw_bytes: Vec<u8>) {
         if let Ok(val) = rmp_serde::from_slice::<T>(&raw_bytes) {
-            let _ = self.sender.send(val);
+            if let Some(gauge) = &self.gauge {
+                if gauge.len.load(Ordering::Relaxed) >= gauge.cap {
+                    return;
+                }
+            }
+            if self.sender.send(val).is_ok() {
+                if let Some(gauge) = &self.gauge {
+                    gauge.len.fetch_add(1, Ordering::Relaxed);
+                }
+            }
         }
     }
 }
@@ -139,12 +215,18 @@ impl<T: 'static + Serialize + DeserializeOwned + Send> Serialize for RpcStreamSe
     where
         S: serde::Serializer,
     {
-        let RpcStreamSender::Local { channel, cancel } = self else {
+        let RpcStreamSender::Local {
+            channel,
+            cancel,
+            gauge,
+        } = self
+        else {
             panic!();
         };
 
-        let id = channel.lock().unwrap().serialize_with(|sender| {
-            let endpoint = IpcStreamCallback { sender };
+        let gauge = gauge.clone();
+        let id = channel.lock().unwrap().serialize_with(move |sender| {
+            let endpoint = IpcStreamCallback { sender, gauge };
             let (id, close_sender) = ipc_register(endpoint);
 
             let cancel = cancel.clone();

--- a/crates/common/src/rpc/stream_sender.rs
+++ b/crates/common/src/rpc/stream_sender.rs
@@ -1,32 +1,39 @@
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc, Mutex,
-};
+use std::sync::{Arc, Mutex};
+
+use bevy::log::warn;
 
 use crate::rpc::*;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 use tokio_util::sync::CancellationToken;
 
-// In-flight counter for a bounded stream: the sender drops when full, the receiver decrements as it drains.
-#[derive(Debug)]
-struct QueueGaugeInner {
-    len: AtomicUsize,
-    cap: usize,
-}
+// All stream channels are bounded: once `cap` items are in flight, further sends are dropped.
+// The default is sized so it is never approached by well-behaved producers; channels fed by
+// untrusted peer traffic should pass a tighter explicit capacity.
+const DEFAULT_CHANNEL_CAP: usize = 4096;
 
-type QueueGauge = Arc<QueueGaugeInner>;
+// Dropping on a full channel is expected never to happen in normal operation, so leave a
+// diagnostic trace of what was lost.
+fn warn_dropped<T: Serialize>(val: &T) {
+    let mut preview = serde_json::to_string(val).unwrap_or_else(|_| "<unserializable>".to_owned());
+    if preview.len() > 100 {
+        let mut end = 100;
+        while !preview.is_char_boundary(end) {
+            end -= 1;
+        }
+        preview.truncate(end);
+        preview.push('…');
+    }
+    warn!("channel full, dropping message starting {preview}");
+}
 
 #[derive(Clone)]
 pub enum LocalChannel<T> {
-    Channel(tokio::sync::mpsc::UnboundedSender<T>),
+    Channel(tokio::sync::mpsc::Sender<T>),
     Serialized(u64),
 }
 
 impl<T> LocalChannel<T> {
-    fn serialize_with<F: FnOnce(tokio::sync::mpsc::UnboundedSender<T>) -> u64>(
-        &mut self,
-        f: F,
-    ) -> u64 {
+    fn serialize_with<F: FnOnce(tokio::sync::mpsc::Sender<T>) -> u64>(&mut self, f: F) -> u64 {
         let id = match std::mem::replace(self, LocalChannel::Serialized(u64::MAX)) {
             LocalChannel::Channel(sender) => (f)(sender),
             LocalChannel::Serialized(id) => id,
@@ -42,7 +49,6 @@ pub enum RpcStreamSender<T> {
     Local {
         channel: Arc<Mutex<LocalChannel<T>>>,
         cancel: CancellationToken,
-        gauge: Option<QueueGauge>,
     },
     Remote {
         id: u64,
@@ -59,30 +65,17 @@ impl<T> std::fmt::Debug for RpcStreamSender<T> {
 }
 
 pub struct RpcStreamReceiver<T> {
-    channel: tokio::sync::mpsc::UnboundedReceiver<T>,
+    channel: tokio::sync::mpsc::Receiver<T>,
     cancel: CancellationToken,
-    gauge: Option<QueueGauge>,
 }
 
 impl<T> RpcStreamReceiver<T> {
     pub fn try_recv(&mut self) -> Result<T, tokio::sync::mpsc::error::TryRecvError> {
-        let result = self.channel.try_recv();
-        if result.is_ok() {
-            if let Some(gauge) = &self.gauge {
-                gauge.len.fetch_sub(1, Ordering::Relaxed);
-            }
-        }
-        result
+        self.channel.try_recv()
     }
 
     pub async fn recv(&mut self) -> Option<T> {
-        let result = self.channel.recv().await;
-        if result.is_some() {
-            if let Some(gauge) = &self.gauge {
-                gauge.len.fetch_sub(1, Ordering::Relaxed);
-            }
-        }
-        result
+        self.channel.recv().await
     }
 }
 
@@ -96,67 +89,41 @@ impl<T> Drop for RpcStreamReceiver<T> {
 
 impl<T: Serialize> RpcStreamSender<T> {
     pub fn channel() -> (Self, RpcStreamReceiver<T>) {
-        let (sx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let cancel = CancellationToken::new();
-
-        (
-            Self::Local {
-                channel: Arc::new(Mutex::new(LocalChannel::Channel(sx))),
-                cancel: cancel.clone(),
-                gauge: None,
-            },
-            RpcStreamReceiver {
-                channel: rx,
-                cancel,
-                gauge: None,
-            },
-        )
+        Self::channel_with_capacity(DEFAULT_CHANNEL_CAP)
     }
 
-    // Caps in-flight items at `cap`; once full the sender drops further messages (fail closed).
-    pub fn bounded_channel(cap: usize) -> (Self, RpcStreamReceiver<T>) {
-        let (sx, rx) = tokio::sync::mpsc::unbounded_channel();
+    pub fn channel_with_capacity(cap: usize) -> (Self, RpcStreamReceiver<T>) {
+        let (sx, rx) = tokio::sync::mpsc::channel(cap.max(1));
         let cancel = CancellationToken::new();
-        let gauge: QueueGauge = Arc::new(QueueGaugeInner {
-            len: AtomicUsize::new(0),
-            cap: cap.max(1),
-        });
 
         (
             Self::Local {
                 channel: Arc::new(Mutex::new(LocalChannel::Channel(sx))),
                 cancel: cancel.clone(),
-                gauge: Some(gauge.clone()),
             },
             RpcStreamReceiver {
                 channel: rx,
                 cancel,
-                gauge: Some(gauge),
             },
         )
     }
 
     pub fn send(&self, val: T) -> Result<(), tokio::sync::mpsc::error::SendError<T>> {
         match self {
-            RpcStreamSender::Local { channel, gauge, .. } => {
-                if let Some(gauge) = gauge {
-                    if gauge.len.load(Ordering::Relaxed) >= gauge.cap {
-                        return Ok(());
+            RpcStreamSender::Local { channel, .. } => match &*channel.lock().unwrap() {
+                LocalChannel::Channel(sender) => match sender.try_send(val) {
+                    Ok(()) => Ok(()),
+                    // full: drop the message, that's the bound
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(val)) => {
+                        warn_dropped(&val);
+                        Ok(())
                     }
-                }
-                match &*channel.lock().unwrap() {
-                    LocalChannel::Channel(unbounded_sender) => {
-                        let result = unbounded_sender.send(val);
-                        if result.is_ok() {
-                            if let Some(gauge) = gauge {
-                                gauge.len.fetch_add(1, Ordering::Relaxed);
-                            }
-                        }
-                        result
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(val)) => {
+                        Err(tokio::sync::mpsc::error::SendError(val))
                     }
-                    LocalChannel::Serialized(_) => panic!(),
-                }
-            }
+                },
+                LocalChannel::Serialized(_) => panic!(),
+            },
             RpcStreamSender::Remote {
                 id,
                 router,
@@ -177,7 +144,7 @@ impl<T: Serialize> RpcStreamSender<T> {
     pub fn is_closed(&self) -> bool {
         match self {
             RpcStreamSender::Local { channel, .. } => match &*channel.lock().unwrap() {
-                LocalChannel::Channel(unbounded_sender) => unbounded_sender.is_closed(),
+                LocalChannel::Channel(sender) => sender.is_closed(),
                 LocalChannel::Serialized(_) => panic!(),
             },
             RpcStreamSender::Remote {
@@ -188,23 +155,18 @@ impl<T: Serialize> RpcStreamSender<T> {
     }
 }
 
-struct IpcStreamCallback<T: DeserializeOwned + Send + 'static> {
-    sender: tokio::sync::mpsc::UnboundedSender<T>,
-    gauge: Option<QueueGauge>,
+struct IpcStreamCallback<T: Serialize + DeserializeOwned + Send + 'static> {
+    sender: tokio::sync::mpsc::Sender<T>,
 }
 
-impl<T: DeserializeOwned + Send + 'static> IpcEndpoint for IpcStreamCallback<T> {
+impl<T: Serialize + DeserializeOwned + Send + 'static> IpcEndpoint for IpcStreamCallback<T> {
     fn send(&mut self, raw_bytes: Vec<u8>) {
         if let Ok(val) = rmp_serde::from_slice::<T>(&raw_bytes) {
-            if let Some(gauge) = &self.gauge {
-                if gauge.len.load(Ordering::Relaxed) >= gauge.cap {
-                    return;
-                }
-            }
-            if self.sender.send(val).is_ok() {
-                if let Some(gauge) = &self.gauge {
-                    gauge.len.fetch_add(1, Ordering::Relaxed);
-                }
+            // full: drop the message, that's the bound
+            if let Err(tokio::sync::mpsc::error::TrySendError::Full(val)) =
+                self.sender.try_send(val)
+            {
+                warn_dropped(&val);
             }
         }
     }
@@ -215,18 +177,12 @@ impl<T: 'static + Serialize + DeserializeOwned + Send> Serialize for RpcStreamSe
     where
         S: serde::Serializer,
     {
-        let RpcStreamSender::Local {
-            channel,
-            cancel,
-            gauge,
-        } = self
-        else {
+        let RpcStreamSender::Local { channel, cancel } = self else {
             panic!();
         };
 
-        let gauge = gauge.clone();
-        let id = channel.lock().unwrap().serialize_with(move |sender| {
-            let endpoint = IpcStreamCallback { sender, gauge };
+        let id = channel.lock().unwrap().serialize_with(|sender| {
+            let endpoint = IpcStreamCallback { sender };
             let (id, close_sender) = ipc_register(endpoint);
 
             let cancel = cancel.clone();

--- a/crates/comms/src/livekit/participant/plugin.rs
+++ b/crates/comms/src/livekit/participant/plugin.rs
@@ -45,7 +45,6 @@ use crate::{
     SceneRoom,
 };
 
-const MAX_INBOUND_PACKET_BYTES: usize = 128 * 1024;
 const INBOUND_RATE_WINDOW_SECS: f64 = 1.0;
 const MAX_MESSAGES_PER_WINDOW: usize = 300;
 const MAX_RATE_ENTRIES: usize = 4096;
@@ -260,16 +259,6 @@ fn participant_payload(
         participant,
         payload,
     } = trigger.event();
-
-    if payload.len() > MAX_INBOUND_PACKET_BYTES {
-        warn!(
-            "dropping oversized ({} bytes) payload from participant {} ({}).",
-            payload.len(),
-            participant.sid(),
-            participant.identity()
-        );
-        return;
-    }
 
     if !rate_limiter.allow(participant.identity().as_str(), time.elapsed_secs_f64()) {
         trace!(

--- a/crates/comms/src/livekit/participant/plugin.rs
+++ b/crates/comms/src/livekit/participant/plugin.rs
@@ -47,9 +47,9 @@ use crate::{
 
 const INBOUND_RATE_WINDOW_SECS: f64 = 1.0;
 const MAX_MESSAGES_PER_WINDOW: usize = 300;
-const MAX_RATE_ENTRIES: usize = 4096;
 
-// Per-peer sliding-window rate limit; `windows` is bounded by MAX_RATE_ENTRIES against an identity flood.
+// Per-peer sliding-window rate limit; entries are evicted when the participant entity is removed,
+// which bounds the map by the number of connected participants.
 #[derive(Resource, Default)]
 struct InboundRateLimiter {
     windows: HashMap<String, VecDeque<f64>>,
@@ -58,18 +58,6 @@ struct InboundRateLimiter {
 impl InboundRateLimiter {
     fn allow(&mut self, identity: &str, now: f64) -> bool {
         let cutoff = now - INBOUND_RATE_WINDOW_SECS;
-
-        if !self.windows.contains_key(identity) && self.windows.len() >= MAX_RATE_ENTRIES {
-            self.windows.retain(|_, times| {
-                while times.front().is_some_and(|&t| t < cutoff) {
-                    times.pop_front();
-                }
-                !times.is_empty()
-            });
-            if !self.windows.contains_key(identity) && self.windows.len() >= MAX_RATE_ENTRIES {
-                return false;
-            }
-        }
 
         let times = self.windows.entry(identity.to_owned()).or_default();
         while times.front().is_some_and(|&t| t < cutoff) {
@@ -90,6 +78,7 @@ impl Plugin for LivekitParticipantPlugin {
         app.init_resource::<InboundRateLimiter>();
         app.add_observer(participant_connected);
         app.add_observer(participant_disconnected);
+        app.add_observer(participant_entity_removed);
         app.add_observer(participant_connection_quality_changed);
         app.add_observer(participant_payload);
         app.add_observer(participant_metadata_changed);
@@ -200,6 +189,18 @@ fn participant_disconnected(
     };
 
     commands.entity(entity).despawn();
+}
+
+// Covers both explicit disconnects and relationship-cascade despawns on room teardown, so
+// rate-limiter entries can't outlive their participant.
+fn participant_entity_removed(
+    trigger: Trigger<OnRemove, LivekitParticipant>,
+    participants: Query<&LivekitParticipant>,
+    mut rate_limiter: ResMut<InboundRateLimiter>,
+) {
+    if let Ok(participant) = participants.get(trigger.target()) {
+        rate_limiter.windows.remove(participant.identity().as_str());
+    }
 }
 
 fn participant_connection_quality_changed(

--- a/crates/comms/src/livekit/participant/plugin.rs
+++ b/crates/comms/src/livekit/participant/plugin.rs
@@ -49,17 +49,18 @@ const INBOUND_RATE_WINDOW_SECS: f64 = 1.0;
 const MAX_MESSAGES_PER_WINDOW: usize = 300;
 
 // Per-peer sliding-window rate limit; entries are evicted when the participant entity is removed,
-// which bounds the map by the number of connected participants.
+// which bounds the map by the number of connected participants. Keyed per room as well as
+// identity so the same identity string in two rooms (island + scene) can't share a window.
 #[derive(Resource, Default)]
 struct InboundRateLimiter {
-    windows: HashMap<String, VecDeque<f64>>,
+    windows: HashMap<(Entity, String), VecDeque<f64>>,
 }
 
 impl InboundRateLimiter {
-    fn allow(&mut self, identity: &str, now: f64) -> bool {
+    fn allow(&mut self, room: Entity, identity: &str, now: f64) -> bool {
         let cutoff = now - INBOUND_RATE_WINDOW_SECS;
 
-        let times = self.windows.entry(identity.to_owned()).or_default();
+        let times = self.windows.entry((room, identity.to_owned())).or_default();
         while times.front().is_some_and(|&t| t < cutoff) {
             times.pop_front();
         }
@@ -195,11 +196,23 @@ fn participant_disconnected(
 // rate-limiter entries can't outlive their participant.
 fn participant_entity_removed(
     trigger: Trigger<OnRemove, LivekitParticipant>,
-    participants: Query<&LivekitParticipant>,
+    participants: Query<(&LivekitParticipant, Option<&HostedBy>)>,
     mut rate_limiter: ResMut<InboundRateLimiter>,
 ) {
-    if let Ok(participant) = participants.get(trigger.target()) {
-        rate_limiter.windows.remove(participant.identity().as_str());
+    let Ok((participant, maybe_hosted)) = participants.get(trigger.target()) else {
+        return;
+    };
+    let identity = participant.identity();
+    match maybe_hosted {
+        Some(hosted) => {
+            rate_limiter
+                .windows
+                .remove(&(hosted.get(), identity.as_str().to_owned()));
+        }
+        // no room to scope by; over-evicting just forgets ≤1s of history
+        None => rate_limiter
+            .windows
+            .retain(|(_, id), _| id != identity.as_str()),
     }
 }
 
@@ -261,7 +274,11 @@ fn participant_payload(
         payload,
     } = trigger.event();
 
-    if !rate_limiter.allow(participant.identity().as_str(), time.elapsed_secs_f64()) {
+    if !rate_limiter.allow(
+        *room_entity,
+        participant.identity().as_str(),
+        time.elapsed_secs_f64(),
+    ) {
         trace!(
             "rate-limited payload from participant {} ({}).",
             participant.sid(),

--- a/crates/comms/src/livekit/participant/plugin.rs
+++ b/crates/comms/src/livekit/participant/plugin.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, VecDeque};
+
 use bevy::{
     ecs::{entity::EntityHashSet, relationship::Relationship},
     platform::collections::HashSet,
@@ -43,10 +45,50 @@ use crate::{
     SceneRoom,
 };
 
+const MAX_INBOUND_PACKET_BYTES: usize = 128 * 1024;
+const INBOUND_RATE_WINDOW_SECS: f64 = 1.0;
+const MAX_MESSAGES_PER_WINDOW: usize = 300;
+const MAX_RATE_ENTRIES: usize = 4096;
+
+// Per-peer sliding-window rate limit; `windows` is bounded by MAX_RATE_ENTRIES against an identity flood.
+#[derive(Resource, Default)]
+struct InboundRateLimiter {
+    windows: HashMap<String, VecDeque<f64>>,
+}
+
+impl InboundRateLimiter {
+    fn allow(&mut self, identity: &str, now: f64) -> bool {
+        let cutoff = now - INBOUND_RATE_WINDOW_SECS;
+
+        if !self.windows.contains_key(identity) && self.windows.len() >= MAX_RATE_ENTRIES {
+            self.windows.retain(|_, times| {
+                while times.front().is_some_and(|&t| t < cutoff) {
+                    times.pop_front();
+                }
+                !times.is_empty()
+            });
+            if !self.windows.contains_key(identity) && self.windows.len() >= MAX_RATE_ENTRIES {
+                return false;
+            }
+        }
+
+        let times = self.windows.entry(identity.to_owned()).or_default();
+        while times.front().is_some_and(|&t| t < cutoff) {
+            times.pop_front();
+        }
+        if times.len() >= MAX_MESSAGES_PER_WINDOW {
+            return false;
+        }
+        times.push_back(now);
+        true
+    }
+}
+
 pub struct LivekitParticipantPlugin;
 
 impl Plugin for LivekitParticipantPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<InboundRateLimiter>();
         app.add_observer(participant_connected);
         app.add_observer(participant_disconnected);
         app.add_observer(participant_connection_quality_changed);
@@ -210,12 +252,33 @@ fn participant_payload(
     global_crdt_state: Res<GlobalCrdtState>,
     mut player_update_tasks: ResMut<PlayerUpdateTasks>,
     livekit_runtime: Res<LivekitRuntime>,
+    mut rate_limiter: ResMut<InboundRateLimiter>,
+    time: Res<Time>,
 ) {
     let ParticipantPayload {
         room: room_entity,
         participant,
         payload,
     } = trigger.event();
+
+    if payload.len() > MAX_INBOUND_PACKET_BYTES {
+        warn!(
+            "dropping oversized ({} bytes) payload from participant {} ({}).",
+            payload.len(),
+            participant.sid(),
+            participant.identity()
+        );
+        return;
+    }
+
+    if !rate_limiter.allow(participant.identity().as_str(), time.elapsed_secs_f64()) {
+        trace!(
+            "rate-limited payload from participant {} ({}).",
+            participant.sid(),
+            participant.identity()
+        );
+        return;
+    }
 
     let packet = match rfc4::Packet::decode(payload.as_slice()) {
         Ok(packet) => packet,

--- a/crates/dcl/src/js/comms.rs
+++ b/crates/dcl/src/js/comms.rs
@@ -11,6 +11,9 @@ use crate::{interface::crdt_context::CrdtContext, RpcCalls, SceneResourceCounter
 
 use super::State;
 
+const MAX_COMMS_MESSAGE_BYTES: usize = 30_000;
+const MAX_NETWORK_MESSAGE_QUEUE: usize = 1024;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum CommsMessageType {
@@ -28,6 +31,10 @@ struct BinaryBusReceiver(RpcStreamReceiver<(String, Vec<u8>)>);
 
 pub async fn op_comms_send_string(state: Rc<RefCell<impl State>>, message: String) {
     debug!("op_comms_send_string");
+    if message.len() > MAX_COMMS_MESSAGE_BYTES {
+        debug!("op_comms_send_string: dropping oversized message");
+        return;
+    }
     let mut state = state.borrow_mut();
     let scene = state.borrow::<CrdtContext>().scene_id.0;
     let mut data = vec![CommsMessageType::String as u8];
@@ -50,6 +57,10 @@ pub async fn op_comms_send_binary_single(
     recipient: Option<String>,
 ) {
     debug!("op_comms_send_binary_single");
+    if message.as_ref().len() > MAX_COMMS_MESSAGE_BYTES {
+        debug!("op_comms_send_binary_single: dropping oversized message");
+        return;
+    }
     let mut state = state.borrow_mut();
 
     let context = state.borrow::<CrdtContext>();
@@ -84,7 +95,8 @@ pub async fn op_comms_recv_binary(
     let mut results = Vec::default();
 
     if !state.has::<BinaryBusReceiver>() {
-        let (sx, rx) = RpcStreamSender::<(String, Vec<u8>)>::channel();
+        let (sx, rx) =
+            RpcStreamSender::<(String, Vec<u8>)>::bounded_channel(MAX_NETWORK_MESSAGE_QUEUE);
         state
             .borrow_mut::<RpcCalls>()
             .push(RpcCall::SubscribeBinaryBus { hash, sender: sx });

--- a/crates/dcl/src/js/comms.rs
+++ b/crates/dcl/src/js/comms.rs
@@ -13,6 +13,26 @@ use super::State;
 
 const MAX_COMMS_MESSAGE_BYTES: usize = 30_000;
 const MAX_NETWORK_MESSAGE_QUEUE: usize = 1024;
+const MAX_SEND_MESSAGES_PER_TICK: usize = 512;
+
+// Outbound message budget, reset each tick by `crdt_send_to_renderer`. Enforced in the op (not
+// the JS wrapper) so a scene calling the op directly is still bounded.
+#[derive(Default)]
+pub struct CommsSendBudget {
+    pub sent: usize,
+}
+
+fn try_spend_budget(state: &mut impl State) -> bool {
+    if !state.has::<CommsSendBudget>() {
+        state.put(CommsSendBudget::default());
+    }
+    let budget = state.borrow_mut::<CommsSendBudget>();
+    if budget.sent >= MAX_SEND_MESSAGES_PER_TICK {
+        return false;
+    }
+    budget.sent += 1;
+    true
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
@@ -36,6 +56,10 @@ pub async fn op_comms_send_string(state: Rc<RefCell<impl State>>, message: Strin
         return;
     }
     let mut state = state.borrow_mut();
+    if !try_spend_budget(&mut *state) {
+        debug!("op_comms_send_string: message budget exhausted, dropping");
+        return;
+    }
     let scene = state.borrow::<CrdtContext>().scene_id.0;
     let mut data = vec![CommsMessageType::String as u8];
     data.extend(message.into_bytes());
@@ -62,6 +86,10 @@ pub async fn op_comms_send_binary_single(
         return;
     }
     let mut state = state.borrow_mut();
+    if !try_spend_budget(&mut *state) {
+        debug!("op_comms_send_binary_single: message budget exhausted, dropping");
+        return;
+    }
 
     let context = state.borrow::<CrdtContext>();
     let scene = context.scene_id.0;

--- a/crates/dcl/src/js/comms.rs
+++ b/crates/dcl/src/js/comms.rs
@@ -96,7 +96,7 @@ pub async fn op_comms_recv_binary(
 
     if !state.has::<BinaryBusReceiver>() {
         let (sx, rx) =
-            RpcStreamSender::<(String, Vec<u8>)>::bounded_channel(MAX_NETWORK_MESSAGE_QUEUE);
+            RpcStreamSender::<(String, Vec<u8>)>::channel_with_capacity(MAX_NETWORK_MESSAGE_QUEUE);
         state
             .borrow_mut::<RpcCalls>()
             .push(RpcCall::SubscribeBinaryBus { hash, sender: sx });

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -101,6 +101,10 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
 
     let rpc_calls = std::mem::take(op_state.borrow_mut::<RpcCalls>());
 
+    if let Some(budget) = op_state.try_borrow_mut::<super::comms::CommsSendBudget>() {
+        budget.sent = 0;
+    }
+
     let sender = op_state.borrow_mut::<SceneResponseSender>();
     sender
         .try_send(SceneResponse::Ok(

--- a/crates/dcl/src/js/events.rs
+++ b/crates/dcl/src/js/events.rs
@@ -8,6 +8,8 @@ use crate::{interface::crdt_context::CrdtContext, RpcCalls};
 
 use super::State;
 
+const MAX_NETWORK_MESSAGE_QUEUE: usize = 1024;
+
 struct EventReceiver<T: EventType> {
     inner: RpcStreamReceiver<String>,
     _p: PhantomData<fn() -> T>,
@@ -94,9 +96,23 @@ pub fn op_subscribe(state: &mut impl State, id: &str) {
     register!(id, state, PlayerClicked, |sender| {
         RpcCall::SubscribePlayerClicked { sender }
     });
-    register!(id, state, MessageBus, |sender| {
-        RpcCall::SubscribeMessageBus { sender, hash }
-    });
+
+    // MessageBus carries untrusted peer traffic, so bound it rather than use the unbounded event channel.
+    if id == <MessageBus as EventType>::label() {
+        if state.has::<EventReceiver<MessageBus>>() {
+            return;
+        }
+        let (sender, rx) = RpcEventSender::bounded_channel(MAX_NETWORK_MESSAGE_QUEUE);
+        state
+            .borrow_mut::<RpcCalls>()
+            .push(RpcCall::SubscribeMessageBus { sender, hash });
+        state.put(EventReceiver::<MessageBus> {
+            inner: rx,
+            _p: Default::default(),
+        });
+        debug!("subscribed to {}", <MessageBus as EventType>::label());
+        return;
+    }
 
     warn!("subscribe to unrecognised event {id}");
 }

--- a/crates/dcl/src/js/events.rs
+++ b/crates/dcl/src/js/events.rs
@@ -97,12 +97,12 @@ pub fn op_subscribe(state: &mut impl State, id: &str) {
         RpcCall::SubscribePlayerClicked { sender }
     });
 
-    // MessageBus carries untrusted peer traffic, so bound it rather than use the unbounded event channel.
+    // MessageBus carries untrusted peer traffic, so use a tighter bound than the default event channel.
     if id == <MessageBus as EventType>::label() {
         if state.has::<EventReceiver<MessageBus>>() {
             return;
         }
-        let (sender, rx) = RpcEventSender::bounded_channel(MAX_NETWORK_MESSAGE_QUEUE);
+        let (sender, rx) = RpcEventSender::channel_with_capacity(MAX_NETWORK_MESSAGE_QUEUE);
         state
             .borrow_mut::<RpcCalls>()
             .push(RpcCall::SubscribeMessageBus { sender, hash });

--- a/crates/dcl/src/js/modules/CommunicationsController.js
+++ b/crates/dcl/src/js/modules/CommunicationsController.js
@@ -1,44 +1,25 @@
-// Cap one sendBinary call so a scene can't amplify it into a broadcast storm.
-const MAX_SEND_PEERS = 256;
-const MAX_SEND_MESSAGES = 512;
-const MAX_COMMS_MESSAGE_BYTES = 30000;
-
 module.exports.send = async function (body) {
     await Deno.core.ops.op_comms_send_string(body.message, "");
     return {}
 }
 
 module.exports.sendBinary = async function (body) {
-    let messageCount = 0;
-    const peers = new Set();
     // old style
     for (const buffer of body.data) {
-        if (messageCount >= MAX_SEND_MESSAGES) break;
-        if (buffer.byteLength > MAX_COMMS_MESSAGE_BYTES) continue;
         await Deno.core.ops.op_comms_send_binary_single(new Uint8Array(buffer));
-        messageCount++;
     }
     // new style
     if (body.peerData !== undefined) {
         for (const peerData of body.peerData) {
-            if (messageCount >= MAX_SEND_MESSAGES) break;
             if (Array.isArray(peerData.address) && peerData.address.length > 0) {
                 for (const address of peerData.address) {
-                    if (!peers.has(address) && peers.size >= MAX_SEND_PEERS) continue;
-                    peers.add(address);
                     for (const buffer of peerData.data) {
-                        if (messageCount >= MAX_SEND_MESSAGES) break;
-                        if (buffer.byteLength > MAX_COMMS_MESSAGE_BYTES) continue;
                         await Deno.core.ops.op_comms_send_binary_single(new Uint8Array(buffer), address);
-                        messageCount++;
                     }
                 }
             } else {
                 for (const buffer of peerData.data) {
-                    if (messageCount >= MAX_SEND_MESSAGES) break;
-                    if (buffer.byteLength > MAX_COMMS_MESSAGE_BYTES) continue;
                     await Deno.core.ops.op_comms_send_binary_single(new Uint8Array(buffer), null);
-                    messageCount++;
                 }
             }
         }

--- a/crates/dcl/src/js/modules/CommunicationsController.js
+++ b/crates/dcl/src/js/modules/CommunicationsController.js
@@ -1,25 +1,44 @@
+// Cap one sendBinary call so a scene can't amplify it into a broadcast storm.
+const MAX_SEND_PEERS = 256;
+const MAX_SEND_MESSAGES = 512;
+const MAX_COMMS_MESSAGE_BYTES = 30000;
+
 module.exports.send = async function (body) {
     await Deno.core.ops.op_comms_send_string(body.message, "");
     return {}
 }
 
 module.exports.sendBinary = async function (body) {
+    let messageCount = 0;
+    const peers = new Set();
     // old style
     for (const buffer of body.data) {
+        if (messageCount >= MAX_SEND_MESSAGES) break;
+        if (buffer.byteLength > MAX_COMMS_MESSAGE_BYTES) continue;
         await Deno.core.ops.op_comms_send_binary_single(new Uint8Array(buffer));
+        messageCount++;
     }
     // new style
     if (body.peerData !== undefined) {
         for (const peerData of body.peerData) {
+            if (messageCount >= MAX_SEND_MESSAGES) break;
             if (Array.isArray(peerData.address) && peerData.address.length > 0) {
                 for (const address of peerData.address) {
+                    if (!peers.has(address) && peers.size >= MAX_SEND_PEERS) continue;
+                    peers.add(address);
                     for (const buffer of peerData.data) {
+                        if (messageCount >= MAX_SEND_MESSAGES) break;
+                        if (buffer.byteLength > MAX_COMMS_MESSAGE_BYTES) continue;
                         await Deno.core.ops.op_comms_send_binary_single(new Uint8Array(buffer), address);
+                        messageCount++;
                     }
                 }
             } else {
                 for (const buffer of peerData.data) {
+                    if (messageCount >= MAX_SEND_MESSAGES) break;
+                    if (buffer.byteLength > MAX_COMMS_MESSAGE_BYTES) continue;
                     await Deno.core.ops.op_comms_send_binary_single(new Uint8Array(buffer), null);
+                    messageCount++;
                 }
             }
         }


### PR DESCRIPTION
Per-scene comms has no inbound rate or size cap, no outbound amplification bound, and an unbounded message-bus queue. One scene can flood the bus and the cost lands on the shared process.

Adds an inbound rate and size cap, an outbound amplification bound, and a bounded bus queue.

Note on the size cap: LiveKit's own negotiated data-message maximum is 64KiB, stricter than the 128KiB here, so in practice the rate cap is the effective inbound protection. The size mechanism was proven by lowering it to 32KiB rather than by hitting 128KiB.

Verified: `cargo check --workspace` clean on this base.
