### PR TITLE
Allow a bounded number of CRDT batches per tick

### DIFF
--- a/crates/dcl/src/js/engine.rs
+++ b/crates/dcl/src/js/engine.rs
@@ -12,7 +12,7 @@ use crate::{
     crdt::{append_component, delete_entity, put_component},
     interface::{crdt_context::CrdtContext, CrdtType},
     js::{
-        AllocatorContext, CommunicatedWithRenderer, CrdtSentThisTick, CrdtStoreNextCheck,
+        AllocatorContext, CommunicatedWithRenderer, CrdtSendsThisTick, CrdtStoreNextCheck,
         FilteredCrdtStore, KillFlag, RendererStore, SceneResponseSender, SceneStatsFlush,
     },
     AllocError, CrdtComponentInterfaces, CrdtStore, RendererResponse, RpcCalls, SceneElapsedTime,
@@ -35,6 +35,14 @@ pub(crate) const MAX_CRDT_BATCH_BYTES: usize = 64 * 1024 * 1024;
 // only a scene that pushes CRDT data without holding it in its own heap can. Set to the heap
 // cap so legitimate scenes are never clipped and only that cheating pattern is caught.
 pub(crate) const MAX_CRDT_STORE_BYTES: usize = 512 * 1024 * 1024;
+
+// Upper bound on CRDT batches a scene sends within one tick. Each send is paired with an
+// awaited receive in the EngineApi glue, so multiple sends per tick are renderer-paced and
+// don't stack the response channel — but a scene that loops renderer comms without surfacing
+// to the top-level scene loop escapes diagnostics, dt accounting and shutdown tracking, so
+// the number is kept small. Four is the most any known-legitimate runtime uses: the sdk6
+// adaption layer pumps exactly four engine updates inside onStart to bootstrap the scene.
+pub(crate) const MAX_CRDT_SENDS_PER_TICK: u32 = 4;
 
 /// Returns whether this scene runs in authoritative-server role. Read synchronously
 /// from the scene's CrdtContext (seeded from the `IsServer` engine resource). MUST stay
@@ -93,23 +101,29 @@ pub fn crdt_send_to_renderer(op_state: Rc<RefCell<impl State>>, messages: &[u8])
         return;
     }
 
-    // One batch per tick: a scene that sends again without an intervening tick boundary is
-    // breaching the runtime contract — and un-awaited send spam would otherwise stack frames
-    // onto the bounded response channel, whose overflow panics inside an op and takes down
-    // the shared sidecar. The marker is cleared by the scene loop at each tick boundary.
-    if op_state.has::<CrdtSentThisTick>() {
+    // Bounded batches per tick: a scene that keeps sending without surfacing to the scene
+    // loop is breaching the runtime contract — un-awaited send spam would stack frames onto
+    // the bounded response channel, whose overflow panics inside an op and takes down the
+    // shared sidecar, and even awaited in-loop comms escape diagnostics and shutdown
+    // tracking. The counter is cleared by the scene loop at each tick boundary.
+    let sends = op_state
+        .try_take::<CrdtSendsThisTick>()
+        .unwrap_or_default()
+        .0
+        + 1;
+    op_state.put(CrdtSendsThisTick(sends));
+    if sends > MAX_CRDT_SENDS_PER_TICK {
         let scene_id = op_state.borrow::<CrdtContext>().scene_id;
-        error!("[{scene_id:?}] multiple CRDT batches in one tick; terminating the scene");
+        error!("[{scene_id:?}] more than {MAX_CRDT_SENDS_PER_TICK} CRDT batches in one tick; terminating the scene");
         let _ = op_state
             .borrow_mut::<SceneResponseSender>()
             .try_send(SceneResponse::Error(
                 scene_id,
-                "scene sent more than one CRDT batch in a tick".to_owned(),
+                format!("scene sent more than {MAX_CRDT_SENDS_PER_TICK} CRDT batches in a tick"),
             ));
         op_state.borrow::<KillFlag>().kill();
         return;
     }
-    op_state.put(CrdtSentThisTick);
 
     // Reject an oversized batch before it is copied into the store, serialised, and framed
     // onto the shared connection. Report it as a scene error and flag the scene for shutdown

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -106,11 +106,13 @@ pub struct CommunicatedWithRenderer;
 // scene-elapsed time (seconds) of the last SceneResponse::Stats flush
 pub struct SceneStatsFlush(pub f32);
 
-// Set by `crdt_send_to_renderer`, cleared at each tick boundary by the scene loop: a scene
-// may send at most one CRDT batch per tick (the response channel is sized for that contract,
-// and un-awaited send spam could otherwise fill it). A second send in one tick is a breach
-// that shuts the scene down.
-pub struct CrdtSentThisTick;
+// Count of CRDT batches sent this tick, incremented by `crdt_send_to_renderer` and cleared
+// at each tick boundary by the scene loop: a scene may send at most MAX_CRDT_SENDS_PER_TICK
+// batches per tick (un-awaited send spam could otherwise fill the bounded response channel,
+// and a scene that loops renderer comms without surfacing to the top-level loop escapes
+// diagnostics and shutdown tracking). Exceeding the cap is a breach that shuts the scene down.
+#[derive(Default)]
+pub struct CrdtSendsThisTick(pub u32);
 
 // Ingest total (SceneResourceCounters::crdt_bytes) at which the retained store could next
 // reach its cap. Retained bytes grow at most 1:1 with ingest, so after a measurement finds
@@ -600,33 +602,35 @@ mod scene_log_budget_tests {
         );
     }
 
