### PR TITLE
fix preview socket reconnect spin

### DIFF
--- a/crates/comms/src/preview.rs
+++ b/crates/comms/src/preview.rs
@@ -75,6 +75,18 @@ pub async fn handle_preview_socket(
     server: String,
     sender: tokio::sync::mpsc::UnboundedSender<PreviewCommand>,
 ) -> Result<(), anyhow::Error> {
+    let result = preview_socket(server, sender).await;
+    // back off on every exit path, not just a clean disconnect: a preview server with
+    // no ws endpoint fails the upgrade immediately and the caller respawns us as soon
+    // as the task completes, so an early error spins one attempt per frame
+    async_std::task::sleep(Duration::from_secs(5)).await;
+    result
+}
+
+async fn preview_socket(
+    server: String,
+    sender: tokio::sync::mpsc::UnboundedSender<PreviewCommand>,
+) -> Result<(), anyhow::Error> {
     let (protocol, rest) = server
         .split_once("//")
         .ok_or(anyhow!("invalid preview server address `{server}`"))?;
@@ -127,6 +139,5 @@ pub async fn handle_preview_socket(
     }
 
     warn!("preview socket disconnected, waiting 5 secs to attempt reconnect");
-    async_std::task::sleep(Duration::from_secs(5)).await;
     Ok(())
 }


### PR DESCRIPTION
The 5s reconnect backoff in `handle_preview_socket` only ran on the clean-disconnect tail. A preview server with no ws endpoint fails the upgrade immediately, so the socket returned `Err` before ever reaching that sleep, and `connect_preview_server` respawned the task on the very next frame — one failing ws upgrade per frame, spamming the log and the server.

Wrap the socket body so the existing 5s backoff applies to every exit path, error included. No new mechanism: the backoff is still just the task staying incomplete, which is exactly how the clean-disconnect path already paced reconnects.

Note the other caller (`restricted_actions`, startup preview scenes) spawns this detached with no restart logic at all, so it only gains a harmless 5s tail before the task ends. That path never reconnecting is a separate issue.