### PR TITLE
fix: report scene-relative positions for foreign player transforms

### DIFF
--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -32,6 +32,10 @@ pub enum Localizer {
     Unimplemented,
     /// Localize `PbAvatarMovementInfo`: offset `walk_target` (field 8) by scene origin.
     AvatarMovementInfo,
+    /// Localize `DclTransformAndParent`: world-space transforms (parented to `WORLD_ORIGIN`)
+    /// get their translation offset by scene origin and are re-parented to `ROOT`, so scenes
+    /// read scene-relative positions for foreign players.
+    Transform,
 }
 
 impl Localizer {
@@ -60,6 +64,30 @@ impl Localizer {
 
                 let mut buf = Vec::with_capacity(payload.len());
                 info.encode(&mut buf).expect("re-encode failed");
+                buf
+            }
+            Localizer::Transform => {
+                use transform_and_parent::DclTransformAndParent;
+
+                let mut reader = DclReader::new(payload);
+                let Ok(mut transform) = reader.read::<DclTransformAndParent>() else {
+                    return payload.to_vec();
+                };
+
+                // Only WORLD_ORIGIN-parented transforms carry world-space positions;
+                // anything else is already in scene space.
+                if transform.parent != SceneEntityId::WORLD_ORIGIN {
+                    return payload.to_vec();
+                }
+
+                let origin = &scene_origin.0;
+                transform.translation.0[0] -= origin.x;
+                transform.translation.0[1] -= origin.y;
+                transform.translation.0[2] -= origin.z;
+                transform.parent = SceneEntityId::ROOT;
+
+                let mut buf = Vec::with_capacity(payload.len());
+                DclWriter::new(&mut buf).write(&transform);
                 buf
             }
         }
