### PR TITLE
Fix preview hot reload: skip binary frames on the dev-server socket

### DIFF
--- a/crates/comms/src/preview.rs
+++ b/crates/comms/src/preview.rs
@@ -96,7 +96,11 @@ pub async fn handle_preview_socket(
         let msg = msg?;
         info!("preview server message: {msg}");
 
-        if let Ok(value) = serde_json::Value::from_str(msg.into_text()?.as_str()) {
+        // the dev server interleaves protobuf binary frames (WsSceneMessage) with the
+        // legacy JSON text frames we speak; erroring here killed the socket before the
+        // SCENE_UPDATE text frame arrived, so hot reload never fired
+        let Ok(text) = msg.into_text() else { continue };
+        if let Ok(value) = serde_json::Value::from_str(text.as_str()) {
             let Some(ty) = value
                 .get("type")
                 .and_then(|v| v.as_str().map(ToOwned::to_owned))


### PR DESCRIPTION
## Summary

Preview hot reload dies against current `sdk-commands` — but only for some scenes, which is why it has been hard to pin down. On every rebuild the dev server sends a protobuf `WsSceneMessage` **binary** frame before the legacy JSON text frames. `handle_preview_socket` calls `msg.into_text()?` on it; whether that errors depends on the frame's bytes:

- The frame is nearly all ASCII — the only possible invalid-UTF-8 bytes are the protobuf **length varints**, which grow a high bit only when a length exceeds 127.
- `sceneId = 'b64-' + base64(projectPath + '-' + hostname)`: once path+hostname exceeds ~87 chars, the varint goes multi-byte (`0x80+`), the frame stops being valid UTF-8, `into_text()?` kills the socket task (`preview socket error: UTF-8 encoding error, restarting`), and the `SCENE_UPDATE` text frame arriving milliseconds later hits a closed socket. No reload, on any bevy client (desktop, web, headless server).
- Shorter paths produce all-ASCII frames: `into_text()` succeeds, the garbage fails JSON parse harmlessly, and reload works — hence "works on my machine".

Verified concretely: `/Users/.../towerofmadness` → 108-byte frame, valid UTF-8, reload works; `/Users/.../multiplayer-server/engine-conformance-scene` → 150-byte frame, invalid UTF-8, reload dead.

Fix: skip frames that don't decode as text instead of erroring; the reload protocol we speak is the legacy JSON text frame.

## What could break

- Nothing anticipated: the only behavior change is that non-text frames no longer kill the socket. Text-frame handling is untouched.
- We still ignore the protobuf protocol (`updateScene`/`updateModel`); moving to it is a separate improvement.

## How to test

1. Put a scene in a deeply nested folder (path + hostname > ~87 chars) and `sdk-commands start` with this engine (headless: `DCL_SERVER_ENGINE=bevy DCL_SERVER_PACKAGE=<local launcher> DCL_BEVY_SERVER_PATH=<this build>`).
2. Edit scene source; with `RUST_LOG=comms::preview=debug` observe: binary frame logged and skipped → `SCENE_UPDATE` received → scene despawns/respawns running the new bundle.
3. Validated end-to-end on the headless server: a live edit of a probe scene's boot log appeared in the server output ~1s after save, without restarting the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kdcjTPn62CzqTLdjnM6Cn