### PR TITLE
fix: remove same-origin storage APIs from the scene sandbox worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,6 @@ dependencies = [
  "common",
  "dcl",
  "dcl_component",
- "futures-lite",
  "ipfs",
  "js-sys",
  "log",
@@ -3538,7 +3537,7 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-fs",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,20 @@ web-sys = { version = "0.3", features = [
   "ResponseInit",
   "Headers",
   "Url",
+  # OPFS, for the scene-storage directory dcl_wasm holds open (crates/dcl_wasm/.../local_storage.rs).
+  # Enabled here rather than relied on via web-fs's own web-sys features: dcl_wasm no longer depends
+  # on web-fs, so that unification is not ours to count on.
+  "Blob",
+  "File",
+  "FileSystemDirectoryHandle",
+  "FileSystemFileHandle",
+  "FileSystemGetDirectoryOptions",
+  "FileSystemGetFileOptions",
+  "FileSystemWritableFileStream",
+  "StorageManager",
+  "WorkerGlobalScope",
+  "WorkerNavigator",
+  "WritableStream",
 ] }
 web-time = "1.1"
 copypwasmta = { git = "https://github.com/robtfm/copypwasmta" }

--- a/crates/dcl_wasm/Cargo.toml
+++ b/crates/dcl_wasm/Cargo.toml
@@ -18,15 +18,14 @@ system_bridge = { workspace = true }
 bevy = { workspace = true }
 tokio = { workspace = true }
 once_cell = { workspace = true }
-futures-lite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 anyhow = { workspace = true }
-web-fs = { workspace = true }
 
 serde-wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }
+web-sys = { workspace = true }
 
 log = "0.4"

--- a/crates/dcl_wasm/src/inner/local_storage.rs
+++ b/crates/dcl_wasm/src/inner/local_storage.rs
@@ -4,10 +4,14 @@ use bevy::{
     platform::collections::HashMap,
 };
 use dcl::{interface::crdt_context::CrdtContext, js::player_identity};
-use futures_lite::io::{AsyncReadExt, AsyncWriteExt};
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::spawn_local;
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+use web_sys::{
+    FileSystemDirectoryHandle, FileSystemFileHandle, FileSystemGetDirectoryOptions,
+    FileSystemGetFileOptions, FileSystemWritableFileStream, WorkerGlobalScope,
+};
 
 // wrap localStorage to include player address in all operations
 // TODO: init / store
@@ -15,22 +19,98 @@ use wasm_bindgen_futures::spawn_local;
 #[derive(Default, Serialize, Deserialize, Clone)]
 struct LocalStorage(HashMap<String, String>);
 
