### PR TITLE
security: bound livekit audio decode by frame data length

### DIFF
--- a/crates/comms/src/livekit/kira_bridge.rs
+++ b/crates/comms/src/livekit/kira_bridge.rs
@@ -46,7 +46,8 @@ impl kira::sound::streaming::Decoder for LivekitKiraBridge {
                 warn!("frame has {} channels", frame.num_channels);
             }
 
-            for i in 0..frame.samples_per_channel as usize {
+            let samples = (frame.samples_per_channel as usize).min(frame.data.len());
+            for i in 0..samples {
                 let sample = frame.data[i] as f32 / i16::MAX as f32;
                 frames.push(kira::Frame::new(sample, sample));
             }

--- a/crates/comms/src/livekit/livekit_bridge.rs
+++ b/crates/comms/src/livekit/livekit_bridge.rs
@@ -109,7 +109,8 @@ impl kira::sound::streaming::Decoder for AudioTrackKiraBridge {
                 warn!("frame has {} channels", frame.num_channels);
             }
 
-            for i in 0..frame.samples_per_channel as usize {
+            let samples = (frame.samples_per_channel as usize).min(frame.data.len());
+            for i in 0..samples {
                 let sample = frame.data[i] as f32 / i16::MAX as f32;
                 frames.push(kira::Frame::new(sample, sample));
             }


### PR DESCRIPTION
The LiveKit audio path indexes a decoded frame using a length taken from the frame header rather than the delivered data, so a peer-supplied frame whose header overstates its payload panics the decode.

Bound the decode by the actual data length.

+4/-2. Reachable from any peer publishing audio. Marginal for a headless server, which has no audio sink and does not subscribe, so this is really client hardening — included because it is peer-triggered and cheap.
