### PR TITLE
fix: reject non-finite translation and scale in to_bevy_transform

### DIFF
--- a/crates/dcl_component/src/transform_and_parent.rs
+++ b/crates/dcl_component/src/transform_and_parent.rs
@@ -170,6 +170,9 @@ impl DclTransformAndParent {
         };
 
         let mut scale = self.scale;
+        if !scale.is_finite() {
+            scale = Vec3::ONE;
+        }
         if scale.x == 0.0 {
             scale.x = f32::EPSILON;
         };
@@ -180,8 +183,15 @@ impl DclTransformAndParent {
             scale.z = f32::EPSILON;
         };
 
+        let translation = self.translation.to_bevy_translation();
+        let translation = if translation.is_finite() {
+            translation
+        } else {
+            Vec3::ZERO
+        };
+
         Transform {
-            translation: self.translation.to_bevy_translation(),
+            translation,
             rotation,
             scale,
         }


### PR DESCRIPTION
`to_bevy_transform` already guards rotation with `is_finite` and coerces zero scale to `f32::EPSILON`, but leaves translation unguarded and misses NaN/inf scale entirely — `NaN == 0.0` is false, so it passes straight through.

A scene (or a remote peer, via the comms CRDT path) can therefore push a NaN or inf transform into the engine, where it reaches:

- `mesh_collider.rs:247`/`:253` — `Ball::scaled(..).unwrap()` and `ConvexPolyhedron::scaled(..).unwrap()`, both of which return `None` for a degenerate scale
- `collider.set_position()` at `mesh_collider.rs:359`, feeding non-finite isometries into the rapier BVH

Worth noting the asymmetry that made this easy to miss: **inf** reaches the `scaled().unwrap()` calls, **NaN does not**. The rescale gate at `:344` is `size_change > COLLIDER_RESCALE_SIZE`, and `NaN > x` is false, so a NaN-scaled collider silently skips the rescale and lands at `set_position` instead.

This matters most on the headless authoritative server. A raw panic unwinds through `app.run()` and exits the process, so the orchestrator reads it as an engine crash and drops **every co-tenant scene**. `GLOBAL_ERROR_HANDLER = warn` does not help — it catches fallible systems returning `Err`, which is a clean return with world access released, not panics.

## The change

Non-finite scale → `Vec3::ONE`, non-finite translation → `Vec3::ZERO`, matching the identity-fallback shape of the existing rotation guard three lines above (`→ Quat::IDENTITY`). The zero-scale `f32::EPSILON` coercion is untouched — that's a separate case, degenerate but intentional.

Finiteness is checked per-vector rather than per-axis, matching how the rotation guard treats the whole quat; a transform with one NaN axis is broken data regardless.

## Coverage

Both live callers of `to_bevy_transform` are fixed by this one edit:

- `scene_runner/src/update_world/transform_and_parent.rs:151` — the scene CRDT path, the server-reachable one
- `avatar/src/foreign_dynamics.rs:66` — remote peer transforms

The third reference, `comms/src/global_crdt.rs:540`, is commented out; peer positions reach the renderer via the CRDT store and land at the `foreign_dynamics` call, so they're covered too.

Closes the transform-boundary rows of #1063. The remaining sites there are per-site graceful skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)