### PR TITLE
Stop scene code reaching the raw deno ops table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "deno_console"
 version = "0.168.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "deno_core",
 ]
@@ -3686,7 +3686,7 @@ checksum = "a13951ea98c0a4c372f162d669193b4c9d991512de9f2381dd161027f34b26b1"
 [[package]]
 name = "deno_fetch"
 version = "0.192.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "deno_net"
 version = "0.160.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "deno_core",
  "deno_permissions",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "deno_permissions"
 version = "0.28.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "deno_core",
  "deno_terminal",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "deno_tls"
 version = "0.155.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "deno_core",
  "deno_native_certs",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "deno_url"
 version = "0.168.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "deno_core",
  "urlpattern",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "deno_web"
 version = "0.199.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "async-trait",
  "base64-simd 0.8.0",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "deno_webidl"
 version = "0.168.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "deno_core",
 ]
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "deno_websocket"
 version = "0.173.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "bytes",
  "deno_core",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "deno_webstorage"
 version = "0.163.0"
-source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#a476e471e54c289b59759327ae08c9fb9deee3b1"
+source = "git+https://github.com/robtfm/deno?branch=1_46_hotfix#4ecaf52e29460848d24b8300ec769e8b184dba47"
 dependencies = [
  "deno_core",
  "deno_web",

--- a/crates/common/src/util.rs
+++ b/crates/common/src/util.rs
@@ -697,7 +697,6 @@ pub fn is_forbidden_ip(ip: &std::net::IpAddr) -> bool {
 /// wasm/web client relies on the browser's own network sandbox.
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn assert_public_url(url_str: &str, allow_loopback: bool) -> Result<(), anyhow::Error> {
-    use std::net::ToSocketAddrs;
     let url = url::Url::parse(url_str)?;
     match url.scheme() {
         "https" | "http" | "wss" | "ws" => {}
@@ -711,6 +710,26 @@ pub async fn assert_public_url(url_str: &str, allow_loopback: bool) -> Result<()
         .ok_or_else(|| anyhow::anyhow!("request URL has no host"))?
         .to_owned();
     let port = url.port_or_known_default().unwrap_or(443);
+    resolve_public_addrs(&host, port, allow_loopback).await?;
+    Ok(())
+}
+
+/// Resolve `host:port` and reject the answer unless EVERY address is public.
+///
+/// Rejecting the whole answer rather than filtering out the bad records is deliberate: a
+/// host that replies with a mix of public and private addresses is doing so on purpose,
+/// and silently dropping the private ones would let the request proceed looking legitimate.
+///
+/// This is the shared primitive behind [`assert_public_url`] (pre-flight, by URL) and the
+/// connect-time resolver used by the authoritative server's http client, so both reach the
+/// same verdict from the same code.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn resolve_public_addrs(
+    host: &str,
+    port: u16,
+    allow_loopback: bool,
+) -> Result<Vec<std::net::SocketAddr>, anyhow::Error> {
+    use std::net::ToSocketAddrs;
     // std resolver on the blocking pool (avoids pulling tokio's `net` feature into the
     // wasm-shared workspace dependency)
     let hostport = format!("{host}:{port}");
@@ -722,12 +741,15 @@ pub async fn assert_public_url(url_str: &str, allow_loopback: bool) -> Result<()
     if addrs.is_empty() {
         anyhow::bail!("host `{host}` did not resolve to any address");
     }
-    for addr in addrs {
+    for addr in &addrs {
+        if allow_loopback && addr.ip().is_loopback() {
+            continue;
+        }
         if is_forbidden_ip(&addr.ip()) {
             anyhow::bail!("request to a non-public address is not allowed");
         }
     }
-    Ok(())
+    Ok(addrs)
 }
 
 /// A colour ramp keyed by a normalized parameter in `[0, 1)` (e.g. time of day).

--- a/crates/common/src/util.rs
+++ b/crates/common/src/util.rs
@@ -692,17 +692,18 @@ pub fn is_forbidden_ip(ip: &std::net::IpAddr) -> bool {
 /// SSRF guard for scene-controlled URLs (fetch / signedFetch / readFile). Enforces an
 /// http(s)/ws(s) scheme and resolves the host, rejecting if ANY resolved address is
 /// non-public (defeats a literal private IP and static-DNS pointers to internal hosts).
-/// `allow_loopback` is for local preview only. Returns Ok for a public destination.
+/// `allow_private` widens the allowance to the local network for local preview only (never
+/// to link-local / metadata). Returns Ok for a public destination.
 /// Native-only: it is invoked exclusively from the native request-executing ops; the
 /// wasm/web client relies on the browser's own network sandbox.
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn assert_public_url(url_str: &str, allow_loopback: bool) -> Result<(), anyhow::Error> {
+pub async fn assert_public_url(url_str: &str, allow_private: bool) -> Result<(), anyhow::Error> {
     let url = url::Url::parse(url_str)?;
     match url.scheme() {
         "https" | "http" | "wss" | "ws" => {}
         other => anyhow::bail!("scheme `{other}` is not allowed"),
     }
-    if allow_loopback && url.is_loopback() {
+    if allow_private && url.is_loopback() {
         return Ok(());
     }
     let host = url
@@ -710,7 +711,46 @@ pub async fn assert_public_url(url_str: &str, allow_loopback: bool) -> Result<()
         .ok_or_else(|| anyhow::anyhow!("request URL has no host"))?
         .to_owned();
     let port = url.port_or_known_default().unwrap_or(443);
-    resolve_public_addrs(&host, port, allow_loopback).await?;
+    resolve_public_addrs(&host, port, allow_private).await?;
+    Ok(())
+}
+
+/// True for addresses on this machine or its local network: loopback and RFC1918 / IPv6
+/// unique-local. Deliberately EXCLUDES link-local (`169.254/16`, `fe80::/10`) so cloud
+/// metadata (`169.254.169.254`) stays unreachable even where local network is permitted
+/// (i.e. preview). This is the set that `allow_private` opens up.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn is_private_lan(ip: &std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    match ip {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_private(),
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_private_lan(&IpAddr::V4(mapped));
+            }
+            // unique local fc00::/7
+            v6.is_loopback() || (v6.segments()[0] & 0xfe00) == 0xfc00
+        }
+    }
+}
+
+/// Reject the set unless EVERY address is public (or, under `allow_private`, on the local
+/// network). Whole-set rejection is deliberate — see [`resolve_public_addrs`]. This is the
+/// pure validation step, shared by the fetch resolver (which resolves first) and the
+/// WebSocket `check_resolved` hook (which is handed addresses already resolved by deno).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn validate_public_addrs(
+    addrs: &[std::net::SocketAddr],
+    allow_private: bool,
+) -> Result<(), anyhow::Error> {
+    for addr in addrs {
+        if allow_private && is_private_lan(&addr.ip()) {
+            continue;
+        }
+        if is_forbidden_ip(&addr.ip()) {
+            anyhow::bail!("request to a non-public address is not allowed");
+        }
+    }
     Ok(())
 }
 
@@ -721,13 +761,14 @@ pub async fn assert_public_url(url_str: &str, allow_loopback: bool) -> Result<()
 /// and silently dropping the private ones would let the request proceed looking legitimate.
 ///
 /// This is the shared primitive behind [`assert_public_url`] (pre-flight, by URL) and the
-/// connect-time resolver used by the authoritative server's http client, so both reach the
-/// same verdict from the same code.
+/// connect-time resolver used by every scene http client, so both reach the same verdict
+/// from the same code. `allow_private` (preview only) permits [`is_private_lan`] addresses
+/// but never link-local, so metadata stays blocked in every mode.
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn resolve_public_addrs(
     host: &str,
     port: u16,
-    allow_loopback: bool,
+    allow_private: bool,
 ) -> Result<Vec<std::net::SocketAddr>, anyhow::Error> {
     use std::net::ToSocketAddrs;
     // std resolver on the blocking pool (avoids pulling tokio's `net` feature into the
@@ -741,14 +782,7 @@ pub async fn resolve_public_addrs(
     if addrs.is_empty() {
         anyhow::bail!("host `{host}` did not resolve to any address");
     }
-    for addr in &addrs {
-        if allow_loopback && addr.ip().is_loopback() {
-            continue;
-        }
-        if is_forbidden_ip(&addr.ip()) {
-            anyhow::bail!("request to a non-public address is not allowed");
-        }
-    }
+    validate_public_addrs(&addrs, allow_private)?;
     Ok(addrs)
 }
 
@@ -825,6 +859,53 @@ impl Curve {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The egress policy hinges on this split: `allow_private` (preview) opens loopback and
+    /// the local network, but link-local — including cloud metadata `169.254.169.254` — is
+    /// NOT `is_private_lan`, so it stays `is_forbidden_ip` and is refused in every mode.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn private_lan_excludes_link_local_metadata() {
+        use std::net::IpAddr;
+        let lan: &[&str] = &["127.0.0.1", "10.0.0.1", "192.168.1.1", "172.16.5.4", "::1"];
+        for s in lan {
+            let ip: IpAddr = s.parse().unwrap();
+            assert!(is_private_lan(&ip), "{s} should count as local network");
+        }
+        // fc00::/7 unique-local is local network; fe80::/10 link-local is not
+        assert!(is_private_lan(&"fc00::1".parse().unwrap()));
+        assert!(!is_private_lan(&"fe80::1".parse().unwrap()));
+
+        // the metadata endpoint: never local network, always forbidden — so a preview
+        // `allow_private` skip never reaches it.
+        let meta: IpAddr = "169.254.169.254".parse().unwrap();
+        assert!(!is_private_lan(&meta), "metadata must not be local network");
+        assert!(is_forbidden_ip(&meta), "metadata must stay forbidden");
+
+        // ordinary public address is neither
+        let pubip: IpAddr = "8.8.8.8".parse().unwrap();
+        assert!(!is_private_lan(&pubip));
+        assert!(!is_forbidden_ip(&pubip));
+    }
+
+    /// End-to-end on the shared primitive both the fetch resolver and the WebSocket
+    /// `resolve_checked` hook depend on: literal private/loopback is refused normally and
+    /// allowed only under `allow_private` (preview), while cloud metadata stays refused even
+    /// under preview. Uses literal IPs so no network lookup happens.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn resolve_public_addrs_enforces_egress_policy() {
+        assert!(resolve_public_addrs("127.0.0.1", 80, false).await.is_err());
+        assert!(resolve_public_addrs("127.0.0.1", 80, true).await.is_ok());
+        assert!(resolve_public_addrs("192.168.1.1", 80, false)
+            .await
+            .is_err());
+        assert!(resolve_public_addrs("192.168.1.1", 80, true).await.is_ok());
+        // link-local / metadata: refused in every mode, preview included
+        assert!(resolve_public_addrs("169.254.169.254", 80, true)
+            .await
+            .is_err());
+    }
 
     #[test]
     fn inverted_scale() {

--- a/crates/dcl_deno/src/js/fetch/mod.rs
+++ b/crates/dcl_deno/src/js/fetch/mod.rs
@@ -132,9 +132,10 @@ where
         }
     }
 