-    // A scene may send at most one CRDT batch per tick: a second send with no intervening
-    // tick boundary is a contract breach that terminates the scene — un-awaited send spam
-    // must not stack frames onto the bounded response channel.
+    // A scene may send at most MAX_CRDT_SENDS_PER_TICK CRDT batches per tick — the sdk6
+    // adaption layer legitimately pumps that many paired round-trips inside onStart — but
+    // one more with no intervening tick boundary is a contract breach that terminates the
+    // scene: un-awaited send spam must not stack frames onto the bounded response channel,
+    // and in-loop comms that never surface to the scene loop escape diagnostics.
     #[test]
-    fn second_send_in_one_tick_terminates_the_scene() {
+    fn sends_over_the_per_tick_cap_terminate_the_scene() {
         let (sx, mut rx) = scene_response_channel();
         let mut s = crdt_state();
         s.put(sx);
         let state = std::rc::Rc::new(std::cell::RefCell::new(s));
 
-        super::engine::crdt_send_to_renderer(state.clone(), &[]);
-        assert!(matches!(rx.try_recv(), Ok(crate::SceneResponse::Ok(..))));
+        for _ in 0..super::engine::MAX_CRDT_SENDS_PER_TICK {
+            super::engine::crdt_send_to_renderer(state.clone(), &[]);
+            assert!(matches!(rx.try_recv(), Ok(crate::SceneResponse::Ok(..))));
+        }
+        assert!(!state.borrow().borrow::<KillFlag>().killed());
 
         super::engine::crdt_send_to_renderer(state.clone(), &[]);
         match rx.try_recv() {
             Ok(crate::SceneResponse::Error(id, msg)) => {
                 assert_eq!(id, crate::SceneId::DUMMY);
-                assert!(
-                    msg.contains("more than one CRDT batch"),
-                    "unexpected message: {msg}"
-                );
+                assert!(msg.contains("CRDT batches"), "unexpected message: {msg}");
             }
             other => panic!("expected Error, got {other:?}"),
         }
         assert!(
             state.borrow().borrow::<KillFlag>().killed(),
-            "a second send in one tick must flag the scene for shutdown"
+            "sends over the per-tick cap must flag the scene for shutdown"
         );
     }
 
@@ -642,7 +646,7 @@ mod scene_log_budget_tests {
             super::engine::crdt_send_to_renderer(state.clone(), &[]);
             assert!(matches!(rx.try_recv(), Ok(crate::SceneResponse::Ok(..))));
             // what the scene loop does at each tick boundary
-            state.borrow_mut().try_take::<CrdtSentThisTick>();
+            state.borrow_mut().try_take::<CrdtSendsThisTick>();
         }
         assert!(!state.borrow().borrow::<KillFlag>().killed());
     }

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -6,7 +6,7 @@ use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
     js::{
-        engine::crdt_send_to_renderer, init_state, CommunicatedWithRenderer, CrdtSentThisTick,
+        engine::crdt_send_to_renderer, init_state, CommunicatedWithRenderer, CrdtSendsThisTick,
         KillFlag, SceneResponseSender, SuperUserScene,
     },
     RendererResponse, RpcCalls, SceneElapsedTime, SceneResourceCounters, SceneResponse,
