### PR TITLE
render: exclude world entities from world-ui camera visibility passes

### DIFF
--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -13,6 +13,7 @@ use bevy::{
             AsBindGroup, Extent3d, ShaderRef, TextureDimension, TextureFormat, TextureUsages,
         },
         renderer::RenderDevice,
+        view::RenderLayers,
     },
     transform::TransformSystem,
     ui::UiSystem,
@@ -130,6 +131,8 @@ pub fn spawn_world_ui_view(
         .spawn((
             WorldUiRenderTarget(image.clone()),
             Camera2d,
+            // this camera only renders ui; keep world entities out of its visibility pass
+            RenderLayers::none(),
             Camera {
                 target: RenderTarget::Image(image.clone().into()),
                 order: -1,


### PR DESCRIPTION
# render: exclude world entities from world-ui camera visibility passes

Extracted from #1002 (the rest of that PR is not being taken forward in its current form — see discussion there).

The world-ui RTT cameras (text shape views and the scene-UI canvas camera) are `Camera2d`s that only render UI, but with default `RenderLayers` each one still ran a whole-world visibility pass over layer-0 entities every frame. Spawn them with `RenderLayers::none()` so the visibility pass has nothing to check; UI rendering is unaffected since UI extraction targets cameras via `UiTargetCamera`, not `RenderLayers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