-    // authoritative-server mode only: never auto-follow redirects, so a 3xx onto a
-    // private host can't bypass the per-request SSRF check or leak signed headers. The
-    // desktop/web client keeps the default redirect-following behaviour unchanged.
+    // On the authoritative server redirects are never auto-followed, so a 3xx onto a private
+    // host can't bypass the per-request SSRF check or leak signed headers. The desktop/web
+    // client still follows them, but under the public-only redirect policy (see
+    // `build_scene_client` / `public_only_redirect`).
     let (is_server, preview) = {
         let ctx = state.borrow::<CrdtContext>();
         (ctx.is_server, ctx.preview)
@@ -455,31 +456,68 @@ fn scene_client_builder(allow_private: bool) -> reqwest::ClientBuilder {
 }
 
 /// The default client for a scene's own requests. On the authoritative server redirects are
-/// disabled as well (a 3xx must not silently re-target or forward signed headers); the
-/// desktop client keeps following them, which the resolver makes safe — every hop
-/// re-resolves through the same public-only check.
+/// disabled entirely (a 3xx must not silently re-target or forward signed headers). The
+/// desktop client keeps following them — matching the browser — but through
+/// [`public_only_redirect`]: a hostname hop is re-resolved by [`PublicOnlyResolver`] at
+/// connect, and an IP-literal hop (dialled with no DNS lookup, so the resolver never sees it)
+/// is vetted by the policy.
 fn build_scene_client(allow_private: bool, is_server: bool) -> reqwest::Client {
-    let mut builder = scene_client_builder(allow_private);
-    if is_server {
-        builder = builder.redirect(reqwest::redirect::Policy::none());
-    }
-    builder.build().unwrap()
+    scene_client_builder(allow_private)
+        .redirect(if is_server {
+            reqwest::redirect::Policy::none()
+        } else {
+            public_only_redirect(allow_private)
+        })
+        .build()
+        .unwrap()
 }
 
-/// A proxy given as a literal IP is dialled without a DNS lookup, so [`PublicOnlyResolver`]
-/// never sees it. Vet it synchronously: a forbidden (non-public) IP literal is refused unless
-/// `allow_private` (preview) permits the local network. A hostname proxy passes here — the
-/// resolver vets it when the connection is actually made.
+/// Parse a URL host component as an IP literal, tolerating the brackets the `url` crate keeps
+/// around an IPv6 literal (`[::1]`). Returns `None` for a hostname.
+fn host_ip_literal(host: &str) -> Option<std::net::IpAddr> {
+    host.strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host)
+        .parse()
+        .ok()
+}
+
+/// Redirect policy for the desktop client. Redirects are followed (as the browser would), but
+/// a hop onto a non-public IP *literal* is refused: reqwest dials an IP literal with no DNS
+/// lookup, so [`PublicOnlyResolver`] — which vets every hostname hop at connect — never sees
+/// it. This is the redirect-time twin of [`reject_non_public_proxy`]. `allow_private`
+/// (preview) permits the local network but never link-local / metadata.
+fn public_only_redirect(allow_private: bool) -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(move |attempt| {
+        // Policy::custom replaces reqwest's built-in hop cap, so re-impose the default of 10.
+        if attempt.previous().len() >= 10 {
+            return attempt.error("too many redirects".to_string());
+        }
+        if let Some(ip) = attempt.url().host_str().and_then(host_ip_literal) {
+            let permitted = allow_private && common::util::is_private_lan(&ip);
+            if !permitted && common::util::is_forbidden_ip(&ip) {
+                return attempt.error(format!(
+                    "redirect to non-public address {ip} is not allowed"
+                ));
+            }
+        }
+        attempt.follow()
+    })
+}
+
+/// Vet a scene-supplied proxy endpoint. Only an IP *literal* needs checking here: reqwest's
+/// proxy connector is an `HttpConnector<DynResolver>`, which dials an IP literal directly but
+/// routes a *hostname* endpoint through [`PublicOnlyResolver`] at connect — so a hostname
+/// proxy is already egress-checked there and a literal is the one case that skips it. (A
+/// `socks*://` proxy needs no handling: the `socks` feature is off, so `reqwest::Proxy::http`
+/// rejects it before we get here.) `allow_private` (preview) permits the local network but
+/// never link-local / metadata.
 fn reject_non_public_proxy(proxy_url: &str, allow_private: bool) -> Result<(), AnyError> {
     let url = deno_core::url::Url::parse(proxy_url)?;
-    if let Some(host) = url.host_str() {
-        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-            if allow_private && common::util::is_private_lan(&ip) {
-                return Ok(());
-            }
-            if common::util::is_forbidden_ip(&ip) {
-                anyhow::bail!("custom fetch client proxy may not target a non-public address");
-            }
+    if let Some(ip) = url.host_str().and_then(host_ip_literal) {
+        let permitted = allow_private && common::util::is_private_lan(&ip);
+        if !permitted && common::util::is_forbidden_ip(&ip) {
+            anyhow::bail!("custom fetch client proxy may not target a non-public address");
         }
     }
     Ok(())
@@ -530,10 +568,11 @@ pub fn op_fetch_custom_client(
     }
 
     // Client mode: the scene may still tune TLS trust/identity for its own machine, but its
-    // connections stay public-only via the resolver (unless preview). A proxy given as a
-    // literal IP skips the resolver — reqwest dials the IP without a lookup — so a private
-    // proxy endpoint is refused here; a hostname proxy is caught at connect by the resolver.
-    let mut builder = scene_client_builder(preview);
+    // connections stay public-only via the resolver (unless preview), and redirects are held
+    // to the same egress policy as the default client (see `public_only_redirect`). A proxy
+    // endpoint given as an IP literal skips that resolver, so it is vetted synchronously by
+    // `reject_non_public_proxy` (a hostname endpoint is resolved through the resolver).
+    let mut builder = scene_client_builder(preview).redirect(public_only_redirect(preview));
     if let Some(proxy_def) = args.proxy {
         reject_non_public_proxy(&proxy_def.url, preview)?;
         let mut proxy = reqwest::Proxy::http(proxy_def.url)?;

--- a/crates/dcl_deno/src/js/fetch/mod.rs
+++ b/crates/dcl_deno/src/js/fetch/mod.rs
@@ -143,31 +143,17 @@ where
     let client = if let Some(rid) = client_rid {
         let r = state.resource_table.get::<ClientResource>(rid)?;
         r.0.clone()
-    } else if is_server {
-        match state.try_borrow::<ServerHttpClient>() {
+    } else {
+        // One guarded default client for both modes: public-only DNS (unless preview), so a
+        // scene can never reach loopback / private / metadata from a plain `fetch()`.
+        match state.try_borrow::<SceneHttpClient>() {
             Some(client) => client.0.clone(),
             None => {
-                let client = build_server_client(preview);
-                state.put(ServerHttpClient(client.clone()));
+                let client = build_scene_client(preview, is_server);
+                state.put(SceneHttpClient(client.clone()));
                 client
             }
         }
-    } else {
-        match state.try_borrow::<reqwest::Client>() {
-            Some(client) => client,
-            None => {
-                state.put(
-                    reqwest::Client::builder()
-                        .connect_timeout(Duration::from_secs(5))
-                        .use_native_tls()
-                        .user_agent("DCLExplorer/0.1")
-                        .build()
-                        .unwrap(),
-                );
-                state.borrow::<reqwest::Client>()
-            }
-        }
-        .clone()
     };
 
     if method.len() > 50 {
@@ -325,19 +311,16 @@ async fn fetch_send_inner(
         anyhow::bail!("User denied fetch request");
     }
 
-    // SSRF guard — SERVER MODE ONLY. On the shared multi-tenant server a scene must not
-    // reach cloud metadata / loopback / private ranges. The desktop and web clients run
-    // on the user's own machine (and the browser sandboxes the web build), so they keep
-    // unrestricted behaviour. Auto-redirects are disabled for the server client above,
-    // so this check can't be bypassed by a 3xx onto a private host.
-    let (is_server, allow_loopback) = {
+    // SSRF guard — every scene, every mode. No deployed scene may reach cloud metadata /
+    // loopback / private ranges, on the shared server OR the desktop client (a scene is
+    // untrusted code with the user's network position — the web build is already held to
+    // this by the browser's Private Network Access rules). `preview` widens the allowance
+    // to the local network for local development, but never to link-local / metadata.
+    let preview = {
         let op_state = state.borrow();
-        let ctx = op_state.borrow::<CrdtContext>();
-        (ctx.is_server, ctx.preview)
+        op_state.borrow::<CrdtContext>().preview
     };
-    if is_server {
-        common::util::assert_public_url(&url, allow_loopback).await?;
-    }
+    common::util::assert_public_url(&url, preview).await?;
 
     let async_req = if let Some(body_id) = request_body_rid {
         let body = state.borrow_mut().resource_table.take_any(body_id)?;
@@ -426,10 +409,10 @@ pub struct BasicAuth {
 pub struct ClientResource(reqwest::Client);
 impl deno_core::Resource for ClientResource {}
 
-/// Cached default fetch client for authoritative-server mode: redirects disabled so the
-/// per-request SSRF guard can't be bypassed by a 3xx onto a private host. Kept separate
-/// from the client-mode `reqwest::Client` so client/web behaviour is unchanged.
-struct ServerHttpClient(reqwest::Client);
+/// Cached default client for a scene's own requests, in both server and client mode. Its
+/// connections are public-only (see [`PublicOnlyResolver`]) unless `preview` widened them to
+/// the local network; on the server, redirects are disabled too.
+struct SceneHttpClient(reqwest::Client);
 
 /// DNS resolver that only ever hands back public addresses.
 ///
@@ -440,16 +423,16 @@ struct ServerHttpClient(reqwest::Client);
 /// reach it: plain `fetch()` from the SDK is enough. Enforcing inside the resolver makes
 /// the checked answer and the dialled answer the same answer by construction.
 struct PublicOnlyResolver {
-    allow_loopback: bool,
+    allow_private: bool,
 }
 
 impl reqwest::dns::Resolve for PublicOnlyResolver {
     fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
-        let allow_loopback = self.allow_loopback;
+        let allow_private = self.allow_private;
         let host = name.as_str().to_owned();
         Box::pin(async move {
             // port 0: reqwest fills in the real port after resolution
-            let addrs = common::util::resolve_public_addrs(&host, 0, allow_loopback)
+            let addrs = common::util::resolve_public_addrs(&host, 0, allow_private)
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
                     e.to_string().into()
@@ -459,17 +442,47 @@ impl reqwest::dns::Resolve for PublicOnlyResolver {
     }
 }
 
-/// The http client used for every scene request on the authoritative server: no
-/// auto-redirects, and public-only DNS.
-fn build_server_client(allow_loopback: bool) -> reqwest::Client {
+/// Shared base for every scene http client: connect timeout, native TLS, UA, and the
+/// resolver that refuses any non-public address at connect time, so the address that was
+/// checked is the address that is dialled. `allow_private` (preview) widens this to the
+/// local network but never to link-local / metadata.
+fn scene_client_builder(allow_private: bool) -> reqwest::ClientBuilder {
     reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(5))
         .use_native_tls()
         .user_agent("DCLExplorer/0.1")
-        .redirect(reqwest::redirect::Policy::none())
-        .dns_resolver(std::sync::Arc::new(PublicOnlyResolver { allow_loopback }))
-        .build()
-        .unwrap()
+        .dns_resolver(std::sync::Arc::new(PublicOnlyResolver { allow_private }))
+}
+
+/// The default client for a scene's own requests. On the authoritative server redirects are
+/// disabled as well (a 3xx must not silently re-target or forward signed headers); the
+/// desktop client keeps following them, which the resolver makes safe — every hop
+/// re-resolves through the same public-only check.
+fn build_scene_client(allow_private: bool, is_server: bool) -> reqwest::Client {
+    let mut builder = scene_client_builder(allow_private);
+    if is_server {
+        builder = builder.redirect(reqwest::redirect::Policy::none());
+    }
+    builder.build().unwrap()
+}
+
+/// A proxy given as a literal IP is dialled without a DNS lookup, so [`PublicOnlyResolver`]
+/// never sees it. Vet it synchronously: a forbidden (non-public) IP literal is refused unless
+/// `allow_private` (preview) permits the local network. A hostname proxy passes here — the
+/// resolver vets it when the connection is actually made.
+fn reject_non_public_proxy(proxy_url: &str, allow_private: bool) -> Result<(), AnyError> {
+    let url = deno_core::url::Url::parse(proxy_url)?;
+    if let Some(host) = url.host_str() {
+        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+            if allow_private && common::util::is_private_lan(&ip) {
+                return Ok(());
+            }
+            if common::util::is_forbidden_ip(&ip) {
+                anyhow::bail!("custom fetch client proxy may not target a non-public address");
+            }
+        }
+    }
+    Ok(())
 }
 
 #[op2]
@@ -513,11 +526,16 @@ pub fn op_fetch_custom_client(
         // same transport rules as the default server client: no redirects, public-only DNS
         return Ok(state
             .resource_table
-            .add(ClientResource(build_server_client(preview))));
+            .add(ClientResource(build_scene_client(preview, true))));
     }
 
-    let mut builder = reqwest::Client::builder().use_native_tls();
+    // Client mode: the scene may still tune TLS trust/identity for its own machine, but its
+    // connections stay public-only via the resolver (unless preview). A proxy given as a
+    // literal IP skips the resolver — reqwest dials the IP without a lookup — so a private
+    // proxy endpoint is refused here; a hostname proxy is caught at connect by the resolver.
+    let mut builder = scene_client_builder(preview);
     if let Some(proxy_def) = args.proxy {
+        reject_non_public_proxy(&proxy_def.url, preview)?;
         let mut proxy = reqwest::Proxy::http(proxy_def.url)?;
         if let Some(creds) = proxy_def.basic_auth {
             proxy = proxy.basic_auth(&creds.username, &creds.password);

--- a/crates/dcl_deno/src/js/fetch/mod.rs
+++ b/crates/dcl_deno/src/js/fetch/mod.rs
@@ -24,15 +24,20 @@ use fetch_response_body_resource::FetchResponseBodyResource;
 
 use dcl::{interface::crdt_context::CrdtContext, RpcCalls, SceneResourceCounters};
 
-// we have to provide fetch perm structs even though we don't use them
+// We have to provide these perm structs for the deno extensions even though the ops we
+// actually expose don't route through them. They DENY rather than panic: the ops that
+// consult them (`deno_net`'s socket ops in particular) are registered on the runtime and
+// callable from JS, and a `panic!()` there unwinds across the V8 boundary -- which is
+// `panic_cannot_unwind`, i.e. an immediate process abort, not a catchable error. Scene
+// input must never be able to reach that, so refusing is the only safe answer.
 pub struct FP;
 impl FetchPermissions for FP {
     fn check_net_url(&mut self, _: &deno_core::url::Url, _: &str) -> Result<(), AnyError> {
-        panic!();
+        anyhow::bail!("network access is not available to scenes through this API")
     }
 
     fn check_read(&mut self, _: &std::path::Path, _: &str) -> Result<(), AnyError> {
-        panic!();
+        anyhow::bail!("file access is not available to scenes")
     }
 }
 
@@ -50,15 +55,15 @@ impl NetPermissions for NP {
         _host: &(T, Option<u16>),
         _api_name: &str,
     ) -> Result<(), AnyError> {
-        panic!();
+        anyhow::bail!("raw socket access is not available to scenes")
     }
 
     fn check_read(&mut self, _p: &std::path::Path, _api_name: &str) -> Result<(), AnyError> {
-        panic!();
+        anyhow::bail!("file access is not available to scenes")
     }
 
     fn check_write(&mut self, _p: &std::path::Path, _api_name: &str) -> Result<(), AnyError> {
-        panic!();
+        anyhow::bail!("file access is not available to scenes")
     }
 }
 
@@ -130,7 +135,10 @@ where
     // authoritative-server mode only: never auto-follow redirects, so a 3xx onto a
     // private host can't bypass the per-request SSRF check or leak signed headers. The
     // desktop/web client keeps the default redirect-following behaviour unchanged.
-    let is_server = state.borrow::<CrdtContext>().is_server;
+    let (is_server, preview) = {
+        let ctx = state.borrow::<CrdtContext>();
+        (ctx.is_server, ctx.preview)
+    };
 
     let client = if let Some(rid) = client_rid {
         let r = state.resource_table.get::<ClientResource>(rid)?;
@@ -139,13 +147,7 @@ where
         match state.try_borrow::<ServerHttpClient>() {
             Some(client) => client.0.clone(),
             None => {
-                let client = reqwest::Client::builder()
-                    .connect_timeout(Duration::from_secs(5))
-                    .use_native_tls()
-                    .user_agent("DCLExplorer/0.1")
-                    .redirect(reqwest::redirect::Policy::none())
-                    .build()
-                    .unwrap();
+                let client = build_server_client(preview);
                 state.put(ServerHttpClient(client.clone()));
                 client
             }
@@ -429,6 +431,47 @@ impl deno_core::Resource for ClientResource {}
 /// from the client-mode `reqwest::Client` so client/web behaviour is unchanged.
 struct ServerHttpClient(reqwest::Client);
 
+/// DNS resolver that only ever hands back public addresses.
+///
+/// `assert_public_url` runs before the request is sent, but the client resolves the host
+/// AGAIN when it connects — nothing ties the two lookups together. A hostile authoritative
+/// nameserver can therefore answer the pre-flight check with a public address and the
+/// connect with 169.254.169.254 (DNS rebinding), and no scene-side trickery is needed to
+/// reach it: plain `fetch()` from the SDK is enough. Enforcing inside the resolver makes
+/// the checked answer and the dialled answer the same answer by construction.
+struct PublicOnlyResolver {
+    allow_loopback: bool,
+}
+
+impl reqwest::dns::Resolve for PublicOnlyResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let allow_loopback = self.allow_loopback;
+        let host = name.as_str().to_owned();
+        Box::pin(async move {
+            // port 0: reqwest fills in the real port after resolution
+            let addrs = common::util::resolve_public_addrs(&host, 0, allow_loopback)
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                    e.to_string().into()
+                })?;
+            Ok(Box::new(addrs.into_iter()) as reqwest::dns::Addrs)
+        })
+    }
+}
+
+/// The http client used for every scene request on the authoritative server: no
+/// auto-redirects, and public-only DNS.
+fn build_server_client(allow_loopback: bool) -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .use_native_tls()
+        .user_agent("DCLExplorer/0.1")
+        .redirect(reqwest::redirect::Policy::none())
+        .dns_resolver(std::sync::Arc::new(PublicOnlyResolver { allow_loopback }))
+        .build()
+        .unwrap()
+}
+
 #[op2]
 #[serde]
 pub fn op_fetch_custom_client(
@@ -436,11 +479,44 @@ pub fn op_fetch_custom_client(
     #[serde] args: CreateHttpClientOptions,
 ) -> Result<ResourceId, AnyError> {
     debug!("op_fetch_custom_client");
-    let mut builder = reqwest::Client::builder().use_native_tls();
-    // server mode: no auto-redirects (SSRF), matching the default server client
-    if state.borrow::<CrdtContext>().is_server {
-        builder = builder.redirect(reqwest::redirect::Policy::none());
+
+    // A custom client is scene-supplied transport configuration, and on the shared
+    // authoritative server none of it may be honoured:
+    //
+    // * `proxy` re-targets the connection at an address the SSRF guard never sees. The
+    //   guard inspects the request URL; the proxy is what actually gets dialled. Pointing
+    //   it at 169.254.169.254 reaches cloud metadata with a perfectly public-looking URL,
+    //   and disabling redirects does nothing about it.
+    // * `ca_certs` makes the scene a trust root for the server's outbound TLS.
+    // * `cert_chain`/`private_key` let a scene present a client identity as the server.
+    //
+    // Refused rather than ignored so a scene that tries gets an error it can see.
+    // Everything else (the plain `createHttpClient()` case) still works.
+    let (is_server, preview) = {
+        let ctx = state.borrow::<CrdtContext>();
+        (ctx.is_server, ctx.preview)
+    };
+    if is_server {
+        if args.proxy.is_some() {
+            anyhow::bail!("custom fetch clients may not set a proxy on the authoritative server");
+        }
+        if !args.ca_certs.is_empty() {
+            anyhow::bail!(
+                "custom fetch clients may not add root certificates on the authoritative server"
+            );
+        }
+        if args.cert_chain.is_some() || args.private_key.is_some() {
+            anyhow::bail!(
+                "custom fetch clients may not set a client identity on the authoritative server"
+            );
+        }
+        // same transport rules as the default server client: no redirects, public-only DNS
+        return Ok(state
+            .resource_table
+            .add(ClientResource(build_server_client(preview))));
     }
+
+    let mut builder = reqwest::Client::builder().use_native_tls();
     if let Some(proxy_def) = args.proxy {
         let mut proxy = reqwest::Proxy::http(proxy_def.url)?;
         if let Some(creds) = proxy_def.basic_auth {

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -49,6 +49,7 @@ pub fn create_runtime(
     inspect: bool,
     super_user: bool,
     storage_root: &str,
+    preview: bool,
 ) -> (JsRuntime, Option<InspectorServer>) {
     // add fetch stack
     let net = deno_net::deno_net::init_ops_and_esm::<NP>(None, None);
@@ -174,6 +175,7 @@ pub fn create_runtime(
         let mut state = state.borrow_mut();
         state.put(TP);
         state.put(NP);
+        state.put(WebSocketPerms { preview });
     }
 
     // On approaching the cap, terminate this isolate's execution so its JS unwinds and the
@@ -242,7 +244,8 @@ pub(crate) fn scene_thread(
 ) {
     let scene_id = scene_context.scene_id;
     let preview = scene_context.preview;
-    let (mut runtime, inspector) = create_runtime(inspect, super_user.is_some(), &storage_root);
+    let (mut runtime, inspector) =
+        create_runtime(inspect, super_user.is_some(), &storage_root, preview);
 
     // store handle
     let vm_handle = runtime.v8_isolate().thread_safe_handle();
@@ -272,9 +275,6 @@ pub(crate) fn scene_thread(
     state
         .borrow_mut()
         .put(runtime.v8_isolate().thread_safe_handle());
-
-    // store websocket permissions object
-    state.borrow_mut().put(WebSocketPerms { preview });
 
     if inspector.is_some() {
         let _ = state
@@ -622,7 +622,7 @@ mod tests {
     /// is evaluated (`op_require("~scene.js")` -> `evalContext`). A `throw` in the scene
     /// surfaces as `Err`.
     fn run_scene(is_server: bool, scene_js: &str) -> Result<(), String> {
-        let (mut runtime, _) = create_runtime(false, false, "test-scene-realm");
+        let (mut runtime, _) = create_runtime(false, false, "test-scene-realm", false);
         {
             let state = runtime.op_state();
             let mut state = state.borrow_mut();
@@ -706,7 +706,7 @@ mod tests {
     /// authoritative server the option must be refused outright.
     #[test]
     fn server_refuses_a_scene_supplied_proxy() {
-        let (mut runtime, _) = create_runtime(false, false, "test-custom-client");
+        let (mut runtime, _) = create_runtime(false, false, "test-custom-client", false);
         runtime.op_state().borrow_mut().put(context(true));
         let err = runtime
             .execute_script(
@@ -724,7 +724,7 @@ mod tests {
     /// own outbound TLS.
     #[test]
     fn server_refuses_scene_supplied_ca_certs() {
-        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-ca");
+        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-ca", false);
         runtime.op_state().borrow_mut().put(context(true));
         let err = runtime
             .execute_script(
@@ -742,7 +742,7 @@ mod tests {
     /// this restriction is server-only.
     #[test]
     fn client_still_allows_custom_clients() {
-        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-clientmode");
+        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-clientmode", false);
         runtime.op_state().borrow_mut().put(context(false));
         runtime
             .execute_script(

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -164,6 +164,18 @@ pub fn create_runtime(
         ..Default::default()
     });
 
+    // Deno extension permission objects. These must be in the op state from the moment the
+    // runtime exists: the ops that consult them look the type up unconditionally, and a
+    // missing type is itself a panic -- which across the V8 boundary aborts the process
+    // rather than raising a JS error. Put here rather than at scene setup so no entry point
+    // can forget them.
+    {
+        let state = runtime.op_state();
+        let mut state = state.borrow_mut();
+        state.put(TP);
+        state.put(NP);
+    }
+
     // On approaching the cap, terminate this isolate's execution so its JS unwinds and the
     // scene ends cleanly; raise the reported limit so V8 has headroom to run the
     // termination itself instead of hard-aborting the whole sidecar process.
@@ -252,9 +264,6 @@ pub(crate) fn scene_thread(
         super_user,
         scene_origin,
     );
-
-    // store deno permission objects
-    state.borrow_mut().put(TP);
 
     let span = info_span!("js startup").entered();
     state.borrow_mut().put(span);
@@ -586,4 +595,162 @@ fn op_log(state: Rc<RefCell<OpState>>, #[string] message: String) {
 #[op2(fast)]
 fn op_error(state: Rc<RefCell<OpState>>, #[string] message: String) {
     dcl::js::op_error(state, message);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use dcl::{interface::crdt_context::CrdtContext, SceneId};
+    use deno_core::ascii_str;
+    use ipfs::SceneJsFile;
+
+    use super::create_runtime;
+
+    fn context(is_server: bool) -> CrdtContext {
+        CrdtContext::new(
+            SceneId(bevy::prelude::Entity::from_raw(0)),
+            "hash".to_owned(),
+            "title".to_owned(),
+            false,
+            false,
+            is_server,
+        )
+    }
+
+    /// Boot a scene runtime and evaluate `scene_js` exactly the way a deployed scene bundle
+    /// is evaluated (`op_require("~scene.js")` -> `evalContext`). A `throw` in the scene
+    /// surfaces as `Err`.
+    fn run_scene(is_server: bool, scene_js: &str) -> Result<(), String> {
+        let (mut runtime, _) = create_runtime(false, false, "test-scene-realm");
+        {
+            let state = runtime.op_state();
+            let mut state = state.borrow_mut();
+            state.put(context(is_server));
+            state.put(SceneJsFile(Arc::new(scene_js.to_owned())));
+        }
+        runtime
+            .execute_script("<test>", ascii_str!("require(\"~scene.js\")"))
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    /// The scene bundle shares a realm with the runtime, so anything left on the global
+    /// object is scene-reachable -- and `Deno.core.ops` is every op with none of the checks
+    /// the `~system/*` wrappers apply. This is the property, not an implementation detail.
+    #[test]
+    fn scene_cannot_reach_the_ops_table_on_the_server() {
+        run_scene(
+            true,
+            r#"
+            if (typeof Deno !== "undefined") { throw new Error("`Deno` is reachable"); }
+            if (typeof __bootstrap !== "undefined") { throw new Error("`__bootstrap` is reachable"); }
+            if (typeof __infra !== "undefined") { throw new Error("`__infra` is reachable"); }
+            // the global object itself, reached the indirect way
+            const g = Function("return this")();
+            if (g.Deno !== undefined) { throw new Error("`Deno` is reachable via globalThis"); }
+            if (g.__bootstrap !== undefined) { throw new Error("`__bootstrap` is reachable via globalThis"); }
+            "#,
+        )
+        .unwrap();
+    }
+
+    /// ...while the modules the scene is *supposed* to use still get it, via the `Deno`
+    /// parameter `require` injects. Required from scene code, i.e. after the seal.
+    #[test]
+    fn system_modules_still_work_after_sealing() {
+        run_scene(
+            true,
+            r#"
+            const engine = require("~system/EngineApi");
+            if (typeof engine.crdtSendToRenderer !== "function") {
+                throw new Error("EngineApi did not load");
+            }
+            if (typeof require("~system/Runtime").readFile !== "function") {
+                throw new Error("Runtime did not load");
+            }
+            "#,
+        )
+        .unwrap();
+    }
+
+    /// The seal is scoped to the authoritative server on purpose: the desktop client runs on
+    /// the user's own machine, and narrowing the change keeps preview and every deployed
+    /// scene behaving exactly as they do today. Pinned so the scoping is a decision rather
+    /// than something that drifts.
+    #[test]
+    fn client_realm_is_left_alone() {
+        run_scene(
+            false,
+            r#"if (typeof Deno === "undefined") { throw new Error("client behaviour changed"); }"#,
+        )
+        .unwrap();
+    }
+
+    /// `deno_net`'s ops are registered, unwrapped, and reachable from any scene that gets at
+    /// the ops table. They used to `panic!()` in the permission check -- across the V8
+    /// boundary that is `panic_cannot_unwind`, i.e. SIGABRT, and on the client one sidecar
+    /// hosts every scene and losing it exits the engine. It must be an ordinary JS error.
+    #[test]
+    fn raw_socket_ops_raise_instead_of_aborting() {
+        let err = run_scene(
+            false,
+            r#"Deno.core.ops.op_net_listen_tcp({ hostname: "127.0.0.1", port: 9999, transport: "tcp" }, false, false)"#,
+        )
+        .expect_err("raw socket access must be refused");
+        assert!(err.contains("raw socket access"), "unexpected error: {err}");
+    }
+
+    /// A scene-supplied proxy is dialled instead of the URL host, so it walks straight past
+    /// the per-request `assert_public_url` check -- the check only ever sees the URL. On the
+    /// authoritative server the option must be refused outright.
+    #[test]
+    fn server_refuses_a_scene_supplied_proxy() {
+        let (mut runtime, _) = create_runtime(false, false, "test-custom-client");
+        runtime.op_state().borrow_mut().put(context(true));
+        let err = runtime
+            .execute_script(
+                "<test>",
+                ascii_str!(
+                    r#"Deno.core.ops.op_fetch_custom_client({ caCerts: [], proxy: { url: "http://169.254.169.254:80" } })"#
+                ),
+            )
+            .expect_err("proxy must be refused on the authoritative server")
+            .to_string();
+        assert!(err.contains("proxy"), "unexpected error: {err}");
+    }
+
+    /// Same for a scene-supplied trust root: it would make the scene a CA for the server's
+    /// own outbound TLS.
+    #[test]
+    fn server_refuses_scene_supplied_ca_certs() {
+        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-ca");
+        runtime.op_state().borrow_mut().put(context(true));
+        let err = runtime
+            .execute_script(
+                "<test>",
+                ascii_str!(
+                    r#"Deno.core.ops.op_fetch_custom_client({ caCerts: ["-----BEGIN CERTIFICATE-----"] })"#
+                ),
+            )
+            .expect_err("ca_certs must be refused on the authoritative server")
+            .to_string();
+        assert!(err.contains("root certificates"), "unexpected error: {err}");
+    }
+
+    /// The desktop/web client runs on the user's own machine and keeps the old behaviour --
+    /// this restriction is server-only.
+    #[test]
+    fn client_still_allows_custom_clients() {
+        let (mut runtime, _) = create_runtime(false, false, "test-custom-client-clientmode");
+        runtime.op_state().borrow_mut().put(context(false));
+        runtime
+            .execute_script(
+                "<test>",
+                ascii_str!(
+                    r#"Deno.core.ops.op_fetch_custom_client({ caCerts: [], proxy: { url: "http://localhost:8080" } })"#
+                ),
+            )
+            .expect("client mode must keep working");
+    }
 }

--- a/crates/dcl_deno/src/js/modules/init.js
+++ b/crates/dcl_deno/src/js/modules/init.js
@@ -3,6 +3,41 @@
 // required for async ops (engine.sendMessage is declared as async)
 // Deno.core.initializeAsyncOps();
 
+// Private handle on the runtime internals, captured before they are removed from the
+// global object (see `sealRealm` below). `require` is the only thing that keeps a
+// reference, and it hands it out only to `~system/*` modules -- never to scene code.
+const denoRef = Deno;
+
+// The scene bundle is untrusted code that runs in THIS realm, so every global reachable
+// here is reachable from it -- including the raw ops table, which is the whole API surface
+// with none of the checks the `~system/*` wrappers apply. Drop the routes to it just
+// before the scene is evaluated (not at load time: the deno ext modules read these during
+// their own module evaluation, which happens first).
+//
+// `~system/*` modules still need the ops table, so `require` passes `denoRef` in as the
+// `Deno` parameter of their wrapper function. They are unchanged and see `Deno` as before;
+// the scene gets `undefined` for that parameter and no global to fall back to.
+//
+// AUTHORITATIVE SERVER ONLY. That is where scenes are multi-tenant and the host has
+// credentials and a network position worth reaching, so the reward for a deployed scene
+// escaping into the ops table is real. The desktop client runs on the user's own machine
+// and keeps today's behaviour, so a scene that reaches `Deno` there is not a regression
+// against a working preview.
+function isAuthoritativeServer() {
+    return !!(denoRef.core.ops.op_is_server && denoRef.core.ops.op_is_server());
+}
+
+let realmSealed = false;
+function sealRealm() {
+    if (realmSealed) {
+        return;
+    }
+    realmSealed = true;
+    delete globalThis.Deno;        // Deno.core.ops
+    delete globalThis.__bootstrap; // { core, internals, primordials } -- same ops table
+    delete globalThis.__infra;
+}
+
 // load a cjs/node-style module
 // TODO: consider using deno.land/std/node's `createRequire` directly.
 // Deno's node polyfill doesn't work without the full deno runtime, and i
@@ -11,14 +46,23 @@
 // this is a very simplified version of the deno_std/node `createRequire` implementation.
 function require(moduleName) {
     // dynamically load the module source
-    var source = Deno.core.ops.op_require(moduleName);
+    var source = denoRef.core.ops.op_require(moduleName);
 
     // create a wrapper for the imported script
     source = source.replace(/^#!.*?\n/, "");
-    const head = "(function (exports, require, module, __filename, __dirname) { (function (exports, require, module, __filename, __dirname) {";
-    const foot = "\n}).call(this, exports, require, module, __filename, __dirname); })";
+    const head = "(function (exports, require, module, __filename, __dirname, Deno) { (function (exports, require, module, __filename, __dirname, Deno) {";
+    const foot = "\n}).call(this, exports, require, module, __filename, __dirname, Deno); })";
     source = `${head}${source}${foot}`;
-    const [wrapped, err] = Deno.core.evalContext(source, "file://${moduleName}");
+
+    // the scene bundle is the untrusted one; everything else here is ours. Hiding the
+    // internals from it is authoritative-server only -- on the client the scene keeps
+    // seeing exactly what it sees today, global and wrapper parameter alike.
+    const hideInternals = moduleName === "~scene.js" && isAuthoritativeServer();
+    if (hideInternals) {
+        sealRealm();
+    }
+
+    const [wrapped, err] = denoRef.core.evalContext(source, "file://${moduleName}");
     if (err) {
         throw err.thrown;
     }
@@ -35,7 +79,8 @@ function require(moduleName) {
         require,                    // require
         module,                     // module
         moduleName.substring(1),    // __filename
-        moduleName.substring(0, 1)   // __dirname
+        moduleName.substring(0, 1), // __dirname
+        hideInternals ? undefined : denoRef // Deno
     );
 
     return module.exports;
@@ -91,16 +136,16 @@ function logValue(value, seen) {
 
 const console = {
     trace: function (...args) {
-        Deno.core.ops.op_log("TRACE " + customLog(...args))
+        denoRef.core.ops.op_log("TRACE " + customLog(...args))
     },
     log: function (...args) {
-        Deno.core.ops.op_log("LOG " + customLog(...args))
+        denoRef.core.ops.op_log("LOG " + customLog(...args))
     },
     error: function (...args) {
-        Deno.core.ops.op_error("ERROR " + customLog(...args))
+        denoRef.core.ops.op_error("ERROR " + customLog(...args))
     },
     warn: function (...args) {
-        Deno.core.ops.op_log("WARN " + customLog(...args))
+        denoRef.core.ops.op_log("WARN " + customLog(...args))
     },
 }
 
@@ -160,11 +205,11 @@ globalThis.BroadcastChannel = class BroadcastChannel {
         this.onmessage = null;
         this._closed = false;
         const self = this;
-        if (Deno.core.ops.op_get_bridge_stream) {
-            Deno.core.ops.op_get_bridge_stream().then(function (rid) {
+        if (denoRef.core.ops.op_get_bridge_stream) {
+            denoRef.core.ops.op_get_bridge_stream().then(function (rid) {
                 (async function () {
                     while (!self._closed) {
-                        const s = await Deno.core.ops.op_read_bridge_stream(rid);
+                        const s = await denoRef.core.ops.op_read_bridge_stream(rid);
                         if (!s) break; // "" => stream closed
                         if (self.onmessage) {
                             try { self.onmessage({ data: JSON.parse(s) }); } catch (e) {}
@@ -175,8 +220,8 @@ globalThis.BroadcastChannel = class BroadcastChannel {
         }
     }
     postMessage(msg) {
-        if (Deno.core.ops.op_bridge_to_page) {
-            try { Deno.core.ops.op_bridge_to_page(JSON.stringify(msg)); } catch (e) {}
+        if (denoRef.core.ops.op_bridge_to_page) {
+            try { denoRef.core.ops.op_bridge_to_page(JSON.stringify(msg)); } catch (e) {}
         }
     }
     addEventListener(type, fn) { if (type === 'message') this.onmessage = fn; }
@@ -184,7 +229,7 @@ globalThis.BroadcastChannel = class BroadcastChannel {
     close() { this._closed = true; }
 };
 
-Deno.core.setUnhandledPromiseRejectionHandler((promise, reason) => {
+denoRef.core.setUnhandledPromiseRejectionHandler((promise, reason) => {
     console.error('Unhandled promise rejection: ', reason)
     return true;
 })

--- a/crates/dcl_deno/src/js/websocket.rs
+++ b/crates/dcl_deno/src/js/websocket.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashSet, rc::Rc, time::Duration};
+use std::{cell::RefCell, collections::HashSet, net::SocketAddr, rc::Rc, time::Duration};
 
 use common::{
     rpc::{RpcCall, RpcResultSender},
@@ -69,6 +69,13 @@ impl WebSocketPermissions for WebSocketPerms {
             Err(anyhow::anyhow!("URL scheme must be `wss`"))
         }
     }
+
+    fn check_resolved(&mut self, addrs: &[SocketAddr], _api_name: &str) -> Result<(), AnyError> {
+        // These are the exact addresses the handshake is about to dial, so vetting them here
+        // closes the DNS-rebind window a pre-flight check leaves open. `preview` widens the
+        // allowance to the local network, never link-local / metadata.
+        common::util::validate_public_addrs(addrs, self.preview)
+    }
 }
 
 #[op2(async)]
@@ -101,18 +108,11 @@ where
         anyhow::bail!("User denied fetch request");
     }
 
-    // SSRF guard — SERVER MODE ONLY (client/web keep the browser-like behaviour). The
-    // scheme check above still lets `wss://<private-ip>` through; resolve and refuse any
-    // non-public destination on the shared server. Loopback stays reachable in preview,
-    // where the whole point is talking to a local dev server — same rule as fetch.
-    let (is_server, allow_loopback) = {
-        let op_state = state.borrow();
-        let ctx = op_state.borrow::<CrdtContext>();
-        (ctx.is_server, ctx.preview)
-    };
-    if is_server {
-        common::util::assert_public_url(&url, allow_loopback).await?;
-    }
+    // SSRF guard — every scene, every mode (same rule as fetch). Enforced at the connection
+    // itself: `WebSocketPerms::resolve_checked` (called inside the deno handshake) resolves +
+    // validates and returns only public addresses, and those exact addresses are what get
+    // dialled — so it cannot be beaten by a rebinding nameserver the way a pre-flight can.
+    // `preview` widens the allowance to the local network there (never link-local / metadata).
 
     // set default headers
     let mut headers = headers.unwrap_or_default();


### PR DESCRIPTION
## Summary

Scene JS can reach `Deno.core.ops` — the full op table, minus every check the `~system/*` wrappers apply.

`op_require("~scene.js")` returns the deployed bundle's source and `require` evaluates it with `Deno.core.evalContext` in the runtime's own realm (`init.js`). There's no membrane — no `delete globalThis`, no `Object.freeze`, no `Proxy` — anywhere in `crates/dcl_deno/src/js` or `crates/dcl/src/js`. `EngineApi.js` proves the point: its first line is `const {…} = Deno.core.ops`, and it is loaded through the identical path as the scene bundle.

The SDK never exposes `Deno`, but that only constrains the creator's editor. What ships is a bundled `.js` that nothing re-derives from the TypeScript — a creator appends one line to `bin/index.js` after `sdk-commands build` and deploys to a world they own. The join event spawns the worker automatically; there is no review step anywhere in that path.

Two things reach through it.

**On the authoritative server — SSRF to cloud metadata.** `op_fetch_custom_client`'s `proxy` option re-targets the connection at an address the SSRF guard never sees: `assert_public_url` inspects the request URL, the proxy is what actually gets dialled. `proxy: { url: "http://169.254.169.254:80" }` reaches metadata behind a public-looking URL, and `redirect::Policy::none()` does nothing about it. `ca_certs` compounds it — a scene-supplied trust root for the server's own outbound TLS.

Separately, and needing no `Deno` at all: `assert_public_url` and the connect resolve the host independently, so DNS rebinding defeats the guard from plain SDK `fetch()`.

**Everywhere, including the desktop client — one line aborts the process.** The `deno_net` ops are registered (`js/mod.rs:54`), have no `~system/*` wrapper, and are reachable only this way. `NP::check_net` was `panic!()`, and `NP` wasn't even in the OpState so the lookup panicked before reaching it. Across the V8 boundary that's `panic_cannot_unwind` → SIGABRT, not a catchable JS error — verified by running it:

```js
Deno.core.ops.op_net_listen_tcp({hostname:"127.0.0.1",port:9999,transport:"tcp"}, false, false)
```

The `dcl_deno_ipc` sidecar hosts every scene in one process (`main.rs:124`), and losing it deliberately exits the engine (`lib.rs:178-184`). So any creator could deploy a scene that kills the explorer of everyone who walks into it — no permission prompt, no SDK involvement.

**What I checked and found sound.** Signed-fetch metadata is built in Rust from the scene's own `CrdtContext.hash` (`dcl/src/js/fetch.rs:73-86`), so a scene cannot claim to be a different scene, parcel or realm — and `~system/SignedFetch` already exports `getHeaders`, so the raw headers were never behind the wrapper anyway. Permission decisions live behind the `RpcCall` boundary in `crates/restricted_actions` (Web3 signing also requires user activity within the last second), so reaching an op directly doesn't dodge them. Super-user is gated on both paths. The `localStorage` ops are the address-prefixing overrides, so calling them raw changes nothing. I diffed every registered op against every op name referenced by the 15 system modules — `op_fetch_custom_client` and the `deno_net` ops are the only meaningful ones with no wrapper.

## The fix

1. **`op_fetch_custom_client` refuses scene-supplied transport in server mode** — `proxy`, `ca_certs`, `cert_chain`/`private_key` rejected outright; the scene gets a client with the same rules as the default one.
2. **Public-only DNS inside the server http client** — a `PublicOnlyResolver` enforces the rule at connect time, so the checked answer and the dialled answer are the same answer. Shared logic moved to `common::util::resolve_public_addrs`, which `assert_public_url` also calls.
3. **The deno permission structs deny instead of panicking**, and are put into the op state at runtime construction rather than at scene setup (a missing type is itself a panic, and this way no entry point can forget them). Raw socket access now raises an ordinary JS error.
4. **On the authoritative server only, the realm is sealed before the scene bundle runs** — `init.js` captures `Deno` privately and `require` passes it in as the `Deno` parameter of the module wrapper, so all 15 `~system/*` modules are unchanged and still see `Deno`; then `Deno`, `__bootstrap` and `__infra` are deleted from the global object. `__bootstrap.core` is the same ops table, so deleting only `Deno` would not have been enough. The deletion happens at that moment rather than at load time because the deno ext modules read those globals during their own evaluation, which happens first.

## Scope

1, 2 and 4 are gated on `is_server`. That's deliberate: the server is where scenes are multi-tenant and the host has credentials and a network position worth reaching, so the reward for escaping into the ops table is real there. On the desktop client the scene keeps seeing exactly what it sees today — same global, same wrapper parameter — so no deployed scene or preview can regress. The process-abort bug is fixed for everyone by 3, which needs no realm surgery.

The consequence worth stating plainly: on the client, `Deno.core.ops` stays reachable from scene code, so any op added in future is exposed there by default. Sealing the client realm is a follow-up decision, not something this PR forecloses — the mechanism is in place and it's a one-line change to the gate.

## What could break

The realm seal is the risky part, and it now only applies to the authoritative server. A server-side scene bundle legitimately touching `Deno` would stop working; I grepped `js-sdk-toolchain` and there are no references. The `~system/*` modules keep working via the injected wrapper parameter, covered by a test that requires them from scene code after the seal.

It assumes no ext module reads `globalThis.Deno` / `__bootstrap` lazily after startup (they import `ext:core/mod.js` at evaluation time) and that dynamic `import()` stays unavailable (no `module_loader` is configured). Both hold today; the first is the one to re-check on a deno bump.

One deliberate behaviour change outside the server gate: in preview, a hostname that *resolves* to loopback is now allowed, where before only a literally-loopback URL was.

## How to test

`cargo test -p dcl_deno` — 7 tests:

- `scene_cannot_reach_the_ops_table_on_the_server` runs a scene through the real `op_require` → `evalContext` path and asserts `Deno` / `__bootstrap` / `__infra` are gone, including via `Function("return this")()`.
- `client_realm_is_left_alone` asserts the opposite in client mode. The two are each other's negative control — the scoping is pinned, not incidental.
- `system_modules_still_work_after_sealing` requires `~system/EngineApi` and `~system/Runtime` from scene code, i.e. after the seal.
- `raw_socket_ops_raise_instead_of_aborting` calls `op_net_listen_tcp` from scene scope and expects a JS error. Before the change this test aborts the whole test binary with SIGABRT.
- three on the custom-client rules, one pinning that client mode still accepts a custom client with a proxy.

Manually: deploy a scene whose bundle calls `Deno.core.ops.op_fetch_custom_client({ ca_certs: [], proxy: { url: "http://169.254.169.254:80" } })`. Before, it builds a working client; after, `Deno` is `undefined` in scene scope on the server, and the op refuses the proxy if reached any other way.

## Not in this PR

- Sealing the client realm (see Scope).
- The WebSocket path (`op_ws_create`) still uses the pre-flight check only; pinning its resolution needs a different hook in `deno_websocket`.
- Blocking IMDS from the worker's network namespace on the multiplayer-server side — the defence-in-depth layer that makes a future regression here not instantly credential disclosure.
