### PR TITLE
Drop token auth from headless publish now that names exist

### DIFF
--- a/.github/workflows/publish-headless.yml
+++ b/.github/workflows/publish-headless.yml
@@ -15,14 +15,12 @@ name: Publish headless server
 # publish of a new name has to be bootstrapped manually (npm requires the package to exist
 # before a trusted publisher can be attached).
 #
-# ONE-TIME BOOTSTRAP (per new package name): trusted publishing can't attach to a name
-# that doesn't exist yet, so the first publish authenticates with a token instead. Add an
-# `NPM_TOKEN` repo secret (a granular automation token with publish rights on the
-# @dcl-regenesislabs org) and run this workflow once via workflow_dispatch. The publish
-# steps read it as NODE_AUTH_TOKEN; when the secret is absent it expands to empty, which is
-# exactly today's OIDC path — so nothing here needs reverting. After the run: attach the
-# trusted publisher (repo decentraland/bevy-explorer, workflow publish-headless.yml) to all
-# five names on npmjs.com, then DELETE the NPM_TOKEN secret. Every subsequent run is OIDC.
+# The five current names were bootstrapped and now publish via OIDC only (no token in this
+# workflow). ADDING A NEW PACKAGE NAME later needs a one-time bootstrap first, since trusted
+# publishing can't attach to a name that doesn't exist: publish its first version manually
+# (`npm publish` while logged in), or temporarily add an `NPM_TOKEN` secret + read it as
+# NODE_AUTH_TOKEN on the publish steps for a single run, then attach the trusted publisher on
+# npmjs.com and remove the token again.
 #
 # Only the launcher's dist-tag matters to installers: it pins the platform packages by
 # exact version, so their tags are cosmetic.
@@ -194,12 +192,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish platform packages
-        # platform packages first: the launcher pins them by exact version.
-        # NODE_AUTH_TOKEN is set only during the one-time bootstrap (see header): with the
-        # NPM_TOKEN secret present it authenticates by token; absent, it expands to empty
-        # and npm falls back to OIDC trusted publishing — the normal path.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # platform packages first: the launcher pins them by exact version
         run: |
           set -euo pipefail
           for tgz in deploy/headless/artifacts/*.tgz; do
@@ -208,9 +201,6 @@ jobs:
 
       - name: Publish launcher
         uses: decentraland/oddish-action@0074f2d535c43b5c83f136525304a6277166d77f # @master
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           cwd: './deploy/headless/launcher'
           deterministic-snapshot: true


### PR DESCRIPTION
## Summary
The five `@dcl-regenesislabs/bevy-headless-server` names were bootstrapped in the first
`workflow_dispatch` run (all published at `0.1.0-31413755159.commit-5b7586c`). Now that the
names exist and their trusted publishers are being attached, the publish steps no longer need
a token — they revert to **OIDC trusted publishing**, exactly like the web package.

Removes the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env from both publish steps and
rewrites the header note to document how to bootstrap a *new* name if one is ever added.

## What could break
- Nothing on the current path: publishing stays on OIDC (`id-token: write`), same as before the
  token PR. Requires the trusted publisher to be attached to each of the 5 names (in progress)
  and the `NPM_TOKEN` secret deleted.
- Keeps a future `NPM_TOKEN` secret from silently reactivating token auth (which npm is
  deprecating).

## How to test
After merge, trigger a `workflow_dispatch` run: it publishes a new snapshot via OIDC and the
job should be fully green (the first-publish 404 race is gone now that the packages exist).