### PR TITLE
build: inline the wasm glue into the sandbox worker bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,30 @@ jobs:
           rm -f ./deploy/web/engine/pkg/.gitignore
           WASM_SIZE=$(wc -c < ./deploy/web/engine/pkg/webgpu_build_bg.wasm)
           echo "{\"wasmSize\":${WASM_SIZE}}" > ./deploy/web/engine/pkg/manifest.json
+          # Inline the glue into the sandbox worker: scene code shares that worker's realm and
+          # can re-import any module in it by URL, which for pkg/webgpu_build.js hands back our
+          # INITIALISED instance and with it the shared engine heap. Inlining turns the glue's
+          # exports into module-scope bindings of the bundle. Re-runs on every wasm build,
+          # since it embeds a copy of the generated glue.
+          npx --yes esbuild@0.28.1 ./deploy/web/engine/sandbox_worker.js \
+            --bundle --format=esm --log-level=error \
+            --metafile="${RUNNER_TEMP:-/tmp}/sandbox_worker.meta.json" \
+            --outfile=./deploy/web/engine/pkg/sandbox_worker.bundle.js
+          # A scene can still import the bundle's OWN url, and a namespace object hands out
+          # exactly the module's exports — so the entire guarantee reduces to "this entry
+          # exports nothing". Enforce that instead of trusting a comment to hold: an `export`
+          # added to sandbox_worker.js (worst case a re-export of the glue) would silently
+          # undo the fix. esbuild's metafile is authoritative, so nothing has to be executed.
+          node -e '
+            const meta = require(process.argv[1]);
+            const [out] = Object.values(meta.outputs).filter((o) => o.entryPoint);
+            if (!out) { console.error("no entry output found in esbuild metafile"); process.exit(1); }
+            if (out.exports.length) {
+              console.error("sandbox_worker bundle must export nothing, or scene code can import it and reach the live wasm instance. Found: " + out.exports.join(", "));
+              process.exit(1);
+            }
+            console.log("sandbox worker bundle exports nothing - ok");
+          ' "${RUNNER_TEMP:-/tmp}/sandbox_worker.meta.json"
       - name: Install
         run: npm i
         working-directory: deploy/web

