### PR TITLE
Requeue failed active-entities batches, cap requests at 1000 pointers

### DIFF
--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -1388,12 +1388,20 @@ fn load_active_entities(
         let retrieved_parcels = match task_result {
             Ok(res) => {
                 *consecutive_fetch_fail_count = 0;
-                *fetch_count = (*fetch_count * 2).min(3200);
+                *fetch_count = (*fetch_count * 2).min(1000);
                 res
             }
             Err(e) => {
-                warn!("failed to retrieve active scenes, will retry");
+                warn!(
+                    "failed to retrieve active scenes ({} parcels), will retry",
+                    requested_parcels.len()
+                );
                 warn!("error: {e:?}");
+                // re-append the failed batch to the fetch end of the stored list so it is
+                // retried with the reduced fetch_count
+                stored_parcels
+                    .1
+                    .extend(requested_parcels.into_iter().map(|parcel| (0.0, parcel)));
                 *fetch_count = (*fetch_count / 2).max(100);
                 if *fetch_count == 100 {
                     *consecutive_fetch_fail_count += 1;


### PR DESCRIPTION
The catalyst content server rejects `/entities/active` requests with more than 1000 pointers (schema `maxItems: 1000`, 400 Bad Request; verified empirically — 1000 succeeds, 1001 fails), while `fetch_count` grew up to 3200 on success.

A failed batch's parcels were dropped until the focus parcel changed. While walking around this self-heals, but after a teleport with a grown `fetch_count` the *nearest* batch — including the parcel under the player — exceeds the limit, fails, and is never re-requested: the player is stuck out-of-world behind the loading screen, and the focus parcel can't change while out-of-world. The 800↔1600 success/failure oscillation also kept `fetch_count` above the floor, so the consecutive-failure abort never fired either.

- re-append a failed batch to the fetch end of the stored parcel list so it is retried with the halved `fetch_count` (verified by lifting the cap locally: the failed 1600-parcel batch is retried at 800 and the teleport completes)
- cap `fetch_count` growth at the server's 1000-pointer limit
- include the batch size in the failure warning so a future limit change is visible in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)