+const STORAGE_DIR: &str = "local_storage";
+
+// The scene's storage directory, held open for the life of the worker.
+//
+// Deliberately NOT `web_fs`: that resolves navigator.storage.getDirectory() — the OPFS *root*, which
+// also holds config.json and the ipfs cache — on every single open, so it would need OPFS reachable
+// from the scene's realm the whole time the scene runs. sandbox_worker.js scrubs the API off the
+// worker global instead, and this handle keeps working afterwards because it is a live object rather
+// than a fresh lookup. It also can't be walked upwards (`..` is rejected), so it grants the subtree
+// and nothing else.
+thread_local! {
+    static DIR: RefCell<Option<FileSystemDirectoryHandle>> = const { RefCell::new(None) };
+}
+
+async fn open_dir() -> Result<FileSystemDirectoryHandle, JsValue> {
+    let global = js_sys::global().unchecked_into::<WorkerGlobalScope>();
+    let root: FileSystemDirectoryHandle =
+        JsFuture::from(global.navigator().storage().get_directory())
+            .await?
+            .unchecked_into();
+
+    let options = FileSystemGetDirectoryOptions::new();
+    options.set_create(true);
+    Ok(
+        JsFuture::from(root.get_directory_handle_with_options(STORAGE_DIR, &options))
+            .await?
+            .unchecked_into(),
+    )
+}
+
+async fn read(scene_urn: &str) -> Result<Option<String>, JsValue> {
+    let Some(dir) = DIR.with(|dir| dir.borrow().clone()) else {
+        return Ok(None);
+    };
+    // A scene that has never stored anything has no file; that isn't an error.
+    let Ok(handle) = JsFuture::from(dir.get_file_handle(scene_urn)).await else {
+        return Ok(None);
+    };
+    let file = JsFuture::from(handle.unchecked_into::<FileSystemFileHandle>().get_file()).await?;
+    let text = JsFuture::from(file.unchecked_into::<web_sys::File>().text()).await?;
+    Ok(text.as_string())
+}
+
+async fn store(scene_urn: &str, data: &str) -> Result<(), JsValue> {
+    let Some(dir) = DIR.with(|dir| dir.borrow().clone()) else {
+        return Err(JsValue::from_str("scene storage unavailable"));
+    };
+    let options = FileSystemGetFileOptions::new();
+    options.set_create(true);
+    let handle: FileSystemFileHandle =
+        JsFuture::from(dir.get_file_handle_with_options(scene_urn, &options))
+            .await?
+            .unchecked_into();
+
+    let writable: FileSystemWritableFileStream = JsFuture::from(handle.create_writable())
+        .await?
+        .unchecked_into();
+    JsFuture::from(writable.write_with_str(data)?).await?;
+    JsFuture::from(writable.close()).await?;
+    Ok(())
+}
+
 pub async fn init(state: &WorkerContext) {
     let scene_urn = state.state.borrow().borrow::<CrdtContext>().hash.clone();
 
-    if let Ok(mut existing) = web_fs::File::open(format!("local_storage/{scene_urn}")).await {
-        let mut buf = String::default();
-        if let Err(e) = existing.read_to_string(&mut buf).await {
+    // Unconditional, and ahead of the read: this is what captures the handle, and it has to happen
+    // while navigator.storage is still there. wasm_init_scene (our caller) returns before
+    // sandbox_worker.js builds the js context and scrubs, so this is the last chance to take it —
+    // including for a scene with nothing stored yet, which still needs the handle to write later.
+    match open_dir().await {
+        Ok(dir) => DIR.with(|slot| *slot.borrow_mut() = Some(dir)),
+        Err(e) => {
+            warn!("failed to open scene storage: {e:?}");
+            return;
+        }
+    }
+
+    let buf = match read(&scene_urn).await {
+        Ok(Some(buf)) => buf,
+        Ok(None) => return,
+        Err(e) => {
             warn!("failed to read storage: {e:?}");
             return;
         }
-        let Ok(storage) = serde_json::from_str::<LocalStorage>(&buf) else {
-            warn!("failed to deserialize storage");
-            return;
-        };
+    };
 
-        state.state.borrow_mut().put(storage);
-    }
+    let Ok(storage) = serde_json::from_str::<LocalStorage>(&buf) else {
+        warn!("failed to deserialize storage");
+        return;
+    };
+
+    state.state.borrow_mut().put(storage);
 }
 
 fn write(state: &WorkerContext) {
@@ -43,13 +123,9 @@ fn write(state: &WorkerContext) {
             return;
         };
 
-        let _ = web_fs::create_dir_all("local_storage").await;
-        let Ok(mut file) = web_fs::File::create(format!("local_storage/{scene_urn}")).await else {
-            warn!("failed to write storage");
-            return;
-        };
-
-        let _ = file.write_all(data.as_bytes()).await;
+        if let Err(e) = store(&scene_urn, &data).await {
+            warn!("failed to write storage: {e:?}");
+        }
     })
 }
 

