### PR TITLE
fix: drop out-of-range triangles before handing a gltf collider to parry

### DIFF
--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -1274,10 +1274,22 @@ pub fn mesh_to_parry_shape(mesh_data: &Mesh) -> Option<SharedShape> {
         Some(Indices::U16(ixs)) => ixs.iter().map(|ix| *ix as u32).collect(),
         Some(Indices::U32(ixs)) => ixs.to_vec(),
     };
+    // parry indexes vertices directly (TriMesh::triangle) and its builder rejects only
+    // empty index buffers, so a triangle pointing past the position count panics inside
+    // trimesh_with_flags rather than erroring. drop those triangles.
+    let vertex_count = positions_ref.len() as u32;
+    let total_triangles = indices.len() / 3;
     let indices_parry: Vec<_> = indices
         .chunks_exact(3)
+        .filter(|chunk| chunk.iter().all(|ix| *ix < vertex_count))
         .map(|chunk| chunk.try_into().unwrap())
         .collect();
+    if indices_parry.len() < total_triangles {
+        warn!(
+            "gltf collider mesh: dropped {} triangle(s) indexing past {vertex_count} vertices",
+            total_triangles - indices_parry.len()
+        );
+    }
 
     Some(
         SharedShape::trimesh_with_flags(


### PR DESCRIPTION
The last server-reachable panic from #1063.

A scene GLB can reference vertices past the end of its own position buffer, and nothing between the file and parry checks:

- bevy's gltf loader copies accessor data straight into `Indices::U16`/`U32` without validating against the vertex count
- parry's `TriMeshBuilderError` has only two variants — empty indices, and topology failure. There is no bounds error to surface.
- `TriMesh::triangle` (`robtfm/parry@8705700`, `trimesh.rs:1896`) indexes raw: `self.vertices[idx[0] as usize]`

We pass `DELETE_DEGENERATE_TRIANGLES | MERGE_DUPLICATE_VERTICES`, so `set_flags` walks every triangle during construction (`trimesh.rs:718`). The panic fires **inside `trimesh_with_flags` itself**, not on some later query.

## Why it matters

A raw panic aborts the whole engine — bevy's multi-threaded executor `catch_unwind`s each system but `resume_unwind`s on the main thread, so the unwind goes through `app.run()` and the process exits. On the headless authoritative server the orchestrator reads that as an engine crash and drops **every co-tenant scene**, so one scene's malformed mesh takes down all of them. `GLOBAL_ERROR_HANDLER = warn` doesn't help; it catches fallible systems returning `Err`, not panics.

`mesh_to_parry_shape` is reached headless via `MeshColliderShape::GltfShape`, and serves both call sites — `gltf_container.rs:795` (collider extraction during gltf processing) and `mesh_collider.rs:1053`.

## The change

Filter the offending triangles rather than rejecting the mesh, so a GLB with a few broken faces still gets a collider from the rest. If *every* triangle is bad the index buffer ends up empty and the existing `unwrap_or_else` at `:1290` already degrades to a placeholder ball — that path was built, it just wasn't being fed correctly.

The drop count is logged. Silently truncated collision geometry presents as holes you can walk through, which is miserable to diagnose from a bug report.

The comment is deliberate: the filter looks removable unless you know `trimesh_with_flags` panics rather than erroring.

Untouched — the `None` arm at `:1273` generates `0..len`, always in range, and the `chunks_exact(3)` remainder was already discarded, so a non-multiple-of-3 index buffer was never a problem.

## Verification

Confirmed by reading the parry source, **not** by running a malformed GLB through it — I don't have such an asset to hand.

## Scope

This does not fix `pointer_results.rs:504-510`, which indexes `posns`/`uvs` with the same raw index data. That reads the bevy `Mesh` rather than the parry shape, is client-only (`PointerResultPlugin` is gated headless), and is tracked separately in #1063.

With this, #1065 and #1066, the server-reachable set in #1063 is closed. What remains there is client-only, plus two latent sites that no current input reaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)