@@ -331,8 +331,8 @@ pub(crate) fn scene_thread(
 
     // send any initial rpc requests
     crdt_send_to_renderer(state.clone(), &[]);
-    // the initial send consumed the tick's batch allowance; give onStart its own
-    state.borrow_mut().try_take::<CrdtSentThisTick>();
+    // the initial send drew on the tick's send allowance; give onStart a full one
+    state.borrow_mut().try_take::<CrdtSendsThisTick>();
 
     // run startup function
     let run_start = thread_cpu_us();
@@ -378,8 +378,8 @@ pub(crate) fn scene_thread(
         state
             .borrow_mut()
             .put(SceneElapsedTime(elapsed.as_secs_f32()));
-        // tick boundary: reset the one-batch-per-tick send allowance
-        state.borrow_mut().try_take::<CrdtSentThisTick>();
+        // tick boundary: reset the bounded per-tick send allowance
+        state.borrow_mut().try_take::<CrdtSendsThisTick>();
 
         // heap gauges: sampling walks the isolate's spaces, so cap it at ~once per 5s
         if last_heap_sample.is_none_or(|at| now.saturating_duration_since(at).as_secs() >= 5) {

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -9,7 +9,7 @@ use common::structs::GlobalCrdtStateUpdate;
 use dcl::{
     interface::{crdt_context::CrdtContext, CrdtComponentInterfaces, CrdtStore},
     js::{
-        CommunicatedWithRenderer, CrdtSentThisTick, KillFlag, SceneResponseSender, SuperUserScene,
+        CommunicatedWithRenderer, CrdtSendsThisTick, KillFlag, SceneResponseSender, SuperUserScene,
     },
     RendererResponse, SceneElapsedTime,
 };
@@ -220,8 +220,8 @@ impl From<WasmError> for JsValue {
 pub fn op_set_elapsed(state: &WorkerContext, elapsed: f32) {
     let mut state = state.state.borrow_mut();
     state.put(SceneElapsedTime(elapsed));
-    // tick boundary: reset the one-batch-per-tick send allowance
-    state.try_take::<CrdtSentThisTick>();
+    // tick boundary: reset the bounded per-tick send allowance
+    state.try_take::<CrdtSendsThisTick>();
 }
 
 #[wasm_bindgen]

--- a/deploy/web/engine/sandbox_worker.js
+++ b/deploy/web/engine/sandbox_worker.js
@@ -413,7 +413,7 @@ self.onmessage = async (event) => {
       // send any initial rpc requests
       ops.op_crdt_send_to_renderer([]);
 
-      // the initial send consumed the tick's batch allowance; give onStart its own
+      // the initial send drew on the tick's send allowance; give onStart a full one
       ops.op_set_elapsed(0);
 
       await module.onStart();


### PR DESCRIPTION
#1085's one-batch-per-tick contract kill turned out to fire on every sdk6 scene (e.g. the Genesis City road scenes): the sdk6 adaption layer's `onStart` deliberately pumps four paired `crdtSendToRenderer` round-trips to bootstrap the scene (load game.js → update, flush, update, start, update, forceUpdate, update), and the second send inside onStart tripped the kill at load.

Each of those sends awaits its receive in the EngineApi glue, so they're renderer-paced and can't stack the bounded response channel — the hazard #1085 targets. But in-loop renderer comms that never surface to the top-level scene loop still escape diagnostics, dt accounting and shutdown tracking, so instead of resetting the allowance on receive this keeps the per-tick bound and raises it to a counted cap: `MAX_CRDT_SENDS_PER_TICK = 4`, exactly what the adaption layer bootstrap uses. Un-awaited send spam still dies, one send later than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)