### PR TITLE
Drop the publish checkbox from the headless publish dispatch

### DIFF
--- a/.github/workflows/publish-headless.yml
+++ b/.github/workflows/publish-headless.yml
@@ -12,10 +12,9 @@ name: Publish headless server
 # npm OIDC trusted publishing — no NPM_TOKEN.
 #
 # RELEASING TO CONSUMERS: the SDK preview (js-sdk-toolchain `sdk-commands start`) tracks
-# `latest`, which only moves when someone dispatches this workflow with publish=true
-# (a manual dispatch IS the release path — pushes already cover `next`, so there is
-# nothing else a dispatched publish could mean). That publishes a fresh build of the
-# chosen ref as a NEW version
+# `latest`, which only moves when someone manually dispatches this workflow — a
+# dispatch IS a release; pushes already cover `next`, so there is nothing else a
+# dispatch could mean. That publishes a fresh build of the chosen ref as a NEW version
 # (the version embeds the run id, so there is no collision with the `next` snapshot of
 # the same commit) tagged latest — promotion stays tokenless because it is a plain
 # OIDC-covered `npm publish`, not an `npm dist-tag` (which trusted publishing does not
@@ -35,12 +34,8 @@ name: Publish headless server
 # exact version, so their tags are cosmetic.
 
 on:
+  # dispatch = release: builds the chosen ref and publishes it to `latest`
   workflow_dispatch:
-    inputs:
-      publish:
-        description: Publish to npm as `latest` (release to SDK previews; otherwise build and upload artifacts only)
-        type: boolean
-        default: false
   push:
     branches:
       - main
@@ -162,7 +157,7 @@ jobs:
   publish:
     # all-or-nothing: never advertise a version that is missing a platform
     needs: build
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.publish
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       id-token: write # npm OIDC trusted publishing — no token secret


### PR DESCRIPTION
## Summary
Follow-up to #1109. The `publish` checkbox (default unchecked) made the release flow a two-step trap: a reflexive dispatch built all platforms and released nothing. One trigger, one meaning now — push → `next` snapshot, dispatch → build + release to `latest`. The dispatch dialog has no inputs left.

## What could break
- Clicking "Run workflow" IS a release: it moves `latest`, which SDK previews track. There is no build-only dispatch anymore.
- Dispatching from a non-main branch still builds but oddish skips the launcher publish (pre-existing behavior, noted in a comment).

## How to test
1. Merge, then open the workflow's "Run workflow" dialog — it should only offer the branch picker, no checkbox.
2. Dispatch from `main`: the publish job must run (previously it was skipped unless the box was ticked) and the launcher log should show `npm publish ... --tag "latest"`.
3. `npm view @dcl-regenesislabs/bevy-headless-server dist-tags` — `latest` moves to the new version (also repairs the stale Aug 10 `commit-5b7586c` tag).