### PR TITLE
image_processing: skip non-texture labeled image subassets

### DIFF
--- a/crates/image_processing/src/engine.rs
+++ b/crates/image_processing/src/engine.rs
@@ -83,6 +83,7 @@ struct ImgReprocessStats {
     alive: bool,
     total: usize,
     skip_imposter: usize,
+    skip_label: usize,
     skip_unloaded: usize,
     skip_tiny: usize,
     skip_unknown: usize,
@@ -152,13 +153,21 @@ fn check_assets(
                 continue;
             }
 
-            let (ty, asset_path) = if asset_path.to_string().contains("#Texture") {
-                (
+            let (ty, asset_path) = match asset_path.label() {
+                None => (ProcessingAssetType::Image, asset_path.clone_owned()),
+                Some(label) if label.starts_with("Texture") => (
                     ProcessingAssetType::Gltf,
                     asset_path.without_label().clone_owned(),
-                )
-            } else {
-                (ProcessingAssetType::Image, asset_path.clone_owned())
+                ),
+                // labeled image subassets that aren't gltf textures (e.g.
+                // `Mesh{}/Primitive{}/MorphTargets`) are raw data, not compressible
+                // pictures. processing one would fail against the source file's bytes,
+                // and its entry in `paths_processed` would block texture compression
+                // for the whole source file
+                Some(_) => {
+                    stats.skip_label += 1;
+                    continue;
+                }
             };
             let Ok(Some(ipfs_path)) = IpfsPath::new_from_path(asset_path.path()) else {
                 // skip ... ?

--- a/crates/image_processing/src/processor/mod.rs
+++ b/crates/image_processing/src/processor/mod.rs
@@ -35,7 +35,7 @@ pub(crate) async fn process_events(
             ProcessingAssetType::Gltf => match process_gltf(&raw_bytes) {
                 Ok(gltf) => gltf,
                 Err(e) => {
-                    error!("failed to process image {:?}: {:?}", req.base_path, e);
+                    error!("failed to process gltf {:?}: {:?}", req.base_path, e);
                     let _ = resp_sx.send(Err(()));
                     continue;
                 }
@@ -43,7 +43,7 @@ pub(crate) async fn process_events(
             ProcessingAssetType::Image => match process_image(&raw_bytes) {
                 Ok(dds) => dds,
                 Err(e) => {
-                    error!("failed to process gltf {:?}: {:?}", req.base_path, e);
+                    error!("failed to process image {:?}: {:?}", req.base_path, e);
                     let _ = resp_sx.send(Err(()));
                     continue;
                 }


### PR DESCRIPTION
Gltf morph-target images (bevy label `Mesh{}/Primitive{}/MorphTargets`) fell into the standalone-image branch of `check_assets`, which resolved the labeled path to the source glb and tried to decode the glb's bytes as an image — always failing (`failed to process gltf ...#Mesh0/Primitive0/MorphTargets: CantLoad` in the logs, visible on genesis plaza's clocktower cuckoo models). Worse, the doomed request claimed the glb's slot in `paths_processed`, so when a morph event was picked up before the glb's `#TextureN` events, texture compression for that glb was blocked entirely — and since morph images never become compressed, the same failure repeated every session.

`check_assets` now classifies by the asset path's label: unlabeled paths are standalone images, `Texture*` labels take the gltf transcode route (equivalent to the previous `#Texture` substring test, since `#` only occurs at the label boundary), and any other label is skipped — with a new `skip_label` stat — before touching `paths_processed`, so the glb's real texture events still drive compression. Skipping (rather than routing non-texture labels to the gltf branch by file extension) also avoids re-triggering a glb reprocess every session from the perpetually-uncompressed morph image.

Also un-swaps the gltf/image error messages in the processor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)