### PR TITLE
Run tweens in the headless server binary

### DIFF
--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -64,6 +64,7 @@ use scene_runner::{
     SceneRunnerPlugin,
 };
 use system_bridge::SystemBridgePlugin;
+use tween::TweenPlugin;
 use user_input::avatar_movement::{
     ActivePlayerComponent, AvatarMovement, AvatarMovementInfo, FromConfig, GroundCollider,
 };
@@ -327,6 +328,9 @@ fn main() {
         .add_plugins(GizmoPlugin)
         .add_plugins(UtilsPlugin)
         .add_plugins(SceneRunnerPlugin)
+        // tweens drive transforms (moving platforms → colliders), so they run headless
+        // like AnimatorPlugin; texture-move no-ops without material components
+        .add_plugins(TweenPlugin)
         .add_plugins(SceneBoundPlugin)
         .add_plugins(RestrictedActionsPlugin);
 


### PR DESCRIPTION
## Summary

The headless server never registered `TweenPlugin` (it was only in the desktop client's plugin list), so authoritative server scenes got no tween motion, no `TweenState` writeback, and no completion signal — tween-driven moving platforms were frozen server-side while colliders and raycasts depended on them. Register the plugin in `headless.rs`, mirroring the reasoning that keeps `AnimatorPlugin` headless (animation drives transforms → colliders).

No cargo changes: `tween` is a non-optional root dependency and compiles under `--no-default-features --features headless,livekit`. Texture-move modes degrade structurally: with `MaterialDefinitionPlugin` absent headless no entity carries `PbMaterialComponent`, and `Tween::apply` early-returns for both TextureMove variants. Transform tweens (Move/Rotate/Scale/MoveRotateScale/continuous), `TWEEN_STATE` writeback, the TRANSFORM echo, and `clean_scene_tween_state` are fully active.

## What could break

- Headless-only change (the client already runs this plugin). Server scenes that previously saw `TweenState` as null will start seeing real states and `tweenSystem.tweenCompleted()` firing — which is the point, but scene code written around the old dead behavior would newly execute its completion paths.

## How to test

1. Build: `cargo build --bin headless --no-default-features --features headless,livekit`.
2. Run a server scene that creates a `Tween` (move mode) and polls `TweenState` / `tweenSystem.tweenCompleted()`.
3. Validated with a conformance scene: `TweenState` reports active progress (`0 @ 0.36`) and completion fires each 4s cycle of a ping-pong shuttle, where before both stayed null/silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kdcjTPn62CzqTLdjnM6Cn