### PR TITLE
fix: clamp malformed mesh indices in pointer uv projection

### DIFF
--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -500,6 +500,16 @@ fn update_manual_cursor(
             None => [face * 3, face * 3 + 1, face * 3 + 2],
         };
 
+        // a malformed gltf can index past its own position buffer, or carry fewer uvs than
+        // positions. clamp rather than drop the hit: this only feeds uv projection for ui
+        // rendered onto a mesh, so a wrong uv beats aborting, and the fix is for the creator
+        // to clean up the mesh.
+        let usable_verts = posns.len().min(uvs.len());
+        if usable_verts == 0 {
+            return None;
+        }
+        let indices = indices.map(|ix| ix.min(usable_verts - 1));
+
         let posns: [Vec3; 3] = [
             gt.transform_point(Vec3::from(posns[indices[0]])),
             gt.transform_point(Vec3::from(posns[indices[1]])),
@@ -547,6 +557,12 @@ fn update_manual_cursor(
                 None => 0..posns.len() / 3,
             };
 
+            // as above: clamp malformed indices rather than aborting
+            let usable_verts = posns.len().min(uvs.len());
+            if usable_verts == 0 {
+                return;
+            }
+
             let mut distances_and_barycoords = faces
                 .into_iter()
                 .filter_map(|face| {
@@ -563,6 +579,7 @@ fn update_manual_cursor(
                         ],
                         None => [face * 3, face * 3 + 1, face * 3 + 2],
                     };
+                    let indices = indices.map(|ix| ix.min(usable_verts - 1));
 
                     let posns: [Vec3; 3] = [
                         gt.transform_point(Vec3::from(posns[indices[0]])),


### PR DESCRIPTION
`update_manual_cursor` indexes `posns` and `uvs` with values taken straight from the mesh index buffer. The **face offset** is bounds-checked (`ixs.get(face * 3)?`), but the **index it yields** is not.

Two kinds of malformed gltf panic:

- an index past the mesh's own position buffer
- fewer UVs than positions — here the index is perfectly valid for `posns` and only overruns `uvs`

Both copies of the pattern are affected: the `face_uvs` closure, and the primitive-collider arm that walks every face of the rendered mesh.

## The change

Clamp to `posns.len().min(uvs.len())` — one bound covering both triggers.

This path only feeds UV projection for UI rendered onto an arbitrary mesh, which is a bevy-only feature. A wrong UV is an acceptable outcome there, and the remedy is for the creator to clean up the mesh. Precise recovery would mean carrying a parry-triangle → source-triangle map through collider construction, which isn't worth its cost for this.

Two details that aren't obvious from the diff:

- **The empty-buffer guard isn't redundant with the clamp.** With no UVs at all the clamp target is `0` and `uvs[0]` still panics — and `usable_verts - 1` would underflow first.
- **In the second copy the bound is hoisted out of the face loop**, since that arm iterates every triangle in the mesh.

## Left alone

`world_target.position.unwrap()` at the same two sites. `WorldPointerTarget.0` is written in exactly two places (`:400`, `:422`), both with `position: Some(..)`, so it holds by construction.

## Not covered

This does nothing for the separate face-index mismatch: parry renumbers triangles when `merge_duplicate_vertices` drops degenerate or duplicate ones (`trimesh.rs:1279-1310`), while `face_uvs` applies that index to the *original* bevy mesh index buffer. So UVs can already be silently wrong on well-formed meshes that merely contain slivers or doubled faces. Deliberately not addressed — same reasoning as above.

Part of #1063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)