@@ -279,5 +307,63 @@ impl FromDclReader for SceneCrdtTimestamp {
 impl ToDclWriter for SceneCrdtTimestamp {
     fn to_writer(&self, buf: &mut DclWriter) {
         buf.write_u32(self.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use transform_and_parent::{DclQuat, DclTransformAndParent, DclTranslation};
+
+    fn encode(transform: &DclTransformAndParent) -> Vec<u8> {
+        let mut buf = Vec::new();
+        DclWriter::new(&mut buf).write(transform);
+        buf
+    }
+
+    #[test]
+    fn transform_localizer_offsets_world_origin_transforms() {
+        let payload = encode(&DclTransformAndParent {
+            translation: DclTranslation([1456.4, 0.13, -135.1]),
+            rotation: DclQuat([0.0, 0.0, 0.0, 1.0]),
+            scale: Vec3::ONE,
+            parent: SceneEntityId::WORLD_ORIGIN,
+        });
+        let origin = SceneOrigin(Vec3::new(1440.0, 0.0, -144.0));
+
+        let localized = Localizer::Transform.localize_payload(&payload, &origin);
+        let result: DclTransformAndParent = DclReader::new(&localized).read().unwrap();
+
+        assert_eq!(result.parent, SceneEntityId::ROOT);
+        assert!((result.translation.0[0] - 16.4).abs() < 1e-3);
+        assert!((result.translation.0[1] - 0.13).abs() < 1e-6);
+        assert!((result.translation.0[2] - 8.9).abs() < 1e-3);
+    }
+
+    #[test]
+    fn transform_localizer_leaves_scene_space_transforms_untouched() {
+        let payload = encode(&DclTransformAndParent {
+            translation: DclTranslation([1.0, 2.0, 3.0]),
+            rotation: DclQuat([0.0, 0.0, 0.0, 1.0]),
+            scale: Vec3::ONE,
+            parent: SceneEntityId::ROOT,
+        });
+        let origin = SceneOrigin(Vec3::new(160.0, 0.0, 320.0));
+
+        assert_eq!(
+            Localizer::Transform.localize_payload(&payload, &origin),
+            payload
+        );
+    }
+
+    #[test]
+    fn transform_localizer_passes_through_malformed_payloads() {
+        let origin = SceneOrigin(Vec3::new(160.0, 0.0, 320.0));
+        let truncated = vec![0u8; 10];
+
+        assert_eq!(
+            Localizer::Transform.localize_payload(&truncated, &origin),
+            truncated
+        );
     }
 }

--- a/crates/dcl_component/src/transform_and_parent.rs
+++ b/crates/dcl_component/src/transform_and_parent.rs
@@ -2,7 +2,9 @@ use std::ops::{Add, Sub};
 
 use bevy::prelude::{Quat, Transform, Vec3};
 
-use super::{DclReader, DclReaderError, FromDclReader, PositionFree, SceneEntityId, ToDclWriter};
+use super::{
+    DclReader, DclReaderError, FromDclReader, GlobalCrdtData, Localizer, SceneEntityId, ToDclWriter,
+};
 
 // for dcl: +z -> forward
 // for bevy: +z -> backward
@@ -231,5 +233,10 @@ impl ToDclWriter for DclTransformAndParent {
     }
 }
 
-// Transforms are localized via WORLD_ORIGIN parenting, not payload adjustment
-impl PositionFree for DclTransformAndParent {}
+// World-space transforms (parented to WORLD_ORIGIN) are localized per scene:
+// translation offset by scene origin, re-parented to ROOT.
+impl GlobalCrdtData for DclTransformAndParent {
+    fn localizer() -> Localizer {
+        Localizer::Transform
+    }
+}

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -30,7 +30,6 @@ use dcl::{
 };
 use dcl_component::{
     proto_components::sdk::components::{PbMainCamera, PbRealmInfo, PbVisibilityComponent},
-    transform_and_parent::DclTransformAndParent,
     DclReader, DclWriter, SceneComponentId, SceneEntityId,
 };
 use ipfs::{
@@ -427,19 +426,6 @@ pub(crate) fn load_scene_javascript(
         let scene_origin = Vec3::new(initial_position.x, 0.0, initial_position.y);
         let (mut initial_crdt, global_updates) = global_scene.subscribe(scene_origin);
 
-        // set the world origin (for parents of world-space entities, using world-space coords as local coords)
-        let mut buf = Vec::new();
-        DclWriter::new(&mut buf).write(&DclTransformAndParent::from_bevy_transform_and_parent(
-            &Transform::from_translation(Vec3::new(-initial_position.x, 0.0, initial_position.y)),
-            SceneEntityId::ROOT,
-        ));
-        initial_crdt.force_update(
-            SceneComponentId::TRANSFORM,
-            CrdtType::LWW_ANY,
-            SceneEntityId::WORLD_ORIGIN,
-            Some(&mut DclReader::new(&buf)),
-        );
-
         // set initial realm info
         let base_url = realm
             .about_url
@@ -463,7 +449,7 @@ pub(crate) fn load_scene_javascript(
             room: None,
             is_connected_scene_room: None,
         };
-        buf.clear();
+        let mut buf = Vec::new();
         DclWriter::new(&mut buf).write(&realm_info);
         initial_crdt.force_update(
             SceneComponentId::REALM_INFO,


### PR DESCRIPTION
## Summary

Foreign player `Transform`s were broadcast into scene CRDTs with raw world-space translations, parented to the `WORLD_ORIGIN` entity. Rendering resolved correctly through the parent chain, but any scene script reading `Transform.position` directly for a player entity (`getPlayer().position`, distance checks, trigger zones) saw world coordinates instead of scene-local ones — masked only when the scene sits at parcel `0,0`. On the headless authoritative server every connected player goes through the foreign-player path, so server-side game logic over player positions was wrong for any non-origin scene.

This is the bevy-side counterpart of decentraland/hammurabi-headless#27, which fixed the same issue (same `GlobalCenterOfCoordinates`/`WORLD_ORIGIN` convention) on the fork backend — with this change scenes observe the same player coordinates on either multiplayer backend.

Changes:
- Add `Localizer::Transform`: `WORLD_ORIGIN`-parented transform payloads get their translation offset by the scene origin and are re-parented to `ROOT`. This rides the existing per-scene localization infra from #653, so it applies to both the initial CRDT snapshot (`subscribe`) and live updates, across all execution paths (deno, deno-ipc, wasm, headless).
- `DclTransformAndParent` now registers that localizer instead of opting out via `PositionFree`.
- Drop the per-scene `WORLD_ORIGIN` entity seeding in `initialize_scene.rs` — no scene-visible payload references entity 5 anymore.
- Unit tests for the localizer (offset + reparent, scene-space pass-through, malformed payload pass-through).

Stacked on `feat/per-room-presence-isolation`.

## What could break

- Every scene now observes foreign players scene-relative and `ROOT`-parented. This is the SDK convention (and what the fork backend does after hammurabi-headless#27), but a scene that manually compensated for the old world-space behavior would now double-convert.
- The bridge scene's nametag distance math mixed `getPlayer().position` (world) with the camera transform (scene-relative); it was wrong for non-origin scenes before and is fixed, not broken, by this change.
- Scenes still receive a `DELETE_ENTITY`-free tombstone-less entity 5; anything that read the seeded `WORLD_ORIGIN` transform (none found in-repo, and it's not part of the SDK protocol) would now see no `Transform` on it.

## How to test

- `cargo test -p dcl_component` — covers the localizer directly.
- Manual: run a scene whose base parcel is not `0,0` (Genesis City scene or a world with a non-origin base parcel), connect a second client, and log `getPlayer({ userId }).position` for the remote player — values should be small scene-local coordinates matching the local player's convention, with parent `0` (ROOT) instead of `5`.
- Headless: spawn a non-origin scene through the multiplayer server, have a client join, and verify server-side `Transform` reads for the joined player are scene-local.