### PR TITLE
Scope the super-user bridge BroadcastChannel per browser tab

### DIFF
--- a/deploy/web/engine/engine.js
+++ b/deploy/web/engine/engine.js
@@ -264,6 +264,12 @@ export async function initEngine() {
           payload: {
             compiledModule,
             sharedMemory,
+            // Set by host pages that want the super-user scene's BroadcastChannel names scoped
+            // to this tab (react-web seeds it before booting — issue #1089). Left unset, channel
+            // names stay bare — embedders like creator-hub's inspector share the bus with the
+            // scene from a DIFFERENT document (parent of the engine iframe), which can't see
+            // this window's session id.
+            bridgeSession: window.__bridgeSession,
           },
         });
         sandboxWorker.onmessage = (workerEvent) => {

--- a/deploy/web/engine/sandbox_worker.js
+++ b/deploy/web/engine/sandbox_worker.js
@@ -83,6 +83,8 @@ function deleteFromPrototypeChain(obj, name) {
 const jsContext = Object.create(null);
 var jsProxy = undefined;
 var jsPreamble = undefined;
+// Per-boot bridge session id from engine.js (INIT_WORKER payload); see the isSuper block below.
+var bridgeSession = undefined;
 function createJsContext(wasmApi, context) {
   const isSuper = wasmApi.is_super(context);
 
@@ -135,10 +137,23 @@ function createJsContext(wasmApi, context) {
   // BroadcastChannel is a same-origin, serverless side channel — handed ONLY to the trusted
   // super-user (--ui) scene, so an embedded host page can drive it; ordinary scenes never see it
   // (it would otherwise let an untrusted scene coordinate with the page / other scenes off-network).
+  //
+  // Same-origin means same-origin across ALL tabs, so when the host page provided a session id
+  // (react-web seeds window.__bridgeSession; engine.js forwards it), channel names are suffixed
+  // with it — otherwise one tab's HUD drives every tab's bridge scene (issue #1089). Wrapping the
+  // constructor here keeps the scene code unchanged; the page appends the same suffix
+  // (bridgeChannelName()). No session id → bare names, for embedders whose bus partner is a
+  // different document that can't see the engine window's id (creator-hub's inspector iframe).
   if (isSuper) {
     Object.defineProperty(jsContext, "BroadcastChannel", {
       configurable: false,
-      value: RealBroadcastChannel,
+      value: bridgeSession
+        ? class BroadcastChannel extends RealBroadcastChannel {
+            constructor(name) {
+              super(`${name}#${bridgeSession}`);
+            }
+          }
+        : RealBroadcastChannel,
     });
   }
 
@@ -324,6 +339,7 @@ function require(moduleName) {
 self.onmessage = async (event) => {
   if (event.data && event.data.type === "INIT_WORKER") {
     const { compiledModule, sharedMemory } = event.data.payload;
+    bridgeSession = event.data.payload.bridgeSession;
 
     if (!compiledModule || !sharedMemory) {
       console.error("[Sandbox Worker] Invalid payload received.");

--- a/react-web/bridge-scene/src/bridge.ts
+++ b/react-web/bridge-scene/src/bridge.ts
@@ -13,6 +13,8 @@
 import { engine } from '@dcl/sdk/ecs'
 import type { Envelope, PageToScene, SceneToPage } from '../../src/engine/protocol'
 
+// The bare name: the sandbox's injected BroadcastChannel appends a per-tab session suffix
+// (sandbox_worker.js), matching the page's bridgeChannelName() — so two tabs never share a bridge.
 const CHANNEL = 'bevy-ui-bridge'
 
 // BroadcastChannel is a runtime global injected only into the super-user (--ui) scene

--- a/react-web/e2e/helpers.ts
+++ b/react-web/e2e/helpers.ts
@@ -64,7 +64,11 @@ export async function installBridgeSpy(page: Page): Promise<void> {
     if (w.__bridgeLog) return
     w.__bridgeLog = []
     try {
-      const ch = new BroadcastChannel(channel)
+      // Same lazy per-boot suffix as the app's bridgeChannelName() — the init script runs first,
+      // so it seeds __bridgeSession and the app's `??=` picks it up.
+      const ws = window as unknown as { __bridgeSession?: string }
+      ws.__bridgeSession ??= crypto.randomUUID().slice(0, 8)
+      const ch = new BroadcastChannel(`${channel}#${ws.__bridgeSession}`)
       ch.onmessage = (e: MessageEvent) => w.__bridgeLog!.push(e.data)
     } catch {
       /* BroadcastChannel unavailable — spy disabled */

--- a/react-web/src/engine/EngineDriver.ts
+++ b/react-web/src/engine/EngineDriver.ts
@@ -9,7 +9,7 @@ import { getStoredLogin, rootAddress, type AuthIdentity } from '../features/auth
 import type { LoginDriver } from './driver'
 import type { EngineRpc } from './engineRpc'
 import {
-  BRIDGE_CHANNEL,
+  bridgeChannelName,
   type Envelope,
   type PageToScene,
   type SceneToPage
@@ -29,7 +29,7 @@ export class EngineDriver implements LoginDriver {
   private readyFallbackTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(private readonly rpc: EngineRpc) {
-    this.ch = new BroadcastChannel(BRIDGE_CHANNEL)
+    this.ch = new BroadcastChannel(bridgeChannelName())
     this.ch.onmessage = (e: MessageEvent<Envelope>) => {
       const env = e.data
       if (env?.to !== 'page') return

--- a/react-web/src/engine/bridge.ts
+++ b/react-web/src/engine/bridge.ts
@@ -7,7 +7,7 @@
 
 import type { AuthIdentity } from '../features/auth/sso'
 import {
-  BRIDGE_CHANNEL,
+  bridgeChannelName,
   type Envelope,
   type LoginPreviousResult,
   type PageToScene,
@@ -23,7 +23,7 @@ export class BridgeClient {
   private readonly pending = new Map<string, Pending>()
   private readonly listeners = new Set<(msg: SceneToPage) => void>()
 
-  constructor(channel: string = BRIDGE_CHANNEL) {
+  constructor(channel: string = bridgeChannelName()) {
     this.ch = new BroadcastChannel(channel)
     this.ch.onmessage = (e: MessageEvent<Envelope>) => {
       const env = e.data

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -4,7 +4,7 @@
 // page-side BridgeClient does not change at all.
 
 import {
-  BRIDGE_CHANNEL,
+  bridgeChannelName,
   type Envelope,
   type Outfit,
   type OutfitsMetadata,
@@ -214,7 +214,7 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
     ],
     namesForExtraSlots: []
   }
-  const ch = new BroadcastChannel(BRIDGE_CHANNEL)
+  const ch = new BroadcastChannel(bridgeChannelName())
   const wait = (ms: number): Promise<void> =>
     new Promise((r) => setTimeout(r, ms))
 

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -23,12 +23,12 @@ export const BRIDGE_CHANNEL = 'bevy-ui-bridge'
  */
 export function bridgeChannelName(): string {
   // Structural globalThis, not window/crypto: this module is also compiled into the bridge
-  // scene's program (type-only imports), whose tsconfig has no DOM lib. There crypto is absent
-  // and this falls back to the bare name — the scene never calls it anyway; its suffix is
-  // applied by the sandbox's injected BroadcastChannel wrapper.
-  const g = globalThis as { __bridgeSession?: string; crypto?: { randomUUID(): string } }
-  if (!g.crypto?.randomUUID) return BRIDGE_CHANNEL
-  g.__bridgeSession ??= g.crypto.randomUUID().slice(0, 8)
+  // scene's program (type-only imports), whose tsconfig has no DOM lib. (The scene never calls
+  // this at runtime — its suffix is applied by the sandbox's injected BroadcastChannel wrapper.)
+  const g = globalThis as { __bridgeSession?: string; crypto?: { randomUUID?(): string } }
+  // The id needs uniqueness, not unpredictability — Math.random covers insecure contexts
+  // (plain-http LAN testing), where crypto.randomUUID is absent.
+  g.__bridgeSession ??= g.crypto?.randomUUID?.().slice(0, 8) ?? Math.random().toString(36).slice(2, 10)
   return `${BRIDGE_CHANNEL}#${g.__bridgeSession}`
 }
 

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -11,6 +11,27 @@ import type { SceneLoadingUi } from './generated'
 
 export const BRIDGE_CHANNEL = 'bevy-ui-bridge'
 
+/**
+ * The channel name to actually open: BRIDGE_CHANNEL plus a per-boot session suffix.
+ * BroadcastChannel is same-origin across ALL tabs, so the bare name lets one tab's HUD drive
+ * every tab's bridge scene (issue #1089). The id lives on `window.__bridgeSession` — lazily
+ * created by whichever page-side caller touches it first (this helper, or the e2e spy's init
+ * script). engine.js only FORWARDS it to the scene sandbox, which appends the same suffix
+ * (deploy/web/engine/sandbox_worker.js) — it never generates one, so embedders that share the
+ * bus across documents (creator-hub's inspector) keep bare names. EngineHost calls this before
+ * booting the engine, which is what opts this page in.
+ */
+export function bridgeChannelName(): string {
+  // Structural globalThis, not window/crypto: this module is also compiled into the bridge
+  // scene's program (type-only imports), whose tsconfig has no DOM lib. There crypto is absent
+  // and this falls back to the bare name — the scene never calls it anyway; its suffix is
+  // applied by the sandbox's injected BroadcastChannel wrapper.
+  const g = globalThis as { __bridgeSession?: string; crypto?: { randomUUID(): string } }
+  if (!g.crypto?.randomUUID) return BRIDGE_CHANNEL
+  g.__bridgeSession ??= g.crypto.randomUUID().slice(0, 8)
+  return `${BRIDGE_CHANNEL}#${g.__bridgeSession}`
+}
+
 /** Mirrors SystemApi.getPreviousLogin(): userId is absent for a fresh user. */
 export interface PreviousLogin {
   userId: string | null

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -26,14 +26,16 @@ const CDN_LIBS = [
 
 let injected = false
 function injectEngine(): void {
-  // Once per page — the engine is a singleton (StrictMode remounts and HMR must not double-boot).
-  if (injected || window.__bevyBootConfig != null) return
-  injected = true
-
   // Seed window.__bridgeSession BEFORE the engine boots: engine.js forwards it to the scene
   // sandbox, which then scopes the bridge BroadcastChannel to this tab (issue #1089). The suffix
   // is opt-in per host page — engine.js never generates one — so this call is what turns it on.
+  // Above the guard so a host page that pre-set __bevyBootConfig (and bails below) still seeds
+  // the id the page-side channel constructors will use.
   bridgeChannelName()
+
+  // Once per page — the engine is a singleton (StrictMode remounts and HMR must not double-boot).
+  if (injected || window.__bevyBootConfig != null) return
+  injected = true
 
   const params = new URLSearchParams(location.search)
   // pkg/ fetch base: the versioned CDN in prod builds (BASE_URL), the served engine dir otherwise.

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect } from 'react'
 import type { EngineRpc } from '../../engine/engineRpc'
+import { bridgeChannelName } from '../../engine/protocol'
 import { bootMode } from '../../lib/bootMode'
 import { PAGE_DIR } from '../../lib/publicUrl'
 // Moved to lib/systemScene.ts, which also decides whether a link is allowed to override it.
@@ -28,6 +29,11 @@ function injectEngine(): void {
   // Once per page — the engine is a singleton (StrictMode remounts and HMR must not double-boot).
   if (injected || window.__bevyBootConfig != null) return
   injected = true
+
+  // Seed window.__bridgeSession BEFORE the engine boots: engine.js forwards it to the scene
+  // sandbox, which then scopes the bridge BroadcastChannel to this tab (issue #1089). The suffix
+  // is opt-in per host page — engine.js never generates one — so this call is what turns it on.
+  bridgeChannelName()
 
   const params = new URLSearchParams(location.search)
   // pkg/ fetch base: the versioned CDN in prod builds (BASE_URL), the served engine dir otherwise.

--- a/react-web/src/lib/cefNativeBridge.ts
+++ b/react-web/src/lib/cefNativeBridge.ts
@@ -5,7 +5,7 @@
 //
 // No-op when window.cef is absent (web).
 
-import { BRIDGE_CHANNEL } from '../engine/protocol'
+import { bridgeChannelName } from '../engine/protocol'
 
 interface CefApi {
   emit: (payload: unknown) => void
@@ -16,7 +16,7 @@ export function installCefNativeBridge(): void {
   const cef = (window as Window & { cef?: CefApi }).cef
   if (!cef?.emit || !cef?.listen) return
 
-  const ch = new BroadcastChannel(BRIDGE_CHANNEL)
+  const ch = new BroadcastChannel(bridgeChannelName())
   // page -> engine: only scene-bound Envelopes cross the boundary
   ch.onmessage = (e) => {
     const env = e.data as { to?: string } | undefined


### PR DESCRIPTION
Fixes #1089

## Problem

`BroadcastChannel` is same-origin across **all** tabs, and the HUD ↔ bridge-scene transport uses the fixed name `bevy-ui-bridge` with no tab identity in the envelope. With two web clients open, a `/goto` typed in one tab is received and executed by every tab's bridge scene — and it's broader than teleports: any page→scene request (chat sends, emotes, settings, logout) fans out to all tabs, and scene→page streams (chat relay, player pose, profile) cross-pollinate every tab's HUD.

## Fix

A per-boot session id suffixes the channel name on both ends, **opt-in by the host page**:

- The page seeds `window.__bridgeSession` before booting the engine (react-web does this in `EngineHost`, and all page-side consumers open the channel via the new `bridgeChannelName()` — lazy `??=` init makes it load-order independent, including the e2e bridge spy's init script).
- `engine.js` forwards the id (if set) to the sandbox worker in the `INIT_WORKER` payload.
- `sandbox_worker.js` hands the super-user scene a `BroadcastChannel` wrapper that appends `#<id>` to every channel name — the bridge-scene code is untouched.
- No id seeded → names stay bare, exactly today's behavior.

Native is unaffected either way: the deno `BroadcastChannel` polyfill ignores channel names entirely (it's a per-process op-backed pipe), and each native instance runs its own CEF browser process, so nothing can cross.

## Why opt-in: creator-hub (cc @nicoecheza)

creator-hub's inspector embeds this engine in an iframe and talks to its editor-agent super-user scene over the same mechanism on a different channel (`dcl-editor-bus`) — but from the **parent document**, which can't see the engine iframe's `window`. An engine-generated id would have suffixed the scene side only and silently broken that integration on the next engine bump. With the id opt-in and unset, creator-hub keeps bare names and needs no changes.

It also gives creator-hub a migration path: multiple editor windows in one Electron session are same-origin, so `dcl-editor-bus` has the same cross-window leak this PR fixes for the web client. To adopt the fix there:

1. `engine-iframe.ts` generates a per-mount id and appends it to the engine URL (alongside `realm`/`position`/`systemScene`),
2. `host-boot.js` sets `window.__bridgeSession` from the query param before `__bevyLaunch` (the engine reads it at sandbox-spawn time, so anywhere before launch works),
3. the inspector-side bridges open `dcl-editor-bus#<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)