### PR TITLE
Allow token auth for the first headless npm publish

### DIFF
--- a/.github/workflows/publish-headless.yml
+++ b/.github/workflows/publish-headless.yml
@@ -15,6 +15,15 @@ name: Publish headless server
 # publish of a new name has to be bootstrapped manually (npm requires the package to exist
 # before a trusted publisher can be attached).
 #
+# ONE-TIME BOOTSTRAP (per new package name): trusted publishing can't attach to a name
+# that doesn't exist yet, so the first publish authenticates with a token instead. Add an
+# `NPM_TOKEN` repo secret (a granular automation token with publish rights on the
+# @dcl-regenesislabs org) and run this workflow once via workflow_dispatch. The publish
+# steps read it as NODE_AUTH_TOKEN; when the secret is absent it expands to empty, which is
+# exactly today's OIDC path — so nothing here needs reverting. After the run: attach the
+# trusted publisher (repo decentraland/bevy-explorer, workflow publish-headless.yml) to all
+# five names on npmjs.com, then DELETE the NPM_TOKEN secret. Every subsequent run is OIDC.
+#
 # Only the launcher's dist-tag matters to installers: it pins the platform packages by
 # exact version, so their tags are cosmetic.
 
@@ -185,7 +194,12 @@ jobs:
           merge-multiple: true
 
       - name: Publish platform packages
-        # platform packages first: the launcher pins them by exact version
+        # platform packages first: the launcher pins them by exact version.
+        # NODE_AUTH_TOKEN is set only during the one-time bootstrap (see header): with the
+        # NPM_TOKEN secret present it authenticates by token; absent, it expands to empty
+        # and npm falls back to OIDC trusted publishing — the normal path.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           for tgz in deploy/headless/artifacts/*.tgz; do
@@ -194,6 +208,9 @@ jobs:
 
       - name: Publish launcher
         uses: decentraland/oddish-action@0074f2d535c43b5c83f136525304a6277166d77f # @master
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           cwd: './deploy/headless/launcher'
           deterministic-snapshot: true


### PR DESCRIPTION
## Summary
The headless server publishes to npm as five new names under `@dcl-regenesislabs`
(`bevy-headless-server` launcher + `-darwin-arm64` / `-darwin-x64` / `-linux-x64` /
`-win32-x64`). npm OIDC **trusted publishing** can only attach to a package that already
exists, so these brand-new names can't be created via OIDC — the very first publish needs
a token.

This wires `NPM_TOKEN` into the publish steps as `NODE_AUTH_TOKEN` (and `NPM_TOKEN` for the
oddish launcher step). It's self-toggling: the current OIDC path already runs with an empty
`NODE_AUTH_TOKEN`, so with the secret **present** the run authenticates by token, and with
it **absent** the value expands to empty and the workflow behaves exactly as today (OIDC).

## One-time bootstrap
1. Add repo secret `NPM_TOKEN` (granular automation token, publish rights on the
   `@dcl-regenesislabs` org). *(already added)*
2. Run **Publish headless server** via `workflow_dispatch` (`publish: true`) — creates all
   five names on the `next` tag.
3. On npmjs.com, attach the trusted publisher (repo `decentraland/bevy-explorer`, workflow
   `publish-headless.yml`) to all five names.
4. **Delete the `NPM_TOKEN` secret.** Every subsequent push publishes via OIDC.

## What could break
- Nothing on the normal (OIDC) path: with no `NPM_TOKEN` secret the added env is empty,
  identical to current behavior — no revert needed after bootstrap.
- If the token lacks publish rights on the org, the bootstrap run 403s (publishes nothing —
  the job is all-or-nothing via `needs: build`).

## How to test
- Without the secret: a `main` push touching engine code still publishes via OIDC (unchanged).
- With the secret: `workflow_dispatch` publishes the five names by token.