--- a/deploy/web/engine/sandbox_worker.js
+++ b/deploy/web/engine/sandbox_worker.js
@@ -117,6 +117,14 @@ function createJsContext(wasmApi, context) {
   deleteFromPrototypeChain(self.navigator, "storage");
   deleteFromPrototypeChain(self.navigator, "storageBuckets");
 
+  // IndexedDB is same-origin too, and holds more than its own data: platform/src/web_save.js keeps
+  // the FileSystemDirectoryHandle for the user's picked scene folder there (db `dcl-editor`, store
+  // `handles`), with readwrite permission already granted. A handle read back out of IndexedDB is
+  // as live as the one that was stored, so a scene reaching it would get the user's real
+  // filesystem, not origin-private storage. Nothing in this worker uses IndexedDB — web_save.js and
+  // gpu_cache.js both run on the main thread.
+  deleteFromPrototypeChain(self, "indexedDB");
+
   // BroadcastChannel is a same-origin, serverless side channel — handed ONLY to the trusted
   // super-user (--ui) scene, so an embedded host page can drive it; ordinary scenes never see it
   // (it would otherwise let an untrusted scene coordinate with the page / other scenes off-network).

--- a/deploy/web/engine/sandbox_worker.js
+++ b/deploy/web/engine/sandbox_worker.js
@@ -70,6 +70,16 @@ const allowListES2020 = [
   "WeakSet",
 ];
 
+// Remove an inherited property. Interface objects (BroadcastChannel, Worker) are own properties of
+// the global and go with a plain delete; attributes like navigator.storage live on a prototype, and
+// deleting them off the instance silently succeeds without removing anything.
+function deleteFromPrototypeChain(obj, name) {
+  for (let o = obj; o != null; o = Object.getPrototypeOf(o)) {
+    if (Object.prototype.hasOwnProperty.call(o, name)) return delete o[name];
+  }
+  return false;
+}
+
 const jsContext = Object.create(null);
 var jsProxy = undefined;
 var jsPreamble = undefined;
@@ -89,6 +99,23 @@ function createJsContext(wasmApi, context) {
   delete self.BroadcastChannel;
   delete self.Worker;
   delete self.SharedWorker;
+
+  // OPFS is the origin's storage: config.json, the ipfs cache and every scene's localStorage all
+  // hang off the one root that navigator.storage.getDirectory() hands out. The scene's own storage
+  // no longer goes through it from here — crates/dcl_wasm/src/inner/local_storage.rs took a handle
+  // to just the local_storage/ subtree during wasm_init_scene, above, and that handle stays live
+  // once the accessor is gone.
+  //
+  // `delete navigator.storage` would return true and do nothing: WorkerNavigator exposes it on its
+  // prototype, so the own-property delete succeeds against a property that was never there. Walk to
+  // the prototype that actually holds it. (Same reason `delete self.navigator` is a no-op.)
+  //
+  // storageBuckets is the second door to the same API — navigator.storageBuckets.open(name) hands
+  // back a bucket with its own getDirectory(). A named bucket can't reach the default bucket's
+  // contents, so it isn't a route to engine state, but it is unmetered scene-controlled storage and
+  // two scenes agreeing on a bucket name would have a shared filesystem.
+  deleteFromPrototypeChain(self.navigator, "storage");
+  deleteFromPrototypeChain(self.navigator, "storageBuckets");
 
   // BroadcastChannel is a same-origin, serverless side channel — handed ONLY to the trusted
   // super-user (--ui) scene, so an embedded host page can drive it; ordinary scenes never see it

--- a/deploy/web/engine/sandbox_worker.js
+++ b/deploy/web/engine/sandbox_worker.js
@@ -125,6 +125,13 @@ function createJsContext(wasmApi, context) {
   // gpu_cache.js both run on the main thread.
   deleteFromPrototypeChain(self, "indexedDB");
 
+  // CacheStorage is the last same-origin store the sandbox could see — it holds the ipfs fetch
+  // cache (`ipfs-path-cache-v1`), so a scene could read every asset the client has pulled and, more
+  // to the point, write to keys the loader later serves. Its users are elsewhere:
+  // image_processing/src/processor/wasm_fs.rs runs under asset_processor.js, which engine.js spawns
+  // as its own worker, and service_worker.js is a different context entirely.
+  deleteFromPrototypeChain(self, "caches");
+
   // BroadcastChannel is a same-origin, serverless side channel — handed ONLY to the trusted
   // super-user (--ui) scene, so an embedded host page can drive it; ordinary scenes never see it
   // (it would otherwise let an untrusted scene coordinate with the page / other scenes off-network).


### PR DESCRIPTION
Scene workers could reach every same-origin storage API in the realm: OPFS, IndexedDB and CacheStorage. Each holds engine or user data belonging to something other than the calling scene.

## OPFS

`navigator.storage.getDirectory()` returns the OPFS *root* — which holds `config.json`, the ipfs cache, and every scene's stored data, not only the calling scene's. `navigator.storageBuckets` reaches the same API by another door and goes too: a named bucket can't see the default bucket's contents, but it is unmetered scene-controlled storage, and two scenes agreeing on a bucket name would share a filesystem.

### Keeping scene localStorage working

`localStorage` is the only filesystem user inside a scene's worker, and it went through `web-fs`. That crate calls `navigator.storage.getDirectory()` on *every* open rather than caching it, so it would have needed the API reachable for as long as the scene runs — reads happen during init, but writes happen at scene runtime, after the scrub.

It now resolves a handle to the `local_storage/` subtree once, in `wasm_init_scene`, which returns before `createJsContext` builds the js context and scrubs. The handle keeps working after that because it is a live object, not a fresh lookup, and directory handles can't be walked upwards (`..` is rejected), so it confines the worker to that subtree rather than handing back the root.

The `web-sys` features this needs are declared in `[workspace.dependencies]` rather than inherited from `web-fs`'s own feature set, since `dcl_wasm` no longer depends on `web-fs` and that unification isn't ours to rely on.

### Side effect: a latent panic

Dropping `web-fs` from `dcl_wasm` also drops its dedicated worker. `Fs::new()` calls `new Worker`, which cf934adb removed from this global, and the FS is constructed lazily on the first *successful* open — so a scene with nothing stored yet would fall through init without one and panic on its first `setItem`. That path no longer exists.

## IndexedDB

`platform/src/web_save.js` stores the `FileSystemDirectoryHandle` for the user's picked scene folder in IndexedDB (db `dcl-editor`, store `handles`) with readwrite permission already granted. A handle read back out is as live as the one that went in, so a scene reaching it would have had the user's *real* filesystem rather than origin-private storage.

Its users are elsewhere: `web_save.js` is driven from `scene_inspector`'s asset commands and `gpu_cache.js` from `engine.js`, both on the main thread.

## CacheStorage

Holds the ipfs fetch cache (`ipfs-path-cache-v1`) — so a scene could read every asset the client has pulled, and write to keys the loader later serves, which is the worse half.

Its users are in other contexts too: `image_processing/src/processor/wasm_fs.rs` runs under `asset_processor.js`, which `engine.js` spawns as its own worker, and `service_worker.js` is a separate context a worker-global scrub can't affect.

## A shared footgun

Every property removed here is an accessor on `WorkerNavigator.prototype` / `WorkerGlobalScope.prototype`, not an own property of `navigator` / the global. `delete self.indexedDB` and friends therefore return `true` and remove nothing — they delete an own property that was never there, leaving the inherited one in place. The deletes walk the prototype chain to whichever object actually holds the property. (Interface objects like `BroadcastChannel` and `Worker` *are* own properties of the global, which is why the existing deletes above work as written.)

## Verification

Confirmed in headless chromium that, after the scrub:

- a directory handle taken beforehand still reads and writes, and rejects `..`
- `navigator.storage`, `navigator.storageBuckets`, `new StorageManager()` and a nested `Worker` are unreachable
- an IndexedDB record and a `ipfs-path-cache-v1` entry, both seeded *before* the scrub, cannot be reached afterwards; `indexedDB` and `caches` are `ReferenceError`s and neither `IDBFactory` nor `CacheStorage` is constructible

`cargo fmt`, `cargo clippy --all -- -D warnings` and the wasm build are clean, and the sandbox worker bundle still exports nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)