### PR TITLE
Despawn foreign players when all their transports disconnect

### DIFF
--- a/crates/comms/src/archipelago.rs
+++ b/crates/comms/src/archipelago.rs
@@ -99,7 +99,6 @@ pub fn start_archipelago(mut commands: Commands, mut archi_events: EventReader<S
                 transport_type: TransportType::Archipelago,
                 sender,
                 control: None,
-                foreign_aliases: Default::default(),
             },
             ArchipelagoTransport {
                 address: ev.address.to_owned(),

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -86,6 +86,7 @@ impl Plugin for GlobalCrdtPlugin {
         app.add_systems(Update, process_transport_updates);
         app.add_systems(Update, despawn_players);
         app.add_observer(remove_transport_from_foreign_audio_source);
+        app.add_observer(remove_transport_from_foreign_players);
         app.add_systems(Update, handle_foreign_audio);
         app.add_systems(
             Update,
@@ -144,6 +145,10 @@ pub struct NonPlayerUpdate {
 pub enum NetworkUpdate {
     Player(PlayerUpdate),
     NonPlayer(NonPlayerUpdate),
+    PlayerLeft {
+        transport_id: Entity,
+        address: Address,
+    },
 }
 
 impl From<PlayerUpdate> for NetworkUpdate {
@@ -276,7 +281,10 @@ impl GlobalCrdtState {
 #[derive(Component, Debug)]
 pub struct ForeignPlayer {
     pub address: Address,
-    pub transport_id: Entity,
+    /// Transports this player is currently connected through. Membership is implied
+    /// by receiving data; transports report explicit departures (`NetworkUpdate::PlayerLeft`)
+    /// and transport despawn removes the entity from every set. Empty set = disconnected.
+    pub transports: HashSet<Entity>,
     pub last_update: f32,
     pub scene_id: SceneEntityId,
     pub profile_version: u32,
@@ -431,7 +439,7 @@ pub fn process_transport_updates(
                 } else if let Some(existing) = state.lookup.get_by_left(&update.address) {
                     let mut foreign_player = players.get_mut(*existing).unwrap();
                     foreign_player.last_update = time.elapsed_secs();
-                    foreign_player.transport_id = update.transport_id;
+                    foreign_player.transports.insert(update.transport_id);
                     (
                         *existing,
                         foreign_player.scene_id,
@@ -461,7 +469,7 @@ pub fn process_transport_updates(
                             Visibility::default(),
                             ForeignPlayer {
                                 address: update.address,
-                                transport_id: update.transport_id,
+                                transports: HashSet::from_iter([update.transport_id]),
                                 last_update: time.elapsed_secs(),
                                 scene_id: next_free,
                                 profile_version: 0,
@@ -773,6 +781,19 @@ pub fn process_transport_updates(
                     &mut binary_senders,
                 );
             }
+            NetworkUpdate::PlayerLeft {
+                transport_id,
+                address,
+            } => {
+                // players spawned earlier this frame aren't in the query yet; they
+                // fall back to the inactivity timeout in despawn_players
+                if let Some(entity) = state.lookup.get_by_left(&address) {
+                    if let Ok(mut foreign_player) = players.get_mut(*entity) {
+                        debug!("player {address:#x} left transport {transport_id}");
+                        foreign_player.transports.remove(&transport_id);
+                    }
+                }
+            }
         }
     }
 }
@@ -928,15 +949,31 @@ fn despawn_players(
     time: Res<Time>,
 ) {
     for (entity, player) in players.iter() {
-        if player.last_update + 10.0 < time.elapsed_secs() {
+        // transports report disconnects explicitly; the inactivity timeout is a backstop
+        // for departures the server hasn't noticed yet (server-side timeouts for other
+        // clients' connections are not under our control)
+        let disconnected = player.transports.is_empty();
+        let stale = player.last_update + 15.0 < time.elapsed_secs();
+        if disconnected || stale {
             if let Ok(mut commands) = commands.get_entity(entity) {
-                info!("removing stale player: {entity:?} : {player:?}");
+                info!("removing disconnected player: {entity:?} : {player:?}");
                 commands.despawn();
             }
 
             state.delete_entity(player.scene_id);
             state.lookup.remove_by_right(&entity);
         }
+    }
+}
+
+fn remove_transport_from_foreign_players(
+    trigger: Trigger<OnReplace, Transport>,
+    mut players: Query<&mut ForeignPlayer>,
+) {
+    let transport_id = trigger.target();
+
+    for mut player in players.iter_mut() {
+        player.transports.remove(&transport_id);
     }
 }
 

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -20,12 +20,11 @@ use bevy::{
     prelude::*,
     tasks::{IoTaskPool, Task},
 };
-use bimap::BiMap;
 use common::{
     structs::{CurrentRealm, MicState},
     util::{TaskCompat, TaskExt},
 };
-use ethers_core::types::{Address, H160};
+use ethers_core::types::H160;
 use http::{StatusCode, Uri};
 use preview::PreviewPlugin;
 use serde::{Deserialize, Serialize};
@@ -152,7 +151,6 @@ pub struct Transport {
     pub transport_type: TransportType,
     pub sender: Sender<NetworkMessage>,
     pub control: Option<Sender<ChannelControl>>,
-    pub foreign_aliases: BiMap<u32, Address>,
 }
 
 fn process_realm_change(

--- a/crates/comms/src/livekit/participant/plugin.rs
+++ b/crates/comms/src/livekit/participant/plugin.rs
@@ -28,7 +28,8 @@ use crate::livekit::participant::{StreamImage, StreamViewer};
 use crate::livekit::web::Participant;
 use crate::{
     global_crdt::{
-        GlobalCrdtState, NonPlayerUpdate, PlayerMessage, PlayerUpdate, VoiceMessageStreams,
+        GlobalCrdtState, NetworkUpdate, NonPlayerUpdate, PlayerMessage, PlayerUpdate,
+        VoiceMessageStreams,
     },
     livekit::{
         participant::{
@@ -152,6 +153,9 @@ fn participant_disconnected(
     mut commands: Commands,
     participants: Query<(Entity, &LivekitParticipant)>,
     rooms: Query<(&LivekitRoom, Option<&HostingParticipants>)>,
+    global_crdt_state: Res<GlobalCrdtState>,
+    mut player_update_tasks: ResMut<PlayerUpdateTasks>,
+    livekit_runtime: Res<LivekitRuntime>,
 ) {
     let ParticipantDisconnected {
         participant,
@@ -166,6 +170,23 @@ fn participant_disconnected(
         participant.identity(),
         room.name()
     );
+
+    if let Some(address) = participant.identity().as_str().as_h160() {
+        let transport_id = *room_entity;
+        let sender = global_crdt_state.get_sender();
+        let task = livekit_runtime.spawn(async move {
+            sender
+                .send(NetworkUpdate::PlayerLeft {
+                    transport_id,
+                    address,
+                })
+                .await
+        });
+        player_update_tasks.push(PlayerUpdateTask {
+            runtime: livekit_runtime.clone(),
+            task,
+        });
+    }
 
     let Some(hosting_participants) = maybe_hosting_participants else {
         debug_panic!("Room {} is not hosting participants.", room.name());

--- a/crates/comms/src/livekit/plugin.rs
+++ b/crates/comms/src/livekit/plugin.rs
@@ -87,7 +87,6 @@ fn start_livekit(
                 transport_type: TransportType::Livekit,
                 sender,
                 control: Some(control_sender),
-                foreign_aliases: Default::default(),
             },
             LivekitTransport {
                 address: ev.address.to_owned(),

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -376,7 +376,11 @@ fn request_missing_profiles(
             }
         }
 
-        if let Ok(transport) = transports.get(player.transport_id) {
+        if let Some(transport) = player
+            .transports
+            .iter()
+            .find_map(|t| transports.get(*t).ok())
+        {
             let request = rfc4::Packet {
                 message: Some(rfc4::packet::Message::ProfileRequest(
                     rfc4::ProfileRequest {
@@ -424,15 +428,19 @@ pub fn process_profile_events(
                         let Ok((player, _)) = players.get(ev.sender) else {
                             continue;
                         };
-                        if last_sent_request.get(&player.transport_id).is_some() {
-                            debug!("ignoring request for my profile (sent recently)");
-                            continue;
-                        }
-
-                        let Ok(transport) = transports.get(player.transport_id) else {
+                        let Some((transport_id, transport)) = player
+                            .transports
+                            .iter()
+                            .find_map(|t| transports.get(*t).ok().map(|transport| (*t, transport)))
+                        else {
                             debug!("not sending profile, no transport");
                             continue;
                         };
+
+                        if last_sent_request.get(&transport_id).is_some() {
+                            debug!("ignoring request for my profile (sent recently)");
+                            continue;
+                        }
 
                         let Some(current_profile) = current_profile.profile.as_ref() else {
                             return;
@@ -454,7 +462,7 @@ pub fn process_profile_events(
                         let _ = transport
                             .sender
                             .try_send(NetworkMessage::reliable(&response));
-                        last_sent_request.insert(player.transport_id, time.elapsed_secs());
+                        last_sent_request.insert(transport_id, time.elapsed_secs());
                     }
                 }
             }

--- a/crates/comms/src/websocket_room.rs
+++ b/crates/comms/src/websocket_room.rs
@@ -86,7 +86,6 @@ pub fn start_ws_room(
                 transport_type: TransportType::WebsocketRoom,
                 sender,
                 control: None,
-                foreign_aliases: Default::default(),
             },
             WebsocketRoomTransport {
                 address: ev.address.to_owned(),
@@ -123,6 +122,7 @@ fn connect_websocket(
 }
 
 fn reconnect_websocket(
+    mut commands: Commands,
     mut websockets: Query<(
         Entity,
         &mut WebsocketRoomTransport,
@@ -153,8 +153,10 @@ fn reconnect_websocket(
             }
         } else if transport.retries == 3 {
             if let Some((_, err)) = conn.0.complete() {
-                transport.retries += 1;
                 warn!("websocket room error: {err}, giving up");
+                // despawning the transport scrubs it from all foreign players' transport
+                // sets, so members don't linger on a connection that will never recover
+                commands.entity(transport_id).despawn();
             }
         }
     }
@@ -321,7 +323,15 @@ async fn websocket_room_handler_inner(
                         peer.alias,
                         foreign_aliases.get_by_left(&peer.alias)
                     );
-                    foreign_aliases.remove_by_left(&peer.alias);
+                    if let Some((_, address)) = foreign_aliases.remove_by_left(&peer.alias) {
+                        sender
+                            .send(NetworkUpdate::PlayerLeft {
+                                transport_id,
+                                address,
+                            })
+                            .await
+                            .map_err(|_| anyhow!("Send error"))?;
+                    }
                 }
                 ws_packet::Message::PeerUpdateMessage(update) => {
                     let packet = match rfc4::Packet::decode(update.body.as_slice()) {


### PR DESCRIPTION
Player removal previously relied only on a 10s inactivity timeout, so even a graceful disconnect left the avatar (and its global-CRDT entities) visible for up to 10 seconds.

This PR makes removal event-driven:

- `ForeignPlayer` now holds the set of transports it is connected through. Membership is implied by receiving data; transports report explicit departures as a new `NetworkUpdate::PlayerLeft` message through the existing update channel (wire-ordered with data for ws-room, so a final packet can't race its own leave notice), and an `OnReplace<Transport>` observer scrubs a dying transport from every player's set. An empty set despawns the player and deletes its CRDT state immediately.
- livekit reports departures from `participant_disconnected` (native + web share the path); ws-room reports them from `PeerLeaveMessage`. Future transports (pulse) only need to send `PlayerLeft` from their read side to participate.
- The inactivity timeout remains as a backstop, raised to 15s: it covers departures the peer's server hasn't detected yet (server-side timeouts for other clients' connections are configurable out of our control), stale members after our own connection blips, and players spawned the same frame a leave arrives.

Also folded in: the ws-room transport entity now despawns when it gives up retrying (previously it lingered forever with a dead connection — no recovery path is lost, retries never reset anyway); the never-populated `Transport.foreign_aliases` field is removed; and profile requests pick any live transport from the player's set instead of a "last transport heard from" scalar, which the set supersedes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)