### PR TITLE
patch gltf to unreleased empty-accessor fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5312,8 +5312,7 @@ dependencies = [
 [[package]]
 name = "gltf"
 version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
+source = "git+https://github.com/gltf-rs/gltf?rev=12fc1b7c#12fc1b7ce28c7b4c6d1b881a30df24060dccfbda"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -5327,8 +5326,7 @@ dependencies = [
 [[package]]
 name = "gltf-derive"
 version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14070e711538afba5d6c807edb74bcb84e5dbb9211a3bf5dea0dfab5b24f4c51"
+source = "git+https://github.com/gltf-rs/gltf?rev=12fc1b7c#12fc1b7ce28c7b4c6d1b881a30df24060dccfbda"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -5339,8 +5337,7 @@ dependencies = [
 [[package]]
 name = "gltf-json"
 version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6176f9d60a7eab0a877e8e96548605dedbde9190a7ae1e80bbcc1c9af03ab14"
+source = "git+https://github.com/gltf-rs/gltf?rev=12fc1b7c#12fc1b7ce28c7b4c6d1b881a30df24060dccfbda"
 dependencies = [
  "gltf-derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -435,6 +435,13 @@ deno_webstorage = { git = "https://github.com/robtfm/deno", branch = "1_46_hotfi
 # deno_websocket = { path = "../deno/ext/websocket" }
 # deno_webstorage = { path = "../deno/ext/webstorage" }
 
+# gltf 1.4.1 (latest release, 2024-05) predates gltf-rs/gltf#449 "allow empty accessors"
+# (robtfm, merged 2025-05): dense accessors with no bufferView (zero-filled per spec,
+# blender emits them for morph targets) get NO reader, so MorphTargetImage comes up
+# short and texture upload panics. Pin the #449 merge commit until a release ships it.
+gltf = { git = "https://github.com/gltf-rs/gltf", rev = "12fc1b7c" }
+gltf-json = { git = "https://github.com/gltf-rs/gltf", rev = "12fc1b7c" }
+
 winit = { git = "https://github.com/robtfm/winit", branch = "v0.30.x" }
 wgpu = { git = "https://github.com/robtfm/wgpu", branch = "24.0.5-dcl" }
 wgpu-types = { git = "https://github.com/robtfm/wgpu", branch = "24.0.5-dcl" }


### PR DESCRIPTION
`regenesislabs.dcl.eth` crashes the engine on load (repeatable, web and native):

```
panicked at wgpu/src/util/device.rs:148:26:
range end index 2016 out of range for slice of length 1152
```

(on web this often shows as a follow-on `RefCell already borrowed` winit panic — wasm panics don't unwind, so the runner's RefCell stays borrowed and the next event trips over it.)

Several of the scene's GLBs (RGLFRONT01, TeslaCoil01, LabVials01, Ray01/03/04) have morph targets whose POSITION/NORMAL accessors are dense with no `bufferView` — spec-legal, meaning zero-filled; blender exports zero-displacement targets like this. In gltf 1.4.1 (the latest crates.io release, 2024-05) such accessors get **no reader at all**: `accessor::Iter::new` only handles view-less accessors in its sparse branch. `read_morph_targets` then yields empty iterators for those targets, `MorphTargetImage::new` emits fewer layers than the descriptor declares (its length check is a `debug_assert`), and texture upload panics — e.g. Primitive1 of RGLFRONT01: 7 declared targets × 72 floats = 2016 bytes expected, 4 populated targets = 1152 bytes present.

This was already fixed upstream in gltf-rs/gltf#449 (allow empty accessors, merged 2025-05) but no gltf release has shipped since 1.4.1, so the fix never reached us — the `from_slice_without_validation` retry in the bevy fork's gltf loader assumes the #449 reader behaviour, which is how these files load at all.

Pin `gltf`/`gltf-json` to the #449 merge commit via `[patch.crates-io]`. The crate versions at that rev are still 1.4.1 so the patch applies cleanly, and it deliberately avoids gltf `main`, which has since taken API-affecting changes (KHR_animation_pointer, lifetime reworks). The patch can be dropped when a gltf release ships the fix.

Verified against `regenesislabs.dcl.eth` on web (fresh profile, guest): crashes 100% before, loads clean after, with an instrumented build confirming no image asset carries less data than its descriptor implies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)