### PR TITLE
Bound scene RpcCalls per tick

### DIFF
--- a/crates/dcl/src/js/adaption_layer_helper.rs
+++ b/crates/dcl/src/js/adaption_layer_helper.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::anyhow;
 use common::rpc::{RpcCall, RpcResultSender};
+use common::util::ReportErr;
 use serde::Serialize;
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
@@ -25,7 +26,8 @@ pub async fn op_get_texture_size(state: Rc<RefCell<impl State>>, src: String) ->
             scene,
             src,
             response: sx,
-        });
+        })
+        .report();
 
     let Ok(result) = rx.await.map_err(|e| anyhow::anyhow!(e)) else {
         return TextureSize {

--- a/crates/dcl/src/js/adaption_layer_helper.rs
+++ b/crates/dcl/src/js/adaption_layer_helper.rs
@@ -2,7 +2,6 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::anyhow;
 use common::rpc::{RpcCall, RpcResultSender};
-use common::util::ReportErr;
 use serde::Serialize;
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
@@ -15,7 +14,10 @@ pub struct TextureSize {
     height: f32,
 }
 
-pub async fn op_get_texture_size(state: Rc<RefCell<impl State>>, src: String) -> TextureSize {
+pub async fn op_get_texture_size(
+    state: Rc<RefCell<impl State>>,
+    src: String,
+) -> Result<TextureSize, anyhow::Error> {
     let (sx, rx) = RpcResultSender::channel();
     let scene = state.borrow().borrow::<CrdtContext>().scene_id.0;
 
@@ -26,17 +28,16 @@ pub async fn op_get_texture_size(state: Rc<RefCell<impl State>>, src: String) ->
             scene,
             src,
             response: sx,
-        })
-        .report();
+        })?;
 
     let Ok(result) = rx.await.map_err(|e| anyhow::anyhow!(e)) else {
-        return TextureSize {
+        return Ok(TextureSize {
             width: 1.0,
             height: 1.0,
-        };
+        });
     };
 
-    result
+    Ok(result
         .map_err(|e| anyhow!(e))
         .map(|v| TextureSize {
             width: v.x,
@@ -45,5 +46,5 @@ pub async fn op_get_texture_size(state: Rc<RefCell<impl State>>, src: String) ->
         .unwrap_or(TextureSize {
             width: 1.0,
             height: 1.0,
-        })
+        }))
 }

--- a/crates/dcl/src/js/comms.rs
+++ b/crates/dcl/src/js/comms.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use bevy::log::debug;
 use common::{
     rpc::{RpcCall, RpcStreamReceiver, RpcStreamSender},
-    util::{AsH160, ReportErr},
+    util::AsH160,
 };
 use serde::{Deserialize, Serialize};
 
@@ -49,16 +49,20 @@ pub struct MessageBusMessage {
 
 struct BinaryBusReceiver(RpcStreamReceiver<(String, Vec<u8>)>);
 
-pub async fn op_comms_send_string(state: Rc<RefCell<impl State>>, message: String) {
+pub async fn op_comms_send_string(
+    state: Rc<RefCell<impl State>>,
+    message: String,
+) -> Result<(), anyhow::Error> {
     debug!("op_comms_send_string");
     if message.len() > MAX_COMMS_MESSAGE_BYTES {
-        debug!("op_comms_send_string: dropping oversized message");
-        return;
+        anyhow::bail!(
+            "message too large ({} > {MAX_COMMS_MESSAGE_BYTES} bytes)",
+            message.len()
+        );
     }
     let mut state = state.borrow_mut();
     if !try_spend_budget(&mut *state) {
-        debug!("op_comms_send_string: message budget exhausted, dropping");
-        return;
+        anyhow::bail!("per-tick message budget exhausted ({MAX_SEND_MESSAGES_PER_TICK})");
     }
     let scene = state.borrow::<CrdtContext>().scene_id.0;
     let mut data = vec![CommsMessageType::String as u8];
@@ -73,23 +77,23 @@ pub async fn op_comms_send_string(state: Rc<RefCell<impl State>>, message: Strin
             data,
             recipient: None,
         })
-        .report();
 }
 
 pub async fn op_comms_send_binary_single(
     state: Rc<RefCell<impl State>>,
     message: impl AsRef<[u8]>,
     recipient: Option<String>,
-) {
+) -> Result<(), anyhow::Error> {
     debug!("op_comms_send_binary_single");
     if message.as_ref().len() > MAX_COMMS_MESSAGE_BYTES {
-        debug!("op_comms_send_binary_single: dropping oversized message");
-        return;
+        anyhow::bail!(
+            "message too large ({} > {MAX_COMMS_MESSAGE_BYTES} bytes)",
+            message.as_ref().len()
+        );
     }
     let mut state = state.borrow_mut();
     if !try_spend_budget(&mut *state) {
-        debug!("op_comms_send_binary_single: message budget exhausted, dropping");
-        return;
+        anyhow::bail!("per-tick message budget exhausted ({MAX_SEND_MESSAGES_PER_TICK})");
     }
 
     let context = state.borrow::<CrdtContext>();
@@ -110,7 +114,6 @@ pub async fn op_comms_send_binary_single(
             data,
             recipient,
         })
-        .report();
 }
 
 pub async fn op_comms_recv_binary(

--- a/crates/dcl/src/js/comms.rs
+++ b/crates/dcl/src/js/comms.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use bevy::log::debug;
 use common::{
     rpc::{RpcCall, RpcStreamReceiver, RpcStreamSender},
-    util::AsH160,
+    util::{AsH160, ReportErr},
 };
 use serde::{Deserialize, Serialize};
 
@@ -72,7 +72,8 @@ pub async fn op_comms_send_string(state: Rc<RefCell<impl State>>, message: Strin
             scene,
             data,
             recipient: None,
-        });
+        })
+        .report();
 }
 
 pub async fn op_comms_send_binary_single(
@@ -108,7 +109,8 @@ pub async fn op_comms_send_binary_single(
             scene,
             data,
             recipient,
-        });
+        })
+        .report();
 }
 
 pub async fn op_comms_recv_binary(
@@ -127,7 +129,7 @@ pub async fn op_comms_recv_binary(
             RpcStreamSender::<(String, Vec<u8>)>::channel_with_capacity(MAX_NETWORK_MESSAGE_QUEUE);
         state
             .borrow_mut::<RpcCalls>()
-            .push(RpcCall::SubscribeBinaryBus { hash, sender: sx });
+            .push(RpcCall::SubscribeBinaryBus { hash, sender: sx })?;
         state.put(BinaryBusReceiver(rx));
     }
 

--- a/crates/dcl/src/js/ethereum_controller.rs
+++ b/crates/dcl/src/js/ethereum_controller.rs
@@ -5,7 +5,7 @@ use ethers_providers::{Provider, Ws};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use tokio::sync::Mutex;
 
-use crate::interface::crdt_context::CrdtContext;
+use crate::{interface::crdt_context::CrdtContext, RpcCalls};
 
 use super::State;
 
@@ -27,12 +27,12 @@ pub async fn op_send_async(
 
             state
                 .borrow_mut()
-                .borrow_mut::<Vec<RpcCall>>()
+                .borrow_mut::<RpcCalls>()
                 .push(RpcCall::SendAsync {
                     body: RPCSendableMessage { method, params },
                     scene,
                     response: sx,
-                });
+                })?;
 
             rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))
         }

