### PR TITLE
Bound scene CRDT ingress: per-batch and cumulative store caps

### DIFF
--- a/crates/dcl/src/interface/mod.rs
+++ b/crates/dcl/src/interface/mod.rs
@@ -150,6 +150,26 @@ impl CrdtStore {
         }
     }
 
+    /// Total bytes of component payload currently retained: LWW last-write values plus any
+    /// grow-only entries. `Vec::len` is O(1), so this is O(retained entries). Used to bound
+    /// a scene's cumulative CRDT footprint.
+    pub fn retained_data_bytes(&self) -> usize {
+        let lww: usize = self
+            .lww
+            .values()
+            .flat_map(|state| state.last_write.values())
+            .map(|entry| entry.data.len())
+            .sum();
+        let go: usize = self
+            .go
+            .values()
+            .flat_map(|state| state.0.values())
+            .flat_map(|queue| queue.iter())
+            .map(|entry| entry.data.len())
+            .sum();
+        lww + go
+    }
+
     pub fn take_updates(&mut self) -> CrdtStore {
         let mut lww = HashMap::new();
         for (component_id, state) in self.lww.iter_mut() {
@@ -464,5 +484,66 @@ mod test {
         assert!(context.init(max));
         context.kill(max);
         assert!(context.is_dead(max));
+    }
+
+    fn entity(id: u16) -> SceneEntityId {
+        SceneEntityId { id, generation: 0 }
+    }
+
+    // retained_data_bytes must sum LWW last-write payloads and grow-only entries, and must
+    // reflect overwrites/deletes so a store that churns without growing doesn't inflate.
+    #[test]
+    fn retained_data_bytes_counts_lww_and_go() {
+        let mut store = CrdtStore::default();
+        let comp = SceneComponentId(1);
+        let ts = SceneCrdtTimestamp(1);
+
+        // two LWW entries of 10 and 25 bytes
+        store.try_update(
+            comp,
+            CrdtType::LWW_ANY,
+            entity(0),
+            ts,
+            Some(&mut DclReader::new(&[0u8; 10])),
+        );
+        store.try_update(
+            comp,
+            CrdtType::LWW_ANY,
+            entity(1),
+            ts,
+            Some(&mut DclReader::new(&[0u8; 25])),
+        );
+        assert_eq!(store.retained_data_bytes(), 35);
+
+        // a grow-only append of 40 bytes adds to the total
+        let go_comp = SceneComponentId(2);
+        store.try_update(
+            go_comp,
+            CrdtType::GO_ANY,
+            entity(0),
+            ts,
+            Some(&mut DclReader::new(&[0u8; 40])),
+        );
+        assert_eq!(store.retained_data_bytes(), 75);
+
+        // overwriting an LWW entry replaces, not adds: 10 -> 4 shrinks the total
+        store.try_update(
+            comp,
+            CrdtType::LWW_ANY,
+            entity(0),
+            SceneCrdtTimestamp(2),
+            Some(&mut DclReader::new(&[0u8; 4])),
+        );
+        assert_eq!(store.retained_data_bytes(), 69);
+
+        // a delete (None) frees the entry's payload
+        store.try_update(
+            comp,
+            CrdtType::LWW_ANY,
+            entity(1),
+            SceneCrdtTimestamp(2),
+            None,
+        );
+        assert_eq!(store.retained_data_bytes(), 44);
     }
 }

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -86,6 +86,13 @@ fn localize_crdt_message(
 pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8]) {
     let mut op_state = op_state.borrow_mut();
 
+    // Once flagged for shutdown the scene is inert: ingest nothing further and emit no
+    // frames, so a scene that ignores the unwind can't keep growing the store or pushing
+    // frames at a scene the renderer has already marked broken.
+    if op_state.has::<ShuttingDown>() {
+        return;
+    }
+
     // Reject an oversized batch before it is copied into the store, serialised, and framed
     // onto the shared connection. Report it as a scene error and flag the scene for shutdown
     // so only this isolate is torn down; the frame is never built and co-tenant scenes are
@@ -222,6 +229,14 @@ pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Ve
     }
 
     debug!("op_crdt_recv_from_renderer");