--- a/deploy/web/engine/engine.js
+++ b/deploy/web/engine/engine.js
@@ -159,7 +159,16 @@ export async function initEngine() {
   window.spawn_and_init_sandbox = async () => {
     var timeoutId;
     return new Promise((resolve, _reject) => {
-      const sandboxWorkerPath = new URL("./sandbox_worker.js", import.meta.url);
+      // The BUNDLE, not sandbox_worker.js. Scene code shares this worker's realm, and any
+      // module in that realm can be re-imported by URL — which for "./pkg/webgpu_build.js"
+      // hands back OUR initialised instance (wasm-bindgen's init returns the cached exports),
+      // shared engine heap and all. Inlining makes the glue's exports ordinary module-scope
+      // bindings of the bundle instead. A scene can still import the bundle's URL, but a
+      // namespace object exposes only that module's *exports*, and this entry has none — so
+      // it gets an empty object. Keep sandbox_worker.js export-free or that stops being true.
+      // Built alongside the wasm (see react-web/README.md); lives in pkg/ so the glue's
+      // relative paths still resolve. sandbox_worker.js is unchanged, just no longer the entry.
+      const sandboxWorkerPath = new URL("./pkg/sandbox_worker.bundle.js", import.meta.url);
       var sandboxWorker = new Worker(sandboxWorkerPath, { type: "module" });
       sandboxWorker.onerror = workerCrashHandler("sandbox");
 

--- a/justfile
+++ b/justfile
@@ -7,6 +7,9 @@ wasm:
     wasm-pack build --target web --out-dir ./deploy/web/engine/pkg --no-default-features --features="livekit,social"
     rm -f ./deploy/web/engine/pkg/.gitignore
     WASM_SIZE=$(wc -c < ./deploy/web/engine/pkg/webgpu_build_bg.wasm) && echo "{\"wasmSize\":${WASM_SIZE}}" > ./deploy/web/engine/pkg/manifest.json
+    # inline the glue into the sandbox worker — the engine loads pkg/sandbox_worker.bundle.js,
+    # so this must re-run on every wasm build (it embeds a copy of the generated glue).
+    npx --yes esbuild@0.28.1 ./deploy/web/engine/sandbox_worker.js --bundle --format=esm --log-level=error --outfile=./deploy/web/engine/pkg/sandbox_worker.bundle.js
     cd react-web && npm install
     cd react-web/bridge-scene && npm install
     cd react-web && npm run dev -- --open

--- a/react-web/README.md
+++ b/react-web/README.md
@@ -87,10 +87,20 @@ explorer URL (e.g. `decentraland.zone/bevy-web`, assets on the versioned CDN pat
 - The **engine module + bridge scene + service worker must stay same-origin** with the page
   (BroadcastChannel / `contentWindow`): they resolve against `PAGE_DIR`
   (`src/lib/publicUrl.ts`), *never* against the CDN base.
+- The sandbox worker is loaded as **`pkg/sandbox_worker.bundle.js`**, with the wasm glue
+  inlined. Scene code shares that worker's realm, and any module in a realm can be re-imported
+  by URL — so a scene importing `./pkg/webgpu_build.js` would otherwise be handed the
+  *initialised* instance (wasm-bindgen's `init` returns the cached exports) and with it the
+  shared engine heap. Inlining turns the glue's exports into module-scope bindings of the
+  bundle: a scene can still import the bundle's own URL, but a namespace exposes only a
+  module's **exports** and this entry has none, so it gets an empty object. **Keep
+  `sandbox_worker.js` export-free** — anything it exports becomes reachable. The bundle embeds
+  a copy of the generated glue, so it must be rebuilt whenever the wasm is.
 
 ```bash
 # CI does, in order (see .github/workflows/ci.yml build-deploy-web):
 wasm-pack build --out-dir deploy/web/engine/pkg …   # engine wasm
+npx esbuild engine/sandbox_worker.js --bundle …     # inlines the glue — see note below
 npm i                 # in deploy/web — prebuild.js stamps PUBLIC_URL/homepage
 PUBLIC_URL=<homepage> npm run build                 # in react-web — the HUD → deploy/web
 npm run bundle        # in react-web/bridge-scene — realm → deploy/web/bridge-scene/static


### PR DESCRIPTION
Scene code is evaluated in the sandbox worker's realm, and any module in a realm can be re-imported by URL — `new Function` does not create a realm, so scene code shares the worker's module map. wasm-bindgen's `init` returns its cached exports once initialised (`if (wasm !== undefined) return wasm`), so re-importing `pkg/webgpu_build.js` from that realm hands back the engine's **live** instance rather than a fresh one, along with everything reachable through it.

Build the worker with the glue inlined and load that bundle instead. The glue's exports become module-scope bindings of the bundle; the standalone `pkg/webgpu_build.js` stays on disk as a separate module record that nobody has initialised, so importing it yields an inert instance with its own memory.

The bundle has a URL of its own and can still be imported — but a namespace object exposes exactly a module's *exports*, and `sandbox_worker.js` exports nothing, so that import yields an empty object. The whole guarantee reduces to that one property, so CI asserts it: esbuild's metafile reports the output's export list, and the build fails if it is ever non-empty. An `export` added to `sandbox_worker.js` — worst case a re-export of the glue — would otherwise quietly undo this, and the bundle can't be imported in Node to check at runtime (its top level touches `self`/`postMessage`).

`sandbox_worker.js` itself is unchanged; it is simply no longer the entry point.

### Notes for review

- The bundle lands in `pkg/` deliberately: the glue's `new URL("webgpu_build_bg.wasm", import.meta.url)` fallback then still resolves correctly. At the `engine/` root it would point at a nonexistent path — harmless while `module_or_path` is always passed, but a trap.
- The step is in all three places that build the wasm: `justfile`, CI, and the documented order in `react-web/README.md`. It must re-run on every wasm build, since it embeds a copy of the generated glue.
- `esbuild@0.28.1` is pinned in two places. A `deploy/web` devDependency would centralise it, but `npm i` there currently runs after the wasm build, so the ordering would need a nudge. Happy to do that instead.
- Not closed by this: a scene can still import `pkg/webgpu_build.js` and instantiate its *own* engine, which is inert but costs ~80MB a go. Closing that means bundling `engine.js` the same way and not serving the standalone glue at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)