### PR TITLE
Fix wasm gltf reprocess reload: load processed glb via url-form IpfsPath

### DIFF
--- a/crates/image_processing/src/engine.rs
+++ b/crates/image_processing/src/engine.rs
@@ -289,7 +289,25 @@ fn pipe_events(
                 match req.ty {
                     ProcessingAssetType::Gltf => {
                         if let Some(h) = asset_server.get_handle::<Gltf>(&req.base_path) {
-                            processing_gltfs.insert(asset_server.load(req.cache_path), h.id());
+                            // on wasm the cache path is the source url (the processed bytes
+                            // overwrite the service-worker cache entry for that url), so wrap
+                            // it in a url-form IpfsPath to make it loadable
+                            #[cfg(target_arch = "wasm32")]
+                            let cache_path = {
+                                let ext = req
+                                    .base_path
+                                    .path()
+                                    .extension()
+                                    .and_then(|e| e.to_str())
+                                    .unwrap_or("glb");
+                                std::path::PathBuf::from(&IpfsPath::new_from_url(
+                                    &req.cache_path,
+                                    ext,
+                                ))
+                            };
+                            #[cfg(not(target_arch = "wasm32"))]
+                            let cache_path = req.cache_path;
+                            processing_gltfs.insert(asset_server.load(cache_path), h.id());
                         }
                     }
                     ProcessingAssetType::Image => asset_server.reload(req.base_path),


### PR DESCRIPTION
On wasm the BC7 reprocessor's \`cache_path\` for a glTF is the source url — the processed bytes overwrite the service-worker cache entry keyed by that url (\`ipfs-path-cache-v1\`), so re-fetching the url yields the processed file. But \`pipe_events\` passed the raw url string straight to \`asset_server.load\`, which bevy rejects with \`Asset Source 'https' does not exist\` — so the processed-glTF image swap (the bevy#18267 workaround) silently never ran on web, only the plain-image path worked.

Wrap the url in \`IpfsPath::new_from_url\` (same pattern as \`load_url_uncached\`) so the load routes through the ipfs asset source and the fetch is served pre-processed by the service worker. Native keeps its filesystem cache path unchanged.

Verified on web against genesis: 96 textures processed, 25 images swapped onto live glTFs across 6 scenes, no asset-source errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)