### PR TITLE
Isolate player presence per scene room in orchestrated mode

### DIFF
--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -181,12 +181,13 @@ fn setup(mut commands: Commands, images: ResMut<Assets<Image>>, mut view: ResMut
 
 // send received avatar info into scenes
 fn update_avatar_info(
-    updated_players: Query<(Option<&ForeignPlayer>, &UserProfile), Changed<UserProfile>>,
+    updated_players: Query<(Entity, Option<&ForeignPlayer>, &UserProfile), Changed<UserProfile>>,
     mut global_state: ResMut<GlobalCrdtState>,
 ) {
-    for (player, profile) in &updated_players {
+    for (entity, player, profile) in &updated_players {
         let avatar = &profile.content.avatar;
-        global_state.update_crdt(
+        global_state.update_crdt_player(
+            entity,
             SceneComponentId::AVATAR_BASE,
             CrdtType::LWW_ANY,
             player.map(|p| p.scene_id).unwrap_or(SceneEntityId::PLAYER),
@@ -202,7 +203,8 @@ fn update_avatar_info(
                     .unwrap_or(base_wearables::default_bodyshape_urn().to_string()),
             },
         );
-        global_state.update_crdt(
+        global_state.update_crdt_player(
+            entity,
             SceneComponentId::AVATAR_EQUIPPED_DATA,
             CrdtType::LWW_ANY,
             player.map(|p| p.scene_id).unwrap_or(SceneEntityId::PLAYER),

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -165,6 +165,8 @@ pub enum RpcCall {
         response: RpcResultSender<Result<SerializedProfile, ()>>,
     },
     GetConnectedPlayers {
+        /// calling scene — scopes the answer to its own room in partitioned mode
+        scene: Entity,
         response: RpcResultSender<Vec<String>>,
     },
     GetPlayersInScene {
@@ -177,9 +179,11 @@ pub enum RpcCall {
         response: RpcResultSender<Result<(), String>>,
     },
     SubscribePlayerConnected {
+        scene: Entity,
         sender: RpcEventSender,
     },
     SubscribePlayerDisconnected {
+        scene: Entity,
         sender: RpcEventSender,
     },
     SubscribePlayerEnteredScene {

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -35,7 +35,10 @@ use dcl_component::{
     DclReader, DclWriter, GlobalCrdtData, Localizer, SceneComponentId, SceneEntityId, SceneOrigin,
 };
 
-use crate::{movement_compressed::MovementCompressed, profile::ProfileMetaCache, Transport};
+use crate::{
+    movement_compressed::MovementCompressed, profile::ProfileMetaCache, PartitionPresenceByScene,
+    SceneRoom, Transport,
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 use kira::sound::streaming::StreamingSoundData;
@@ -76,6 +79,8 @@ impl Plugin for GlobalCrdtPlugin {
             lookup: Default::default(),
             realm_bounds: (IVec2::MAX, IVec2::MIN),
             localizers: Default::default(),
+            rooms: Default::default(),
+            player_rooms: Default::default(),
         });
 
         let (sender, _) = tokio::sync::broadcast::channel(1_000);
@@ -163,13 +168,30 @@ impl From<NonPlayerUpdate> for NetworkUpdate {
     }
 }
 
+/// Per-scene-room slice of foreign-player CRDT state (`PartitionPresenceByScene` mode).
+/// The `SceneEntityId` allocator and `Address→Entity` lookup stay global.
+struct RoomCrdt {
+    store: CrdtStore,
+    int_sender: broadcast::Sender<GlobalCrdtStateUpdate>,
+}
+
+impl Default for RoomCrdt {
+    fn default() -> Self {
+        let (int_sender, _) = broadcast::channel(1000);
+        Self {
+            store: Default::default(),
+            int_sender,
+        }
+    }
+}
+
 #[derive(Resource)]
 pub struct GlobalCrdtState {
     // receiver from sockets
     ext_receiver: mpsc::Receiver<NetworkUpdate>,
     // sender for sockets to post to
     ext_sender: mpsc::Sender<NetworkUpdate>,
-    // sender for broadcast updates
+    // sender for broadcast updates (client / non-partitioned path)
     int_sender: broadcast::Sender<GlobalCrdtStateUpdate>,
     context: CrdtContext,
     store: CrdtStore,
@@ -177,6 +199,11 @@ pub struct GlobalCrdtState {
     pub(crate) realm_bounds: (IVec2, IVec2),
     // per-component localizer registry (populated as components are first sent)
     localizers: HashMap<SceneComponentId, Localizer>,
+    // per-scene-hash CRDT slices; empty unless PartitionPresenceByScene
+    rooms: HashMap<String, RoomCrdt>,
+    // room slices each foreign player was written into — kept here because the
+    // transport (and its SceneRoom) may be gone by despawn time
+    player_rooms: HashMap<Entity, HashSet<String>>,
 }
 
 impl GlobalCrdtState {
@@ -192,9 +219,27 @@ impl GlobalCrdtState {
         scene_origin: bevy::prelude::Vec3,
     ) -> (CrdtStore, broadcast::Receiver<GlobalCrdtStateUpdate>) {
         let mut store = self.store.clone();
-        let origin = SceneOrigin(scene_origin);
+        self.localize_store(&mut store, scene_origin);
+        (store, self.int_sender.subscribe())
+    }
 
-        // Localize position-containing entries in the initial store snapshot
+    /// Partitioned subscribe: only the given scene room's players. The room slice is
+    /// created lazily so a scene that loads before anyone joins gets an empty view.
+    pub fn subscribe_room(
+        &mut self,
+        hash: &str,
+        scene_origin: bevy::prelude::Vec3,
+    ) -> (CrdtStore, broadcast::Receiver<GlobalCrdtStateUpdate>) {
+        let room = self.room_entry(hash);
+        let mut store = room.store.clone();
+        let receiver = room.int_sender.subscribe();
+        self.localize_store(&mut store, scene_origin);
+        (store, receiver)
+    }
+
+    // localize position-containing entries in an initial store snapshot
+    fn localize_store(&self, store: &mut CrdtStore, scene_origin: bevy::prelude::Vec3) {
+        let origin = SceneOrigin(scene_origin);
         for (component_id, localizer) in &self.localizers {
             if matches!(localizer, Localizer::None | Localizer::Unimplemented) {
                 continue;
@@ -207,8 +252,24 @@ impl GlobalCrdtState {
                 }
             }
         }
+    }
 
-        (store, self.int_sender.subscribe())
+    fn room_entry(&mut self, hash: &str) -> &mut RoomCrdt {
+        self.rooms.entry(hash.to_owned()).or_default()
+    }
+
+    // the store and sender an update should be written to: a room slice, or the global pair
+    fn slice(
+        &mut self,
+        room: Option<&str>,
+    ) -> (&mut CrdtStore, &broadcast::Sender<GlobalCrdtStateUpdate>) {
+        match room {
+            Some(hash) => {
+                let room = self.room_entry(hash);
+                (&mut room.store, &room.int_sender)
+            }
+            None => (&mut self.store, &self.int_sender),
+        }
     }
 
     pub fn set_bounds(&mut self, min: IVec2, max: IVec2) {
@@ -216,8 +277,11 @@ impl GlobalCrdtState {
         self.realm_bounds = (min, max);
     }
 
+    /// Write a component into the CRDT store and broadcast it. `room` = scene hash routes
+    /// to that room's slice (partitioned mode); `None` = the global store.
     pub fn update_crdt<T: GlobalCrdtData>(
         &mut self,
+        room: Option<&str>,
         component_id: SceneComponentId,
         crdt_type: CrdtType,
         id: SceneEntityId,
@@ -236,43 +300,78 @@ impl GlobalCrdtState {
 
         let mut buf = Vec::new();
         DclWriter::new(&mut buf).write(data);
+        let (store, sender) = self.slice(room);
         let timestamp =
-            self.store
-                .force_update(component_id, crdt_type, id, Some(&mut DclReader::new(&buf)));
+            store.force_update(component_id, crdt_type, id, Some(&mut DclReader::new(&buf)));
         let crdt_message = match crdt_type {
             CrdtType::LWW(_) => put_component(&id, &component_id, &timestamp, Some(&buf)),
             CrdtType::GO(_) => append_component(&id, &component_id, &buf),
         };
-        self.send_update(
+        Self::send_on(
+            sender,
             GlobalCrdtStateUpdate::Crdt(crdt_message, localizer),
             "foreign player",
         );
     }
 
-    pub fn delete_entity(&mut self, id: SceneEntityId) {
-        self.store.clean_up(&HashSet::from_iter(Some(id)));
+    /// Write a component for a player entity, fanning out to the room slices the player
+    /// is in. No recorded rooms (client path, or the local player) → the global store.
+    pub fn update_crdt_player<T: GlobalCrdtData>(
+        &mut self,
+        player: Entity,
+        component_id: SceneComponentId,
+        crdt_type: CrdtType,
+        id: SceneEntityId,
+        data: &T,
+    ) {
+        let rooms = self.player_rooms.get(&player).cloned().unwrap_or_default();
+        if rooms.is_empty() {
+            self.update_crdt(None, component_id, crdt_type, id, data);
+        } else {
+            for hash in &rooms {
+                self.update_crdt(Some(hash), component_id, crdt_type, id, data);
+            }
+        }
+    }
+
+    pub fn delete_entity(&mut self, room: Option<&str>, id: SceneEntityId) {
+        let (store, sender) = self.slice(room);
+        store.clean_up(&HashSet::from_iter(Some(id)));
         let crdt_message = delete_entity(&id);
-        self.send_update(
+        Self::send_on(
+            sender,
             GlobalCrdtStateUpdate::Crdt(crdt_message, Localizer::None),
             "foreign player",
         );
     }
 
     pub fn update_time(&mut self, time: f32) {
-        self.send_update(GlobalCrdtStateUpdate::Time(time), "time");
+        self.broadcast_shared(GlobalCrdtStateUpdate::Time(time), "time");
     }
 
     pub fn update_camera_fov(&mut self, fov_y: f32) {
-        self.send_update(GlobalCrdtStateUpdate::CameraFov(fov_y), "camera fov");
+        self.broadcast_shared(GlobalCrdtStateUpdate::CameraFov(fov_y), "camera fov");
+    }
+
+    // time/fov are not room-scoped: fan out to the global sender and every room sender
+    fn broadcast_shared(&self, update: GlobalCrdtStateUpdate, what: &str) {
+        Self::send_on(&self.int_sender, update.clone(), what);
+        for room in self.rooms.values() {
+            Self::send_on(&room.int_sender, update.clone(), what);
+        }
     }
 
     // a broadcast send fails exactly when there are no subscribers, which is the
     // normal state whenever no scenes are live — not an error, just nobody listening
-    fn send_update(&self, update: GlobalCrdtStateUpdate, what: &str) {
-        if self.int_sender.receiver_count() == 0 {
+    fn send_on(
+        sender: &broadcast::Sender<GlobalCrdtStateUpdate>,
+        update: GlobalCrdtStateUpdate,
+        what: &str,
+    ) {
+        if sender.receiver_count() == 0 {
             return;
         }
-        if let Err(e) = self.int_sender.send(update) {
+        if let Err(e) = sender.send(update) {
             error!("failed to send {what} update to scenes: {e}");
         }
     }
@@ -404,7 +503,16 @@ pub fn process_transport_updates(
     mut duplicate_chat_filter: Local<HashMap<Entity, f64>>,
     mut last_remote_anim: Local<HashMap<Entity, CachedRemoteAnim>>,
     discard_player_updates: Res<DiscardPlayerUpdates>,
+    partition: Res<PartitionPresenceByScene>,
+    scene_rooms: Query<&SceneRoom>,
 ) {
+    // partitioned mode: scene hash of the room an update arrived on; None = global path
+    let room_of = |transport: Entity| -> Option<String> {
+        if !partition.0 {
+            return None;
+        }
+        scene_rooms.get(transport).ok().map(|r| r.0.clone())
+    };
     // gather any event receivers
     for ev in subscribers.read() {
         match ev {
@@ -431,6 +539,8 @@ pub fn process_transport_updates(
                 if discard_player_updates.0 {
                     continue;
                 }
+                let room = room_of(update.transport_id);
+                let room = room.as_deref();
                 // create/update timestamp/transport_id on the foreign player
                 let (entity, scene_id, audio_channel) = if let Some((entity, scene_id, channel)) =
                     created_this_frame.get(&update.address)
@@ -452,6 +562,7 @@ pub fn process_transport_updates(
                     };
 
                     state.update_crdt(
+                        room,
                         SceneComponentId::PLAYER_IDENTITY_DATA,
                         CrdtType::LWW_ANY,
                         next_free,
@@ -500,6 +611,14 @@ pub fn process_transport_updates(
                     (new_entity, next_free, audio_sender)
                 };
 
+                if let Some(hash) = room {
+                    state
+                        .player_rooms
+                        .entry(entity)
+                        .or_default()
+                        .insert(hash.to_owned());
+                }
+
                 // process update
                 match update.message {
                     PlayerMessage::MetaData(str) => {
@@ -547,6 +666,7 @@ pub fn process_transport_updates(
                         //     .entity(entity)
                         //     .insert(dcl_transform.to_bevy_transform());
                         state.update_crdt(
+                            room,
                             SceneComponentId::TRANSFORM,
                             CrdtType::LWW_ANY,
                             scene_id,
@@ -608,6 +728,17 @@ pub fn process_transport_updates(
                     }
                     PlayerMessage::PlayerData(Message::Scene(scene)) => {
                         let address = format!("{:#x}", update.address);
+                        // a client may only address the scene owning its arrival room —
+                        // rejects cross-room bus injection via a forged scene_id
+                        if let Some(arrival_hash) = room {
+                            if scene.scene_id != arrival_hash {
+                                debug!(
+                                    "dropping cross-room bus message from {address}: declared scene {} != arrival room {arrival_hash}",
+                                    scene.scene_id
+                                );
+                                continue;
+                            }
+                        }
                         process_messagebus(
                             scene,
                             address,
@@ -647,6 +778,7 @@ pub fn process_transport_updates(
                         };
 
                         state.update_crdt(
+                            room,
                             SceneComponentId::TRANSFORM,
                             CrdtType::LWW_ANY,
                             scene_id,
@@ -718,6 +850,7 @@ pub fn process_transport_updates(
                         debug!("player: {:#x} -> {} -> {}", update.address, pos, vel);
 
                         state.update_crdt(
+                            room,
                             SceneComponentId::TRANSFORM,
                             CrdtType::LWW_ANY,
                             scene_id,
@@ -960,7 +1093,15 @@ fn despawn_players(
                 commands.despawn();
             }
 
-            state.delete_entity(player.scene_id);
+            // delete from the room slices this player was written into; empty = global
+            let rooms = state.player_rooms.remove(&entity).unwrap_or_default();
+            if rooms.is_empty() {
+                state.delete_entity(None, player.scene_id);
+            } else {
+                for hash in &rooms {
+                    state.delete_entity(Some(hash), player.scene_id);
+                }
+            }
             state.lookup.remove_by_right(&entity);
         }
     }

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -71,6 +71,7 @@ impl Plugin for CommsPlugin {
         app.add_event::<SetCurrentScene>()
             .init_resource::<SceneRoomConnection>()
             .init_resource::<ServerSceneRooms>()
+            .init_resource::<PartitionPresenceByScene>()
             .init_resource::<DisableSceneRoomGatekeeper>();
 
         app.add_plugins((
@@ -224,6 +225,12 @@ pub struct ServerSceneRooms(pub bevy::platform::collections::HashMap<String, (St
 /// trusted parent — the engine must never sign gatekeeper handshakes itself in that mode.
 #[derive(Resource, Default)]
 pub struct DisableSceneRoomGatekeeper(pub bool);
+
+/// Orchestrated multi-tenant servers only: partition player presence per scene room, so
+/// each scene sees ONLY players in its own LiveKit room. Off everywhere else (client,
+/// single-realm server), keeping the shared "nearby players" view unchanged.
+#[derive(Resource, Default)]
+pub struct PartitionPresenceByScene(pub bool);
 
 /// When set (headless servers only), the engine never joins realm-wide comms
 /// (archipelago / world room / preview ws-room) — scene rooms via per-scene

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -200,8 +200,9 @@ pub fn setup_primary_profile(
             // update cache
             cache.update(profile.clone());
 
-            // send to scenes
+            // send to scenes — the local player is visible to every scene (global store)
             global_crdt.update_crdt(
+                None,
                 SceneComponentId::PLAYER_IDENTITY_DATA,
                 CrdtType::LWW_ANY,
                 SceneEntityId::PLAYER,
@@ -343,7 +344,8 @@ fn request_missing_profiles(
             Ok(Some(profile)) => {
                 // catalyst fetch complete
                 if profile.version >= player.profile_version {
-                    global_crdt.update_crdt(
+                    global_crdt.update_crdt_player(
+                        ent,
                         SceneComponentId::PLAYER_IDENTITY_DATA,
                         CrdtType::LWW_ANY,
                         player.scene_id,
@@ -507,7 +509,8 @@ pub fn process_profile_events(
                         base_url: r.base_url.clone(),
                     };
 
-                    global_crdt.update_crdt(
+                    global_crdt.update_crdt_player(
+                        ev.sender,
                         SceneComponentId::PLAYER_IDENTITY_DATA,
                         CrdtType::LWW_ANY,
                         player.scene_id,

--- a/crates/dcl/src/js/events.rs
+++ b/crates/dcl/src/js/events.rs
@@ -72,10 +72,10 @@ pub fn op_subscribe(state: &mut impl State, id: &str) -> Result<(), anyhow::Erro
     let hash = context.hash.clone();
 
     register!(id, state, PlayerConnected, |sender| {
-        RpcCall::SubscribePlayerConnected { sender }
+        RpcCall::SubscribePlayerConnected { sender, scene }
     });
     register!(id, state, PlayerDisconnected, |sender| {
-        RpcCall::SubscribePlayerDisconnected { sender }
+        RpcCall::SubscribePlayerDisconnected { sender, scene }
     });
     register!(id, state, PlayerEnteredScene, |sender| {
         RpcCall::SubscribePlayerEnteredScene { sender, scene }

--- a/crates/dcl/src/js/player.rs
+++ b/crates/dcl/src/js/player.rs
@@ -13,10 +13,17 @@ pub async fn op_get_connected_players(
     debug!("op_get_connected_players");
     let (sx, rx) = RpcResultSender::channel();
 
-    state
-        .borrow_mut()
-        .borrow_mut::<RpcCalls>()
-        .push(RpcCall::GetConnectedPlayers { response: sx })?;
+    {
+        let mut state = state.borrow_mut();
+        let scene = state.borrow::<CrdtContext>().scene_id.0;
+
+        state
+            .borrow_mut::<RpcCalls>()
+            .push(RpcCall::GetConnectedPlayers {
+                scene,
+                response: sx,
+            })?;
+    }
 
     Ok(rx.await.unwrap_or_default())
 }

--- a/crates/restricted_actions/src/agent_commands.rs
+++ b/crates/restricted_actions/src/agent_commands.rs
@@ -191,7 +191,11 @@ fn connected_players_cmd(
 ) {
     if let Some(Ok(_)) = input.take() {
         let (response, rx) = RpcResultSender::<Vec<String>>::channel();
-        events.write(RpcCall::GetConnectedPlayers { response });
+        // console command has no scene context; in partitioned mode it reports nobody
+        events.write(RpcCall::GetConnectedPlayers {
+            scene: Entity::PLACEHOLDER,
+            response,
+        });
         let responder = input.take_responder();
         pending.push_receiver(
             rx,

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::anyhow;
 use bevy::{
     asset::{io::AssetReader, AsyncReadExt, LoadState},
+    ecs::system::SystemParam,
     math::Vec3Swizzles,
     platform::collections::{HashMap, HashSet},
     prelude::*,
@@ -33,7 +34,8 @@ use comms::{
     global_crdt::ForeignPlayer,
     preview::handle_preview_socket,
     profile::{CurrentUserProfile, ProfileManager, UserProfile},
-    NetworkMessage, NetworkMessageRecipient, SceneRoom, Transport,
+    NetworkMessage, NetworkMessageRecipient, PartitionPresenceByScene, SceneRoom, ServerSceneRooms,
+    Transport,
 };
 use console::DoAddConsoleCommand;
 use copypwasmta::{ClipboardContext, ClipboardProvider};
@@ -1142,6 +1144,7 @@ fn get_user_data(
     >,
     mut scenes: Query<&mut RendererSceneContext>,
     mut profile_manager: ProfileManager,
+    presence: ScenePresence,
 ) {
     for (user, scene, response) in events.read().filter_map(|ev| match ev {
         RpcCall::GetUserData {
@@ -1174,10 +1177,10 @@ fn get_user_data(
                 }
             },
             Some(address) => {
-                if let Some((_, profile)) = others
-                    .iter()
-                    .find(|(fp, _)| *address == format!("{:#x}", fp.address))
-                {
+                // partitioned mode: don't serve a co-tenant room's cached profile
+                if let Some((_, profile)) = others.iter().find(|(fp, _)| {
+                    *address == format!("{:#x}", fp.address) && presence.visible(*scene, fp)
+                }) {
                     response.send(Ok(profile.content.clone()));
                     return;
                 }
@@ -1229,17 +1232,49 @@ fn get_user_data(
     });
 }
 
+/// Presence scoping: in partitioned mode a scene only sees players connected through its
+/// own room transport; a scene with no room yet sees nobody (fail closed).
+#[derive(SystemParam)]
+struct ScenePresence<'w, 's> {
+    partition: Res<'w, PartitionPresenceByScene>,
+    rooms: Res<'w, ServerSceneRooms>,
+    scenes: Query<'w, 's, &'static RendererSceneContext>,
+}
+
+impl ScenePresence<'_, '_> {
+    fn transport_of(&self, scene: Entity) -> Option<Entity> {
+        let hash = &self.scenes.get(scene).ok()?.hash;
+        self.rooms.0.get(hash).map(|(_, transport)| *transport)
+    }
+
+    fn visible_from(&self, scene: Entity, transports: &HashSet<Entity>) -> bool {
+        if !self.partition.0 {
+            return true;
+        }
+        self.transport_of(scene)
+            .is_some_and(|transport| transports.contains(&transport))
+    }
+
+    fn visible(&self, scene: Entity, player: &ForeignPlayer) -> bool {
+        self.visible_from(scene, &player.transports)
+    }
+}
+
 fn get_connected_players(
     me: Res<Wallet>,
     others: Query<&ForeignPlayer>,
     mut events: EventReader<RpcCall>,
     is_server: Res<IsServer>,
+    presence: ScenePresence,
 ) {
-    for response in events.read().filter_map(|ev| match ev {
-        RpcCall::GetConnectedPlayers { response } => Some(response),
+    for (scene, response) in events.read().filter_map(|ev| match ev {
+        RpcCall::GetConnectedPlayers { scene, response } => Some((scene, response)),
         _ => None,
     }) {
-        let others = others.iter().map(|f| format!("{:#x}", f.address));
+        let others = others
+            .iter()
+            .filter(|f| presence.visible(*scene, f))
+            .map(|f| format!("{:#x}", f.address));
         // a headless server has no real local player — don't report its fake player as
         // a connected peer (it would appear as a ghost to every scene)
         let own = (!is_server.0)
@@ -1257,6 +1292,7 @@ fn get_players_in_scene(
     mut events: EventReader<RpcCall>,
     containing_scene: ContainingScene,
     is_server: Res<IsServer>,
+    presence: ScenePresence,
 ) {
     for (scene, response) in events.read().filter_map(|ev| match ev {
         RpcCall::GetPlayersInScene { scene, response } => Some((scene, response)),
@@ -1274,10 +1310,18 @@ fn get_players_in_scene(
             }
         }
 
+        // partitioned mode: membership is the scene's room (the positional
+        // ContainingScene path is meaningless there — portables union into every position)
         results.extend(
             others
                 .iter()
-                .filter(|(e, _)| containing_scene.get(*e).contains(scene))
+                .filter(|(e, f)| {
+                    if presence.partition.0 {
+                        presence.visible(*scene, f)
+                    } else {
+                        containing_scene.get(*e).contains(scene)
+                    }
+                })
                 .map(|(_, f)| format!("{:#x}", f.address)),
         );
         response.send(results);
@@ -1286,19 +1330,23 @@ fn get_players_in_scene(
 
 // todo: move this to global_crdt to do it all in one place?
 fn event_player_connected(
-    mut senders: Local<Vec<RpcEventSender>>,
+    mut senders: Local<Vec<(Entity, RpcEventSender)>>,
     mut events: EventReader<RpcCall>,
     players: Query<&ForeignPlayer, Added<ForeignPlayer>>,
+    presence: ScenePresence,
 ) {
-    for sender in events.read().filter_map(|ev| match ev {
-        RpcCall::SubscribePlayerConnected { sender } => Some(sender),
+    for (scene, sender) in events.read().filter_map(|ev| match ev {
+        RpcCall::SubscribePlayerConnected { scene, sender } => Some((scene, sender)),
         _ => None,
     }) {
-        senders.push(sender.clone());
+        senders.push((*scene, sender.clone()));
     }
 
-    senders.retain_mut(|sender| {
+    senders.retain_mut(|(scene, sender)| {
         for player in players.iter() {
+            if !presence.visible(*scene, player) {
+                continue;
+            }
             let data = json!({
                 "userId": format!("{:#x}", player.address)
             })
@@ -1312,33 +1360,39 @@ fn event_player_connected(
 
 // todo: move this to global_crdt to do it all in one place?
 fn event_player_disconnected(
-    mut senders: Local<Vec<RpcEventSender>>,
+    mut senders: Local<Vec<(Entity, RpcEventSender)>>,
     mut events: EventReader<RpcCall>,
-    players: Query<(Entity, &ForeignPlayer), Added<ForeignPlayer>>,
+    players: Query<(Entity, &ForeignPlayer), Changed<ForeignPlayer>>,
     mut removed: RemovedComponents<ForeignPlayer>,
-    mut last_players: Local<HashMap<Entity, Address>>,
+    // (address, transports) recorded while the player still exists — the component is
+    // already gone by the time the removal is visible
+    mut last_players: Local<HashMap<Entity, (Address, HashSet<Entity>)>>,
+    presence: ScenePresence,
 ) {
     // gather new receivers
-    for sender in events.read().filter_map(|ev| match ev {
-        RpcCall::SubscribePlayerDisconnected { sender } => Some(sender),
+    for (scene, sender) in events.read().filter_map(|ev| match ev {
+        RpcCall::SubscribePlayerDisconnected { scene, sender } => Some((scene, sender)),
         _ => None,
     }) {
-        senders.push(sender.clone());
+        senders.push((*scene, sender.clone()));
     }
 
-    // add new players to our local record
+    // refresh on change: room membership can change over a player's life
     for (ent, player) in players.iter() {
-        last_players.insert(ent, player.address);
+        last_players.insert(ent, (player.address, player.transports.clone()));
     }
 
-    // gather addresses of removed players
+    // gather removed players with their last known room membership
     let removed = removed
         .read()
         .flat_map(|e| last_players.remove(&e))
         .collect::<Vec<_>>();
 
-    senders.retain_mut(|sender| {
-        for address in removed.iter() {
+    senders.retain_mut(|(scene, sender)| {
+        for (address, transports) in removed.iter() {
+            if !presence.visible_from(*scene, transports) {
+                continue;
+            }
             let data = json!({
                 "userId": format!("{:#x}", address)
             })

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -249,11 +249,12 @@ pub(crate) fn load_scene_javascript(
     ipfas: IpfsAssetServer,
     crdt_component_interfaces: Res<CrdtExtractors>,
     mut scene_updates: ResMut<SceneUpdates>,
-    global_scene: Res<GlobalCrdtState>,
+    mut global_scene: ResMut<GlobalCrdtState>,
     portable_scenes: Res<PortableScenes>,
     realm: Res<CurrentRealm>,
     frame: Res<FrameCount>,
     preview_mode: Res<PreviewMode>,
+    partition_presence: Res<comms::PartitionPresenceByScene>,
 ) {
     for (root, state, h_scene) in loading_scenes
         .iter()
@@ -425,7 +426,12 @@ pub(crate) fn load_scene_javascript(
         // start from the global shared crdt state, with position data localized for this scene
         // Scene origin in DCL proto-space (z-forward, matching proto Vector3 coordinates)
         let scene_origin = Vec3::new(initial_position.x, 0.0, initial_position.y);
-        let (mut initial_crdt, global_updates) = global_scene.subscribe(scene_origin);
+        // partitioned mode: only this scene's own room slice, not co-tenants' players
+        let (mut initial_crdt, global_updates) = if partition_presence.0 {
+            global_scene.subscribe_room(&definition.id, scene_origin)
+        } else {
+            global_scene.subscribe(scene_origin)
+        };
 
         // set the world origin (for parents of world-space entities, using world-space coords as local coords)
         let mut buf = Vec::new();

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -893,6 +893,7 @@ fn broadcast_movement_info(
     debug!("broadcast {:?}", info.0);
 
     global_crdt.update_crdt(
+        None,
         SceneComponentId::AVATAR_MOVEMENT_INFO,
         CrdtType::LWW_ANY,
         SceneEntityId::PLAYER,

--- a/docs/PRESENCE_ISOLATION.md
+++ b/docs/PRESENCE_ISOLATION.md
@@ -1,0 +1,51 @@
+# Per-scene player-presence isolation (orchestrated multi-tenant server)
+
+One orchestrated engine process hosts scenes from different worlds, each with its own
+LiveKit room (`SceneRoom(hash)` transport). Player presence, however, was process-global:
+every room's inbound state funneled into one `GlobalCrdtState` store, and every scene read
+all of it. A scene in world A could observe world B's players — address, position, name,
+wearables, connect/disconnect timing — and a client in room B could inject MessageBus
+messages into scene A by forging A's hash as `scene_id`.
+
+The desktop client must be unaffected: there, all scenes share the realm transport and a
+shared "nearby players" view is correct.
+
+## Gate
+
+`comms::PartitionPresenceByScene` (resource, default off). Set `true` only by
+`src/bin/headless.rs` in orchestrated mode. When off, every path below is byte-for-byte
+today's behavior.
+
+## Mechanism
+
+**CRDT store** (`crates/comms/src/global_crdt.rs`): `GlobalCrdtState` gains per-scene-hash
+`RoomCrdt` slices (own `CrdtStore` + broadcast sender); the `SceneEntityId` allocator and
+`Address→Entity` lookup stay global, so a player keeps the same id in every room they're
+in. `update_crdt` takes `room: Option<&str>` — `None` is the global (client) path.
+`process_transport_updates` resolves each update's arrival transport to its `SceneRoom`
+hash and writes identity/transform into that slice only, recording the membership in
+`player_rooms` so despawn and profile fan-out (`update_crdt_player`) hit exactly those
+rooms even after the transport is gone. Scenes subscribe via `subscribe_room(hash)` when
+partitioned (`load_scene_javascript`), receiving only their own room's players; time/fov
+broadcasts fan out to all senders.
+
+**RPC queries** (`crates/restricted_actions/src/lib.rs`): `getConnectedPlayers`,
+`getPlayersInScene`, `getUserData`, `onPlayerConnected`, `onPlayerDisconnected` filter
+through the `ScenePresence` param: visible iff the player is connected through the calling
+scene's room transport (`ServerSceneRooms`). `RpcCall::GetConnectedPlayers` /
+`SubscribePlayerConnected` / `SubscribePlayerDisconnected` carry the calling `scene` for
+this. A scene with no room yet sees nobody (fail closed).
+
+**MessageBus**: an inbound scene message is dropped unless its declared `scene_id` matches
+the hash of the room it arrived on.
+
+Known limitation: `FOREIGN_PLAYER_RANGE` remains one process-wide pool (~401 concurrent
+players across all tenants); raising it is an independent follow-up.
+
+## Validation
+
+Two-tenant conformance harness (multiplayer-server): one engine, two scenes from different
+worlds, one synthetic client per room. Assert (1) `getConnectedPlayers()` returns only the
+own-room client; (2) `onPlayerConnected` fires only for it; (3) no foreign-room avatar
+entities in the CRDT; (4) a message naming the co-tenant's hash never reaches its bus. All
+four fail on `main`, pass with this change.

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -427,6 +427,9 @@ fn main() {
             // structural gate: the engine must never sign gatekeeper handshakes in
             // orchestrated mode — adapters are always minted by the trusted parent
             .insert_resource(comms::DisableSceneRoomGatekeeper(true))
+            // scenes here belong to different worlds: a scene must never observe a
+            // co-tenant room's players (docs/PRESENCE_ISOLATION.md)
+            .insert_resource(comms::PartitionPresenceByScene(true))
             .add_systems(
                 Update,
                 (
@@ -645,12 +648,13 @@ fn drain_permissions(mut manager: ResMut<PermissionManager>, config: Res<AppConf
 /// render-bound and omitted headless; without this, SDK getPlayer()/onEnterScene never
 /// see names or wearables.
 fn replicate_avatar_info(
-    updated_players: Query<(Option<&ForeignPlayer>, &UserProfile), Changed<UserProfile>>,
+    updated_players: Query<(Entity, Option<&ForeignPlayer>, &UserProfile), Changed<UserProfile>>,
     mut global_state: ResMut<GlobalCrdtState>,
 ) {
-    for (player, profile) in &updated_players {
+    for (entity, player, profile) in &updated_players {
         let avatar = &profile.content.avatar;
-        global_state.update_crdt(
+        global_state.update_crdt_player(
+            entity,
             SceneComponentId::AVATAR_BASE,
             CrdtType::LWW_ANY,
             player.map(|p| p.scene_id).unwrap_or(SceneEntityId::PLAYER),
@@ -666,7 +670,8 @@ fn replicate_avatar_info(
                     .unwrap_or(base_wearables::default_bodyshape_urn().to_string()),
             },
         );
-        global_state.update_crdt(
+        global_state.update_crdt_player(
+            entity,
             SceneComponentId::AVATAR_EQUIPPED_DATA,
             CrdtType::LWW_ANY,
             player.map(|p| p.scene_id).unwrap_or(SceneEntityId::PLAYER),


### PR DESCRIPTION
## Summary

One orchestrated engine process hosts scenes from different worlds, each with its own LiveKit room — but player presence was process-global. A scene in world A could observe world B's players (address, live position, display name, wearables, connect/disconnect timing) through both the shared presence CRDT and the `ForeignPlayer` RPC queries, and a client in room B could inject MessageBus messages into scene A by forging A's hash as `scene_id`.

This partitions presence per scene room, gated behind a new `PartitionPresenceByScene` resource that only the orchestrated headless binary enables:

- **CRDT**: `GlobalCrdtState` gains per-scene-hash room slices (own store + broadcast). Inbound player state is routed by the room the packet *arrived* on, and partitioned scenes subscribe to their own slice only. The `SceneEntityId` allocator stays global. `player_rooms` records each player's slices so profile fan-out and despawn hit exactly those rooms, even after the transport is gone.
- **RPCs**: `getConnectedPlayers`, `getPlayersInScene`, `getUserData`, `onPlayerConnected`, `onPlayerDisconnected` filter through a `ScenePresence` param — a player is visible iff connected through the calling scene's room transport. A scene with no room yet sees nobody (fail closed).
- **MessageBus**: inbound scene messages are dropped unless the declared `scene_id` matches the arrival room's hash.

Design notes in `docs/PRESENCE_ISOLATION.md`.

## What could break

- Client / single-realm servers: every change is a no-op when the resource is false (default); the shared "nearby players" view is unchanged. `RpcCall` variants gained a `scene` field, which is ignored on that path.
- The `/connected_players` console command has no scene context and reports nobody in partitioned mode.
- `FOREIGN_PLAYER_RANGE` remains one process-wide pool (~401 concurrent players across all tenants) — follow-up.

## How to test

Two-tenant conformance run (multiplayer-server harness): one engine, two scenes from different worlds with different adapters, one synthetic client per room. Assert:
1. each scene's `getConnectedPlayers()` returns only its own client;
2. `onPlayerConnected` fires only for the own-room client;
3. a CRDT dump shows no foreign-room avatar entities;
4. a message to room B naming scene A's hash never reaches A's bus.

All four fail on `main`, pass on this branch. Client regression: connect the desktop client to a populated realm and confirm nearby players still appear/disappear normally.