### PR TITLE
fix: point test_async_tls at a live endpoint

### DIFF
--- a/crates/comms/src/test.rs
+++ b/crates/comms/src/test.rs
@@ -79,11 +79,8 @@ fn test_livekit() {
 #[test]
 fn test_async_tls() {
     futures_lite::future::block_on(async move {
-        let remote_address = "wss://sdk-test-scenes.decentraland.zone/mini-comms/room-1";
-        let mut request = remote_address.into_client_request()?;
-        request
-            .headers_mut()
-            .append("Sec-WebSocket-Protocol", HeaderValue::from_static("rfc5"));
+        let remote_address = "wss://echo.websocket.org/";
+        let request = remote_address.into_client_request()?;
         platform::websocket(request).await
     })
     .unwrap();


### PR DESCRIPTION
`sdk-test-scenes.decentraland.zone` no longer resolves (NXDOMAIN), so `test_async_tls` fails in CI. The test exists to catch SSL build/wiring issues, so any live `wss://` endpoint through `platform::websocket` serves the purpose — switched to `echo.websocket.org`, which is maintained specifically as a websocket test endpoint. Verified the handshake completes and the test passes.

The `Sec-WebSocket-Protocol: rfc5` header was mini-comms-specific and meaningless against an echo server, so it's dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)