--- a/crates/dcl/src/js/events.rs
+++ b/crates/dcl/src/js/events.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use bevy::log::{debug, warn};
 use common::rpc::{RpcCall, RpcEventSender, RpcStreamReceiver};
+use common::util::ReportErr;
 use serde::Serialize;
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
@@ -53,7 +54,7 @@ pub fn op_subscribe(state: &mut impl State, id: &str) {
                 let (sx, rx) = RpcEventSender::channel();
 
                 #[allow(clippy::redundant_closure_call)]
-                state.borrow_mut::<RpcCalls>().push($call(sx));
+                state.borrow_mut::<RpcCalls>().push($call(sx)).report();
 
                 state.put(EventReceiver::<$marker> {
                     inner: rx,
@@ -105,7 +106,8 @@ pub fn op_subscribe(state: &mut impl State, id: &str) {
         let (sender, rx) = RpcEventSender::channel_with_capacity(MAX_NETWORK_MESSAGE_QUEUE);
         state
             .borrow_mut::<RpcCalls>()
-            .push(RpcCall::SubscribeMessageBus { sender, hash });
+            .push(RpcCall::SubscribeMessageBus { sender, hash })
+            .report();
         state.put(EventReceiver::<MessageBus> {
             inner: rx,
             _p: Default::default(),

--- a/crates/dcl/src/js/events.rs
+++ b/crates/dcl/src/js/events.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 
 use bevy::log::{debug, warn};
 use common::rpc::{RpcCall, RpcEventSender, RpcStreamReceiver};
-use common::util::ReportErr;
 use serde::Serialize;
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
@@ -43,25 +42,27 @@ impl_event!(RealmChanged, "onRealmChanged");
 impl_event!(PlayerClicked, "playerClicked");
 impl_event!(MessageBus, "comms");
 
-pub fn op_subscribe(state: &mut impl State, id: &str) {
+pub fn op_subscribe(state: &mut impl State, id: &str) -> Result<(), anyhow::Error> {
     macro_rules! register {
         ($id: expr, $state: expr, $marker: ty, $call: expr) => {{
             if id == <$marker as EventType>::label() {
                 if $state.has::<EventReceiver<$marker>>() {
                     // already subscribed
-                    return;
+                    return Ok(());
                 }
                 let (sx, rx) = RpcEventSender::channel();
 
+                // propagate failure without storing the receiver, so the scene observes the
+                // error and a later resubscribe isn't blocked by the already-subscribed check
                 #[allow(clippy::redundant_closure_call)]
-                state.borrow_mut::<RpcCalls>().push($call(sx)).report();
+                state.borrow_mut::<RpcCalls>().push($call(sx))?;
 
                 state.put(EventReceiver::<$marker> {
                     inner: rx,
                     _p: Default::default(),
                 });
                 debug!("subscribed to {}", <$marker as EventType>::label());
-                return;
+                return Ok(());
             }
         }};
     }
@@ -101,22 +102,22 @@ pub fn op_subscribe(state: &mut impl State, id: &str) {
     // MessageBus carries untrusted peer traffic, so use a tighter bound than the default event channel.
     if id == <MessageBus as EventType>::label() {
         if state.has::<EventReceiver<MessageBus>>() {
-            return;
+            return Ok(());
         }
         let (sender, rx) = RpcEventSender::channel_with_capacity(MAX_NETWORK_MESSAGE_QUEUE);
         state
             .borrow_mut::<RpcCalls>()
-            .push(RpcCall::SubscribeMessageBus { sender, hash })
-            .report();
+            .push(RpcCall::SubscribeMessageBus { sender, hash })?;
         state.put(EventReceiver::<MessageBus> {
             inner: rx,
             _p: Default::default(),
         });
         debug!("subscribed to {}", <MessageBus as EventType>::label());
-        return;
+        return Ok(());
     }
 
     warn!("subscribe to unrecognised event {id}");
+    Ok(())
 }
 
 pub fn op_unsubscribe(state: &mut impl State, id: &str) {

--- a/crates/dcl/src/js/fetch.rs
+++ b/crates/dcl/src/js/fetch.rs
@@ -63,7 +63,7 @@ pub async fn op_signed_fetch_headers(
         .push(RpcCall::EntityDefinition {
             urn: urn.clone(),
             response: sx,
-        });
+        })?;
 
     let entity_definition = rx.await?.ok_or_else(|| anyhow!("no entity definition"))?;
 
@@ -98,7 +98,7 @@ pub async fn op_signed_fetch_headers(
             meta: Some(serde_json::to_string(&meta).unwrap()),
             scene: Some(urn),
             response: sx,
-        });
+        })?;
 
     rx.await?.map_err(|e| anyhow!(e))
 }

--- a/crates/dcl/src/js/modules/EngineApi.js
+++ b/crates/dcl/src/js/modules/EngineApi.js
@@ -1,6 +1,6 @@
 // engine module
 
-const { op_crdt_recv_from_renderer, op_crdt_send_to_renderer, op_subscribe, op_send_batch, op_is_server } = Deno.core.ops;
+const { op_crdt_recv_from_renderer, op_crdt_send_to_renderer, op_subscribe, op_unsubscribe, op_send_batch, op_is_server } = Deno.core.ops;
 
 module.exports.crdtSendToRenderer = async function(messages) {
     op_crdt_send_to_renderer(messages.data);
@@ -40,7 +40,7 @@ module.exports.subscribe = async function(message) {
  * This function unsubscribe to an event from the renderer
  */
 module.exports.unsubscribe = async function(message) {
-    op_subscribe(message.eventId);
+    op_unsubscribe(message.eventId);
 }
 
 /**

--- a/crates/dcl/src/js/player.rs
+++ b/crates/dcl/src/js/player.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use bevy::log::debug;
 use common::rpc::{RpcCall, RpcResultSender};
+use common::util::ReportErr;
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
 
@@ -14,7 +15,8 @@ pub async fn op_get_connected_players(state: Rc<RefCell<impl State>>) -> Vec<Str
     state
         .borrow_mut()
         .borrow_mut::<RpcCalls>()
-        .push(RpcCall::GetConnectedPlayers { response: sx });
+        .push(RpcCall::GetConnectedPlayers { response: sx })
+        .report();
 
     rx.await.unwrap_or_default()
 }
@@ -34,7 +36,8 @@ pub async fn op_get_players_in_scene(state: Rc<RefCell<impl State>>) -> Vec<Stri
             .push(RpcCall::GetPlayersInScene {
                 scene,
                 response: sx,
-            });
+            })
+            .report();
     }
 
     rx.await.unwrap_or_default()

--- a/crates/dcl/src/js/player.rs
+++ b/crates/dcl/src/js/player.rs
@@ -2,26 +2,28 @@ use std::{cell::RefCell, rc::Rc};
 
 use bevy::log::debug;
 use common::rpc::{RpcCall, RpcResultSender};
-use common::util::ReportErr;
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
 
 use super::State;
 
-pub async fn op_get_connected_players(state: Rc<RefCell<impl State>>) -> Vec<String> {
+pub async fn op_get_connected_players(
+    state: Rc<RefCell<impl State>>,
+) -> Result<Vec<String>, anyhow::Error> {
     debug!("op_get_connected_players");
     let (sx, rx) = RpcResultSender::channel();
 
     state
         .borrow_mut()
         .borrow_mut::<RpcCalls>()
-        .push(RpcCall::GetConnectedPlayers { response: sx })
-        .report();
+        .push(RpcCall::GetConnectedPlayers { response: sx })?;
 
-    rx.await.unwrap_or_default()
+    Ok(rx.await.unwrap_or_default())
 }
 
-pub async fn op_get_players_in_scene(state: Rc<RefCell<impl State>>) -> Vec<String> {
+pub async fn op_get_players_in_scene(
+    state: Rc<RefCell<impl State>>,
+) -> Result<Vec<String>, anyhow::Error> {
     debug!("op_get_players_in_scene");
 
     let (sx, rx) = RpcResultSender::channel();
@@ -36,9 +38,8 @@ pub async fn op_get_players_in_scene(state: Rc<RefCell<impl State>>) -> Vec<Stri
             .push(RpcCall::GetPlayersInScene {
                 scene,
                 response: sx,
-            })
-            .report();
+            })?;
     }
 
-    rx.await.unwrap_or_default()
+    Ok(rx.await.unwrap_or_default())
 }

--- a/crates/dcl/src/js/portables.rs
+++ b/crates/dcl/src/js/portables.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use bevy::log::debug;
 use common::rpc::{PortableLocation, RpcCall, RpcResultSender, SpawnResponse};
+use common::util::ReportErr;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
@@ -30,7 +31,7 @@ pub async fn op_portable_spawn(
             location,
             spawner: scene,
             response: sx,
-        });
+        })?;
 
     rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))
 }
@@ -51,7 +52,7 @@ pub async fn op_portable_kill(
             scene,
             location: PortableLocation::Urn(pid.clone()),
             response: sx,
-        });
+        })?;
 
     rx.await.map_err(|e| anyhow::anyhow!(e))
 }
@@ -63,7 +64,8 @@ pub async fn op_portable_list(state: Rc<RefCell<impl State>>) -> Vec<SpawnRespon
     state
         .borrow_mut()
         .borrow_mut::<RpcCalls>()
-        .push(RpcCall::ListPortables { response: sx });
+        .push(RpcCall::ListPortables { response: sx })
+        .report();
 
     let res = rx.await.unwrap_or_default();
     bevy::log::debug!("portable list res: {res:?}");

--- a/crates/dcl/src/js/portables.rs
+++ b/crates/dcl/src/js/portables.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use bevy::log::debug;
 use common::rpc::{PortableLocation, RpcCall, RpcResultSender, SpawnResponse};
-use common::util::ReportErr;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{interface::crdt_context::CrdtContext, RpcCalls};
@@ -57,17 +56,18 @@ pub async fn op_portable_kill(
     rx.await.map_err(|e| anyhow::anyhow!(e))
 }
 
-pub async fn op_portable_list(state: Rc<RefCell<impl State>>) -> Vec<SpawnResponse> {
+pub async fn op_portable_list(
+    state: Rc<RefCell<impl State>>,
+) -> Result<Vec<SpawnResponse>, anyhow::Error> {
     debug!("op_portable_list");
     let (sx, rx) = RpcResultSender::channel();
 
     state
         .borrow_mut()
         .borrow_mut::<RpcCalls>()
-        .push(RpcCall::ListPortables { response: sx })
-        .report();
+        .push(RpcCall::ListPortables { response: sx })?;
 
     let res = rx.await.unwrap_or_default();
     bevy::log::debug!("portable list res: {res:?}");
-    res
+    Ok(res)
 }

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -5,6 +5,7 @@ use bevy::{
     transform::components::Transform,
 };
 use common::rpc::{RpcCall, RpcResultSender, RpcUiFocusAction};
+use common::util::ReportErr;
 use dcl_component::proto_components::common::Vector3 as DclVector3;
 use serde::Serialize;
 use std::{cell::RefCell, rc::Rc};
@@ -44,17 +45,21 @@ pub async fn op_move_player_to(
     {
         let mut op_state = state.borrow_mut();
         let scene = op_state.borrow::<CrdtContext>().scene_id.0;
-        op_state.borrow_mut::<RpcCalls>().push(RpcCall::MovePlayer {
-            scene: Some(scene),
-            to,
-            looking_at,
-            duration,
-            response,
-        });
+        op_state
+            .borrow_mut::<RpcCalls>()
+            .push(RpcCall::MovePlayer {
+                scene: Some(scene),
+                to,
+                looking_at,
+                duration,
+                response,
+            })
+            .report();
         if let Some(facing) = camera_rotation {
             op_state
                 .borrow_mut::<RpcCalls>()
-                .push(RpcCall::MoveCamera { scene, facing });
+                .push(RpcCall::MoveCamera { scene, facing })
+                .report();
         }
     }
 
@@ -79,13 +84,16 @@ pub async fn op_walk_player_to(
     {
         let mut op_state = state.borrow_mut();
         let scene = op_state.borrow::<CrdtContext>().scene_id.0;
-        op_state.borrow_mut::<RpcCalls>().push(RpcCall::WalkPlayer {
-            scene: Some(scene),
-            to,
-            stop_threshold,
-            timeout,
-            response: sx,
-        });
+        op_state
+            .borrow_mut::<RpcCalls>()
+            .push(RpcCall::WalkPlayer {
+                scene: Some(scene),
+                to,
+                stop_threshold,
+                timeout,
+                response: sx,
+            })
+            .report();
     }
 
     matches!(rx.await, Ok(true))
@@ -106,7 +114,8 @@ pub async fn op_teleport_to(
             scene: Some(scene),
             to: IVec2::new(position_x, position_y),
             response: sx,
-        });
+        })
+        .report();
 
     matches!(rx.await, Ok(Ok(_)))
 }
@@ -127,7 +136,8 @@ pub async fn op_change_realm(
             to: realm,
             message,
             response: sx,
-        });
+        })
+        .report();
 
     matches!(rx.await, Ok(Ok(_)))
 }
@@ -143,7 +153,8 @@ pub async fn op_external_url(state: Rc<RefCell<impl State>>, url: String) -> boo
             scene,
             url,
             response: sx,
-        });
+        })
+        .report();
 
     matches!(rx.await, Ok(Ok(_)))
 }
@@ -190,7 +201,8 @@ pub fn send_emote(op_state: &mut impl State, urn: String, r#loop: bool) {
 
     op_state
         .borrow_mut::<RpcCalls>()
-        .push(RpcCall::TriggerEmote { scene, urn, r#loop });
+        .push(RpcCall::TriggerEmote { scene, urn, r#loop })
+        .report();
 }
 
 pub async fn op_open_nft_dialog(
@@ -205,11 +217,13 @@ pub async fn op_open_nft_dialog(
         let context = state.borrow::<CrdtContext>();
         let scene = context.scene_id.0;
 
-        state.borrow_mut::<RpcCalls>().push(RpcCall::OpenNftDialog {
-            scene,
-            urn,
-            response: sx,
-        });
+        state
+            .borrow_mut::<RpcCalls>()
+            .push(RpcCall::OpenNftDialog {
+                scene,
+                urn,
+                response: sx,
+            })?;
     }
 
     rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))
@@ -245,7 +259,7 @@ pub async fn op_ui_focus(
             scene,
             action,
             response: sx,
-        });
+        })?;
     }
 
     rx.await
@@ -271,7 +285,7 @@ pub async fn op_copy_to_clipboard(
                 scene,
                 text,
                 response: sx,
-            });
+            })?;
     }
 
     rx.await.map_err(|e| anyhow!(e))?.map_err(|e| anyhow!(e))

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -5,7 +5,6 @@ use bevy::{
     transform::components::Transform,
 };
 use common::rpc::{RpcCall, RpcResultSender, RpcUiFocusAction};
-use common::util::ReportErr;
 use dcl_component::proto_components::common::Vector3 as DclVector3;
 use serde::Serialize;
 use std::{cell::RefCell, rc::Rc};
@@ -21,7 +20,7 @@ pub async fn op_move_player_to(
     camera_target: Option<DclVector3>,
     avatar_target: Option<DclVector3>,
     duration: Option<f32>,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
     debug!("move player to {position:?}, camera: {camera_target:?}, rotate: {avatar_target:?}, duration: {duration:?}");
 
     let to = DclTranslation([position.x, position.y, position.z]).to_bevy_translation();
@@ -53,21 +52,19 @@ pub async fn op_move_player_to(
                 looking_at,
                 duration,
                 response,
-            })
-            .report();
+            })?;
         if let Some(facing) = camera_rotation {
             op_state
                 .borrow_mut::<RpcCalls>()
-                .push(RpcCall::MoveCamera { scene, facing })
-                .report();
+                .push(RpcCall::MoveCamera { scene, facing })?;
         }
     }
 
-    if let Some(rx) = rx {
+    Ok(if let Some(rx) = rx {
         matches!(rx.await, Ok(true))
     } else {
         true
-    }
+    })
 }
 
 pub async fn op_walk_player_to(
@@ -75,7 +72,7 @@ pub async fn op_walk_player_to(
     position: DclVector3,
     stop_threshold: f32,
     timeout: Option<f32>,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
     debug!("walk player to {position:?}, stop_threshold: {stop_threshold:?}, timeout: {timeout:?}");
 
     let to = DclTranslation([position.x, position.y, position.z]).to_bevy_translation();
@@ -92,18 +89,17 @@ pub async fn op_walk_player_to(
                 stop_threshold,
                 timeout,
                 response: sx,
-            })
-            .report();
+            })?;
     }
 
-    matches!(rx.await, Ok(true))
+    Ok(matches!(rx.await, Ok(true)))
 }
 
 pub async fn op_teleport_to(
     state: Rc<RefCell<impl State>>,
     position_x: i32,
     position_y: i32,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
     debug!("op_teleport_to");
     let (sx, rx) = RpcResultSender::<Result<(), String>>::channel();
     let scene = state.borrow().borrow::<CrdtContext>().scene_id.0;
@@ -114,17 +110,16 @@ pub async fn op_teleport_to(
             scene: Some(scene),
             to: IVec2::new(position_x, position_y),
             response: sx,
-        })
-        .report();
+        })?;
 
-    matches!(rx.await, Ok(Ok(_)))
+    Ok(matches!(rx.await, Ok(Ok(_))))
 }
 
 pub async fn op_change_realm(
     state: Rc<RefCell<impl State>>,
     realm: String,
     message: Option<String>,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
     debug!("op_change_realm");
     let (sx, rx) = RpcResultSender::<Result<(), String>>::channel();
     let scene = state.borrow().borrow::<CrdtContext>().scene_id.0;
@@ -136,13 +131,15 @@ pub async fn op_change_realm(
             to: realm,
             message,
             response: sx,
-        })
-        .report();
+        })?;
 
-    matches!(rx.await, Ok(Ok(_)))
+    Ok(matches!(rx.await, Ok(Ok(_))))
 }
 
-pub async fn op_external_url(state: Rc<RefCell<impl State>>, url: String) -> bool {
+pub async fn op_external_url(
+    state: Rc<RefCell<impl State>>,
+    url: String,
+) -> Result<bool, anyhow::Error> {
     debug!("op_external_url");
     let (sx, rx) = RpcResultSender::<Result<(), String>>::channel();
     let scene = state.borrow().borrow::<CrdtContext>().scene_id.0;
@@ -153,15 +150,14 @@ pub async fn op_external_url(state: Rc<RefCell<impl State>>, url: String) -> boo
             scene,
             url,
             response: sx,
-        })
-        .report();
+        })?;
 
-    matches!(rx.await, Ok(Ok(_)))
+    Ok(matches!(rx.await, Ok(Ok(_))))
 }
 
-pub fn op_emote(op_state: &mut impl State, emote: String) {
+pub fn op_emote(op_state: &mut impl State, emote: String) -> Result<(), anyhow::Error> {
     debug!("op_emote");
-    send_emote(op_state, emote, false);
+    send_emote(op_state, emote, false)
 }
 
 pub async fn op_scene_emote(
@@ -191,18 +187,20 @@ pub async fn op_scene_emote(
     let emote_urn =
         format!("urn:decentraland:off-chain:scene-emote:{scene_hash}-{emote_hash}-{looping}");
 
-    send_emote(&mut *op_state.borrow_mut(), emote_urn, looping);
-    Ok(())
+    send_emote(&mut *op_state.borrow_mut(), emote_urn, looping)
 }
 
-pub fn send_emote(op_state: &mut impl State, urn: String, r#loop: bool) {
+pub fn send_emote(
+    op_state: &mut impl State,
+    urn: String,
+    r#loop: bool,
+) -> Result<(), anyhow::Error> {
     let context = op_state.borrow::<CrdtContext>();
     let scene = context.scene_id.0;
 
     op_state
         .borrow_mut::<RpcCalls>()
         .push(RpcCall::TriggerEmote { scene, urn, r#loop })
-        .report();
 }
 
 pub async fn op_open_nft_dialog(

--- a/crates/dcl/src/js/runtime.rs
+++ b/crates/dcl/src/js/runtime.rs
@@ -81,7 +81,7 @@ pub async fn scene_information(
         .push(RpcCall::EntityDefinition {
             urn: urn.clone(),
             response: sx,
-        });
+        })?;
 
     let entity_definition = rx.await?;
 

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -220,7 +220,7 @@ pub async fn op_kernel_fetch_headers(
             meta,
             scene: None,
             response: sx,
-        });
+        })?;
 
     rx.await?.map_err(|e| anyhow!(e))
 }
@@ -477,7 +477,7 @@ pub async fn op_get_profile_extras(
             user: None, // current user
             scene,
             response: sx,
-        });
+        })?;
 
     let profile = rx
         .await

--- a/crates/dcl/src/js/testing.rs
+++ b/crates/dcl/src/js/testing.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use bevy::log::debug;
 use common::rpc::{CompareSnapshot, CompareSnapshotResult, RpcCall, RpcResultSender};
+use common::util::ReportErr;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot::error::TryRecvError;
 
@@ -48,22 +49,28 @@ pub fn op_log_test_plan(state: &mut impl State, body: SceneTestPlan) {
     debug!("op_log_test_plan");
     let scene = state.borrow::<CrdtContext>().scene_id.0;
 
-    state.borrow_mut::<RpcCalls>().push(RpcCall::TestPlan {
-        scene,
-        plan: body.tests.into_iter().map(|p| p.name).collect(),
-    });
+    state
+        .borrow_mut::<RpcCalls>()
+        .push(RpcCall::TestPlan {
+            scene,
+            plan: body.tests.into_iter().map(|p| p.name).collect(),
+        })
+        .report();
 }
 
 pub fn op_log_test_result(state: &mut impl State, body: SceneTestResult) {
     debug!("op_log_test_results");
     let scene = state.borrow::<CrdtContext>().scene_id.0;
 
-    state.borrow_mut::<RpcCalls>().push(RpcCall::TestResult {
-        scene,
-        name: body.name,
-        success: body.ok,
-        error: body.error,
-    });
+    state
+        .borrow_mut::<RpcCalls>()
+        .push(RpcCall::TestResult {
+            scene,
+            name: body.name,
+            success: body.ok,
+            error: body.error,
+        })
+        .report();
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/dcl/src/js/testing.rs
+++ b/crates/dcl/src/js/testing.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use bevy::log::debug;
 use common::rpc::{CompareSnapshot, CompareSnapshotResult, RpcCall, RpcResultSender};
-use common::util::ReportErr;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot::error::TryRecvError;
 
@@ -45,32 +44,29 @@ pub struct SceneTestResult {
     pub total_time: f32,
 }
 
-pub fn op_log_test_plan(state: &mut impl State, body: SceneTestPlan) {
+pub fn op_log_test_plan(state: &mut impl State, body: SceneTestPlan) -> Result<(), anyhow::Error> {
     debug!("op_log_test_plan");
     let scene = state.borrow::<CrdtContext>().scene_id.0;
 
-    state
-        .borrow_mut::<RpcCalls>()
-        .push(RpcCall::TestPlan {
-            scene,
-            plan: body.tests.into_iter().map(|p| p.name).collect(),
-        })
-        .report();
+    state.borrow_mut::<RpcCalls>().push(RpcCall::TestPlan {
+        scene,
+        plan: body.tests.into_iter().map(|p| p.name).collect(),
+    })
 }
 
-pub fn op_log_test_result(state: &mut impl State, body: SceneTestResult) {
+pub fn op_log_test_result(
+    state: &mut impl State,
+    body: SceneTestResult,
+) -> Result<(), anyhow::Error> {
     debug!("op_log_test_results");
     let scene = state.borrow::<CrdtContext>().scene_id.0;
 
-    state
-        .borrow_mut::<RpcCalls>()
-        .push(RpcCall::TestResult {
-            scene,
-            name: body.name,
-            success: body.ok,
-            error: body.error,
-        })
-        .report();
+    state.borrow_mut::<RpcCalls>().push(RpcCall::TestResult {
+        scene,
+        name: body.name,
+        success: body.ok,
+        error: body.error,
+    })
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/dcl/src/js/user_identity.rs
+++ b/crates/dcl/src/js/user_identity.rs
@@ -56,7 +56,7 @@ pub async fn op_get_user_data(state: Rc<RefCell<impl State>>) -> Result<UserData
             user: None, // current user
             scene,
             response: sx,
-        });
+        })?;
 
     let profile = rx
         .await
@@ -89,7 +89,7 @@ pub async fn op_get_player_data(
             user: Some(id),
             scene,
             response: sx,
-        });
+        })?;
 
     rx.await
         .map_err(|e| anyhow::anyhow!(e))?

--- a/crates/dcl/src/lib.rs
+++ b/crates/dcl/src/lib.rs
@@ -57,7 +57,93 @@ pub enum RendererResponse {
     },
 }
 
-pub type RpcCalls = Vec<RpcCall>;
+/// Ceiling on the RpcCalls a scene may enqueue in one tick. RpcCalls are drained into the
+/// outbound `SceneResponse` at the crdt_send flush, so an unbounded count means an unbounded
+/// frame (and unbounded engine-side work for side-effectful calls) — none of it requiring
+/// scene-side retention. A well-behaved scene issues a handful per tick.
+pub const MAX_RPC_CALLS_PER_TICK: usize = 1000;
+
+/// Per-tick queue of scene-issued RpcCalls. `push` is bounded: the queue is drained (via
+/// `std::mem::take`) each tick at the flush, so its current length is exactly this tick's
+/// count, and no separate budget/reset is needed.
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RpcCalls(Vec<RpcCall>);
+
+impl RpcCalls {
+    /// Enqueue a call for the next flush. Over the per-tick ceiling it returns an error the op
+    /// propagates to its caller (`push(..)?`), so a scene spamming RPCs sees its own call fail
+    /// rather than growing an unbounded outbound frame.
+    pub fn push(&mut self, call: RpcCall) -> Result<(), anyhow::Error> {
+        if self.0.len() >= MAX_RPC_CALLS_PER_TICK {
+            anyhow::bail!("exceeded the per-tick RPC call limit ({MAX_RPC_CALLS_PER_TICK})");
+        }
+        self.0.push(call);
+        Ok(())
+    }
+}
+
+impl std::ops::Deref for RpcCalls {
+    type Target = Vec<RpcCall>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for RpcCalls {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoIterator for RpcCalls {
+    type Item = RpcCall;
+    type IntoIter = std::vec::IntoIter<RpcCall>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod rpc_calls_tests {
+    use super::*;
+    use bevy::prelude::{Entity, Quat};
+
+    fn a_call() -> RpcCall {
+        RpcCall::MoveCamera {
+            scene: Entity::PLACEHOLDER,
+            facing: Quat::IDENTITY,
+        }
+    }
+
+    // push accepts up to the per-tick ceiling then rejects, without enqueuing the rejected call;
+    // draining (the flush) resets the count so the next tick accepts again.
+    #[test]
+    fn push_is_bounded_and_resets_on_drain() {
+        let mut calls = RpcCalls::default();
+        for _ in 0..MAX_RPC_CALLS_PER_TICK {
+            calls.push(a_call()).unwrap();
+        }
+        assert_eq!(calls.len(), MAX_RPC_CALLS_PER_TICK);
+
+        assert!(
+            calls.push(a_call()).is_err(),
+            "over-budget push is rejected"
+        );
+        assert_eq!(
+            calls.len(),
+            MAX_RPC_CALLS_PER_TICK,
+            "a rejected call must not be enqueued"
+        );
+
+        let drained = std::mem::take(&mut calls);
+        assert_eq!(drained.len(), MAX_RPC_CALLS_PER_TICK);
+        assert!(
+            calls.push(a_call()).is_ok(),
+            "a fresh tick accepts calls again"
+        );
+    }
+}
 
 #[allow(clippy::large_enum_variant)] // we don't care since the error case is very rare
 // data from scene to renderer

--- a/crates/dcl_deno/src/js/fetch/mod.rs
+++ b/crates/dcl_deno/src/js/fetch/mod.rs
@@ -306,7 +306,7 @@ async fn fetch_send_inner(
             ty: common::structs::PermissionType::Fetch,
             message: Some(url.clone()),
             response: sx,
-        });
+        })?;
     let permit = rx.await?;
     if !permit {
         anyhow::bail!("User denied fetch request");

--- a/crates/dcl_deno/src/js/op_wrappers/adaption_layer_helper.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/adaption_layer_helper.rs
@@ -1,5 +1,5 @@
 use dcl::js::adaption_layer_helper::TextureSize;
-use deno_core::{op2, OpDecl, OpState};
+use deno_core::{anyhow, op2, OpDecl, OpState};
 use std::{cell::RefCell, rc::Rc};
 
 // list of op declarations
@@ -9,6 +9,9 @@ pub fn ops() -> Vec<OpDecl> {
 
 #[op2(async)]
 #[serde]
-async fn op_get_texture_size(state: Rc<RefCell<OpState>>, #[string] src: String) -> TextureSize {
+async fn op_get_texture_size(
+    state: Rc<RefCell<OpState>>,
+    #[string] src: String,
+) -> Result<TextureSize, anyhow::Error> {
     dcl::js::adaption_layer_helper::op_get_texture_size(state, src).await
 }

--- a/crates/dcl_deno/src/js/op_wrappers/comms.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/comms.rs
@@ -11,7 +11,10 @@ pub fn ops() -> Vec<OpDecl> {
 }
 
 #[op2(async)]
-async fn op_comms_send_string(state: Rc<RefCell<OpState>>, #[string] message: String) {
+async fn op_comms_send_string(
+    state: Rc<RefCell<OpState>>,
+    #[string] message: String,
+) -> Result<(), anyhow::Error> {
     dcl::js::comms::op_comms_send_string(state, message).await
 }
 
@@ -20,7 +23,7 @@ async fn op_comms_send_binary_single(
     state: Rc<RefCell<OpState>>,
     #[buffer(detach)] message: JsBuffer,
     #[string] recipient: Option<String>,
-) {
+) -> Result<(), anyhow::Error> {
     dcl::js::comms::op_comms_send_binary_single(state, message, recipient).await
 }
 

--- a/crates/dcl_deno/src/js/op_wrappers/events.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/events.rs
@@ -1,5 +1,5 @@
 use dcl::js::events::Event;
-use deno_core::{op2, OpDecl, OpState};
+use deno_core::{anyhow, op2, OpDecl, OpState};
 
 // list of op declarations
 pub fn ops() -> Vec<OpDecl> {
@@ -7,7 +7,7 @@ pub fn ops() -> Vec<OpDecl> {
 }
 
 #[op2(fast)]
-fn op_subscribe(state: &mut OpState, #[string] id: &str) {
+fn op_subscribe(state: &mut OpState, #[string] id: &str) -> Result<(), anyhow::Error> {
     dcl::js::events::op_subscribe(state, id)
 }
 

--- a/crates/dcl_deno/src/js/op_wrappers/player.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/player.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use deno_core::{op2, OpDecl, OpState};
+use deno_core::{anyhow, op2, OpDecl, OpState};
 
 // list of op declarations
 pub fn ops() -> Vec<OpDecl> {
@@ -9,12 +9,16 @@ pub fn ops() -> Vec<OpDecl> {
 
 #[op2(async)]
 #[serde]
-async fn op_get_connected_players(state: Rc<RefCell<OpState>>) -> Vec<String> {
+async fn op_get_connected_players(
+    state: Rc<RefCell<OpState>>,
+) -> Result<Vec<String>, anyhow::Error> {
     dcl::js::player::op_get_connected_players(state).await
 }
 
 #[op2(async)]
 #[serde]
-async fn op_get_players_in_scene(state: Rc<RefCell<OpState>>) -> Vec<String> {
+async fn op_get_players_in_scene(
+    state: Rc<RefCell<OpState>>,
+) -> Result<Vec<String>, anyhow::Error> {
     dcl::js::player::op_get_players_in_scene(state).await
 }

--- a/crates/dcl_deno/src/js/op_wrappers/portables.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/portables.rs
@@ -27,6 +27,6 @@ async fn op_portable_kill(
 
 #[op2(async)]
 #[serde]
-async fn op_portable_list(state: Rc<RefCell<OpState>>) -> Vec<SpawnResponse> {
+async fn op_portable_list(state: Rc<RefCell<OpState>>) -> Result<Vec<SpawnResponse>, AnyError> {
     dcl::js::portables::op_portable_list(state).await
 }

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -26,7 +26,7 @@ async fn op_move_player_to(
     #[serde] camera_target: Option<DclVector3>,
     #[serde] avatar_target: Option<DclVector3>,
     duration: Option<f32>,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
     dcl::js::restricted_actions::op_move_player_to(
         state,
         position,
@@ -43,12 +43,16 @@ async fn op_walk_player_to(
     #[serde] position: DclVector3,
     stop_threshold: f32,
     timeout: Option<f32>,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
     dcl::js::restricted_actions::op_walk_player_to(state, position, stop_threshold, timeout).await
 }
 
 #[op2(async)]
-async fn op_teleport_to(state: Rc<RefCell<OpState>>, position_x: i32, position_y: i32) -> bool {
+async fn op_teleport_to(
+    state: Rc<RefCell<OpState>>,
+    position_x: i32,
+    position_y: i32,
+) -> Result<bool, anyhow::Error> {
     dcl::js::restricted_actions::op_teleport_to(state, position_x, position_y).await
 }
 
@@ -57,18 +61,21 @@ async fn op_change_realm(
     state: Rc<RefCell<OpState>>,
     #[string] realm: String,
     #[string] message: Option<String>,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
     dcl::js::restricted_actions::op_change_realm(state, realm, message).await
 }
 
 #[op2(async)]
-async fn op_external_url(state: Rc<RefCell<OpState>>, #[string] url: String) -> bool {
+async fn op_external_url(
+    state: Rc<RefCell<OpState>>,
+    #[string] url: String,
+) -> Result<bool, anyhow::Error> {
     dcl::js::restricted_actions::op_external_url(state, url).await
 }
 
 #[op2(fast)]
-fn op_emote(op_state: &mut OpState, #[string] emote: String) {
-    dcl::js::restricted_actions::op_emote(op_state, emote);
+fn op_emote(op_state: &mut OpState, #[string] emote: String) -> Result<(), anyhow::Error> {
+    dcl::js::restricted_actions::op_emote(op_state, emote)
 }
 
 #[op2(async)]

--- a/crates/dcl_deno/src/js/op_wrappers/testing.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/testing.rs
@@ -25,13 +25,13 @@ fn op_testing_enabled(op_state: &mut OpState) -> bool {
 }
 
 #[op2]
-fn op_log_test_plan(state: &mut OpState, #[serde] body: SceneTestPlan) {
-    dcl::js::testing::op_log_test_plan(state, body);
+fn op_log_test_plan(state: &mut OpState, #[serde] body: SceneTestPlan) -> Result<(), AnyError> {
+    dcl::js::testing::op_log_test_plan(state, body)
 }
 
 #[op2]
-fn op_log_test_result(state: &mut OpState, #[serde] body: SceneTestResult) {
-    dcl::js::testing::op_log_test_result(state, body);
+fn op_log_test_result(state: &mut OpState, #[serde] body: SceneTestResult) -> Result<(), AnyError> {
+    dcl::js::testing::op_log_test_result(state, body)
 }
 
 #[op2]

--- a/crates/dcl_deno/src/js/websocket.rs
+++ b/crates/dcl_deno/src/js/websocket.rs
@@ -104,7 +104,7 @@ where
             ty: common::structs::PermissionType::Websocket,
             message: Some(url.clone()),
             response: sx,
-        });
+        })?;
     let permit = rx.await?;
     if !permit {
         anyhow::bail!("User denied fetch request");

--- a/crates/dcl_wasm/src/inner/op_wrappers/adaption_layer_helper.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/adaption_layer_helper.rs
@@ -1,10 +1,7 @@
-use crate::WorkerContext;
+use crate::{serde_result, WasmError, WorkerContext};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub async fn op_get_texture_size(state: &WorkerContext, src: String) -> JsValue {
-    serde_wasm_bindgen::to_value(
-        &dcl::js::adaption_layer_helper::op_get_texture_size(state.rc(), src).await,
-    )
-    .unwrap()
+pub async fn op_get_texture_size(state: &WorkerContext, src: String) -> Result<JsValue, WasmError> {
+    serde_result!(dcl::js::adaption_layer_helper::op_get_texture_size(state.rc(), src).await)
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/comms.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/comms.rs
@@ -2,8 +2,10 @@ use crate::{WasmError, WorkerContext};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub async fn op_comms_send_string(state: &WorkerContext, message: String) {
-    dcl::js::comms::op_comms_send_string(state.rc(), message).await
+pub async fn op_comms_send_string(state: &WorkerContext, message: String) -> Result<(), WasmError> {
+    dcl::js::comms::op_comms_send_string(state.rc(), message)
+        .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
@@ -11,9 +13,11 @@ pub async fn op_comms_send_binary_single(
     state: &WorkerContext,
     message: js_sys::ArrayBuffer,
     recipient: Option<String>,
-) {
+) -> Result<(), WasmError> {
     let view = js_sys::Uint8Array::new(&message);
-    dcl::js::comms::op_comms_send_binary_single(state.rc(), &view.to_vec(), recipient).await
+    dcl::js::comms::op_comms_send_binary_single(state.rc(), &view.to_vec(), recipient)
+        .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]

--- a/crates/dcl_wasm/src/inner/op_wrappers/events.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/events.rs
@@ -1,9 +1,9 @@
-use crate::WorkerContext;
+use crate::{WasmError, WorkerContext};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn op_subscribe(state: &WorkerContext, id: &str) {
-    dcl::js::events::op_subscribe(&mut *state.state.borrow_mut(), id)
+pub fn op_subscribe(state: &WorkerContext, id: &str) -> Result<(), WasmError> {
+    dcl::js::events::op_subscribe(&mut *state.state.borrow_mut(), id).map_err(WasmError::from)
 }
 
 #[wasm_bindgen]

--- a/crates/dcl_wasm/src/inner/op_wrappers/player.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/player.rs
@@ -1,12 +1,16 @@
-use crate::WorkerContext;
+use crate::{WasmError, WorkerContext};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub async fn op_get_connected_players(state: &WorkerContext) -> Vec<String> {
-    dcl::js::player::op_get_connected_players(state.rc()).await
+pub async fn op_get_connected_players(state: &WorkerContext) -> Result<Vec<String>, WasmError> {
+    dcl::js::player::op_get_connected_players(state.rc())
+        .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
-pub async fn op_get_players_in_scene(state: &WorkerContext) -> Vec<String> {
-    dcl::js::player::op_get_players_in_scene(state.rc()).await
+pub async fn op_get_players_in_scene(state: &WorkerContext) -> Result<Vec<String>, WasmError> {
+    dcl::js::player::op_get_players_in_scene(state.rc())
+        .await
+        .map_err(WasmError::from)
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/portables.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/portables.rs
@@ -18,10 +18,11 @@ pub async fn op_portable_kill(state: &WorkerContext, pid: String) -> Result<bool
 }
 
 #[wasm_bindgen]
-pub async fn op_portable_list(state: &WorkerContext) -> Vec<JsValue> {
-    dcl::js::portables::op_portable_list(state.rc())
+pub async fn op_portable_list(state: &WorkerContext) -> Result<Vec<JsValue>, WasmError> {
+    Ok(dcl::js::portables::op_portable_list(state.rc())
         .await
+        .map_err(WasmError::from)?
         .into_iter()
         .map(|ev| serde_wasm_bindgen::to_value(&ev).unwrap())
-        .collect()
+        .collect())
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -9,7 +9,7 @@ pub async fn op_move_player_to(
     camera_target: JsValue,
     avatar_target: JsValue,
     duration: Option<f32>,
-) -> bool {
+) -> Result<bool, WasmError> {
     let position: DclVector3 = serde_wasm_bindgen::from_value(position).unwrap_or_default();
     let camera_target: Option<DclVector3> = serde_wasm_bindgen::from_value(camera_target).ok();
     let avatar_target: Option<DclVector3> = serde_wasm_bindgen::from_value(avatar_target).ok();
@@ -21,6 +21,7 @@ pub async fn op_move_player_to(
         duration,
     )
     .await
+    .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
@@ -29,15 +30,22 @@ pub async fn op_walk_player_to(
     position: JsValue,
     stop_threshold: f32,
     timeout: Option<f32>,
-) -> bool {
+) -> Result<bool, WasmError> {
     let position: DclVector3 = serde_wasm_bindgen::from_value(position).unwrap_or_default();
     dcl::js::restricted_actions::op_walk_player_to(op_state.rc(), position, stop_threshold, timeout)
         .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
-pub async fn op_teleport_to(state: &WorkerContext, position_x: i32, position_y: i32) -> bool {
-    dcl::js::restricted_actions::op_teleport_to(state.rc(), position_x, position_y).await
+pub async fn op_teleport_to(
+    state: &WorkerContext,
+    position_x: i32,
+    position_y: i32,
+) -> Result<bool, WasmError> {
+    dcl::js::restricted_actions::op_teleport_to(state.rc(), position_x, position_y)
+        .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
@@ -45,18 +53,23 @@ pub async fn op_change_realm(
     state: &WorkerContext,
     realm: String,
     message: Option<String>,
-) -> bool {
-    dcl::js::restricted_actions::op_change_realm(state.rc(), realm, message).await
+) -> Result<bool, WasmError> {
+    dcl::js::restricted_actions::op_change_realm(state.rc(), realm, message)
+        .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
-pub async fn op_external_url(state: &WorkerContext, url: String) -> bool {
-    dcl::js::restricted_actions::op_external_url(state.rc(), url).await
+pub async fn op_external_url(state: &WorkerContext, url: String) -> Result<bool, WasmError> {
+    dcl::js::restricted_actions::op_external_url(state.rc(), url)
+        .await
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
-pub fn op_emote(op_state: &WorkerContext, emote: String) {
-    dcl::js::restricted_actions::op_emote(&mut *op_state.state.borrow_mut(), emote);
+pub fn op_emote(op_state: &WorkerContext, emote: String) -> Result<(), WasmError> {
+    dcl::js::restricted_actions::op_emote(&mut *op_state.state.borrow_mut(), emote)
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]

--- a/crates/dcl_wasm/src/inner/op_wrappers/testing.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/testing.rs
@@ -7,15 +7,17 @@ pub fn op_testing_enabled(op_state: &WorkerContext) -> bool {
 }
 
 #[wasm_bindgen]
-pub fn op_log_test_plan(state: &WorkerContext, body: JsValue) {
+pub fn op_log_test_plan(state: &WorkerContext, body: JsValue) -> Result<(), WasmError> {
     serde_parse!(body);
-    dcl::js::testing::op_log_test_plan(&mut *state.state.borrow_mut(), body);
+    dcl::js::testing::op_log_test_plan(&mut *state.state.borrow_mut(), body)
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]
-pub fn op_log_test_result(state: &WorkerContext, body: JsValue) {
+pub fn op_log_test_result(state: &WorkerContext, body: JsValue) -> Result<(), WasmError> {
     serde_parse!(body);
-    dcl::js::testing::op_log_test_result(&mut *state.state.borrow_mut(), body);
+    dcl::js::testing::op_log_test_result(&mut *state.state.borrow_mut(), body)
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Summary

Scene ops enqueue `RpcCall`s (fetch/websocket permission checks, teleport, emote, portable spawn/kill, ethereum `sendAsync`, event subscriptions, comms message-bus, …). They accumulate in a per-scene `RpcCalls` queue and are drained into the outbound `SceneResponse::Ok` frame at each `crdt_send` flush. Nothing bounded that queue.

So a scene could issue a million calls in one tick — dropping each response immediately — and:
- grow an unbounded outbound IPC frame on the single sidecar↔engine connection every co-tenant scene shares, none of it requiring scene-side retention (so the isolate heap cap never catches it);
- cause unbounded engine-side work for the side-effectful calls, which execute even after the scene drops the response;
- queue an extra `IpcMessage::Closed` per dropped response on top.

`RpcCalls` becomes a newtype whose `push` is fallible and capped at `MAX_RPC_CALLS_PER_TICK = 1000`. The queue is drained via `std::mem::take` at the flush, so its current length *is* this tick's count — the cap needs no separate counter and resets for free each tick. Enforcing on `push` covers every enqueue site across both crates uniformly (`dcl` ops plus the `dcl_deno` fetch/websocket ops), including sites a scene could reach directly.

Every op propagates the cap failure to the scene (`push(..)?` end-to-end through the deno and wasm wrappers), so a spamming scene sees its own call fail — a rejected promise — rather than a plausible-but-wrong default (empty player list, `false` from teleport, a silently-dead event subscription). Event subscriptions only store their receiver once the call is enqueued, so a failed subscribe is retryable rather than permanently blocked by the already-subscribed check.

Comms sends reject on their pre-existing limits too — the 30KB message-size cap and the 512/tick send budget previously dropped the message silently, so a scene saturating the bus couldn't tell. This is the one scene-visible contract change a heavy-but-legitimate scene might notice: silent packet loss at the budget becomes a rejected promise.

Also fixes `EngineApi.js` `unsubscribe()`, which called `op_subscribe` (`op_unsubscribe` wasn't even destructured), making unsubscribe and its sender-side cleanup unreachable from scenes.

Follow-up to the CRDT ingress bound (#1085) — same class of unbounded-outbound-frame issue, a different field of the same frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
