### PR TITLE
security: gate WebSocket loopback egress on preview_egress()

### DIFF
--- a/crates/dcl/src/interface/crdt_context.rs
+++ b/crates/dcl/src/interface/crdt_context.rs
@@ -58,6 +58,12 @@ impl CrdtContext {
         }
     }
 
+    // Loopback / non-`wss` egress is a preview-only relaxation, so a `--preview` server must
+    // not hand its loopback surface to tenants. Mirrors the fetch path.
+    pub fn preview_egress(&self) -> bool {
+        self.preview && !self.is_server
+    }
+
     fn entity_entry(&self, id: u16) -> &(u16, bool) {
         // SAFETY: live entities has u16::MAX members
         unsafe { self.live_entities.get_unchecked(id as usize) }

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -219,7 +219,7 @@ pub(crate) fn scene_thread(
     scene_origin: bevy::prelude::Vec3,
 ) {
     let scene_id = scene_context.scene_id;
-    let preview = scene_context.preview;
+    let preview = scene_context.preview_egress();
     let (mut runtime, inspector) = create_runtime(inspect, super_user.is_some(), &storage_root);
 
     // store handle
@@ -433,7 +433,10 @@ fn thread_cpu_us() -> u64 {
     {
         use std::sync::OnceLock;
         static START: OnceLock<std::time::Instant> = OnceLock::new();
-        START.get_or_init(std::time::Instant::now).elapsed().as_micros() as u64
+        START
+            .get_or_init(std::time::Instant::now)
+            .elapsed()
+            .as_micros() as u64
     }
 }
 

--- a/crates/dcl_deno/src/js/websocket.rs
+++ b/crates/dcl_deno/src/js/websocket.rs
@@ -71,7 +71,7 @@ where
     let (is_server, allow_loopback) = {
         let op_state = state.borrow();
         let ctx = op_state.borrow::<CrdtContext>();
-        (ctx.is_server, ctx.preview)
+        (ctx.is_server, ctx.preview_egress())
     };
     if is_server {
         common::util::assert_public_url(&url, allow_loopback).await?;


### PR DESCRIPTION
The scene WebSocket egress check reads `ctx.preview` directly rather than `preview_egress()`. On a server started with `--preview` that permits loopback WebSocket targets, which is an SSRF into whatever the host runs locally.

Use `preview_egress()`, which already encodes the intended policy.

Narrow: it only bites on the `--preview` plus server combination, which a production authoritative server does not run. One-liner plus the plumbing to reach it.
