### PR TITLE
Keep the Places Live Now highlights on one 4-up row

### DIFF
--- a/react-web/src/features/places/PlacesBrowser.tsx
+++ b/react-web/src/features/places/PlacesBrowser.tsx
@@ -93,8 +93,8 @@ export function PlacesBrowser({
     return list.filter((p) => !liveIds.has(p.id) && !featuredIds.has(p.id))
   }, [list, showHighlights, liveIds, featured])
 
-  const renderGrid = (items: DiscoverPlace[]): React.JSX.Element => (
-    <div className={styles.grid}>
+  const renderGrid = (items: DiscoverPlace[], className = ''): React.JSX.Element => (
+    <div className={`${styles.grid} ${className}`.trim()}>
       {items.map((place) => (
         <PlaceCard key={place.id} place={place} onClick={() => onPick(place)} />
       ))}
@@ -108,7 +108,7 @@ export function PlacesBrowser({
           <h2 className={styles.sectionTitle}>
             <span className={styles.liveDot} /> Live Now
           </h2>
-          {renderGrid(liveNow)}
+          {renderGrid(liveNow, styles.gridLive)}
         </section>
       )}
 

--- a/react-web/src/features/places/PlacesPage.module.css
+++ b/react-web/src/features/places/PlacesPage.module.css
@@ -110,6 +110,11 @@
   gap: 18px;
   align-content: start;
 }
+/* Fixed 4-up row: auto-fill would take the column count from the viewport (3 at 1440px, 7 at 2560px).
+   minmax(0, 1fr) keeps a long title/world pill from widening its track. */
+.gridLive {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
 
 .center {
   display: flex;


### PR DESCRIPTION
## Summary

The Live Now section of the Places browser (in-world page + the post-jump-in destination picker) reused the discover grid's `repeat(auto-fill, minmax(400px, 1fr))`, so its column count was derived from the viewport rather than from the four cards the section is built around. Measured on `main` across 9 widths × 8 heights: 3 columns at 1440×900 and 1512×1000 (the 4th card wraps under the row), 5 at 1920×900, 7 at 2560×869, 10 at 2560×600 — only a narrow band of window sizes actually rendered the intended 4-up row.

Live Now now gets its own track, `repeat(4, minmax(0, 1fr))`. The `minmax(0, …)` also stops a long title or world pill from widening its column. The discover grid below keeps `auto-fill` — filling the width is correct there.

`renderGrid` takes an optional extra class name (the convention already used by `Panel`, `Modal`, `Avatar`, `IconButton`) instead of gaining a positional boolean.

## What could break

Layout-only, scoped to the Live Now row; the discover grid and the Featured carousel are untouched. With fewer than 4 live places the row keeps the 4-up column width and is left-aligned, leaving empty space at the right rather than stretching the cards — the same rhythm as the Featured row below it. No visual-regression baseline covers this section, so nothing to refresh.

## How to test

1. `cd react-web && npm run dev`, open `http://localhost:5173/?mock=1`, click **EXPLORE AS GUEST** to reach the destination picker (or open **Places** from the in-world sidebar).
2. Resize the window across a range of sizes — 1440×900, 1920×900, 2560×869 all used to break. Live Now should stay a single row of exactly 4 cards, aligned with the Featured row below, with nothing extending past the right edge.
3. `npm run typecheck` and `npx vitest run` (326 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxoqxPqZJAPG2cLzidwg6v