### PR TITLE
fix: guard two unwraps in gltf_container whose siblings are already handled

### DIFF
--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -412,7 +412,12 @@ fn update_gltf(
             }
         }
 
-        let gltf = gltfs.get(h_gltf.0.id()).unwrap();
+        let Some(gltf) = gltfs.get(h_gltf.0.id()) else {
+            warn!("gltf {} unloaded between load state and lookup", def.0.src);
+            set_state(scene_ent, LoadingState::FinishedWithError);
+            commands.entity(ent).try_insert(GltfLoaded(None));
+            continue;
+        };
         let gltf_scene_handle = gltf.default_scene.as_ref();
 
         // validate texture types
@@ -2137,14 +2142,15 @@ fn update_gltf_linked_transforms(
                         debug!("[{gltf_ent:?}] s -> r {:?}", gltf_node_transform);
 
                         // and update stored state with the rrt we will compute next frame, to avoid rounding errors
-                        stored_transforms_and_parents.get_mut(&gltf_ent).unwrap().0 = gt_helper
-                            .compute_global_transform_with_overrides(
-                                gltf_ent,
-                                Some(data.transform_root),
-                                &updated_transforms,
-                            )
-                            .unwrap()
-                            .compute_transform();
+                        let Ok(gltf_global) = gt_helper.compute_global_transform_with_overrides(
+                            gltf_ent,
+                            Some(data.transform_root),
+                            &updated_transforms,
+                        ) else {
+                            return None;
+                        };
+                        stored_transforms_and_parents.get_mut(&gltf_ent).unwrap().0 =
+                            gltf_global.compute_transform();
                         None
                     }
                 }


### PR DESCRIPTION
Two panics from #1063. Both are cases the file already knows can fail — each has a nearby twin that handles the failure, and only these copies abort.

## `update_gltf:415`

`gltfs.get(h_gltf.0.id()).unwrap()` runs right after a `LoadState::Loaded` check. The same lookup at `:550` is guarded with an explicit error path:

> `"gltf was unloaded mysteriously. this shouldn't happen and things will be broken as a result."`

So the asset is known to disappear between the load-state check and the `get`. `:415` just aborts the process on it instead.

Handled the way the `Failed` branch twelve lines above does — `FinishedWithError` + `GltfLoaded(None)` — rather than copying `:550`'s handling. That branch is in this same loop and settles the scene's loading promise, so the scene gets a resolved (failed) load instead of one that hangs forever.

## `update_gltf_linked_transforms:2146`

The identical `compute_global_transform_with_overrides` call twenty-two lines above at `:2118` is already `let Ok(..) else { return None }`. This one matches it now.

Degrading here is cheap: the skipped write is the stored root-relative transform kept *"to avoid rounding errors"*, so the cost is one frame of accumulated rounding, which the next frame recomputes. The transform command itself has already been issued by that point.

## Why it matters

Raw panics abort the whole engine. Bevy's multi-threaded executor `catch_unwind`s each system but `resume_unwind`s on the main thread, so the unwind goes through `app.run()` and the process exits. On the headless authoritative server the orchestrator reads that as an engine crash and drops **every co-tenant scene**. `GLOBAL_ERROR_HANDLER = warn` doesn't help — it catches fallible systems returning `Err`, not panics.

`GltfDefinitionPlugin` is not gated headless, so both sites run on the server.

## Deliberately left alone

The neighbouring `stored_transforms_and_parents.get(..).unwrap()` lookups at `:2109` and `:2140` are safe by construction: every `node_movement_state.insert` is paired with a `stored_transforms_and_parents.insert` for the same entity in the same branch (`:2025`/`:2038`, `:2056`/`:2058`).

Part of #1063. Independent of #1065, which covers the transform-boundary rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)