### PR TITLE
fix/ui/09: a teleport to a place carries its realm (Places/map jump-in from a World, /goto main)

### DIFF
--- a/react-web/bridge-scene/src/domains/world.ts
+++ b/react-web/bridge-scene/src/domains/world.ts
@@ -64,29 +64,20 @@ export function registerWorld(ctx: Ctx): void {
     })
   }
 
-  // A place teleport held until its realm change lands (see the teleportToPlace handler).
-  // `waited` is seconds accumulated by the realm poll, so a realm that never arrives drops it
-  // instead of teleporting into whatever realm the player ends up in.
-  let pendingPlace: { realm: string; x: number; y: number; waited: number } | null = null
-  const PLACE_ARRIVAL_TIMEOUT = 60
+  // A teleport held until its realm change lands (see the teleport handler). `waited` is seconds
+  // accumulated by the realm poll, so a realm that never arrives drops it instead of teleporting
+  // into whatever realm the player ends up in.
+  let pendingTeleport: { realm: string; x: number; y: number; waited: number } | null = null
+  const REALM_ARRIVAL_TIMEOUT = 60
 
-  ctx.on('teleport', (msg) => {
-    teleportToParcel(msg.x, msg.y)
-  })
-
-  // Travel to a world/realm (e.g. boedo.dcl.eth). The engine auto-grants ChangeRealm for our
-  // super-user scene, so the React HUD owns the confirmation prompt.
-  ctx.on('changeRealm', (msg) => {
-    changeRealm({ realm: msg.realm }).catch((e: unknown) => {
-      console.error('[world] changeRealm failed', e)
-    })
-  })
-
-  // A place is realm + parcel. Resolved here rather than in React because this is where the
-  // current realm is known first-hand: React only sees the 2s realmInfo poll, and a teleport
-  // fired right after a realm change would read a stale one. The realm switch is skipped when the
-  // player is already there — a changeRealm to the realm you are in is a full scene purge +
-  // reconnect, not a no-op.
+  // Teleport to a parcel. Without a realm the coordinates are relative to wherever the player
+  // already is (a chat location link, a photo's capture spot) and nothing changes realm.
+  //
+  // With one, the parcel belongs to that realm, and getting there is part of the trip. It is
+  // resolved here rather than in React because this is where the current realm is known
+  // first-hand: React only sees the 2s realmInfo poll and would read a stale realm right after a
+  // change. The switch is skipped when the player is already there — a changeRealm to the realm
+  // you are in is a full scene purge + reconnect, not a no-op.
   //
   // The parcel CANNOT be sent on changeRealm's promise. That promise resolves as soon as the engine
   // ACCEPTS the change (restricted_actions/src/lib.rs: it queues a ChangeRealmEvent and answers Ok);
