### PR TITLE
Make manual dispatch of the headless publish release to latest

### DIFF
--- a/.github/workflows/publish-headless.yml
+++ b/.github/workflows/publish-headless.yml
@@ -12,8 +12,10 @@ name: Publish headless server
 # npm OIDC trusted publishing — no NPM_TOKEN.
 #
 # RELEASING TO CONSUMERS: the SDK preview (js-sdk-toolchain `sdk-commands start`) tracks
-# `latest`, which only moves when someone dispatches this workflow with dist_tag=latest
-# (+ publish=true). That publishes a fresh build of the chosen ref as a NEW version
+# `latest`, which only moves when someone dispatches this workflow with publish=true
+# (a manual dispatch IS the release path — pushes already cover `next`, so there is
+# nothing else a dispatched publish could mean). That publishes a fresh build of the
+# chosen ref as a NEW version
 # (the version embeds the run id, so there is no collision with the `next` snapshot of
 # the same commit) tagged latest — promotion stays tokenless because it is a plain
 # OIDC-covered `npm publish`, not an `npm dist-tag` (which trusted publishing does not
@@ -36,16 +38,9 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: Publish to npm (otherwise build and upload artifacts only)
+        description: Publish to npm as `latest` (release to SDK previews; otherwise build and upload artifacts only)
         type: boolean
         default: false
-      dist_tag:
-        description: npm dist-tag for the published packages (latest = release to SDK previews)
-        type: choice
-        options:
-          - next
-          - latest
-        default: next
   push:
     branches:
       - main
@@ -210,7 +205,7 @@ jobs:
         run: |
           set -euo pipefail
           for tgz in deploy/headless/artifacts/*.tgz; do
-            npm publish "$tgz" --access public --tag "${{ inputs.dist_tag || 'next' }}"
+            npm publish "$tgz" --access public --tag "${{ github.event_name == 'workflow_dispatch' && 'latest' || 'next' }}"
           done
 
       - name: Publish launcher
@@ -220,6 +215,10 @@ jobs:
           deterministic-snapshot: true
           registry-url: https://registry.npmjs.org
           access: public
-          # push events have no inputs -> snapshots stay on next; a manual dispatch
-          # with dist_tag=latest is the release path (see header)
-          custom-tag: ${{ inputs.dist_tag || 'next' }}
+          # push -> next snapshot; manual dispatch = release to latest (see header).
+          # custom-tag cannot do this: oddish ignores it on main (only
+          # main-branch-latest-tag selects the tag there) and refuses the value
+          # 'latest' outright, so the old custom-tag release path silently
+          # published to next. Release dispatches must run from main — oddish
+          # skips the launcher publish on other branches.
+          main-branch-latest-tag: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary
Dispatching the headless publish with `dist_tag=latest` never moved the launcher's `latest` tag: oddish-action ignores `custom-tag` on main (only `main-branch-latest-tag` selects the tag there) and refuses the value `latest` outright. Today's manual publish ([run 32158742011](https://github.com/decentraland/bevy-explorer/actions/runs/32158742011)) showed the result: platform packages tagged `latest`, launcher stuck on `next` — and the launcher is the only package whose dist-tag installers follow.

Since every main push already publishes to `next`, a manual dispatch can only mean a release. Both inputs (`dist_tag` and `publish`) are gone: push → `next`, dispatch → build + publish to `latest` (via `main-branch-latest-tag`, the only oddish path that yields `latest` on main).

## What could break
- Dispatching is now always a release — there is no build-only or next-tag dispatch anymore. Clicking "Run workflow" moves `latest`.
- Release dispatches must run from `main`: on other branches oddish skips the launcher publish (pre-existing oddish behavior, now noted in a comment).

## How to test
1. Merge, then dispatch "Publish headless server" from `main`.
2. In the publish job log, the launcher step should show `tag: latest` and `npm publish ... --tag "latest"` (today's run resolved `tag: next`).
3. `npm view @dcl-regenesislabs/bevy-headless-server dist-tags` — `latest` should point at the new version. It currently points at `0.1.0-31413755159.commit-5b7586c` from Aug 10; this dispatch also repairs that.