+
+    // A scene flagged for shutdown must not park on the renderer channel — the renderer marks
+    // it broken and never responds, which would leave the isolate resident until scene unload.
+    // Return an empty batch instead, so the tick unwinds to the scene loop, whose ShuttingDown
+    // check tears the runtime down.
+    if op_state.borrow().has::<ShuttingDown>() {
+        return Vec::new();
+    }
 
     // Receive messages in a loop, handling snapshot/allocation requests immediately (no RefMut held
     // across the await point) and looping for the next.  Exits with the first Ok/shutdown response —

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -12,8 +12,8 @@ use crate::{
     crdt::{append_component, delete_entity, put_component},
     interface::{crdt_context::CrdtContext, CrdtType},
     js::{
-        AllocatorContext, CommunicatedWithRenderer, CrdtStoreNextCheck, FilteredCrdtStore,
-        RendererStore, SceneResponseSender, SceneStatsFlush, ShuttingDown,
+        AllocatorContext, CommunicatedWithRenderer, CrdtSentThisTick, CrdtStoreNextCheck,
+        FilteredCrdtStore, RendererStore, SceneResponseSender, SceneStatsFlush, ShuttingDown,
     },
     AllocError, CrdtComponentInterfaces, CrdtStore, RendererResponse, RpcCalls, SceneElapsedTime,
     SceneLogMessage, SceneResourceCounters, SceneResponse,
@@ -92,6 +92,24 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
     if op_state.has::<ShuttingDown>() {
         return;
     }
+
+    // One batch per tick: a scene that sends again without an intervening tick boundary is
+    // breaching the runtime contract — and un-awaited send spam would otherwise stack frames
+    // onto the bounded response channel, whose overflow panics inside an op and takes down
+    // the shared sidecar. The marker is cleared by the scene loop at each tick boundary.
+    if op_state.has::<CrdtSentThisTick>() {
+        let scene_id = op_state.borrow::<CrdtContext>().scene_id;
+        error!("[{scene_id:?}] multiple CRDT batches in one tick; terminating the scene");
+        let _ = op_state
+            .borrow_mut::<SceneResponseSender>()
+            .try_send(SceneResponse::Error(
+                scene_id,
+                "scene sent more than one CRDT batch in a tick".to_owned(),
+            ));
+        op_state.put(ShuttingDown);
+        return;
+    }
+    op_state.put(CrdtSentThisTick);
 
     // Reject an oversized batch before it is copied into the store, serialised, and framed
     // onto the shared connection. Report it as a scene error and flag the scene for shutdown

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -133,6 +133,10 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
 
     let census = entity_map.take_census();
     crdt_store.clean_up(&census.died);
+    // also reap the sidecar: scene-sent DeleteEntity messages clean it inline, but
+    // engine-initiated deletes only reach the stores via this census, and there's no value
+    // in retaining custom components for dead entities.
+    filtered_store.0.clean_up(&census.died);
     let updates = crdt_store.take_updates();
 
     let rpc_calls = std::mem::take(op_state.borrow_mut::<RpcCalls>());

--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 // Engine module
-use bevy::log::{debug, info, warn};
+use bevy::log::{debug, error, info, warn};
 #[cfg(feature = "span_scene_loop")]
 use bevy::log::{info_span, tracing::span::EnteredSpan};
 use common::structs::{CameraFov, GlobalCrdtStateUpdate, TimeOfDay};
@@ -12,14 +12,29 @@ use crate::{
     crdt::{append_component, delete_entity, put_component},
     interface::{crdt_context::CrdtContext, CrdtType},
     js::{
-        AllocatorContext, CommunicatedWithRenderer, FilteredCrdtStore, RendererStore,
-        SceneResponseSender, SceneStatsFlush, ShuttingDown,
+        AllocatorContext, CommunicatedWithRenderer, CrdtStoreNextCheck, FilteredCrdtStore,
+        RendererStore, SceneResponseSender, SceneStatsFlush, ShuttingDown,
     },
     AllocError, CrdtComponentInterfaces, CrdtStore, RendererResponse, RpcCalls, SceneElapsedTime,
     SceneLogMessage, SceneResourceCounters, SceneResponse,
 };
 
 use super::State;
+
+// Upper bound on a single CRDT batch a scene submits per tick. A well-behaved scene's
+// per-tick delta is orders of magnitude smaller; this only rejects pathological batches
+// that would build an IPC frame large enough to threaten the sidecar<->engine socket —
+// which every co-tenant scene shares. Bounding here, at the JS ingress, keeps the cost
+// attributable to the offending scene and lets us terminate only that scene, rather than
+// tearing down the shared connection after the frame has already been built. Tunable;
+// sized generously to leave headroom over legitimate bulk updates.
+pub(crate) const MAX_CRDT_BATCH_BYTES: usize = 64 * 1024 * 1024;
+
+// Upper bound on a scene's cumulative retained CRDT store. The store mirrors the scene's
+// live heap state, so a stock-SDK scene cannot grow it past the isolate's 512 MiB heap cap;
+// only a scene that pushes CRDT data without holding it in its own heap can. Set to the heap
+// cap so legitimate scenes are never clipped and only that cheating pattern is caught.
+pub(crate) const MAX_CRDT_STORE_BYTES: usize = 512 * 1024 * 1024;
 
 /// Returns whether this scene runs in authoritative-server role. Read synchronously
 /// from the scene's CrdtContext (seeded from the `IsServer` engine resource). MUST stay
@@ -70,6 +85,27 @@ fn localize_crdt_message(
 
 pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8]) {
     let mut op_state = op_state.borrow_mut();
+
+    // Reject an oversized batch before it is copied into the store, serialised, and framed
+    // onto the shared connection. Report it as a scene error and flag the scene for shutdown
+    // so only this isolate is torn down; the frame is never built and co-tenant scenes are
+    // untouched.
+    if messages.len() > MAX_CRDT_BATCH_BYTES {
+        let scene_id = op_state.borrow::<CrdtContext>().scene_id;
+        error!(
+            "[{scene_id:?}] CRDT batch of {} bytes exceeds the {MAX_CRDT_BATCH_BYTES}-byte ingress cap; terminating the scene",
+            messages.len()
+        );
+        let _ = op_state
+            .borrow_mut::<SceneResponseSender>()
+            .try_send(SceneResponse::Error(
+                scene_id,
+                format!("scene exceeded the {MAX_CRDT_BATCH_BYTES}-byte CRDT batch limit"),
+            ));
+        op_state.put(ShuttingDown);
+        return;
+    }
+
     let elapsed_time = op_state.borrow::<SceneElapsedTime>().0;
     let logs = op_state.take::<Vec<SceneLogMessage>>();
     op_state.put(Vec::<SceneLogMessage>::default());
@@ -138,6 +174,40 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
     op_state.put(crdt_store);
     op_state.put(filtered_store);
     op_state.put(allocator);
+
+    // Cumulative footprint guard. Measuring the retained store is O(entries), so amortise it:
+    // retained bytes grow at most 1:1 with ingest, so once a measurement finds `retained` bytes
+    // the store cannot reach the cap until `cap - retained` more are ingested. Only walk when the
+    // ingest total reaches that projected point (floored a batch ahead so a scene sitting just
+    // under the cap doesn't walk every tick). A scene well below the cap rarely walks at all.
+    if !op_state.has::<CrdtStoreNextCheck>() {
+        op_state.put(CrdtStoreNextCheck(MAX_CRDT_STORE_BYTES as u64));
+    }
+    let ingested = op_state.borrow::<SceneResourceCounters>().crdt_bytes;
+    if ingested >= op_state.borrow::<CrdtStoreNextCheck>().0 {
+        let retained = op_state.borrow::<CrdtStore>().retained_data_bytes()
+            + op_state
+                .borrow::<FilteredCrdtStore>()
+                .0
+                .retained_data_bytes();
+        if retained > MAX_CRDT_STORE_BYTES {
+            error!(
+                "[{scene_id:?}] retained CRDT store of {retained} bytes exceeds the {MAX_CRDT_STORE_BYTES}-byte cap; terminating the scene"
+            );
+            let _ = op_state
+                .borrow_mut::<SceneResponseSender>()
+                .try_send(SceneResponse::Error(
+                    scene_id,
+                    format!("scene exceeded the {MAX_CRDT_STORE_BYTES}-byte CRDT store limit"),
+                ));
+            op_state.put(ShuttingDown);
+        } else {
+            let headroom = (MAX_CRDT_STORE_BYTES - retained) as u64;
+            op_state.put(CrdtStoreNextCheck(
+                ingested + headroom.max(MAX_CRDT_BATCH_BYTES as u64),
+            ));
+        }
+    }
 }
 
 pub async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<impl State>>) -> Vec<Vec<u8>> {

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -91,6 +91,12 @@ pub struct CommunicatedWithRenderer;
 // scene-elapsed time (seconds) of the last SceneResponse::Stats flush
 pub struct SceneStatsFlush(pub f32);
 
+// Set by `crdt_send_to_renderer`, cleared at each tick boundary by the scene loop: a scene
+// may send at most one CRDT batch per tick (the response channel is sized for that contract,
+// and un-awaited send spam could otherwise fill it). A second send in one tick is a breach
+// that shuts the scene down.
+pub struct CrdtSentThisTick;
+
 // Ingest total (SceneResourceCounters::crdt_bytes) at which the retained store could next
 // reach its cap. Retained bytes grow at most 1:1 with ingest, so after a measurement finds
 // `retained` bytes the store cannot breach until `cap - retained` more bytes arrive. Storing
@@ -574,6 +580,53 @@ mod scene_log_budget_tests {
             0,
             "dead entities' custom components must not be retained"
         );
+    }
+
+    // A scene may send at most one CRDT batch per tick: a second send with no intervening
+    // tick boundary is a contract breach that terminates the scene — un-awaited send spam
+    // must not stack frames onto the bounded response channel.
+    #[test]
+    fn second_send_in_one_tick_terminates_the_scene() {
+        let (sx, mut rx) = scene_response_channel();
+        let mut s = crdt_state();
+        s.put(sx);
+        let state = std::rc::Rc::new(std::cell::RefCell::new(s));
+
+        super::engine::crdt_send_to_renderer(state.clone(), &[]);
+        assert!(matches!(rx.try_recv(), Ok(crate::SceneResponse::Ok(..))));
+
+        super::engine::crdt_send_to_renderer(state.clone(), &[]);
+        match rx.try_recv() {
+            Ok(crate::SceneResponse::Error(id, msg)) => {
+                assert_eq!(id, crate::SceneId::DUMMY);
+                assert!(
+                    msg.contains("more than one CRDT batch"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+        assert!(
+            state.borrow().has::<ShuttingDown>(),
+            "a second send in one tick must flag the scene for shutdown"
+        );
+    }
+
+    // The scene loop clears the allowance at each tick boundary, so one send per tick flows.
+    #[test]
+    fn one_send_per_tick_boundary_is_fine() {
+        let (sx, mut rx) = scene_response_channel();
+        let mut s = crdt_state();
+        s.put(sx);
+        let state = std::rc::Rc::new(std::cell::RefCell::new(s));
+
+        for _ in 0..3 {
+            super::engine::crdt_send_to_renderer(state.clone(), &[]);
+            assert!(matches!(rx.try_recv(), Ok(crate::SceneResponse::Ok(..))));
+            // what the scene loop does at each tick boundary
+            state.borrow_mut().try_take::<CrdtSentThisTick>();
+        }
+        assert!(!state.borrow().has::<ShuttingDown>());
     }
 
     // A normal batch flows through untouched: an Ok frame is produced and the scene is not

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -510,6 +510,52 @@ mod scene_log_budget_tests {
         );
     }
 
+    // Engine-initiated deletes reach the stores only via the census (the scene never sends a
+    // DeleteEntity message for them) — the sidecar must be reaped there too, so custom
+    // components aren't retained for dead entities.
+    #[test]
+    fn census_deaths_reap_the_filtered_store() {
+        use crate::interface::{crdt_context::CrdtContext, CrdtType};
+        use dcl_component::{DclReader, SceneComponentId, SceneCrdtTimestamp, SceneEntityId};
+
+        let (sx, _rx) = scene_response_channel();
+        let mut s = crdt_state();
+        s.put(sx);
+
+        let entity = SceneEntityId {
+            id: 600,
+            generation: 0,
+        };
+        s.borrow_mut::<FilteredCrdtStore>().0.try_update(
+            SceneComponentId(9999),
+            CrdtType::LWW_ANY,
+            entity,
+            SceneCrdtTimestamp(1),
+            Some(&mut DclReader::new(&[0u8; 16])),
+        );
+        // mimic an engine-initiated delete: killed directly in the context, no DeleteEntity
+        // stream message
+        {
+            let ctx = s.borrow_mut::<CrdtContext>();
+            ctx.init(entity);
+            ctx.take_census();
+            ctx.kill(entity);
+        }
+        let state = std::rc::Rc::new(std::cell::RefCell::new(s));
+
+        super::engine::crdt_send_to_renderer(state.clone(), &[]);
+
+        assert_eq!(
+            state
+                .borrow()
+                .borrow::<FilteredCrdtStore>()
+                .0
+                .retained_data_bytes(),
+            0,
+            "dead entities' custom components must not be retained"
+        );
+    }
+
     // A normal batch flows through untouched: an Ok frame is produced and the scene is not
     // flagged for shutdown.
     #[test]

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -508,6 +508,26 @@ mod scene_log_budget_tests {
             rx.try_recv().is_err(),
             "no Ok frame must be built for a rejected batch"
         );
+
+        // the follow-up recv must not park on the renderer channel (the renderer marks the
+        // scene broken and never responds): it returns an empty batch immediately — the test
+        // state holds no renderer channel at all, so reaching for it would panic — letting
+        // the tick unwind to the scene loop's ShuttingDown check.
+        let batch = futures_lite::future::block_on(super::engine::op_crdt_recv_from_renderer(
+            state.clone(),
+        ));
+        assert!(
+            batch.is_empty(),
+            "a shutting-down scene must receive an empty batch"
+        );
+
+        // and further sends are inert: a scene that ignores the unwind can neither grow the
+        // store nor push frames at the broken scene.
+        super::engine::crdt_send_to_renderer(state, &[]);
+        assert!(
+            rx.try_recv().is_err(),
+            "a shutting-down scene must not emit further frames"
+        );
     }
 
     // Engine-initiated deletes reach the stores only via the census (the scene never sends a

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -91,6 +91,13 @@ pub struct CommunicatedWithRenderer;
 // scene-elapsed time (seconds) of the last SceneResponse::Stats flush
 pub struct SceneStatsFlush(pub f32);
 
+// Ingest total (SceneResourceCounters::crdt_bytes) at which the retained store could next
+// reach its cap. Retained bytes grow at most 1:1 with ingest, so after a measurement finds
+// `retained` bytes the store cannot breach until `cap - retained` more bytes arrive. Storing
+// that projected point lets `crdt_send_to_renderer` skip the O(entries) walk in proportion to
+// how far below the cap the scene sits.
+pub struct CrdtStoreNextCheck(pub u64);
+
 pub trait State {
     fn borrow<T: 'static>(&self) -> &T;
     fn try_borrow<T: 'static>(&self) -> Option<&T>;
@@ -446,5 +453,81 @@ mod scene_log_budget_tests {
             _ => None,
         });
         assert_eq!(set, (5, 64));
+    }
+
+    // full op-state for driving `crdt_send_to_renderer`.
+    fn crdt_state() -> TestState {
+        use crate::interface::crdt_context::CrdtContext;
+        let ctx = || {
+            CrdtContext::new(
+                crate::SceneId::DUMMY,
+                Default::default(),
+                Default::default(),
+                false,
+                false,
+                false,
+            )
+        };
+        let mut s = state();
+        s.put(crate::SceneElapsedTime(0.0));
+        s.put(ctx());
+        s.put(crate::CrdtStore::default());
+        s.put(FilteredCrdtStore::default());
+        s.put(AllocatorContext(ctx()));
+        s.put(crate::CrdtComponentInterfaces::default());
+        s.put(crate::RpcCalls::default());
+        s.put(SceneStatsFlush(0.0));
+        s
+    }
+
+    // An oversized batch is refused at ingress: the scene is reported as errored and flagged
+    // for shutdown, and no Ok frame is built — so the offending scene dies without a giant
+    // frame ever reaching the shared connection.
+    #[test]
+    fn oversized_crdt_batch_terminates_the_scene() {
+        let (sx, mut rx) = scene_response_channel();
+        let mut s = crdt_state();
+        s.put(sx);
+        let state = std::rc::Rc::new(std::cell::RefCell::new(s));
+
+        let oversized = vec![0u8; super::engine::MAX_CRDT_BATCH_BYTES + 1];
+        super::engine::crdt_send_to_renderer(state.clone(), &oversized);
+
+        match rx.try_recv() {
+            Ok(crate::SceneResponse::Error(id, msg)) => {
+                assert_eq!(id, crate::SceneId::DUMMY);
+                assert!(msg.contains("CRDT batch"), "unexpected message: {msg}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+        assert!(
+            state.borrow().has::<ShuttingDown>(),
+            "oversized batch must flag the scene for shutdown"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no Ok frame must be built for a rejected batch"
+        );
+    }
+
+    // A normal batch flows through untouched: an Ok frame is produced and the scene is not
+    // flagged for shutdown.
+    #[test]
+    fn normal_crdt_batch_is_forwarded_and_scene_survives() {
+        let (sx, mut rx) = scene_response_channel();
+        let mut s = crdt_state();
+        s.put(sx);
+        let state = std::rc::Rc::new(std::cell::RefCell::new(s));
+
+        super::engine::crdt_send_to_renderer(state.clone(), &[]);
+
+        match rx.try_recv() {
+            Ok(crate::SceneResponse::Ok(id, ..)) => assert_eq!(id, crate::SceneId::DUMMY),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+        assert!(
+            !state.borrow().has::<ShuttingDown>(),
+            "a normal batch must not shut the scene down"
+        );
     }
 }

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -6,8 +6,8 @@ use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
     js::{
-        engine::crdt_send_to_renderer, init_state, CommunicatedWithRenderer, SceneResponseSender,
-        ShuttingDown, SuperUserScene,
+        engine::crdt_send_to_renderer, init_state, CommunicatedWithRenderer, CrdtSentThisTick,
+        SceneResponseSender, ShuttingDown, SuperUserScene,
     },
     RendererResponse, RpcCalls, SceneElapsedTime, SceneResourceCounters, SceneResponse,
 };
@@ -318,6 +318,8 @@ pub(crate) fn scene_thread(
 
     // send any initial rpc requests
     crdt_send_to_renderer(state.clone(), &[]);
+    // the initial send consumed the tick's batch allowance; give onStart its own
+    state.borrow_mut().try_take::<CrdtSentThisTick>();
 
     // run startup function
     let run_start = thread_cpu_us();
@@ -363,6 +365,8 @@ pub(crate) fn scene_thread(
         state
             .borrow_mut()
             .put(SceneElapsedTime(elapsed.as_secs_f32()));
+        // tick boundary: reset the one-batch-per-tick send allowance
+        state.borrow_mut().try_take::<CrdtSentThisTick>();
 
         // heap gauges: sampling walks the isolate's spaces, so cap it at ~once per 5s
         if last_heap_sample.is_none_or(|at| now.saturating_duration_since(at).as_secs() >= 5) {

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -8,7 +8,10 @@ use bevy::{log::tracing::span::EnteredSpan, tasks::IoTaskPool};
 use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
-    js::{CommunicatedWithRenderer, SceneResponseSender, ShuttingDown, SuperUserScene},
+    js::{
+        CommunicatedWithRenderer, CrdtSentThisTick, SceneResponseSender, ShuttingDown,
+        SuperUserScene,
+    },
     RendererResponse, SceneElapsedTime,
 };
 use gotham_state::GothamState;
@@ -215,7 +218,10 @@ impl From<WasmError> for JsValue {
 
 #[wasm_bindgen]
 pub fn op_set_elapsed(state: &WorkerContext, elapsed: f32) {
-    state.state.borrow_mut().put(SceneElapsedTime(elapsed));
+    let mut state = state.state.borrow_mut();
+    state.put(SceneElapsedTime(elapsed));
+    // tick boundary: reset the one-batch-per-tick send allowance
+    state.try_take::<CrdtSentThisTick>();
 }
 
 #[wasm_bindgen]

--- a/deploy/web/engine/sandbox_worker.js
+++ b/deploy/web/engine/sandbox_worker.js
@@ -397,6 +397,9 @@ self.onmessage = async (event) => {
       // send any initial rpc requests
       ops.op_crdt_send_to_renderer([]);
 
+      // the initial send consumed the tick's batch allowance; give onStart its own
+      ops.op_set_elapsed(0);
+
       await module.onStart();
 
       var elapsed = 0;


### PR DESCRIPTION
## Summary

Scenes drive the sidecar↔engine IPC through `crdt_send_to_renderer`, and nothing bounded what they submit. All scenes are multiplexed over a single sidecar connection, so reacting after a bad frame reaches the shared socket means tearing the connection down for every co-tenant scene. This bounds scene CRDT ingress at the JS op boundary — inside the offending scene's own op call, before anything is copied into the store, serialised, or framed — so the cost stays attributable to that scene and only that scene is terminated.

- **One batch per tick:** `crdt_send_to_renderer` accepts a single batch per tick, tracked by a marker the scene loop clears at each tick boundary (the engine-internal initial send doesn't consume `onStart`'s allowance). A second same-tick send is a contract breach: `crdtSendToRenderer` performs the send op synchronously before its first await, so un-awaited calls through the sanctioned `~system/EngineApi` module could otherwise stack arbitrarily many frames onto the bounded response channel in a single JS turn — and channel overflow panics inside an op, which cannot unwind across the V8 boundary and aborts the shared sidecar.
- **Per-batch cap (64 MiB):** an oversized batch is rejected before any allocation; no frame is built. A well-behaved scene's per-tick delta is orders of magnitude smaller; this only rejects pathological batches that would threaten the shared socket.
- **Cumulative store cap (512 MiB):** bounds a scene's retained store (recognised + custom/filtered components). Set to the isolate's heap cap so stock `@dcl/ecs` scenes — which mirror pushed state in their own heap — can never reach it; only the push-without-retaining pattern is caught. Retained bytes grow at most 1:1 with ingest, so the O(entries) measurement is amortised: after each walk the next check is projected to the earliest ingest point at which the cap could be reached (floored one batch ahead), so a scene well below the cap rarely walks at all. Dead entities don't count toward the cap: engine-initiated deletes reap the custom-component sidecar via the census, as scene-sent `DeleteEntity` messages already do inline.

Breach handling terminates only the offending scene, never the engine or the co-tenanted sidecar: the scene is reported as a `SceneResponse::Error` and flagged with `ShuttingDown`, and from then on it is inert — further sends are dropped, and `op_crdt_recv_from_renderer` returns an empty batch instead of parking on the renderer channel (the renderer marks the scene broken and never responds, which would otherwise leave the isolate resident until scene unload). The tick then unwinds to the scene loop's `ShuttingDown` check and the runtime is torn down through the existing graceful-exit path.

This supersedes the size-defense rationale for #1025 (closed): that bounded the frame on the engine's *read* side, after the sidecar had already built and sent it, and could only recover by closing the shared connection — killing every co-tenant scene rather than just the offender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
