### PR TITLE
fix: warn before a link picks its own super-user scene

### DIFF
--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -39,6 +39,8 @@ import { bootMode } from './lib/bootMode'
 import { isMobile, isChromiumBased, hasBypassCookie } from './lib/isMobile'
 import { hasUsableGpu } from './lib/gpu'
 import { MobileGate, GateChecking } from './features/gate/MobileGate'
+import { UntrustedLaunchGate } from './features/gate/UntrustedLaunchGate'
+import { isTrustedSystemScene } from './lib/systemScene'
 import { ErrorBoundary } from './features/error/ErrorBoundary'
 import { EngineErrorModal } from './features/error/EngineErrorModal'
 
@@ -76,6 +78,14 @@ function gateReason(): 'mobile' | 'browser' | 'gpu' | null {
 }
 const GATE_REASON = gateReason()
 
+// `?systemScene=` picks the super-user scene, which permissions.rs waves through every permission
+// check and hands the whole SystemApi. A link carrying an unrecognised one is a session takeover
+// with no sandbox escape involved, so it gets an interstitial before anything boots — captured at
+// module scope, from the ENTRY url, so a later history.replaceState can't retire the warning.
+const SYSTEM_SCENE_OVERRIDE = bootMode().systemScene
+const UNTRUSTED_SYSTEM_SCENE =
+  SYSTEM_SCENE_OVERRIDE != null && !isTrustedSystemScene(SYSTEM_SCENE_OVERRIDE) ? SYSTEM_SCENE_OVERRIDE : null
+
 export function App(): React.JSX.Element {
   useHudScale() // keep --ui-scale in sync with the viewport (DPI-correct, like Unity)
   const showFps = useFpsToggle()
@@ -84,6 +94,12 @@ export function App(): React.JSX.Element {
   // bevy/wgpu, not WebGPU in this webview, so probing there would gate a HUD that runs fine.
   // 'checking' shows a brief spinner.
   const gpu = useGpuProbe(GATE_REASON != null || MODE === 'mock' || MODE === 'native' || SHOWCASE)
+  // Ahead of every other gate: returning here is what keeps EngineHost unmounted, and EngineHost is
+  // what injects boot.js and starts the scene.
+  const [trustUntrusted, setTrustUntrusted] = useState(false)
+  if (UNTRUSTED_SYSTEM_SCENE != null && !trustUntrusted) {
+    return <UntrustedLaunchGate systemScene={UNTRUSTED_SYSTEM_SCENE} onProceed={() => setTrustUntrusted(true)} />
+  }
   if (GATE_REASON) return <MobileGate reason={GATE_REASON} />
   if (gpu === 'checking') return <GateChecking />
   if (gpu === 'blocked') return <MobileGate reason="gpu" />

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -8,26 +8,13 @@ import { useEffect } from 'react'
 import type { EngineRpc } from '../../engine/engineRpc'
 import { bootMode } from '../../lib/bootMode'
 import { PAGE_DIR } from '../../lib/publicUrl'
+// Moved to lib/systemScene.ts, which also decides whether a link is allowed to override it.
+import { SYSTEM_SCENE } from '../../lib/systemScene'
 
 // The main (Genesis City) realm. Exported: parcel launches pass it EXPLICITLY so a ?realm
 // override — possibly an invalid world — never leaks into a Places pick (always a Genesis
 // coordinate).
 export const DEFAULT_REALM = 'https://realm-provider-ea.decentraland.org/main'
-
-// Our super-user bridge scene. It relays the scene-loading stream + player-ready over
-// BroadcastChannel and renders no UI.
-//   • PROD (built app): the EXPORTED static bundle shipped in this package, loaded from the
-//     VERSIONED CDN base (BASE_URL) — NOT the page origin: the zone site mirror drops the
-//     realm's extensionless files (`about`, bafk… content hashes) and 404s them, while the CDN
-//     serves the full package. The engine only ever FETCHES the realm (CORS, ACAO:* on the CDN),
-//     so it doesn't need to be same-origin — and version-pinning it avoids mirror skew anyway.
-//   • DEV default: the LIVE preview realm from `sdk-commands start` on :8100 (started by the vite
-//     plugin) — fast iteration, the scene hot-reloads. (BASE_URL is '/' in dev, so ?bundled=1
-//     still resolves to this origin's /bridge-scene/static.)
-const SYSTEM_SCENE =
-  import.meta.env.PROD || new URLSearchParams(location.search).has('bundled')
-    ? new URL('bridge-scene/static/BevyExplorerUI', new URL(import.meta.env.BASE_URL, PAGE_DIR)).href
-    : 'http://localhost:8100'
 
 // Engine media libs the wasm expects as globals (LivekitClient, Hls) — loaded from CDNs like the
 // old boot page did.

--- a/react-web/src/features/gate/UntrustedLaunchGate.module.css
+++ b/react-web/src/features/gate/UntrustedLaunchGate.module.css
@@ -1,0 +1,131 @@
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal, 1000);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  overflow-y: auto;
+  /* Darker than --menu-bg: this is a stop sign, not a menu. */
+  background: radial-gradient(circle at 50% 30%, #3b1063 0%, #240a3d 55%, #14051f 100%);
+  font-family: var(--font-family);
+  color: var(--text);
+}
+.card {
+  width: 100%;
+  max-width: 560px;
+  margin: auto;
+  padding: 40px 44px 36px;
+  border-radius: var(--r-panel);
+  background: var(--modal-bg);
+  box-shadow: var(--shadow-modal);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.logo {
+  width: 72px;
+  height: 72px;
+  margin-bottom: 18px;
+}
+.title {
+  margin: 0 0 28px;
+  /* Not --fs-display: that tops out at 3.25rem, which is a full-page headline, not a card title. */
+  font-size: clamp(1.5rem, 3.2vh, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  text-align: center;
+  color: var(--error);
+}
+.lead {
+  width: 100%;
+  margin: 0 0 18px;
+  font-size: var(--fs-lg);
+  line-height: 1.45;
+  color: var(--ink-95);
+}
+
+.params {
+  width: 100%;
+  margin: 0 0 18px;
+}
+.paramName {
+  font-size: var(--fs-lg);
+  line-height: 1.45;
+  color: var(--ink-95);
+}
+/* The attacker controls this string: break it anywhere so a long one can't push the card wide or
+   run under the card's edge, and keep it visually distinct from our own copy. */
+.paramValue {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--error-text);
+  overflow-wrap: anywhere;
+}
+.paramDesc {
+  margin: 2px 0 0;
+  padding-left: 18px;
+  font-size: var(--fs-md);
+  line-height: 1.45;
+  color: var(--ink-7);
+}
+
+.buttons {
+  width: 100%;
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+/* 2-class selectors so these beat Button's own variant/size rules regardless of import order. */
+.buttons .exit,
+.buttons .more,
+.buttons .proceed {
+  width: 100%;
+  min-height: 52px;
+}
+.buttons .exit {
+  background: var(--error);
+  color: var(--text);
+}
+.buttons .exit:hover {
+  background: #ff4444;
+}
+/* The exit button is autofocused, so its ring is on screen from the first paint — the UA default is
+   a blue that fights the palette. */
+.buttons .exit:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 3px;
+}
+.buttons .more {
+  background: var(--fill-2);
+  color: var(--ink-85);
+}
+.buttons .more:hover {
+  background: var(--fill-4);
+}
+
+.advanced {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-card);
+  background: var(--fill-1);
+}
+.advancedNote {
+  margin: 0;
+  font-size: var(--fs-md);
+  line-height: 1.45;
+  color: var(--ink-7);
+}
+/* Understated on purpose — the risky path shouldn't look like the recommended one. */
+.buttons .proceed {
+  min-height: 44px;
+  border: 1px solid var(--error);
+  color: var(--error-text);
+}
+.buttons .proceed:hover {
+  background: rgba(255, 36, 36, 0.12);
+}

--- a/react-web/src/features/gate/UntrustedLaunchGate.module.css
+++ b/react-web/src/features/gate/UntrustedLaunchGate.module.css
@@ -1,64 +1,44 @@
-.root {
-  position: fixed;
-  inset: 0;
-  z-index: var(--z-modal, 1000);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-  overflow-y: auto;
-  /* Darker than --menu-bg: this is a stop sign, not a menu. */
+/* The popup reuses Modal/ModalShell (backdrop + card + focus-trap + Escape), like EngineErrorModal.
+   Only the parts specific to a security stop-sign live here. */
+
+/* The app isn't rendered behind this gate, so the shell's translucent scrim would sit over a blank
+   page. Paint it opaque — and darker than --menu-bg, because this is a stop sign, not a menu. */
+.layer {
   background: radial-gradient(circle at 50% 30%, #3b1063 0%, #240a3d 55%, #14051f 100%);
-  font-family: var(--font-family);
-  color: var(--text);
+  backdrop-filter: none;
 }
-.card {
-  width: 100%;
-  max-width: 560px;
-  margin: auto;
-  padding: 40px 44px 36px;
-  border-radius: var(--r-panel);
-  background: var(--modal-bg);
-  box-shadow: var(--shadow-modal);
+
+/* Alert-style centered header — logo + title-scale type, not the shell's compact panel heading. */
+.head {
   display: flex;
   flex-direction: column;
   align-items: center;
-}
-.logo {
-  width: 72px;
-  height: 72px;
-  margin-bottom: 18px;
+  padding: 12px 12px 0;
+  text-align: center;
 }
 .title {
-  margin: 0 0 28px;
-  /* Not --fs-display: that tops out at 3.25rem, which is a full-page headline, not a card title. */
-  font-size: clamp(1.5rem, 3.2vh, 2rem);
+  margin: 18px 0 0;
+  font-size: var(--fs-title);
   font-weight: 700;
-  letter-spacing: -0.01em;
-  text-align: center;
+  line-height: 1.2;
   color: var(--error);
 }
+
 .lead {
-  width: 100%;
   margin: 0 0 18px;
   font-size: var(--fs-lg);
-  line-height: 1.45;
   color: var(--ink-95);
 }
 
 .params {
-  width: 100%;
   margin: 0 0 18px;
-}
-.paramName {
   font-size: var(--fs-lg);
-  line-height: 1.45;
   color: var(--ink-95);
 }
-/* The attacker controls this string: break it anywhere so a long one can't push the card wide or
-   run under the card's edge, and keep it visually distinct from our own copy. */
+/* The attacker controls this string: break it anywhere so a long one can't push the card wide, and
+   keep it visually distinct from our own copy. */
 .paramValue {
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-mono);
   color: var(--error-text);
   overflow-wrap: anywhere;
 }
@@ -66,43 +46,7 @@
   margin: 2px 0 0;
   padding-left: 18px;
   font-size: var(--fs-md);
-  line-height: 1.45;
   color: var(--ink-7);
-}
-
-.buttons {
-  width: 100%;
-  margin-top: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-/* 2-class selectors so these beat Button's own variant/size rules regardless of import order. */
-.buttons .exit,
-.buttons .more,
-.buttons .proceed {
-  width: 100%;
-  min-height: 52px;
-}
-.buttons .exit {
-  background: var(--error);
-  color: var(--text);
-}
-.buttons .exit:hover {
-  background: #ff4444;
-}
-/* The exit button is autofocused, so its ring is on screen from the first paint — the UA default is
-   a blue that fights the palette. */
-.buttons .exit:focus-visible {
-  outline: 2px solid var(--text);
-  outline-offset: 3px;
-}
-.buttons .more {
-  background: var(--fill-2);
-  color: var(--ink-85);
-}
-.buttons .more:hover {
-  background: var(--fill-4);
 }
 
 .advanced {
@@ -117,15 +61,27 @@
 .advancedNote {
   margin: 0;
   font-size: var(--fs-md);
-  line-height: 1.45;
   color: var(--ink-7);
 }
+
+.exit {
+  background: var(--error);
+  color: var(--text);
+}
+.exit:hover {
+  background: #ff4444;
+}
+/* Autofocused, so its ring is on screen from the first paint — the UA default blue fights the
+   palette. */
+.exit:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 3px;
+}
 /* Understated on purpose — the risky path shouldn't look like the recommended one. */
-.buttons .proceed {
-  min-height: 44px;
+.proceed {
   border: 1px solid var(--error);
   color: var(--error-text);
 }
-.buttons .proceed:hover {
+.proceed:hover {
   background: rgba(255, 36, 36, 0.12);
 }

--- a/react-web/src/features/gate/UntrustedLaunchGate.tsx
+++ b/react-web/src/features/gate/UntrustedLaunchGate.tsx
@@ -1,0 +1,78 @@
+// Interstitial for a link that picks its own super-user scene (`?systemScene=`) — see
+// lib/systemScene.ts for why that parameter is worth stopping on.
+//
+// Deliberately not a dismissible dialog: it renders INSTEAD of the app (App.tsx returns this before
+// EngineHost mounts, so no engine boots and no scene loads while it is up), there is no scrim to
+// click away, and Escape does nothing. Continuing is behind ADVANCED because the safe choice has to
+// be the easy one — the user arrives here having already clicked something the attacker gave them.
+
+import { useState } from 'react'
+import { Button, DclLogo } from '../../design'
+import styles from './UntrustedLaunchGate.module.css'
+
+// A tab the user opened themselves can't be closed by script, so send them somewhere safe instead.
+function exitApplication(): void {
+  window.close()
+  window.location.replace('https://decentraland.org')
+}
+
+export function UntrustedLaunchGate({
+  systemScene,
+  onProceed
+}: {
+  systemScene: string
+  onProceed: () => void
+}): React.JSX.Element {
+  const [advanced, setAdvanced] = useState(false)
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.card} role="dialog" aria-modal="true" aria-labelledby="untrusted-launch-title">
+        <DclLogo size={72} className={styles.logo} />
+        <h1 id="untrusted-launch-title" className={styles.title}>
+          This Launch Link Is Not Trusted
+        </h1>
+
+        <p className={styles.lead}>Someone may be trying to change how your Explorer behaves.</p>
+        <p className={styles.lead}>
+          This link carries a parameter the Explorer does not accept from links, because it replaces
+          the interface with code that runs as you:
+        </p>
+
+        <dl className={styles.params}>
+          <dt className={styles.paramName}>
+            systemScene = <span className={styles.paramValue}>{systemScene}</span>
+          </dt>
+          <dd className={styles.paramDesc}>
+            Replaces the Explorer&apos;s interface with a scene loaded from this address. It can move
+            your avatar, change your profile, and answer permission prompts on your behalf.
+          </dd>
+        </dl>
+
+        <p className={styles.lead}>Unless you built this link yourself, the safe choice is to exit.</p>
+
+        <div className={styles.buttons}>
+          {/* autoFocus lands focus on the safe action rather than whatever the browser picks. */}
+          <Button autoFocus variant="primary" className={styles.exit} onClick={exitApplication}>
+            Exit Application
+          </Button>
+          {advanced ? (
+            <div className={styles.advanced}>
+              <p className={styles.advancedNote}>
+                Continuing hands this address full control of your session for as long as this tab is
+                open. Only do this if you recognise it as your own.
+              </p>
+              <Button variant="ghost" className={styles.proceed} onClick={onProceed}>
+                Continue anyway
+              </Button>
+            </div>
+          ) : (
+            <Button variant="secondary" className={styles.more} onClick={() => setAdvanced(true)}>
+              Advanced
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/react-web/src/features/gate/UntrustedLaunchGate.tsx
+++ b/react-web/src/features/gate/UntrustedLaunchGate.tsx
@@ -1,13 +1,16 @@
 // Interstitial for a link that picks its own super-user scene (`?systemScene=`) — see
 // lib/systemScene.ts for why that parameter is worth stopping on.
 //
-// Deliberately not a dismissible dialog: it renders INSTEAD of the app (App.tsx returns this before
-// EngineHost mounts, so no engine boots and no scene loads while it is up), there is no scrim to
-// click away, and Escape does nothing. Continuing is behind ADVANCED because the safe choice has to
-// be the easy one — the user arrives here having already clicked something the attacker gave them.
+// Not dismissible, by omission rather than by fighting the primitive: with no `onClose`, Modal's
+// Escape handler and its scrim click both call `onClose?.()` and go inert, and `closeButton={false}`
+// drops the X. It renders INSTEAD of the app (App.tsx returns it before EngineHost mounts, so no
+// engine boots and no scene loads while it is up), so there is nothing behind it to dismiss to.
+//
+// Continuing is behind ADVANCED because the safe choice has to be the easy one — the user arrives
+// here having already clicked something the attacker gave them.
 
 import { useState } from 'react'
-import { Button, DclLogo } from '../../design'
+import { Button, DclLogo, ModalShell } from '../../design'
 import styles from './UntrustedLaunchGate.module.css'
 
 // A tab the user opened themselves can't be closed by script, so send them somewhere safe instead.
@@ -15,6 +18,8 @@ function exitApplication(): void {
   window.close()
   window.location.replace('https://decentraland.org')
 }
+
+const TITLE = 'This Launch Link Is Not Trusted'
 
 export function UntrustedLaunchGate({
   systemScene,
@@ -26,32 +31,22 @@ export function UntrustedLaunchGate({
   const [advanced, setAdvanced] = useState(false)
 
   return (
-    <div className={styles.root}>
-      <div className={styles.card} role="dialog" aria-modal="true" aria-labelledby="untrusted-launch-title">
-        <DclLogo size={72} className={styles.logo} />
-        <h1 id="untrusted-launch-title" className={styles.title}>
-          This Launch Link Is Not Trusted
-        </h1>
-
-        <p className={styles.lead}>Someone may be trying to change how your Explorer behaves.</p>
-        <p className={styles.lead}>
-          This link carries a parameter the Explorer does not accept from links, because it replaces
-          the interface with code that runs as you:
-        </p>
-
-        <dl className={styles.params}>
-          <dt className={styles.paramName}>
-            systemScene = <span className={styles.paramValue}>{systemScene}</span>
-          </dt>
-          <dd className={styles.paramDesc}>
-            Replaces the Explorer&apos;s interface with a scene loaded from this address. It can move
-            your avatar, change your profile, and answer permission prompts on your behalf.
-          </dd>
-        </dl>
-
-        <p className={styles.lead}>Unless you built this link yourself, the safe choice is to exit.</p>
-
-        <div className={styles.buttons}>
+    <ModalShell
+      role="alertdialog"
+      ariaLabel={TITLE}
+      width={560}
+      dismissOnScrim={false}
+      closeButton={false}
+      backdropClassName={styles.layer}
+      header={
+        <div className={styles.head}>
+          <DclLogo size={72} />
+          <h2 className={styles.title}>{TITLE}</h2>
+        </div>
+      }
+      actionsDirection="column"
+      actions={
+        <>
           {/* autoFocus lands focus on the safe action rather than whatever the browser picks. */}
           <Button autoFocus variant="primary" className={styles.exit} onClick={exitApplication}>
             Exit Application
@@ -67,12 +62,30 @@ export function UntrustedLaunchGate({
               </Button>
             </div>
           ) : (
-            <Button variant="secondary" className={styles.more} onClick={() => setAdvanced(true)}>
+            <Button variant="secondary" onClick={() => setAdvanced(true)}>
               Advanced
             </Button>
           )}
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    >
+      <p className={styles.lead}>Someone may be trying to change how your Explorer behaves.</p>
+      <p className={styles.lead}>
+        This link carries a parameter the Explorer does not accept from links, because it replaces the
+        interface with code that runs as you:
+      </p>
+
+      <dl className={styles.params}>
+        <dt>
+          systemScene = <span className={styles.paramValue}>{systemScene}</span>
+        </dt>
+        <dd className={styles.paramDesc}>
+          Replaces the Explorer&apos;s interface with a scene loaded from this address. It can move
+          your avatar, change your profile, and answer permission prompts on your behalf.
+        </dd>
+      </dl>
+
+      <p className={styles.lead}>Unless you built this link yourself, the safe choice is to exit.</p>
+    </ModalShell>
   )
 }

--- a/react-web/src/lib/systemScene.ts
+++ b/react-web/src/lib/systemScene.ts
@@ -1,0 +1,58 @@
+// Which super-user scene the engine boots, and whether a link is allowed to choose it.
+//
+// `?systemScene=` substitutes the scene that owns the UI, and that scene is trusted: permissions.rs
+// short-circuits every permission check for it and it gets the whole SystemApi. So a crafted link
+// on our own origin is a complete takeover of the session — no sandbox escape needed, just a click.
+// Anything not on the list below gets the interstitial in features/gate/UntrustedLaunchGate.
+
+import { PAGE_DIR } from './publicUrl'
+
+// Our super-user bridge scene. It relays the scene-loading stream + player-ready over
+// BroadcastChannel and renders no UI.
+//   • PROD (built app): the EXPORTED static bundle shipped in this package, loaded from the
+//     VERSIONED CDN base (BASE_URL) — NOT the page origin: the zone site mirror drops the
+//     realm's extensionless files (`about`, bafk… content hashes) and 404s them, while the CDN
+//     serves the full package. The engine only ever FETCHES the realm (CORS, ACAO:* on the CDN),
+//     so it doesn't need to be same-origin — and version-pinning it avoids mirror skew anyway.
+//   • DEV default: the LIVE preview realm from `sdk-commands start` on :8100 (started by the vite
+//     plugin) — fast iteration, the scene hot-reloads. (BASE_URL is '/' in dev, so ?bundled=1
+//     still resolves to this origin's /bridge-scene/static.)
+export const SYSTEM_SCENE =
+  import.meta.env.PROD || new URLSearchParams(location.search).has('bundled')
+    ? new URL('bridge-scene/static/BevyExplorerUI', new URL(import.meta.env.BASE_URL, PAGE_DIR)).href
+    : 'http://localhost:8100'
+
+// Worlds we ship as first-party UI scenes. Accepted bare or as a full worlds-content-server url —
+// the engine's ipfs layer expands `name.dcl.eth` into the latter, and boot.js reverses it for the
+// address bar, so both spellings reach users.
+const TRUSTED_WORLDS = ['tortilla.dcl.eth', 'sceneviewer.dcl.eth']
+const WORLDS_PREFIX = 'https://worlds-content-server.decentraland.org/world/'
+
+// A scene served from the developer's own machine. `sdk-commands start` is the whole point of the
+// parameter, and a link can't make someone else's machine serve it.
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '[::1]'])
+
+function normalise(value: string): string {
+  return value.trim().replace(/\/+$/, '')
+}
+
+export function isTrustedSystemScene(value: string): boolean {
+  const v = normalise(value)
+  if (v === '') return true
+  // 'none' runs NO ui scene — strictly less privilege than the default, never worth warning about.
+  if (v.toLowerCase() === 'none') return true
+  if (v === normalise(SYSTEM_SCENE)) return true
+
+  // Exact matches only. A suffix/`includes` test would accept `tortilla.dcl.eth.example.com`, and a
+  // prefix test on the worlds url would accept `…/world/tortilla.dcl.eth/../../elsewhere`.
+  const lower = v.toLowerCase()
+  if (TRUSTED_WORLDS.includes(lower)) return true
+  if (lower.startsWith(WORLDS_PREFIX)) return TRUSTED_WORLDS.includes(lower.slice(WORLDS_PREFIX.length))
+
+  try {
+    if (LOOPBACK.has(new URL(v).hostname.toLowerCase())) return true
+  } catch {
+    // not an absolute url — a bare path can't be vouched for, so it falls through to untrusted
+  }
+  return false
+}

--- a/react-web/src/test/systemScene.test.tsx
+++ b/react-web/src/test/systemScene.test.tsx
@@ -1,0 +1,81 @@
+// DOMAIN: the `?systemScene=` launch gate (lib/systemScene.ts + features/gate/UntrustedLaunchGate).
+//
+// The parameter picks the super-user scene, which permissions.rs waves through every permission
+// check and hands the whole SystemApi — so an unrecognised one is a session takeover delivered as a
+// link. These cover the allowlist itself and the near-misses an attacker would actually reach for.
+
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { isTrustedSystemScene, SYSTEM_SCENE } from '../lib/systemScene'
+import { UntrustedLaunchGate } from '../features/gate/UntrustedLaunchGate'
+
+describe('isTrustedSystemScene', () => {
+  it('accepts the default bridge scene, with or without a trailing slash', () => {
+    expect(isTrustedSystemScene(SYSTEM_SCENE)).toBe(true)
+    expect(isTrustedSystemScene(`${SYSTEM_SCENE}/`)).toBe(true)
+  })
+
+  it('accepts "none" — that runs no ui scene at all, which is less privilege, not more', () => {
+    expect(isTrustedSystemScene('none')).toBe(true)
+    expect(isTrustedSystemScene('NONE')).toBe(true)
+  })
+
+  it('accepts a scene served from the developer\'s own machine', () => {
+    expect(isTrustedSystemScene('http://localhost:8100')).toBe(true)
+    expect(isTrustedSystemScene('http://127.0.0.1:8100')).toBe(true)
+    expect(isTrustedSystemScene('http://[::1]:8100')).toBe(true)
+    expect(isTrustedSystemScene('https://localhost:3000/some/path')).toBe(true)
+  })
+
+  it('accepts the first-party worlds, bare or as a worlds-content-server url', () => {
+    for (const world of ['tortilla.dcl.eth', 'sceneviewer.dcl.eth']) {
+      expect(isTrustedSystemScene(world)).toBe(true)
+      expect(isTrustedSystemScene(`https://worlds-content-server.decentraland.org/world/${world}`)).toBe(true)
+    }
+  })
+
+  it('rejects an arbitrary remote scene', () => {
+    expect(isTrustedSystemScene('https://example.com/evil')).toBe(false)
+  })
+
+  // The near-misses: each of these passes a naive `includes`/`startsWith`/suffix check.
+  it('rejects lookalikes of the trusted names', () => {
+    expect(isTrustedSystemScene('https://tortilla.dcl.eth.example.com')).toBe(false)
+    expect(isTrustedSystemScene('https://example.com/tortilla.dcl.eth')).toBe(false)
+    expect(isTrustedSystemScene('https://localhost.example.com/evil')).toBe(false)
+    expect(isTrustedSystemScene('https://example.com/?x=http://localhost')).toBe(false)
+    expect(
+      isTrustedSystemScene('https://worlds-content-server.decentraland.org/world/tortilla.dcl.eth/../../evil')
+    ).toBe(false)
+    expect(isTrustedSystemScene('https://worlds-content-server.decentraland.org.example.com/world/tortilla.dcl.eth')).toBe(
+      false
+    )
+  })
+
+  it('rejects a bare path, which nothing vouches for', () => {
+    expect(isTrustedSystemScene('./scenes/whatever')).toBe(false)
+  })
+})
+
+describe('UntrustedLaunchGate', () => {
+  it('names the offending value and leads with the safe action', () => {
+    render(<UntrustedLaunchGate systemScene="https://example.com/evil" onProceed={vi.fn()} />)
+    expect(screen.getByText(/not trusted/i)).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/evil')).toBeInTheDocument()
+    // Proceeding is not reachable in one click — it sits behind Advanced.
+    expect(screen.queryByRole('button', { name: /continue anyway/i })).not.toBeInTheDocument()
+  })
+
+  it('only proceeds after Advanced, and only on the explicit confirm', async () => {
+    const onProceed = vi.fn()
+    const user = userEvent.setup()
+    render(<UntrustedLaunchGate systemScene="https://example.com/evil" onProceed={onProceed} />)
+
+    await user.click(screen.getByRole('button', { name: /advanced/i }))
+    expect(onProceed).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: /continue anyway/i }))
+    expect(onProceed).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
`?systemScene=` chooses the scene that owns the UI. `permissions.rs` short-circuits every permission check for that scene and hands it the whole `SystemApi` — so it can move the avatar, deploy the profile, and answer permission prompts on the user's behalf.

It was read straight from `location.search` with no gating. A link on our own origin was therefore a complete session takeover with no sandbox escape involved — one click rather than zero, but the same end state.

## The gate

Unrecognised values get an interstitial before anything boots. `App.tsx` returns it ahead of every other gate, which is what keeps `EngineHost` unmounted — and `EngineHost` is what injects `boot.js` and starts the scene.

Continuing is possible but sits behind **Advanced**. The user arrives here having already clicked something an attacker handed them, with the attacker's framing already in mind, so the safe choice has to be the easy one and the risky one has to cost an extra deliberate step.

## Allowlist

Trusted without a prompt:

- the bridge scene we ship (the build's own default)
- `none` — that runs no ui scene at all, which is strictly *less* privilege
- anything on loopback (`localhost`, `127.0.0.1`, `[::1]`) — `sdk-commands start` is the whole point of the parameter, and a link can't make someone else's machine serve it
- `tortilla.dcl.eth` and `sceneviewer.dcl.eth`, bare or as `worlds-content-server` urls (the ipfs layer expands the bare form and `boot.js` reverses it, so both spellings reach users)

Matching is exact rather than substring. Each of these has to fail and each passes a naive `includes`/`startsWith`/suffix test, so they're covered directly by tests:

- `tortilla.dcl.eth.example.com`
- `example.com/tortilla.dcl.eth`
- `localhost.example.com`
- `example.com/?x=http://localhost`
- `…/world/tortilla.dcl.eth/../../elsewhere`
- `worlds-content-server.decentraland.org.example.com/world/tortilla.dcl.eth`

## Notes

`SYSTEM_SCENE` moves from `EngineHost` into `lib/systemScene.ts`, so the default and the check that compares against it sit together.

The value is captured at module scope from the *entry* url, so the `history.replaceState` in `boot.js:181` — which deliberately persists an explicit `?systemScene=` across reloads — can't retire the warning on a later render.

Verified in a browser that the gate blocks the boot (`boot.js` is never injected, `window.__bevyBootConfig` never set) and that a trusted value passes straight through. Typecheck clean; 285 tests pass, 9 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)