### PR TITLE
fix livekit audio decode busy-spin

### DIFF
--- a/crates/comms/src/livekit/kira_bridge.rs
+++ b/crates/comms/src/livekit/kira_bridge.rs
@@ -25,32 +25,36 @@ impl kira::sound::streaming::Decoder for LivekitKiraBridge {
     }
 
     fn decode(&mut self) -> Result<Vec<kira::Frame>, Self::Error> {
+        // kira polls decode() in a tight loop until it gets the frames it wants, so
+        // returning an empty set would busy-spin the decode thread; block until the
+        // next realtime frame arrives instead
+        let Some(mut frame) = self.receiver.blocking_recv() else {
+            return Err(AudioDecoderError::StreamClosed);
+        };
+
         let mut frames = Vec::default();
 
         loop {
-            match self.receiver.try_recv() {
-                Ok(frame) => {
-                    if frame.sample_rate != self.sample_rate {
-                        warn!(
-                            "sample rate changed?! was {}, now {}",
-                            self.sample_rate, frame.sample_rate
-                        );
-                    }
-
-                    if frame.num_channels != 1 {
-                        warn!("frame has {} channels", frame.num_channels);
-                    }
-
-                    for i in 0..frame.samples_per_channel as usize {
-                        let sample = frame.data[i] as f32 / i16::MAX as f32;
-                        frames.push(kira::Frame::new(sample, sample));
-                    }
-                }
-                Err(mpsc::error::TryRecvError::Disconnected) => {
-                    return Err(AudioDecoderError::StreamClosed)
-                }
-                Err(mpsc::error::TryRecvError::Empty) => return Ok(frames),
+            if frame.sample_rate != self.sample_rate {
+                warn!(
+                    "sample rate changed?! was {}, now {}",
+                    self.sample_rate, frame.sample_rate
+                );
             }
+
+            if frame.num_channels != 1 {
+                warn!("frame has {} channels", frame.num_channels);
+            }
+
+            for i in 0..frame.samples_per_channel as usize {
+                let sample = frame.data[i] as f32 / i16::MAX as f32;
+                frames.push(kira::Frame::new(sample, sample));
+            }
+
+            frame = match self.receiver.try_recv() {
+                Ok(frame) => frame,
+                _ => return Ok(frames),
+            };
         }
     }
 

--- a/crates/comms/src/livekit/livekit_bridge.rs
+++ b/crates/comms/src/livekit/livekit_bridge.rs
@@ -88,34 +88,37 @@ impl kira::sound::streaming::Decoder for AudioTrackKiraBridge {
     }
 
     fn decode(&mut self) -> Result<Vec<kira::Frame>, Self::Error> {
+        // kira polls decode() in a tight loop until it gets the frames it wants, so
+        // returning an empty set would busy-spin the decode thread; block until the
+        // next realtime frame arrives instead
+        let Some(mut frame) = self.receiver.blocking_recv() else {
+            return Err(AudioDecoderError::StreamClosed);
+        };
+
         let mut frames = Vec::default();
 
         loop {
-            match self.receiver.try_recv() {
-                Ok(frame) => {
-                    if frame.sample_rate != self.sample_rate {
-                        warn!(
-                            "sample rate changed?! was {}, now {}",
-                            self.sample_rate, frame.sample_rate
-                        );
-                    }
-
-                    if frame.num_channels != 1 {
-                        warn!("frame has {} channels", frame.num_channels);
-                    }
-
-                    for i in 0..frame.samples_per_channel as usize {
-                        let sample = frame.data[i] as f32 / i16::MAX as f32;
-                        frames.push(kira::Frame::new(sample, sample));
-                    }
-                }
-                Err(mpsc::error::TryRecvError::Empty) => break,
-                Err(mpsc::error::TryRecvError::Disconnected) => {
-                    return Err(AudioDecoderError::StreamClosed)
-                }
+            if frame.sample_rate != self.sample_rate {
+                warn!(
+                    "sample rate changed?! was {}, now {}",
+                    self.sample_rate, frame.sample_rate
+                );
             }
+
+            if frame.num_channels != 1 {
+                warn!("frame has {} channels", frame.num_channels);
+            }
+
+            for i in 0..frame.samples_per_channel as usize {
+                let sample = frame.data[i] as f32 / i16::MAX as f32;
+                frames.push(kira::Frame::new(sample, sample));
+            }
+
+            frame = match self.receiver.try_recv() {
+                Ok(frame) => frame,
+                _ => return Ok(frames),
+            };
         }
-        Ok(frames)
     }
 
     fn seek(&mut self, seek: usize) -> Result<usize, Self::Error> {


### PR DESCRIPTION
## What

High native CPU (observed ~1000% on Genesis Plaza with several subscribed remote audio tracks) caused by the livekit→kira audio bridges busy-spinning their decode threads.

kira's `DecodeScheduler::frame_at_index` loops calling `Decoder::decode()` with no sleep until it obtains the frame at the transport position; its only sleep is the outer 1ms wait when the ring buffer is full, which never happens at the live edge of a realtime stream. Both livekit bridges (`LivekitKiraBridge`, `AudioTrackKiraBridge`) returned an empty vec on `TryRecvError::Empty`, so each subscribed track's decode thread spun a full core between 10ms frame arrivals. The ffmpeg bridge (`av/audio_context.rs`) already guards this same behaviour with a sleep; its comment suggests "sleeping until a new frame arrives" as the better option, which is what this does: `blocking_recv()` for the first frame (safe — kira spawns a dedicated decode thread per streaming sound, and the mixer only reads the ring buffer), then drain the rest with `try_recv` as before.

Also returns frames collected before a channel close instead of discarding the stream tail behind `Err(StreamClosed)`; the next `decode()` call reports the closure via `blocking_recv() → None`.

No wasm impact: both modules are `cfg(not(target_arch = "wasm32"))`.

Note: #1035 edits the same `decode()` bodies (bounds clamp); whichever lands second has a trivial conflict to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)