@@ -94,23 +85,36 @@ export function registerWorld(ctx: Ctx): void {
   // teleport sent there addresses the parcel grid of the realm we are LEAVING — you get one
   // out-of-world round trip inside the old realm, then a second one when the realm actually lands.
   // So the parcel waits for getRealm to report the target realm; the poll below completes it.
-  ctx.on('teleportToPlace', (msg) => {
+  ctx.on('teleport', (msg) => {
+    const realm = msg.realm
+    if (realm == null) {
+      teleportToParcel(msg.x, msg.y)
+      return
+    }
     getRealm({})
       .then(async ({ realmInfo }) => {
-        if (inRealm(realmInfo?.baseUrl ?? '', realmInfo?.realmName ?? '', msg.realm)) {
+        if (inRealm(realmInfo?.baseUrl ?? '', realmInfo?.realmName ?? '', realm)) {
           teleportToParcel(msg.x, msg.y)
           return
         }
-        pendingPlace = { realm: msg.realm, x: msg.x, y: msg.y, waited: 0 }
-        await changeRealm({ realm: msg.realm }).catch((e: unknown) => {
+        pendingTeleport = { realm, x: msg.x, y: msg.y, waited: 0 }
+        await changeRealm({ realm }).catch((e: unknown) => {
           console.error('[world] changeRealm failed', e)
-          pendingPlace = null
+          pendingTeleport = null
         })
       })
       .catch((e: unknown) => {
-        console.error('[world] teleportToPlace failed', e)
-        pendingPlace = null
+        console.error('[world] teleport failed', e)
+        pendingTeleport = null
       })
+  })
+
+  // Travel to a world/realm (e.g. boedo.dcl.eth) with no destination parcel. The engine
+  // auto-grants ChangeRealm for our super-user scene, so the React HUD owns the confirmation.
+  ctx.on('changeRealm', (msg) => {
+    changeRealm({ realm: msg.realm }).catch((e: unknown) => {
+      console.error('[world] changeRealm failed', e)
+    })
   })
 
   // `/reload` — reload the scene the player is standing in, resolved by parcel from liveSceneInfo.
@@ -193,21 +197,21 @@ export function registerWorld(ctx: Ctx): void {
   let pendingParcel = ''
   let attempts = 0
 
-  // Realm kind → the minimap (Worlds have no map tiles). Poll ~2s, push on change. While a place
-  // teleport is waiting for its realm, poll ~10×/s instead: that wait is a player standing in front
-  // of the loading screen, and up to 2s of it would be spent looking at the wrong parcel.
+  // Realm kind → the minimap (Worlds have no map tiles). Poll ~2s, push on change. While a teleport
+  // is waiting for its realm, poll ~10×/s instead: that wait is a player standing in front of the
+  // loading screen, and up to 2s of it would be spent looking at the wrong parcel.
   let realmAcc = 2
   let lastRealm = ''
   ctx.push((dt) => {
     realmAcc += dt
-    if (pendingPlace != null) {
-      pendingPlace.waited += dt
-      if (pendingPlace.waited > PLACE_ARRIVAL_TIMEOUT) {
-        console.error(`[world] realm ${pendingPlace.realm} never arrived; dropping the place teleport`)
-        pendingPlace = null
+    if (pendingTeleport != null) {
+      pendingTeleport.waited += dt
+      if (pendingTeleport.waited > REALM_ARRIVAL_TIMEOUT) {
+        console.error(`[world] realm ${pendingTeleport.realm} never arrived; dropping the teleport`)
+        pendingTeleport = null
       }
     }
-    if (realmAcc < (pendingPlace == null ? 2 : 0.1)) return
+    if (realmAcc < (pendingTeleport == null ? 2 : 0.1)) return
     realmAcc = 0
     getRealm({})
       .then(({ realmInfo }) => {
@@ -215,10 +219,10 @@ export function registerWorld(ctx: Ctx): void {
         const realmName = realmInfo?.realmName ?? ''
         // The realm we were held for is live: finish the trip. Done before the change check below
         // so it doesn't depend on the minimap's dedupe key.
-        if (pendingPlace != null && inRealm(baseUrl, realmName, pendingPlace.realm)) {
-          const place = pendingPlace
-          pendingPlace = null
-          teleportToParcel(place.x, place.y)
+        if (pendingTeleport != null && inRealm(baseUrl, realmName, pendingTeleport.realm)) {
+          const target = pendingTeleport
+          pendingTeleport = null
+          teleportToParcel(target.x, target.y)
         }
         // Key on both, so a change in either field re-publishes.
         const key = `${baseUrl}|${realmName}`

--- a/react-web/bridge-scene/src/domains/world.ts
+++ b/react-web/bridge-scene/src/domains/world.ts
@@ -37,6 +37,15 @@ function realmIsWorld(baseUrl: string, realmName: string): boolean {
   return baseUrl.includes('worlds-content-server') || realmName.endsWith('.eth')
 }
 
+// Is the player already in the realm a place lives in? A world target must be that exact world;
+// a Genesis City target is satisfied by any non-World realm (there is one Genesis, and its base
+// url varies by deployment, so the realm kind is the honest comparison).
+function inRealm(baseUrl: string, realmName: string, target: string): boolean {
+  return target.endsWith('.eth')
+    ? realmName.toLowerCase() === target.toLowerCase()
+    : !realmIsWorld(baseUrl, realmName)
+}
+
 // Echo a "DCL System" line into the React chat (empty sender → system member). Used to relay
 // slash-command feedback (/commands output, /reload status) that isn't broadcast to other players.
 function pushSystem(ctx: Ctx, message: string): void {
@@ -49,10 +58,20 @@ export function registerWorld(ctx: Ctx): void {
     ctx.send({ kind: 'mapState', x: Math.floor((pos?.x ?? 0) / 16), y: Math.floor((pos?.z ?? 0) / 16) })
   })
 
-  ctx.on('teleport', (msg) => {
-    teleportTo({ worldCoordinates: { x: msg.x, y: msg.y } }).catch((e: unknown) => {
+  const teleportToParcel = (x: number, y: number): void => {
+    teleportTo({ worldCoordinates: { x, y } }).catch((e: unknown) => {
       console.error('[world] teleport failed', e)
     })
+  }
+
+  // A place teleport held until its realm change lands (see the teleportToPlace handler).
+  // `waited` is seconds accumulated by the realm poll, so a realm that never arrives drops it
+  // instead of teleporting into whatever realm the player ends up in.
+  let pendingPlace: { realm: string; x: number; y: number; waited: number } | null = null
+  const PLACE_ARRIVAL_TIMEOUT = 60
+
+  ctx.on('teleport', (msg) => {
+    teleportToParcel(msg.x, msg.y)
   })
 
   // Travel to a world/realm (e.g. boedo.dcl.eth). The engine auto-grants ChangeRealm for our
@@ -61,6 +80,37 @@ export function registerWorld(ctx: Ctx): void {
     changeRealm({ realm: msg.realm }).catch((e: unknown) => {
       console.error('[world] changeRealm failed', e)
     })
+  })
+
+  // A place is realm + parcel. Resolved here rather than in React because this is where the
+  // current realm is known first-hand: React only sees the 2s realmInfo poll, and a teleport
+  // fired right after a realm change would read a stale one. The realm switch is skipped when the
+  // player is already there — a changeRealm to the realm you are in is a full scene purge +
+  // reconnect, not a no-op.
+  //
+  // The parcel CANNOT be sent on changeRealm's promise. That promise resolves as soon as the engine
+  // ACCEPTS the change (restricted_actions/src/lib.rs: it queues a ChangeRealmEvent and answers Ok);
+  // the about fetch, scene purge and pointer re-resolve all happen over the following frames. A
+  // teleport sent there addresses the parcel grid of the realm we are LEAVING — you get one
+  // out-of-world round trip inside the old realm, then a second one when the realm actually lands.
+  // So the parcel waits for getRealm to report the target realm; the poll below completes it.
+  ctx.on('teleportToPlace', (msg) => {
+    getRealm({})
+      .then(async ({ realmInfo }) => {
+        if (inRealm(realmInfo?.baseUrl ?? '', realmInfo?.realmName ?? '', msg.realm)) {
+          teleportToParcel(msg.x, msg.y)
+          return
+        }
+        pendingPlace = { realm: msg.realm, x: msg.x, y: msg.y, waited: 0 }
+        await changeRealm({ realm: msg.realm }).catch((e: unknown) => {
+          console.error('[world] changeRealm failed', e)
+          pendingPlace = null
+        })
+      })
+      .catch((e: unknown) => {
+        console.error('[world] teleportToPlace failed', e)
+        pendingPlace = null
+      })
   })
 
   // `/reload` — reload the scene the player is standing in, resolved by parcel from liveSceneInfo.
@@ -143,17 +193,33 @@ export function registerWorld(ctx: Ctx): void {
   let pendingParcel = ''
   let attempts = 0
 
-  // Realm kind → the minimap (Worlds have no map tiles). Poll ~2s, push on change.
+  // Realm kind → the minimap (Worlds have no map tiles). Poll ~2s, push on change. While a place
+  // teleport is waiting for its realm, poll ~10×/s instead: that wait is a player standing in front
+  // of the loading screen, and up to 2s of it would be spent looking at the wrong parcel.
   let realmAcc = 2
   let lastRealm = ''
   ctx.push((dt) => {
     realmAcc += dt
-    if (realmAcc < 2) return
+    if (pendingPlace != null) {
+      pendingPlace.waited += dt
+      if (pendingPlace.waited > PLACE_ARRIVAL_TIMEOUT) {
+        console.error(`[world] realm ${pendingPlace.realm} never arrived; dropping the place teleport`)
+        pendingPlace = null
+      }
+    }
+    if (realmAcc < (pendingPlace == null ? 2 : 0.1)) return
     realmAcc = 0
     getRealm({})
       .then(({ realmInfo }) => {
         const baseUrl = realmInfo?.baseUrl ?? ''
         const realmName = realmInfo?.realmName ?? ''
+        // The realm we were held for is live: finish the trip. Done before the change check below
+        // so it doesn't depend on the minimap's dedupe key.
+        if (pendingPlace != null && inRealm(baseUrl, realmName, pendingPlace.realm)) {
+          const place = pendingPlace
+          pendingPlace = null
+          teleportToParcel(place.x, place.y)
+        }
         // Key on both, so a change in either field re-publishes.
         const key = `${baseUrl}|${realmName}`
         if (key === lastRealm) return

--- a/react-web/docs/backlog.md
+++ b/react-web/docs/backlog.md
@@ -486,6 +486,35 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
       out of 60 Hz instead of the engine guessing. Bigger process; the engine-side cycle is the cheap
       first step.
     Needs a WASM rebuild, so it belongs in its own PR, not in the HUD stack.
+44. `[bug]` **The loading screen closes before the destination scene is loaded** — *engine-side (Rust),
+    one to discuss with Rob*. Teleport into Genesis Plaza from a World and you get: "Preparing your
+    surroundings", then the overlay closes onto an empty green parcel, then the plaza pops in over the
+    next few seconds. The HUD can't fix this — `SceneLoadingOverlay` is a pure mirror of the engine's
+    `visible` flag (`wallet.address().is_some() && !oow.is_empty()`, `system_ui/src/oow.rs:264`), and
+    the player is let into the world by `handle_out_of_world` as soon as the scene is "ready"
+    (`restricted_actions/src/teleport.rs:143`): `tick_number > 5` and nothing in `blocked`.
+    - **The asset gate is tick-bounded, not completion-bounded.** `gltf_container.rs:1079` only inserts
+      `GLTF_LOADING` into `blocked` *while* `context.tick_number <= 5`; past that it removes the block
+      unconditionally and forces `GltfLoadingCount` to 0. A scene whose GLTFs take longer to stream than
+      its first 5 ticks (i.e. any real scene) therefore reports "ready" with nothing rendered yet.
+    - **Same reason the asset counter never appears.** `pendingAssets` comes from that same
+      `GltfLoadingCount` (`oow.rs:38`), so outside the 5-tick window it is 0/None and the React overlay
+      falls back to its indeterminate "Preparing your surroundings" bar. Users read that as "the loading
+      screen doesn't work", when what's missing is the number behind it.
+    - **Why it only shows up on a cold destination.** Teleporting inside the realm you're already in
+      usually looks fine: the surroundings have been streaming for a while (`SceneLoadDistance`), the
+      pointers are resolved and the target scene is partly cached, so by tick 5 there is something to
+      draw. A realm change makes everything cold (about, active-entities, entity definition, then the
+      GLTFs), and 5 ticks are ~5 frames against seconds of downloads — hence the empty parcel. The
+      repro to confirm this framing: from Genesis, with no realm change, jump to a far, never-visited
+      place; if the empty-parcel flash appears there too, the realm change is only the reliable way to
+      get a cold destination, not the cause.
+    - **Shape of a fix**: gate on the declared GltfContainers actually finishing (with a timeout, so a
+      broken scene can't strand the player) instead of cutting at tick 5, and keep publishing the
+      pending count for as long as the gate holds. Worth checking with Rob whether the 5-tick cut is
+      load-bearing for something else (it predates the React HUD and the native loading dialog reads the
+      same signal, `oow.rs:100`).
+    Needs a WASM rebuild, so it belongs in its own PR, not in the HUD stack.
 
 ## Not gaps (already good / ahead)
 

--- a/react-web/docs/backlog.md
+++ b/react-web/docs/backlog.md
@@ -25,13 +25,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
    Recurring need (jump-in/create/send → loading; unfriend/reject/leave/delete → danger; a subtle
    underlined text-link like the gate's "try anyway…" → link, currently a bespoke `<button>`). (Old:
    `ButtonComponent`.)
-5. `[bug]` **"Jump in" icon on the initial scene catalog is actually a pencil** — *visible on first
-   impression*. `JumpInGlyph()`'s SVG path (`M5 12l9-9 4 4-9 9-5 1z` + `M13 4l3 3M5 12l-1 7 7-1`) draws a
-   diagonal pencil-with-tip shape, not a "jump in" arrow — a copy/paste-wrong-glyph mistake, not a design
-   choice. **Duplicated identically** in both `PlaceCard.tsx` and `FeaturedCard.tsx` (the login-flow
-   "Live Now"/"Featured Places" catalog, `LoadingAndLogin.tsx`), so fix both — or better, extract one
-   shared glyph while fixing it (there's no `src/design/` icon for this yet).
-6. `[bug]` **Engine boot failure or hang leaves the user on the loading bar forever** — *blocks the app
+5. `[bug]` **Engine boot failure or hang leaves the user on the loading bar forever** — *blocks the app
    completely, no error state; the "no infinite loading" delivery priority*. Every crash signal we have
    needs the engine to have started: the watchdog tick in `deploy/web/engine/boot.js` returns early while
    `beatsSeen` is false, so **before the first frame it is fully inert**. Two uncovered paths, both
@@ -45,7 +39,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
    source alongside the existing `'launch'`/`'realm'`/`'runtime'`), and give the readiness poll a
    no-progress deadline — watch `loadProgress`, and raise a fatal after ~30s **without advancement** (not
    a wall-clock cap, or a slow connection on a legitimately long wasm download would false-trip).
-7. `[bug]` **In-world `/goto <world>`/`/world <world>` to a non-existent realm hangs forever on
+6. `[bug]` **In-world `/goto <world>`/`/world <world>` to a non-existent realm hangs forever on
    "Reconnecting…"** — *no error, no escape, no timeout; the "no infinite loading" delivery priority*.
    The URL-entry path (`?realm=`) pre-flights the destination with a `/about` fetch before launching
    and raises `EngineErrorModal` (`source: 'realm'`) on a 404/timeout — see the `validatingRealm` effect
@@ -59,12 +53,12 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
 
 ## 🟡 Medium
 
-8. `[feature]` **Engine-panic / error capture → popup** — *new* (largely SHIPPED — `ErrorBoundary` +
+7. `[feature]` **Engine-panic / error capture → popup** — *new* (largely SHIPPED — `ErrorBoundary` +
    `EngineErrorModal` + crash watchdog landed on `fix/react-web-hud`). Kept as a tracking entry: engine
    WASM panics on launch (e.g. `can't init wasm queue`) and runtime crashes now surface a popup
    (message + copy details + reload/dismiss). (Old: `error-popup` + `error-popup-service`.)
    **Known gaps** (all are "engine alive, rendering dead" — the heartbeat keeps beating, so the stall
-   watchdog never fires; boot-time gaps are item 6). (a) **GPU device loss is handled nowhere** — nothing
+   watchdog never fires; boot-time gaps are item 5). (a) **GPU device loss is handled nowhere** — nothing
    in the repo awaits `device.lost` (not Rust, not the host JS, not react-web). A driver reset / GPU OOM /
    the browser reclaiming the device gives a black canvas with a live page and **no console output at
    all**, so the flood detector can't see it either. Cheapest real win here, and host-side only: await
@@ -76,7 +70,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
    served by an **engine-side signal**: `on_uncaptured_error` in `src/lib.rs` already exists and could
    call a JS callback directly instead of only `error!()` — exact, no console patching, no thresholds.
    Needs a WASM rebuild, which is why the host-only detector shipped first.
-9. `[DS]` **`showDialog` / `showConfirm` (imperative dialog helpers)** — *mostly DONE (PR #915)*. Added
+8. `[DS]` **`showDialog` / `showConfirm` (imperative dialog helpers)** — *mostly DONE (PR #915)*. Added
    `openPopup` + `showDialog` + `showConfirm` + `<PopupHost/>` in `src/design/popups.tsx` — an
    imperative, stackable popup layer backed by a **module-level store** (like the `hoverPos` store,
    read by the single `<PopupHost/>` via `useSyncExternalStore`), callable from anywhere without a
@@ -92,7 +86,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
    App-local state (`visitWorld`, `exitGuard.confirming`), so Enter still opens + focuses the chat
    behind them. Moving them onto `openPopup` fixes that for free; the alternative (wiring their state
    into the hook) is the reason not to bother.
-10. `[bug]` **`PhotoDetail` keys stay live under a popup opened from the lightbox** — *same
+9. `[bug]` **`PhotoDetail` keys stay live under a popup opened from the lightbox** — *same
     inert-background gap fixed for the menu hotkeys in PR #1014, one surface further in*. The lightbox
     can open a passport from "People in this photo"; its keydown handler (`useWindowKeyDown` in
     `PhotoDetail.tsx`) doesn't check `hasOpenPopup()`, so with the passport on top the arrow keys
@@ -100,11 +94,11 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     PopupHost's on `document` + `stopImmediatePropagation` — closes the *lightbox* instead of the
     passport. Fix: the same `hasOpenPopup()` early-return `useMenuShortcuts` now has. Deferred while
     the gallery has bigger open issues; fold into the next gallery pass.
-11. `[DS]` **`Badge` (standalone)** — *extract*. Badge logic is trapped inside `IconButton`; can't put a
+10. `[DS]` **`Badge` (standalone)** — *extract*. Badge logic is trapped inside `IconButton`; can't put a
     badge on a tab/avatar/chip without reimplementing. (Old: `notification-badge.tsx`.)
-12. `[DS]` **`Chip` / `Tag`** — *new*. "chip" is bespoke in ~11 files (map categories, count pills,
+11. `[DS]` **`Chip` / `Tag`** — *new*. "chip" is bespoke in ~11 files (map categories, count pills,
     status). (Old: `color-tag.tsx`.)
-13. `[DS]` **Consolidate modals onto `Modal`/`ModalShell`** — *mostly DONE (PR #1014)*. ProfileCard,
+12. `[DS]` **Consolidate modals onto `Modal`/`ModalShell`** — *mostly DONE (PR #1014)*. ProfileCard,
     CommunityModal, CommunityCreateModal and WorldVisitModal used to roll their own portal/overlay and
     hardcode `z-index: 10001`; all four now mount via `openPopup`, so `<PopupHost/>` owns backdrop /
     Escape / focus-trap / z-layer for them uniformly (see `design/popups.tsx`). Remaining: `CrashModal`
@@ -125,11 +119,11 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     the per-message `setHover([])`. Covers every popup, present/future, for free. *(Point 1 of the
     review — tooltip only returns after a 1px move on close — is expected native tooltip behavior and is
     not addressed by this; leave as-is.)*
-14. `[DS]` **`Radio` / `RadioGroup`** — *new*. Have Checkbox/Toggle/Select but no Radio; bespoke in
+13. `[DS]` **`Radio` / `RadioGroup`** — *new*. Have Checkbox/Toggle/Select but no Radio; bespoke in
     PermissionDialog. (Old: `radio-button.tsx`.)
-15. `[DS]` **`Skeleton`** — *new*. Only `Spinner` exists; no load placeholders for lists/cards.
+14. `[DS]` **`Skeleton`** — *new*. Only `Spinner` exists; no load placeholders for lists/cards.
     (Old: `loading-placeholder.tsx`.)
-16. `[bug]` **Passport "too far by camera" is confusing in third-person** — *behavior/UX, engine+bridge*.
+15. `[bug]` **Passport "too far by camera" is confusing in third-person** — *behavior/UX, engine+bridge*.
     Hovering a nearby avatar in third-person greys out "Show Profile" with "Get camera closer" even
     when your avatar is standing right next to them. Two causes combine: (1) the avatar pointer in
     `bridge-scene/src/domains/avatarPointer.ts` sets **no** distance fields, so it hits the SDK7
@@ -151,7 +145,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     interaction `camera_distance` player-focus-relative in third-person like Unity, fixing **all**
     SDK pointer events, not just passports. Analysis-only for now (2026-07-09) — user deferred the
     code change.
-17. `[feature]` **Passport — finish the sections (feature parity with unity-explorer / bevy-ui-scene)**
+16. `[feature]` **Passport — finish the sections (feature parity with unity-explorer / bevy-ui-scene)**
     — *feature parity*. The passport has OVERVIEW/BADGES/PHOTOS tabs but is missing sections the old
     scene renders (`bevy-ui-scene`: `ui-classes/main-hud/passport/passport-popup.tsx`). Gaps that
     **need new bridge/protocol data:** (a) **Equipped Wearables + Emotes** of the *viewed* avatar (grid:
@@ -165,7 +159,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     set. (f) Wire the **3D avatar preview** into the passport (machinery exists —
     `setEngineViewport('avatarPreview')`, used by the Backpack) instead of the 2D snapshot, + 3D badge
     preview on the Badges tab.
-18. `[feature]` **Notifications panel — bounded height, load-on-scroll, click-through to a detail
+17. `[feature]` **Notifications panel — bounded height, load-on-scroll, click-through to a detail
     popup** — *feature/bug*. `NotificationsPanel.tsx` fixes `.root` to `top: 16px; bottom: 16px`
     (`NotificationsPanel.module.css`), so the panel is always full-viewport-tall regardless of content —
     both `bevy-ui-scene` (`notifications-menu.tsx`, a fixed `menuHeight = fontSize * 30 * 1.1`) and
@@ -183,7 +177,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     building now, or should this wait on **stackable popups** — i.e. #12 (consolidate modals onto
     `Modal`/`ModalShell`) landing first, so a notification-detail popup doesn't become yet another bespoke
     overlay to migrate later. Leaning toward doing #12 first if both are picked up.
-19. `[arch]` **Pointer-lock / camera-look coordination across the HUD — the "right-click to move the
+18. `[arch]` **Pointer-lock / camera-look coordination across the HUD — the "right-click to move the
     camera again" confusion** — *behavior/parity, review + decision*. On web the engine's camera-look
     *is* the browser Pointer Lock (bevy `CursorGrabMode::Locked` → `requestPointerLock` on the iframe
     canvas; see `crates/user_input/src/camera.rs` `update_cursor_lock` +
@@ -219,7 +213,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     `PointerLock.isPointerLocked = false` on `CameraEntity` on menu open, the way `chat.ts` /
     `avatarPointer.ts` already do for their surfaces. Kept Medium: chat + click-to-open panels + web
     menus work today; only native menu-open cursor release is open.
-20. `[feature]` **Chat links: confirm popup before teleporting and before opening a URL** — *parity with
+19. `[feature]` **Chat links: confirm popup before teleporting and before opening a URL** — *parity with
     `bevy-ui-scene`, safety*. The **parsing** has parity: `chatText.tsx`'s `TOKEN_RE` linkifies the same
     four kinds as the old `LINK_TYPE` (`components/chat/chat-message/ChatMessage.tsx:43`) — url, world,
     location, mention — and react's single-pass regex is the better design (the old one composed four
@@ -237,7 +231,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
       you trust before proceeding." with the URL shown; CONTINUE → `openExternalUrl`.
     - **Worlds** (`boedo.dcl.eth`) — already confirmed via `WorldVisitModal` ✅.
     Build the two missing ones on `openPopup`/`showConfirm` rather than new App-local modals, and fold in
-    `WorldVisitModal` while there (see item 9 — it also fixes the Enter-focus hole). Related, same pass:
+    `WorldVisitModal` while there (see item 8 — it also fixes the Enter-focus hole). Related, same pass:
     (a) react linkifies `http://` too, where the old regex was `https://`-only — neither validates the
     scheme, the old one just incidentally kept `http`/`javascript:`/`data:` out of the click path, so
     make the scheme check explicit; (b) `PlacesPage` (`App.tsx:263`) changes realm with **no** confirm,
@@ -245,7 +239,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     one; (c) `chat.rich.test.tsx` covers url/location/mention clicks but never the `world` token or the
     `rel` attribute.
 
-21. `[arch]` **Unify avatar-equip authority — bridge re-emits `wearables` after every mutation (+
+20. `[arch]` **Unify avatar-equip authority — bridge re-emits `wearables` after every mutation (+
     mutation acks/errors)** — *hardening, from the fix/ui/04-outfits architecture review*. The equipped
     set runs two consistency models today: `equipOutfit` is **bridge-authoritative** (resolves the
     outfit by urn via `resolveEquippedSet` and re-emits `wearables` — the fix/ui/04-outfits fix), but
@@ -276,12 +270,12 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
 
 ## 🟢 Low / when a feature needs it
 
-22. `[DS]` **`Divider`** (bespoke in ~4 places · old `bottom-border`)
-23. `[DS]` **`Pagination`** (unused today · old `pagination/`)
-24. `[DS]` **`CopyButton`** (inline in ProfileCard · old `copy-button`)
-25. `[DS]` **`Username`** (name + verified · old `player-name-component`)
-26. `[DS]` `Button` `iconLeft`/`iconRight` props + `hoverIcon` (niche · old `ButtonComponent`)
-27. `[feature]` **Re-enable "Invite to Community" in `ProfileCard`** — *feature, parked until
+21. `[DS]` **`Divider`** (bespoke in ~4 places · old `bottom-border`)
+22. `[DS]` **`Pagination`** (unused today · old `pagination/`)
+23. `[DS]` **`CopyButton`** (inline in ProfileCard · old `copy-button`)
+24. `[DS]` **`Username`** (name + verified · old `player-name-component`)
+25. `[DS]` `Button` `iconLeft`/`iconRight` props + `hoverIcon` (niche · old `ButtonComponent`)
+26. `[feature]` **Re-enable "Invite to Community" in `ProfileCard`** — *feature, parked until
     communities work*. The row/submenu UI was removed from `ProfileCard` (PR #915 follow-up); the
     protocol messages, `session.communities.invitable`/`requestInvitable`/`invite`, and the bridge
     handlers all remain. When re-enabling: (1) the `/invites` response is `{data:[…]}` but `signed()`
@@ -292,7 +286,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     clear both `invitable` and the ref on logout/identity change; (3) surface invite errors to the user
     (the bridge currently swallows them with `console.error`); (4) build the submenu on the
     `ContextMenu` primitive instead of the removed bespoke `.submenu`/`.subRow` CSS.
-28. `[arch]` **HUD state: `useEngineSession` hook prop-drilled → consider Context / a store** —
+27. `[arch]` **HUD state: `useEngineSession` hook prop-drilled → consider Context / a store** —
     *architecture, low priority*. All HUD state lives in one `useEngineSession` hook at the top of
     `Hud`, prop-drilled down; the returned `session` is a fresh object every render, so the whole HUD
     re-renders on any change. Fine at current scale (engine round-trips are the bottleneck, not React
@@ -304,22 +298,22 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     state-lib-free). Also a test cost (harness passes props today; Context needs a provider wrapper).
     Recommendation: keep prop-drilling; add a single `SessionContext` only if drilling ergonomics annoy;
     memoized slices / store only if re-renders become a *measured* problem. **One concrete exception to
-    "renders aren't the bottleneck": item 38 — `proximity` is a per-frame (~60/s) re-render source while
+    "renders aren't the bottleneck": item 37 — `proximity` is a per-frame (~60/s) re-render source while
     near an interactable, not a user-action change.**
-29. `[arch]` **Deep-linkable / bookmarkable navigation — reflect location in the URL** — *architecture,
+28. `[arch]` **Deep-linkable / bookmarkable navigation — reflect location in the URL** — *architecture,
     low priority*. Entering a scene/world (and, ideally, opening HUD surfaces like the map/backpack)
     should be **parameterized in the URL** so the state is shareable and bookmarkable: reload/paste a
     URL and land in the same realm + coords. Scope to nail down: realm/world + parcel coords (e.g.
     `?realm=…&position=x,y` or a path), whether HUD panels also serialize, and wiring it to the picker
     (`pickDestination`) + `map.teleport`/`changeRealm` so URL ⇄ engine stay in sync (`popstate` → jump,
     jump → `pushState`). Deferred: needs a small router/URL-sync layer (project is router-free today).
-30. `[arch]` **Migrate inline `dt`-throttle timers to `bridge-scene/src/system-helpers.ts`** —
+29. `[arch]` **Migrate inline `dt`-throttle timers to `bridge-scene/src/system-helpers.ts`** —
     *cleanup*. The `throttleByDt` helper (added in PR #915 for `avatarPointer`) replaces a dt-accumulator
     that's re-implemented inline across most bridge domains (`chat`, `world`, `friends`, `project`,
     `nametags` — two timers there —, `avatarPreview`). Migrate them to the helper (and consider
     `singleFlight` / a named `pollSequential` wrapper where a polled async RPC could overlap). Pure
     cleanup, no behavior change; kept out of #915 to stay surgical.
-31. `[feature]` **Voice feedback — "who's speaking" indicator** — *feature parity, when voice chat is
+30. `[feature]` **Voice feedback — "who's speaking" indicator** — *feature parity, when voice chat is
     prioritized*. The old scene showed an **animated speaking indicator on each avatar nametag** while a
     nearby player talked (and used the local mic state for your own tag). Mechanism to port: the engine
     exposes a voice stream — `BevyApi.getVoiceStream()` yielding `{ sender_address, active }`
@@ -331,13 +325,13 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     nametags** (bridge scene) and/or the DOM **nearby-members list** (`chat.members`) — e.g. a pulsing
     mic ring. Depends on voice chat being wired end-to-end; today only the local `mic` toggle exists (no
     per-remote-speaker signal). Could yield a reusable `SpeakingIndicator` primitive.
-32. `[feature]` **Re-add "Report" to the profile card once a moderation/report endpoint exists** —
+31. `[feature]` **Re-add "Report" to the profile card once a moderation/report endpoint exists** —
     *feature, low priority*. Report was removed from `ProfileCard` in PR #915 because there's no backend —
     it was only a `console.log` stub, so shipping a dead action was worse than hiding it. When a report/
     moderation endpoint lands: re-add the `Report` row + `onBlock`-style `onReport` request prop
     (parent-owned confirm, same pattern as Block), the `ReportIcon` glyph, and wire the actual submit.
     (Old scene logged too — this is genuinely new backend work, not just UI.)
-33. `[feature]` **Passport / own-profile edit mode — no UI yet** — *feature, own-profile only; flagged by
+32. `[feature]` **Passport / own-profile edit mode — no UI yet** — *feature, own-profile only; flagged by
     Rob*. bevy-ui-scene lets you edit your own passport in place — About Me, the info-field dropdowns,
     links (add/remove, up to 5), and display name — then deploys the updated profile. react-web can
     *view* the profile (`ProfilePanel` = own profile, `ProfilePassport` = others) but has **no UI to
@@ -346,16 +340,16 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     wiring the profile deploy through the bridge/engine. Larger than the view-parity item (#16) — hence
     separate and lower priority than showing OTHER users' passports correctly. Reference the old client
     for the flow (`unity-explorer` `Explorer/Assets/DCL/UI/`, `bevy-ui-scene` profile screens).
-34. `[feature]` **Chat rate limiting** — *hardening, not in bevy-ui-scene*. unity-explorer's
+33. `[feature]` **Chat rate limiting** — *hardening, not in bevy-ui-scene*. unity-explorer's
     `MultiplayerChatMessagesBus` dedupes + rate-limits + buffers sends; react-web (like bevy-ui-scene)
     sends on every Enter with no client-side throttle. Only worth adding if spam becomes a real problem
     server-side rate limiting doesn't already cover.
-35. `[feature]` **DMs / private chat channels** — *net-new, not a port*. Neither `bevy-ui-scene` nor
+34. `[feature]` **DMs / private chat channels** — *net-new, not a port*. Neither `bevy-ui-scene` nor
     today's react-web have anything beyond the single "Nearby" channel; unity-explorer's
     `ChatChannelsPresenter`/`ChatChannelType.USER` is the only prior-art reference. Large scope (channel
     list UI, per-conversation history, member-list → "message" entry point) — flag for a dedicated design
     pass, not a drive-by addition.
-36. `[arch]` **SSO redirect on the login screen throws away the in-flight engine WASM download** —
+35. `[arch]` **SSO redirect on the login screen throws away the in-flight engine WASM download** —
     *boot perf, not blocking / not a direct bug*. On the login/loading screen the engine WASM is
     already downloading in the background while the sign-in buttons are live. "Start with account" /
     "Use different account" call `redirectToAuth()` → `location.replace('/auth/login?redirectTo=…')`
@@ -369,7 +363,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     a hidden **iframe** and read back the identity via `postMessage`/`storage` (auth site must allow
     being framed same-origin — verify its CSP/`X-Frame-Options`). Both are more moving parts than the
     current straight redirect, so only worth it if boot time on login is a measured concern.
-37. `[feature]` **Radial hover prompts — viewport clamping near screen edges** — *polish, non-blocking;
+36. `[feature]` **Radial hover prompts — viewport clamping near screen edges** — *polish, non-blocking;
     point to review*. When the free cursor is near a viewport edge, the fixed-offset radial slots
     (`HOVER_SLOTS` in `features/pointer/Pointer.tsx`) that point toward that edge run off-screen (cursor
     at the right edge → the right-middle prompt's label clips). No clamp today. Arguments for leaving it:
@@ -382,13 +376,13 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     `ProfileCard`, or flip slot sides near the edge. Review comment (note: it says "root is
     overflow: hidden" — there's no such rule, the clip is just the viewport edge):
     https://github.com/decentraland/bevy-explorer/pull/915#discussion_r3529180273
-38. `[arch]` **`proximity` pushes a full HUD re-render every frame while near an interactable** — *perf,
+37. `[arch]` **`proximity` pushes a full HUD re-render every frame while near an interactable** — *perf,
     when profiling confirms*. Unlike most session changes (user actions), the proximity domain is a
     **per-frame** source: `registerProximity`'s `ctx.push` reprojects each in-range entity world→screen
     and calls `ctx.send({ kind: 'proximity', tips })` **every frame with no dedupe**
     (`bridge-scene/src/domains/proximity.ts:52`) whenever ≥1 interactable is in range. Each message
     hits `setProximity(msg.tips)` with a fresh array (`useEngineSession.ts:416`), so `App` — and, per
-    item 28, the whole tree — re-renders ~60×/s. This is the concrete counterexample to item 28's
+    item 27, the whole tree — re-renders ~60×/s. This is the concrete counterexample to item 27's
     "engine round-trips are the bottleneck, not React renders." Cost is **conditional**: zero when
     nothing is in range (the `inRange.size === 0` early-out short-circuits the send), but scales with
     tree size, per-render cost (e.g. the `notifications.reduce` unread count runs every render), in-range
@@ -396,12 +390,12 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     steals main-thread from the same-origin engine iframe → world frame drops + battery drain near
     interactables. **Measure first** (React Profiler: proximity commit duration × 60) — <1ms is noise,
     5–10ms is a real 30–60% main-thread tax. Fix (pattern already in the repo): mirror the `hoverPos`
-    module store (item 9) — `<Pointer>` is the sole consumer, so move proximity off session state into a
+    module store (item 8) — `<Pointer>` is the sole consumer, so move proximity off session state into a
     store it reads via `useSyncExternalStore` (as it already does for `hoverPos`); then 60/s updates
     re-render only `<Pointer>`, not the tree. Optional bridge-side dedupe (skip `ctx.send` when `tips`
     is unchanged) zeroes the standing-still case but not the moving one (positions legitimately change
     each frame), so the store is the structural fix.
-39. `[bug]` **Chat name click shows the raw address for players who left nearby range** — *UX regression,
+38. `[bug]` **Chat name click shows the raw address for players who left nearby range** — *UX regression,
     P2 pending PR #915 review*. `Chat`/`FriendsPanel` now open the shared card via
     `openProfileCard(user.address, …)` (address only); the container re-resolves name/picture with
     `resolveIdentity` (nearby roster → friends/requests → fetched passports). For a **non-friend who
@@ -410,13 +404,13 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     it). Common cases (nearby / friends) are unaffected. Fix if it matters: pass the message's known
     name/picture into `openProfileCard` as a fallback hint, or give `resolveIdentity` a small
     last-seen name cache.
-40. `[test]` **No tier-1.5 visual baseline for `WorldVisitModal`** — *coverage gap, PR #1014
+39. `[test]` **No tier-1.5 visual baseline for `WorldVisitModal`** — *coverage gap, PR #1014
     follow-up*. Passport, PermissionDialog, CommunityModal, CommunityCreateModal and ExitConfirm all
     got `e2e/visual.spec.ts` baselines; `WorldVisitModal` (`src/components/WorldVisitModal.tsx`) didn't
     because both its triggers (Map world search, a chat message with a `*.dcl.eth` link) need the
     places-API fetch stubbed to be deterministic in mock mode. Add a mock/stub for that fetch and a
     `world visit modal` test case when convenient.
-41. `[bug]` **Tier-2 e2e `profile: the passport is relayed to the page` asserts the opposite of the
+40. `[bug]` **Tier-2 e2e `profile: the passport is relayed to the page` asserts the opposite of the
     shipped behaviour — has never passed** — *test-only, no product impact*. `e2e/engine.spec.ts`
     clicks the Profile sidebar icon and expects `aria-pressed="true"`, but that attribute tracks
     `session.profile.open`, and `Sidebar.tsx` wires the icon to `onClick={onViewProfile ?? session.profile.toggle}`
@@ -425,11 +419,11 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     small panel") asserts exactly that and passes. Both files, plus the `onViewProfile` wiring, landed
     together in #901 — verified by checking out `6abf0ba7` with its own `package-lock.json`: the tier-1
     test passed there too, so the e2e assertion has been impossible to satisfy since day one. It went
-    unnoticed because Playwright never runs in CI (see item 42). Fix: assert the passport opened
+    unnoticed because Playwright never runs in CI (see item 41). Fix: assert the passport opened
     instead — but `ProfilePassport.tsx` exposes no stable handle (no `role="dialog"`, no `data-testid`,
     only a generic `aria-label="Close"`), so give it an accessible role/name first, the way the profile
     *card* already has (`getByRole('dialog', { name: 'Profile' })` in `visual.spec.ts`).
-42. `[bug]` **Tier-2 e2e `backpack: equipping a wearable bumps the profile version` depends on a live
+41. `[bug]` **Tier-2 e2e `backpack: equipping a wearable bumps the profile version` depends on a live
     catalyst deploy** — *test-only, flaky by construction*. The click reaches the bridge (the
     `scene:equip` assertion passes); what times out is `expect.poll(profileVersion).toBeGreaterThan(before)`
     after 60s, which needs a **real profile deploy round-trip to the catalyst on a guest account**.
@@ -439,7 +433,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     network-dependent tag. Related: nothing gates these tests — CI runs vitest only, so `test:e2e` and
     `test:visual` rot silently (visual baselines are macOS-only `*-chromium-darwin.png`). Both tiers
     disagreeing should be treated as "the untested tier is wrong" until proven otherwise.
-43. `[bug]` **Tier-1.5 `maxDiffPixelRatio: 0.01` is loose enough to hide a whole new HUD widget** —
+42. `[bug]` **Tier-1.5 `maxDiffPixelRatio: 0.01` is loose enough to hide a whole new HUD widget** —
     *the safety net is nearly blind*. 1% of 1600×900 is **14,400 px**, and the HUD is mostly dark
     chrome, so anything thin (outline circles, small text, grey-on-black bubbles) falls under the
     per-pixel colour threshold too. Measured on `fix/ui/08-minimap`: the entire minimap plus six chat
@@ -454,17 +448,17 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     byte-equality: those unchanged surfaces still re-encode with a little AA jitter (showcase moved
     57 scattered pixels by ≤3/255 per channel, far under the threshold, which is why it passed while
     its file changed). That jitter is exactly why the tolerance can be tightened hard (~0.001, i.e.
-    ~1.4k px) without flakiness — sub-threshold noise never counts as a differing pixel. Do it together with item 44, the one genuinely
+    ~1.4k px) without flakiness — sub-threshold noise never counts as a differing pixel. Do it together with item 43, the one genuinely
     unstable test.
-44. `[bug]` **`visual.spec.ts` "profile card" never settles** — *flaky, and it hides real drift*. It
+43. `[bug]` **`visual.spec.ts` "profile card" never settles** — *flaky, and it hides real drift*. It
     fails against its own freshly-generated baseline at zero tolerance, with the diff *growing* across
     retries (183 → 208 → 270 → 407 → 567 px), and takes ~23 s against ~4 s for every other case.
     Something in the card is still animating or loading past `settle()` (which only awaits
     `document.fonts.ready`, fast-forwards the clock 15 s, and waits 200 ms) — most likely the avatar
     image or an entrance transition that `animations: 'disabled'` doesn't cover. It passes at the
     current 1% tolerance, so it reads as green while measuring nothing. Fix before tightening the
-    ratio (item 43), or that test starts failing for the wrong reason.
-45. `[arch]` **Texture cameras render every frame; the minimap doesn't need real time** — *engine-side
+    ratio (item 42), or that test starts failing for the wrong reason.
+44. `[arch]` **Texture cameras render every frame; the minimap doesn't need real time** — *engine-side
     (Rust), the last big minimap cost we can't reach from the HUD*. In the Camera style the minimap is
     a second full render pass at 60 Hz. A map is orientation, not gameplay: ~10 Hz would look the same
     and cost ~6× less. Three notes on where the fix belongs:
@@ -486,7 +480,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
       out of 60 Hz instead of the engine guessing. Bigger process; the engine-side cycle is the cheap
       first step.
     Needs a WASM rebuild, so it belongs in its own PR, not in the HUD stack.
-44. `[bug]` **The loading screen closes before the destination scene is loaded** — *engine-side (Rust),
+45. `[bug]` **The loading screen closes before the destination scene is loaded** — *engine-side (Rust),
     one to discuss with Rob*. Teleport into Genesis Plaza from a World and you get: "Preparing your
     surroundings", then the overlay closes onto an empty green parcel, then the plaza pops in over the
     next few seconds. The HUD can't fix this — `SceneLoadingOverlay` is a pure mirror of the engine's
@@ -531,6 +525,6 @@ the old version-bump), `tokens.css`, and primitives the old lacks (`WearableCard
   as `openPopup`/`showDialog` + `<PopupHost/>` — a module store rendering JSX directly (no type map,
   no Redux store/dispatcher). `<PopupHost/>` is a top-level layer; the popups it renders use
   `ModalShell`, which is what portals to `document.body` (to escape the HUD `--ui-scale` transform).
-  See item 9.
+  See item 8.
 - The `friendshipStateVersion` + cached-snapshot + event-bus machinery — an artifact of the SDK7
   per-frame render model; React's targeted re-renders make it unnecessary.

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -311,7 +311,7 @@ function Hud(): React.JSX.Element {
             places={session.places}
             profile={session.profile}
             onNavigate={goToMenuPage}
-            onTeleport={(x, y) => session.map.teleport(x, y)}
+            onTeleport={(x, y) => session.map.teleportToPlace(x, y)}
             onVisitWorld={(realm) => session.map.changeRealm(realm)}
           />
           <GalleryPage

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -478,11 +478,7 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
       return
     }
     if (msg.kind === 'teleport') {
-      reply({ kind: 'mapState', x: msg.x, y: msg.y })
-      return
-    }
-    if (msg.kind === 'teleportToPlace') {
-      // No realm switching in the mock, so a place teleport is just the parcel move.
+      // `realm` is ignored: there is no realm switching in the mock, only the parcel move.
       reply({ kind: 'mapState', x: msg.x, y: msg.y })
       return
     }

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -481,6 +481,11 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
       reply({ kind: 'mapState', x: msg.x, y: msg.y })
       return
     }
+    if (msg.kind === 'teleportToPlace') {
+      // No realm switching in the mock, so a place teleport is just the parcel move.
+      reply({ kind: 'mapState', x: msg.x, y: msg.y })
+      return
+    }
     if (msg.kind === 'changeRealm') return // no realm switching in the mock
     if (msg.kind === 'permissionResolve') return // no engine to apply the decision in the mock
     if (msg.kind === 'getCommunities') {

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -111,7 +111,6 @@ export type PageToScene =
   | GetMapRequest
   | TeleportRequest
   | ChangeRealmRequest
-  | TeleportToPlaceRequest
   | MinimapConfigRequest
   | PermissionResolveRequest
   | EngineViewportRequest
@@ -432,11 +431,23 @@ export type MinimapStyle = 'parcel' | 'satellite' | 'imposters'
 /** 'camera' rotates the map with the camera; 'north' keeps north up. */
 export type MinimapRotation = 'camera' | 'north'
 
-/** Teleport to a parcel (page → scene → teleportTo). */
+/** Teleport to a parcel (page → scene → teleportTo).
+ *
+ *  Parcel coordinates only address one realm's grid, so a destination that belongs to a *known*
+ *  realm carries it: the scene switches realm first (only when it isn't already there, and waiting
+ *  for the new one to be live), then teleports. That is a place picked out of a listing — Places, a
+ *  map pin — and it's the same pair the native explorer's discover page fires together
+ *  (crates/system_ui/src/discover.rs).
+ *
+ *  Omit `realm` for coordinates that are already relative to wherever the player is: a chat
+ *  location link, a photo's capture spot. Nothing changes realm then. */
 export interface TeleportRequest {
   kind: 'teleport'
   x: number
   y: number
+  /** Realm the parcel belongs to: a world name (`boedo.dcl.eth`) or a realm URL. Omitted = the
+   *  realm the player is already in. */
+  realm?: string
 }
 
 /** Change to a world/realm (page → scene → changeRealm). `realm` is a world name
@@ -444,21 +455,6 @@ export interface TeleportRequest {
 export interface ChangeRealmRequest {
   kind: 'changeRealm'
   realm: string
-}
-
-/** Teleport to a place: a parcel *in a given realm*. Parcel coordinates only address the realm
- *  that owns them, so leaving the current one is part of the trip — the scene switches realm
- *  (only when it isn't already there) and then teleports. Same pair the native explorer's discover
- *  page fires together (crates/system_ui/src/discover.rs).
- *
- *  Not the same as `teleport`, which stays in the current realm: that one is for coordinates
- *  that are already realm-relative (a chat location link, a photo's capture spot). */
-export interface TeleportToPlaceRequest {
-  kind: 'teleportToPlace'
-  /** Realm the place lives in: a world name (`boedo.dcl.eth`) or a realm URL. */
-  realm: string
-  x: number
-  y: number
 }
 
 /** A scene's pending permission prompt relayed from the engine (e.g. it wants to move you

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -111,6 +111,7 @@ export type PageToScene =
   | GetMapRequest
   | TeleportRequest
   | ChangeRealmRequest
+  | TeleportToPlaceRequest
   | MinimapConfigRequest
   | PermissionResolveRequest
   | EngineViewportRequest
@@ -443,6 +444,21 @@ export interface TeleportRequest {
 export interface ChangeRealmRequest {
   kind: 'changeRealm'
   realm: string
+}
+
+/** Teleport to a place: a parcel *in a given realm*. Parcel coordinates only address the realm
+ *  that owns them, so leaving the current one is part of the trip — the scene switches realm
+ *  (only when it isn't already there) and then teleports. Same pair the native explorer's discover
+ *  page fires together (crates/system_ui/src/discover.rs).
+ *
+ *  Not the same as `teleport`, which stays in the current realm: that one is for coordinates
+ *  that are already realm-relative (a chat location link, a photo's capture spot). */
+export interface TeleportToPlaceRequest {
+  kind: 'teleportToPlace'
+  /** Realm the place lives in: a world name (`boedo.dcl.eth`) or a realm URL. */
+  realm: string
+  x: number
+  y: number
 }
 
 /** A scene's pending permission prompt relayed from the engine (e.g. it wants to move you

--- a/react-web/src/features/chat/chatCommands.test.ts
+++ b/react-web/src/features/chat/chatCommands.test.ts
@@ -41,9 +41,33 @@ describe('parseChatCommand', () => {
     expect(parseChatCommand('/goto foo.eth')).toEqual({ kind: 'world', realm: 'foo.eth' })
   })
 
-  it('/world behaves like /goto <world> but takes no coordinates', () => {
+  it('/world behaves like /goto <world> but takes no bare coordinates', () => {
     expect(parseChatCommand('/world boedo')).toEqual({ kind: 'world', realm: 'boedo.dcl.eth' })
     expect(parseChatCommand('/world genesis')).toEqual({ kind: 'genesis' })
+  })
+
+  // A trailing x,y after a destination targets a specific parcel there instead of its default
+  // spawn — added for testing the realm-arrival-wait/stale-pointer behavior (backlog 44).
+  it('/goto <world> x,y and /goto genesis x,y carry the override parcel', () => {
+    expect(parseChatCommand('/goto pablo 3,1')).toEqual({ kind: 'world', realm: 'pablo.dcl.eth', x: 3, y: 1 })
+    expect(parseChatCommand('/goto main -3,-2')).toEqual({ kind: 'genesis', x: -3, y: -2 })
+    expect(parseChatCommand('/goto genesis 0,0')).toEqual({ kind: 'genesis', x: 0, y: 0 })
+    // /world shares the same trailing-coords parsing as /goto.
+    expect(parseChatCommand('/world pablo 3,1')).toEqual({ kind: 'world', realm: 'pablo.dcl.eth', x: 3, y: 1 })
+  })
+
+  it('bare /goto <world> and /goto genesis (no coords) carry no x,y', () => {
+    const world = parseChatCommand('/goto pablo')
+    expect(world).toEqual({ kind: 'world', realm: 'pablo.dcl.eth' })
+    expect(world).not.toHaveProperty('x')
+    const genesis = parseChatCommand('/goto main')
+    expect(genesis).toEqual({ kind: 'genesis' })
+    expect(genesis).not.toHaveProperty('x')
+  })
+
+  it('an invalid trailing arg after a destination is a system message, never a broadcast', () => {
+    expect(parseChatCommand('/goto pablo notcoords').kind).toBe('system')
+    expect(parseChatCommand('/goto main 3').kind).toBe('system')
   })
 
   it('missing/invalid args → a system usage message, never a broadcast', () => {

--- a/react-web/src/features/chat/chatCommands.test.ts
+++ b/react-web/src/features/chat/chatCommands.test.ts
@@ -47,7 +47,7 @@ describe('parseChatCommand', () => {
   })
 
   // A trailing x,y after a destination targets a specific parcel there instead of its default
-  // spawn — added for testing the realm-arrival-wait/stale-pointer behavior (backlog 44).
+  // spawn — added for testing the realm-arrival-wait/stale-pointer behavior (backlog 45).
   it('/goto <world> x,y and /goto genesis x,y carry the override parcel', () => {
     expect(parseChatCommand('/goto pablo 3,1')).toEqual({ kind: 'world', realm: 'pablo.dcl.eth', x: 3, y: 1 })
     expect(parseChatCommand('/goto main -3,-2')).toEqual({ kind: 'genesis', x: -3, y: -2 })

--- a/react-web/src/features/chat/chatCommands.ts
+++ b/react-web/src/features/chat/chatCommands.ts
@@ -12,12 +12,15 @@ const GENESIS_ALIASES = new Set(['genesis', 'main'])
 export type ChatCommand =
   /** Not a command (no leading `/`) — send as a normal chat message. */
   | { kind: 'send'; text: string }
-  /** `/goto x,y` — teleport to a parcel. */
+  /** `/goto x,y` — teleport to a parcel of the realm the player is already in. */
   | { kind: 'goto'; x: number; y: number }
-  /** `/goto genesis|main` — change to the default (Genesis) realm. */
-  | { kind: 'genesis' }
-  /** `/goto <world>` or `/world <world>` — jump to a world's realm (normalized to `.dcl.eth`). */
-  | { kind: 'world'; realm: string }
+  /** `/goto genesis|main [x,y]` — go to Genesis Plaza. Defaults to its base parcel (-3,-2); an
+   *  explicit x,y overrides it (testing other Genesis parcels — see backlog 44). */
+  | { kind: 'genesis'; x?: number; y?: number }
+  /** `/goto <world> [x,y]` or `/world <world> [x,y]` — jump to a world's realm (normalized to
+   *  `.dcl.eth`). With x,y, teleports there once the realm is live; without, the world's own
+   *  default spawn applies. */
+  | { kind: 'world'; realm: string; x?: number; y?: number }
   /** `/reload` — reload the current scene. */
   | { kind: 'reload' }
   /** `/commands` — list the engine console commands. */
@@ -30,9 +33,8 @@ export const HELP_TEXT = [
   'Available commands:',
   '/help — show this help',
   '/goto x,y — teleport to parcel x,y',
-  '/goto <world> — jump to a world (e.g. world_name or world_name.dcl.eth)',
-  '/goto genesis — go to Genesis Plaza',
-  '/world <world> — jump to a world (alias of /goto <world>)',
+  '/goto <world> [x,y] — jump to a world, optionally at parcel x,y (e.g. world_name or world_name.dcl.eth)',
+  '/goto genesis [x,y] — go to Genesis Plaza, optionally at parcel x,y',
   '/reload — reload the current scene',
   '/commands — list the engine console commands',
 ].join('\n')
@@ -44,16 +46,41 @@ function toRealm(token: string): string {
 
 const COORDS_RE = /^(-?\d+)\s*,\s*(-?\d+)$/
 
-// `/goto` and `/world` share the realm/coords parsing; only `/goto` accepts coordinates.
+// `/goto` and `/world` share the realm/coords parsing; only `/goto` accepts bare coordinates
+// (`/goto x,y`, no destination — teleport within the current realm). Both accept an optional
+// trailing `x,y` after a destination (`/goto <world|genesis> x,y`) to target a specific parcel
+// there instead of the destination's default.
 function parseGoto(rest: string, allowCoords: boolean): ChatCommand {
-  const arg = rest.trim()
-  if (!arg) return { kind: 'system', message: 'Usage: /goto x,y  ·  /goto <world>  ·  /goto genesis' }
-  if (GENESIS_ALIASES.has(arg.toLowerCase())) return { kind: 'genesis' }
-  const m = allowCoords ? arg.match(COORDS_RE) : null
-  if (m) return { kind: 'goto', x: Number(m[1]), y: Number(m[2]) }
-  // A single token → world name; anything with a space/comma that isn't coords is invalid.
-  if (/\s|,/.test(arg)) return { kind: 'system', message: `Invalid destination: ${arg}` }
-  return { kind: 'world', realm: toRealm(arg) }
+  const trimmed = rest.trim()
+  if (!trimmed) {
+    return { kind: 'system', message: 'Usage: /goto x,y  ·  /goto <world> [x,y]  ·  /goto genesis [x,y]' }
+  }
+
+  // Bare coords (tolerates "x, y" with a space after the comma), checked against the whole
+  // remainder before any tokenizing — a trailing destination coords pair below is checked the
+  // same way, just against the substring after the destination token.
+  if (allowCoords) {
+    const m = trimmed.match(COORDS_RE)
+    if (m) return { kind: 'goto', x: Number(m[1]), y: Number(m[2]) }
+  }
+
+  // <destination> [x,y] — split on the FIRST run of whitespace only, so the trailing coords
+  // argument can itself contain "x, y" with a space after the comma.
+  const firstSpace = trimmed.search(/\s/)
+  const first = firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace)
+  const remainder = firstSpace === -1 ? '' : trimmed.slice(firstSpace).trim()
+
+  let coords: { x: number; y: number } | undefined
+  if (remainder) {
+    const m = remainder.match(COORDS_RE)
+    if (!m) return { kind: 'system', message: `Invalid destination: ${trimmed}` }
+    coords = { x: Number(m[1]), y: Number(m[2]) }
+  }
+
+  if (GENESIS_ALIASES.has(first.toLowerCase())) return { kind: 'genesis', ...coords }
+  // A coords-shaped or otherwise invalid first token isn't a destination name.
+  if (/\s|,/.test(first)) return { kind: 'system', message: `Invalid destination: ${trimmed}` }
+  return { kind: 'world', realm: toRealm(first), ...coords }
 }
 
 /** Parse a raw chat input into an action. Non-`/` lines pass through as `send`. */

--- a/react-web/src/features/chat/chatCommands.ts
+++ b/react-web/src/features/chat/chatCommands.ts
@@ -14,8 +14,8 @@ export type ChatCommand =
   | { kind: 'send'; text: string }
   /** `/goto x,y` — teleport to a parcel of the realm the player is already in. */
   | { kind: 'goto'; x: number; y: number }
-  /** `/goto genesis|main [x,y]` — go to Genesis Plaza. Defaults to its base parcel (-3,-2); an
-   *  explicit x,y overrides it (testing other Genesis parcels — see backlog 44). */
+  /** `/goto genesis|main [x,y]` — go to Genesis Plaza. Defaults to its base parcel (0,0); an
+   *  explicit x,y overrides it (testing other Genesis parcels — see backlog 45). */
   | { kind: 'genesis'; x?: number; y?: number }
   /** `/goto <world> [x,y]` or `/world <world> [x,y]` — jump to a world's realm (normalized to
    *  `.dcl.eth`). With x,y, teleports there once the realm is live; without, the world's own

--- a/react-web/src/features/map/MapPage.tsx
+++ b/react-web/src/features/map/MapPage.tsx
@@ -332,7 +332,7 @@ export function MapPage({
   }
   const jumpTo = (pl: Place): void => {
     const [x, y] = pl.base_position.split(',').map(Number)
-    map.teleport(x, y)
+    map.teleportToPlace(x, y)
     map.toggle()
   }
 

--- a/react-web/src/features/places/FeaturedCard.tsx
+++ b/react-web/src/features/places/FeaturedCard.tsx
@@ -28,11 +28,14 @@ function GlobeGlyph(): React.JSX.Element {
     </svg>
   )
 }
+// An arrow entering a door frame (the "log in" glyph) — reads as "jump in" to a place. The
+// previous path drew a pencil-with-tip shape (a copy/paste of an edit icon), not an entry arrow.
 function JumpInGlyph(): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M5 12l9-9 4 4-9 9-5 1z" />
-      <path d="M13 4l3 3M5 12l-1 7 7-1" />
+      <path d="M15 3h4a2 2 0 012 2v14a2 2 0 01-2 2h-4" />
+      <path d="M10 17l5-5-5-5" />
+      <path d="M15 12H3" />
     </svg>
   )
 }

--- a/react-web/src/features/places/PlaceCard.tsx
+++ b/react-web/src/features/places/PlaceCard.tsx
@@ -40,11 +40,14 @@ function GlobeGlyph(): React.JSX.Element {
   )
 }
 
+// An arrow entering a door frame (the "log in" glyph) — reads as "jump in" to a place. The
+// previous path drew a pencil-with-tip shape (a copy/paste of an edit icon), not an entry arrow.
 function JumpInGlyph(): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M5 12l9-9 4 4-9 9-5 1z" />
-      <path d="M13 4l3 3M5 12l-1 7 7-1" />
+      <path d="M15 3h4a2 2 0 012 2v14a2 2 0 01-2 2h-4" />
+      <path d="M10 17l5-5-5-5" />
+      <path d="M15 12H3" />
     </svg>
   )
 }

--- a/react-web/src/features/places/PlacesBrowser.tsx
+++ b/react-web/src/features/places/PlacesBrowser.tsx
@@ -1,8 +1,8 @@
-// The Places browser, matched to the "What's On" design: three stacked sections —
+// The Places browser, matched to the "What's On" design: a toolbar (Explore all / Favourites /
+// My places + search + Any Category + Sort by) up top, then two stacked sections —
 //   1. LIVE NOW    — the 4 most-populated places (a single full-width row)
 //   2. FEATURED    — places tagged as points of interest
-//   3. ALL          — a toolbar (Explore all / Favourites / My places + search + Any Category +
-//                     Sort by) over a purple grid panel of every place.
+//   3. ALL          — a purple grid panel of every place.
 // Live Now + Featured are curated highlights shown only on the default Explore-all view (no search,
 // no category filter); searching/filtering collapses to the All grid. Shared by the in-world
 // PlacesPage and the post-jump-in PlacesPicker; the host supplies an `onPick(place)` action.
@@ -103,22 +103,6 @@ export function PlacesBrowser({
 
   return (
     <>
-      {showHighlights && liveNow.length > 0 && (
-        <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>
-            <span className={styles.liveDot} /> Live Now
-          </h2>
-          {renderGrid(liveNow)}
-        </section>
-      )}
-
-      {showHighlights && featured.length > 0 && (
-        <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>Featured Places</h2>
-          <FeaturedCarousel places={featured} onPick={onPick} />
-        </section>
-      )}
-
       <div className={styles.toolbar}>
         <div className={styles.tabs} role="tablist" aria-label="Places sections">
           {SECTIONS.map((s) => (
@@ -152,6 +136,22 @@ export function PlacesBrowser({
           {headExtra}
         </div>
       </div>
+
+      {showHighlights && liveNow.length > 0 && (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>
+            <span className={styles.liveDot} /> Live Now
+          </h2>
+          {renderGrid(liveNow)}
+        </section>
+      )}
+
+      {showHighlights && featured.length > 0 && (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Featured Places</h2>
+          <FeaturedCarousel places={featured} onPick={onPick} />
+        </section>
+      )}
 
       <div className={styles.panel}>
         {loading ? (

--- a/react-web/src/features/places/PlacesPage.module.css
+++ b/react-web/src/features/places/PlacesPage.module.css
@@ -1,6 +1,6 @@
-/* Places browser body — "What's On" layout: Live Now + Featured highlight sections, then a toolbar
-   (section tabs + search + Any Category + Sort by) over a purple grid panel. Shared by the in-world
-   PlacesPage and the picker. */
+/* Places browser body — "What's On" layout: a toolbar (section tabs + search + Any Category +
+   Sort by) up top, then Live Now + Featured highlight sections, then a purple grid panel. Shared
+   by the in-world PlacesPage and the picker. */
 
 /* Live Now / Featured Places highlight sections. */
 .section {

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -772,11 +772,26 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           // and the engine then keeps the parcel you were standing on, clamped into the new realm's
           // bounds (scene_runner initialize_scene.rs, RealmInitialLocation::Base) — from a World
           // that means landing on whatever Genesis parcel matches the world coordinates you
-          // happened to be at, often an empty one. Same 0,0 the old system-scene HUD teleported to.
-          driverRef.current?.send({ kind: 'teleport', realm: DEFAULT_REALM, x: 0, y: 0 })
+          // happened to be at, often an empty one.
+          //
+          // Default is the plaza's BASE parcel (-3,-2), deliberately not 0,0. The landing spot is
+          // identical — the engine spawns at the scene's spawn points whichever of its parcels you
+          // target — but 0,0 is also where a World's own scene sits, and that scene survives a
+          // world→Genesis change (the engine only purges scenes for realms with scenes_urn). A
+          // teleport to 0,0 then finds that stale "ready" scene at the parcel and drops the player
+          // in before Genesis Plaza has even spawned: no loading screen, empty land. Backlog 44 has
+          // the full trace. `/goto genesis x,y` overrides the default, for testing other parcels.
+          driverRef.current?.send({ kind: 'teleport', realm: DEFAULT_REALM, x: cmd.x ?? -3, y: cmd.y ?? -2 })
           break
         case 'world':
-          driverRef.current?.send({ kind: 'changeRealm', realm: cmd.realm })
+          // With x,y (`/goto <world> x,y`), the bridge holds the teleport until the realm change
+          // lands — see the `teleport` handler in bridge-scene/src/domains/world.ts. Without, the
+          // realm's own default spawn applies (RealmInitialLocation::Base), unchanged from before.
+          if (cmd.x != null && cmd.y != null) {
+            driverRef.current?.send({ kind: 'teleport', realm: cmd.realm, x: cmd.x, y: cmd.y })
+          } else {
+            driverRef.current?.send({ kind: 'changeRealm', realm: cmd.realm })
+          }
           break
         case 'reload':
           driverRef.current?.send({ kind: 'reloadScene' })

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -773,7 +773,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           // bounds (scene_runner initialize_scene.rs, RealmInitialLocation::Base) — from a World
           // that means landing on whatever Genesis parcel matches the world coordinates you
           // happened to be at, often an empty one. Same 0,0 the old system-scene HUD teleported to.
-          driverRef.current?.send({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x: 0, y: 0 })
+          driverRef.current?.send({ kind: 'teleport', realm: DEFAULT_REALM, x: 0, y: 0 })
           break
         case 'world':
           driverRef.current?.send({ kind: 'changeRealm', realm: cmd.realm })
@@ -905,14 +905,16 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     setGalleryPhotos((list) => list.filter((p) => p.id !== id))
     setGalleryStorage((s) => ({ ...s, current: Math.max(0, s.current - 1) }))
   }, [])
+  // Same request, and the same engine op behind it: the two differ only in whether the parcel
+  // carries the realm it belongs to. Without one the scene teleports inside the current realm.
   const teleport = useCallback((x: number, y: number) => {
     driverRef.current?.send({ kind: 'teleport', x, y })
   }, [])
-  // Teleport to a Genesis City place. The realm is part of the destination: from inside a World these
-  // coordinates address a different parcel grid, so a bare teleport would land on the world's
-  // own x,y. The scene skips the realm switch when we're already in Genesis.
+  // With one, the scene travels there first. These coordinates are Genesis City's, so from inside a
+  // World a bare teleport would land on the world's own x,y. The realm switch is skipped when we're
+  // already in Genesis.
   const teleportToPlace = useCallback((x: number, y: number) => {
-    driverRef.current?.send({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x, y })
+    driverRef.current?.send({ kind: 'teleport', realm: DEFAULT_REALM, x, y })
   }, [])
   const changeRealm = useCallback((realm: string) => {
     driverRef.current?.send({ kind: 'changeRealm', realm })

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -774,14 +774,14 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           // that means landing on whatever Genesis parcel matches the world coordinates you
           // happened to be at, often an empty one.
           //
-          // Default is the plaza's BASE parcel (-3,-2), deliberately not 0,0. The landing spot is
-          // identical — the engine spawns at the scene's spawn points whichever of its parcels you
-          // target — but 0,0 is also where a World's own scene sits, and that scene survives a
-          // world→Genesis change (the engine only purges scenes for realms with scenes_urn). A
-          // teleport to 0,0 then finds that stale "ready" scene at the parcel and drops the player
-          // in before Genesis Plaza has even spawned: no loading screen, empty land. Backlog 44 has
-          // the full trace. `/goto genesis x,y` overrides the default, for testing other parcels.
-          driverRef.current?.send({ kind: 'teleport', realm: DEFAULT_REALM, x: cmd.x ?? -3, y: cmd.y ?? -2 })
+          // Default is the plaza's base parcel (0,0). `handle_out_of_world` used to accept a
+          // ScenePointers entry from whichever realm produced it, so 0,0 — also where a World's own
+          // scene usually sits — could resolve against that stale World-realm pointer and drop the
+          // player in before Genesis Plaza had even spawned (no loading screen, empty land). Fixed
+          // engine-side by #1042 (handle_out_of_world now only accepts a pointer tagged with the
+          // realm the player is actually in). `/goto genesis x,y` overrides the default, for testing
+          // other parcels.
+          driverRef.current?.send({ kind: 'teleport', realm: DEFAULT_REALM, x: cmd.x ?? 0, y: cmd.y ?? 0 })
           break
         case 'world':
           // With x,y (`/goto <world> x,y`), the bridge holds the teleport until the realm change

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -98,9 +98,13 @@ export interface MapState {
   y: number
   open: boolean
   toggle: () => void
+  /** Move to a parcel of the realm the player is already in. For a place picked out of a
+   *  listing use `teleportToPlace` — those coordinates are Genesis City's, not the current realm's. */
   teleport: (x: number, y: number) => void
   /** Travel to a world/realm by name (e.g. `boedo.dcl.eth`). */
   changeRealm: (realm: string) => void
+  /** Teleport to a Genesis City place: returns to Genesis first when the player is in a World. */
+  teleportToPlace: (x: number, y: number) => void
 }
 
 /** Live player pose for the minimap: position in world metres, yaws in degrees. */
@@ -764,7 +768,12 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           driverRef.current?.send({ kind: 'teleport', x: cmd.x, y: cmd.y })
           break
         case 'genesis':
-          driverRef.current?.send({ kind: 'changeRealm', realm: DEFAULT_REALM })
+          // Genesis Plaza, not merely the Genesis realm. A bare realm change names no destination,
+          // and the engine then keeps the parcel you were standing on, clamped into the new realm's
+          // bounds (scene_runner initialize_scene.rs, RealmInitialLocation::Base) — from a World
+          // that means landing on whatever Genesis parcel matches the world coordinates you
+          // happened to be at, often an empty one. Same 0,0 the old system-scene HUD teleported to.
+          driverRef.current?.send({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x: 0, y: 0 })
           break
         case 'world':
           driverRef.current?.send({ kind: 'changeRealm', realm: cmd.realm })
@@ -898,6 +907,12 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   }, [])
   const teleport = useCallback((x: number, y: number) => {
     driverRef.current?.send({ kind: 'teleport', x, y })
+  }, [])
+  // Teleport to a Genesis City place. The realm is part of the destination: from inside a World these
+  // coordinates address a different parcel grid, so a bare teleport would land on the world's
+  // own x,y. The scene skips the realm switch when we're already in Genesis.
+  const teleportToPlace = useCallback((x: number, y: number) => {
+    driverRef.current?.send({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x, y })
   }, [])
   const changeRealm = useCallback((realm: string) => {
     driverRef.current?.send({ kind: 'changeRealm', realm })
@@ -1436,7 +1451,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       saveOutfit, deleteOutfit, equipOutfit
     },
     communities: { list: communities, open: communitiesOpen, toggle: toggleCommunities, create: createCommunity, join: joinCommunity, leave: leaveCommunity, detail: communityDetail, loadDetail: loadCommunityDetail },
-    map: { x: mapParcel.x, y: mapParcel.y, open: mapOpen, toggle: toggleMap, teleport, changeRealm },
+    map: { x: mapParcel.x, y: mapParcel.y, open: mapOpen, toggle: toggleMap, teleport, changeRealm, teleportToPlace },
     minimap: { pose: poseRef, isWorld, sceneTitle, setConfig: setMinimapConfig },
     places: { open: placesOpen, toggle: togglePlaces },
     gallery: {

--- a/react-web/src/test/chat.test.tsx
+++ b/react-web/src/test/chat.test.tsx
@@ -36,14 +36,41 @@ describe('chat domain', () => {
 
   // `/goto main` must name a destination, not just a realm: a bare realm change leaves the engine
   // to keep the parcel you were standing on (clamped into Genesis' bounds), which from a World
-  // drops you on an arbitrary — often empty — Genesis parcel.
+  // drops you on an arbitrary — often empty — Genesis parcel. The destination is the plaza's BASE
+  // parcel (-3,-2), not 0,0: 0,0 is where a World's own scene sits, and its stale state survives
+  // the realm change and skips the loading screen (backlog 44).
   it('/goto main teleports to Genesis Plaza, not just to the Genesis realm', async () => {
     const h = renderSession()
     await enterAsGuest(h)
     act(() => h.session().chat.send('/goto main'))
-    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: 0, y: 0 })
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: -3, y: -2 })
     expect(h.driver.sentOf('changeRealm')).toHaveLength(0)
     expect(h.driver.sentOf('sendChat')).toHaveLength(0) // never broadcast as a chat line
+  })
+
+  // Testing aid (backlog 44): an explicit x,y after the destination overrides the default parcel,
+  // so a specific Genesis parcel or world parcel can be targeted directly from chat.
+  it('/goto genesis x,y overrides the default parcel', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    act(() => h.session().chat.send('/goto genesis 5,5'))
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: 5, y: 5 })
+  })
+
+  it('/goto <world> x,y teleports there (realm-arrival-aware, via the merged teleport request)', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    act(() => h.session().chat.send('/goto pablo 3,1'))
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: 'pablo.dcl.eth', x: 3, y: 1 })
+    expect(h.driver.sentOf('changeRealm')).toHaveLength(0)
+  })
+
+  it('/goto <world> with no coords still just changes realm (world default spawn)', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    act(() => h.session().chat.send('/goto pablo'))
+    expect(h.driver.last('changeRealm')).toEqual({ kind: 'changeRealm', realm: 'pablo.dcl.eth' })
+    expect(h.driver.sentOf('teleport')).toHaveLength(0)
   })
 
   it('members stream updates the nearby roster', async () => {

--- a/react-web/src/test/chat.test.tsx
+++ b/react-web/src/test/chat.test.tsx
@@ -37,18 +37,18 @@ describe('chat domain', () => {
   // `/goto main` must name a destination, not just a realm: a bare realm change leaves the engine
   // to keep the parcel you were standing on (clamped into Genesis' bounds), which from a World
   // drops you on an arbitrary — often empty — Genesis parcel. The destination is the plaza's BASE
-  // parcel (-3,-2), not 0,0: 0,0 is where a World's own scene sits, and its stale state survives
-  // the realm change and skips the loading screen (backlog 44).
+  // parcel (0,0); #1042 fixed the engine-side bug that let a stale World-realm pointer resolve
+  // there and skip the loading screen.
   it('/goto main teleports to Genesis Plaza, not just to the Genesis realm', async () => {
     const h = renderSession()
     await enterAsGuest(h)
     act(() => h.session().chat.send('/goto main'))
-    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: -3, y: -2 })
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: 0, y: 0 })
     expect(h.driver.sentOf('changeRealm')).toHaveLength(0)
     expect(h.driver.sentOf('sendChat')).toHaveLength(0) // never broadcast as a chat line
   })
 
-  // Testing aid (backlog 44): an explicit x,y after the destination overrides the default parcel,
+  // Testing aid (backlog 45): an explicit x,y after the destination overrides the default parcel,
   // so a specific Genesis parcel or world parcel can be targeted directly from chat.
   it('/goto genesis x,y overrides the default parcel', async () => {
     const h = renderSession()

--- a/react-web/src/test/chat.test.tsx
+++ b/react-web/src/test/chat.test.tsx
@@ -41,7 +41,7 @@ describe('chat domain', () => {
     const h = renderSession()
     await enterAsGuest(h)
     act(() => h.session().chat.send('/goto main'))
-    expect(h.driver.last('teleportToPlace')).toEqual({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x: 0, y: 0 })
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: 0, y: 0 })
     expect(h.driver.sentOf('changeRealm')).toHaveLength(0)
     expect(h.driver.sentOf('sendChat')).toHaveLength(0) // never broadcast as a chat line
   })

--- a/react-web/src/test/chat.test.tsx
+++ b/react-web/src/test/chat.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { act } from '@testing-library/react'
 import { renderSession, enterAsGuest } from './harness'
+import { DEFAULT_REALM } from '../features/engine/EngineHost'
 
 // DOMAIN: chat — send Nearby messages, receive relayed chat, nearby members roster.
 describe('chat domain', () => {
@@ -31,6 +32,18 @@ describe('chat domain', () => {
     const msgs = h.session().chat.messages
     expect(msgs).toHaveLength(1)
     expect(msgs[0]).toMatchObject({ sender: '0xabc', message: 'gm', channel: 'Nearby' })
+  })
+
+  // `/goto main` must name a destination, not just a realm: a bare realm change leaves the engine
+  // to keep the parcel you were standing on (clamped into Genesis' bounds), which from a World
+  // drops you on an arbitrary — often empty — Genesis parcel.
+  it('/goto main teleports to Genesis Plaza, not just to the Genesis realm', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    act(() => h.session().chat.send('/goto main'))
+    expect(h.driver.last('teleportToPlace')).toEqual({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x: 0, y: 0 })
+    expect(h.driver.sentOf('changeRealm')).toHaveLength(0)
+    expect(h.driver.sentOf('sendChat')).toHaveLength(0) // never broadcast as a chat line
   })
 
   it('members stream updates the nearby roster', async () => {

--- a/react-web/src/test/harness.tsx
+++ b/react-web/src/test/harness.tsx
@@ -160,7 +160,7 @@ export function fakeSession(): EngineSession {
     emotes: { list: [], open: false, toggle: vi.fn(), play: vi.fn(), equip: vi.fn() },
     backpack: { list: [], total: 0, loading: false, query: vi.fn(), equipped: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn(), outfits: [], outfitSlots: 5, saveOutfit: vi.fn(), deleteOutfit: vi.fn(), equipOutfit: vi.fn() },
     communities: { list: [], open: false, toggle: vi.fn(), create: vi.fn(), join: vi.fn(), leave: vi.fn(), detail: null, loadDetail: vi.fn() },
-    map: { x: 0, y: 0, open: false, toggle: vi.fn(), teleport: vi.fn(), changeRealm: vi.fn() },
+    map: { x: 0, y: 0, open: false, toggle: vi.fn(), teleport: vi.fn(), changeRealm: vi.fn(), teleportToPlace: vi.fn() },
     minimap: { pose: { current: { x: 0, z: 0, yaw: 0, camYaw: 0 } }, isWorld: false, sceneTitle: '', setConfig: vi.fn() },
     places: { open: false, toggle: vi.fn() },
     gallery: { list: [], current: 0, max: 0, loaded: false, open: false, toggle: vi.fn(), metas: {}, loadPhoto: vi.fn(), remove: vi.fn() },

--- a/react-web/src/test/map.clicks.test.tsx
+++ b/react-web/src/test/map.clicks.test.tsx
@@ -6,7 +6,7 @@ import type { MapState } from '../features/session/useEngineSession'
 import { fakeSession } from './harness'
 
 function renderMap(): MapState {
-  const map: MapState = { ...fakeSession().map, open: true, teleport: vi.fn(), toggle: vi.fn() }
+  const map: MapState = { ...fakeSession().map, open: true, teleportToPlace: vi.fn(), toggle: vi.fn() }
   render(<MapPage map={map} profile={{ data: null, open: false, toggle: vi.fn() }} onNavigate={vi.fn()} />)
   return map
 }
@@ -48,7 +48,7 @@ describe('map page', () => {
     fireEvent.mouseUp(view, { clientX: 5, clientY: 5 })
 
     await userEvent.click(await screen.findByRole('button', { name: 'JUMP IN' }))
-    expect(vi.mocked(map.teleport)).toHaveBeenCalledWith(10, -5)
+    expect(vi.mocked(map.teleportToPlace)).toHaveBeenCalledWith(10, -5)
     expect(vi.mocked(map.toggle)).toHaveBeenCalledTimes(1)
   })
 })

--- a/react-web/src/test/world.test.tsx
+++ b/react-web/src/test/world.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { act } from '@testing-library/react'
 import { renderSession, enterAsGuest } from './harness'
+import { DEFAULT_REALM } from '../features/engine/EngineHost'
 
 // DOMAIN: world — map state (parcel), teleport, microphone toggle/state.
 describe('world domain', () => {
@@ -23,6 +24,17 @@ describe('world domain', () => {
     await enterAsGuest(h)
     act(() => h.session().map.teleport(5, -3))
     expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', x: 5, y: -3 })
+  })
+
+  // A place picked from a listing is a Genesis City parcel, so the realm travels with it — a bare
+  // teleport from inside a World would land on that world's own 5,-3.
+  it('teleporting to a place posts the parcel together with the Genesis realm', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    act(() => h.session().map.teleportToPlace(5, -3))
+    expect(h.driver.last('teleportToPlace')).toEqual({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x: 5, y: -3 })
+    // Never the realm-relative teleport: that one would keep the player in the World.
+    expect(h.driver.sentOf('teleport')).toHaveLength(0)
   })
 
   it('sceneInfo drives the minimap title, and re-pushes as the player crosses scenes', async () => {

--- a/react-web/src/test/world.test.tsx
+++ b/react-web/src/test/world.test.tsx
@@ -32,9 +32,8 @@ describe('world domain', () => {
     const h = renderSession()
     await enterAsGuest(h)
     act(() => h.session().map.teleportToPlace(5, -3))
-    expect(h.driver.last('teleportToPlace')).toEqual({ kind: 'teleportToPlace', realm: DEFAULT_REALM, x: 5, y: -3 })
-    // Never the realm-relative teleport: that one would keep the player in the World.
-    expect(h.driver.sentOf('teleport')).toHaveLength(0)
+    // The realm rides along; without it the scene would move the player inside the World.
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: 5, y: -3 })
   })
 
   it('sceneInfo drives the minimap title, and re-pushes as the player crosses scenes', async () => {


### PR DESCRIPTION
Stacked on #1023 (`fix/ui/08-minimap`).

## What

- **Places/map jump-in from a World now carries realm + parcel together** (`teleportToPlace`), instead of the two independent `changeRealm`/`teleport` actions racing each other.
- **`/goto main` / `/goto genesis [x,y]`** now name Genesis Plaza (defaulting to parcel `-3,-2`) instead of only changing realm. `/goto <world> [x,y]` gained the same optional trailing-parcel override, for testing.
- **Jump-in icon fixed**: `JumpInGlyph()` drew a pencil, not an arrow — a copy/paste-wrong-glyph mistake duplicated identically in `PlaceCard.tsx` and `FeaturedCard.tsx`. Replaced with an arrow-into-a-doorframe glyph in both.
- **Places toolbar** (Explore all / Favourites / My places + search + category + sort) now renders above the Live Now / Featured sections instead of below, so it's the first thing on the page.

## Why

- **The jump-in bug** (reported by Gon): from inside a World, jumping into a Genesis City place from **Places** teleports but never leaves the World, so the destination coordinates address that World's own parcel grid instead of Genesis's. `/goto main` does change realm, hence "it works with the command but not from the page." This has been broken since the react-web port (`6abf0ba7`) — not a recent regression. The old system-scene HUD (`community-place-popup.tsx`) and the native explorer (`system_ui/src/discover.rs`) both fire a realm change + teleport together; react-web never did. The map's JUMP IN had the same hole.
- **The jump-in icon**: visible on first impression, so worth fixing on its own regardless of the realm work above.

## How

A place is modelled as what it is, **realm + parcel**, and travels as one `teleportToPlace` request. Plain `teleport` keeps its old meaning: a parcel of the realm you're already in (chat location links, a photo's capture spot).

Resolution lives in the **bridge scene**, not React, because that's where the current realm is known first-hand — React only sees the 2s `realmInfo` poll and would read a stale realm right after a change. The scene skips the switch when the player is already in the target realm, since a `changeRealm` to the realm you're in is a full scene purge and reconnect, not a no-op.

The parcel can't ride on `changeRealm`'s promise: that promise resolves as soon as the engine *accepts* the change (`restricted_actions/src/lib.rs` queues a `ChangeRealmEvent` and answers `Ok` immediately) — the about-fetch, scene purge, and pointer re-resolve all happen over the following frames. Applying the parcel then lands on the realm being *left*, which showed up as two loading screens (one out-of-world round trip in the old world, then another once the new realm lands). So the parcel is held until `getRealm` reports the target realm, with the realm poll tightened to ~10×/s while one is pending and a 60s drop-dead.

`/goto genesis` defaults to parcel `-3,-2` (the plaza's base parcel), **deliberately not `0,0`**: a bare realm change from a World lands you on whatever Genesis parcel matches the world coordinates you happened to be at (`RealmInitialLocation::Base`), and `0,0` also happens to be where a World's own scene usually sits. Because the engine only purges scenes for realms with `scenes_urn`, that World scene survives the realm change and is still "ready" — so a teleport to `0,0` finds it and drops the player in before Genesis Plaza has even spawned (no loading screen, empty land). `-3,-2` sidesteps that; the landing spot is identical either way since the engine spawns at the scene's own spawn points. `/goto genesis x,y` overrides the default for testing other parcels.

**Related, not blocking:** #1042 fixes the actual root cause engine-side (`handle_out_of_world` was accepting a `ScenePointers` entry from the wrong realm). Its own description calls this out directly: *"Once this ships, react-web can drop a workaround (`/goto main` currently avoids parcel `0,0`...)"*. This PR doesn't depend on #1042 to merge — the `-3,-2` workaround is correct standalone — but once #1042 ships, that special-case can simplify back to `0,0`.

## Deliberately unchanged

Chat location links, the gallery's Jump In, and `/goto x,y`: those coordinates are relative to the realm you're already in, and the old HUD didn't change realm for them either.

## Testing

`tsc --noEmit` clean in both `react-web` and `bridge-scene`. Full unit suite green (49 files, 334 tests), including coverage for the message contract (`world.test.tsx`, `chat.test.tsx`) and the map's JUMP IN. Runtime confirmation of the realm-arrival wait still wants a pass with the engine plus a rebuilt bridge scene, entering from a World.

## Anything Else

Backlog item 44, engine-side: the loading screen closes before the destination scene has actually loaded (empty parcel for a few seconds, pending-asset counter never appears). The asset gate is tick-bounded rather than completion-bounded — `gltf_container.rs` only blocks while `tick_number <= 5`, then forces `GltfLoadingCount` to 0. Needs a WASM rebuild, so it's not part of this stack; one to discuss with @robtfm.
