### PR TITLE
Let server scenes signedFetch without player identity data

### DIFF
--- a/crates/dcl/src/js/fetch.rs
+++ b/crates/dcl/src/js/fetch.rs
@@ -37,6 +37,15 @@ pub struct SignedFetchMeta {
     signer: String,
 }
 
+// the server's fake player has no identity crdt (#1102), and the server never signs as a guest
+fn signed_fetch_is_guest(state: &impl State) -> Result<bool, anyhow::Error> {
+    match player_identity(state) {
+        Ok(identity) => Ok(identity.is_guest),
+        Err(_) if state.borrow::<CrdtContext>().is_server => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
 pub async fn op_signed_fetch_headers(
     state: Rc<RefCell<impl State>>,
     uri: String,
@@ -52,7 +61,7 @@ pub async fn op_signed_fetch_headers(
 
     let realm_info = realm_information(state.clone()).await?;
 
-    let player_identity = player_identity(&*state.borrow())?;
+    let is_guest = signed_fetch_is_guest(&*state.borrow())?;
 
     let urn = state.borrow().borrow::<CrdtContext>().hash.clone();
 
@@ -76,7 +85,7 @@ pub async fn op_signed_fetch_headers(
         parcel: Some(scene_meta.scene.base.clone()),
         tld: Some("org".to_owned()),
         network: Some("mainnet".to_owned()),
-        is_guest: Some(player_identity.is_guest),
+        is_guest: Some(is_guest),
         realm: SignedFetchMetaRealm {
             hostname: realm_info.base_url,
             protocol: "v3".to_owned(),
@@ -101,4 +110,62 @@ pub async fn op_signed_fetch_headers(
         })?;
 
     rx.await?.map_err(|e| anyhow!(e))
+}
+
+#[cfg(test)]
+mod signed_fetch_identity_tests {
+    use super::*;
+    use crate::{
+        interface::{CrdtStore, CrdtType},
+        js::{test_state::TestState, RendererStore},
+        SceneId,
+    };
+    use dcl_component::{
+        proto_components::sdk::components::PbPlayerIdentityData, DclReader, DclWriter,
+        SceneComponentId, SceneEntityId, ToDclWriter,
+    };
+
+    fn state(is_server: bool, identity: Option<PbPlayerIdentityData>) -> TestState {
+        let mut store = CrdtStore::default();
+        if let Some(identity) = identity {
+            let mut buf = Vec::new();
+            identity.to_writer(&mut DclWriter::new(&mut buf));
+            store.force_update(
+                SceneComponentId::PLAYER_IDENTITY_DATA,
+                CrdtType::LWW_ANY,
+                SceneEntityId::PLAYER,
+                Some(&mut DclReader::new(&buf)),
+            );
+        }
+        let mut s = TestState::default();
+        s.put(RendererStore(store));
+        s.put(CrdtContext::new(
+            SceneId::DUMMY,
+            Default::default(),
+            Default::default(),
+            false,
+            false,
+            is_server,
+        ));
+        s
+    }
+
+    #[test]
+    fn server_without_identity_is_not_guest() {
+        assert!(!signed_fetch_is_guest(&state(true, None)).unwrap());
+    }
+
+    #[test]
+    fn client_without_identity_still_errors() {
+        assert!(signed_fetch_is_guest(&state(false, None)).is_err());
+    }
+
+    #[test]
+    fn present_identity_wins_over_fallback() {
+        let identity = PbPlayerIdentityData {
+            address: "0x1234".to_owned(),
+            is_guest: true,
+        };
+        assert!(signed_fetch_is_guest(&state(true, Some(identity))).unwrap());
+    }
 }

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -332,13 +332,13 @@ pub fn player_identity(state: &impl State) -> Result<PbPlayerIdentityData, anyho
 }
 
 #[cfg(test)]
-mod scene_log_budget_tests {
-    use super::*;
+pub(crate) mod test_state {
+    use super::State;
     use std::any::{Any, TypeId};
     use std::collections::HashMap;
 
     #[derive(Default)]
-    struct TestState(HashMap<TypeId, Box<dyn Any>>);
+    pub struct TestState(HashMap<TypeId, Box<dyn Any>>);
 
     impl State for TestState {
         fn borrow<T: 'static>(&self) -> &T {
@@ -372,6 +372,11 @@ mod scene_log_budget_tests {
                 .map(|v| *v.downcast().unwrap())
         }
     }
+}
+
+#[cfg(test)]
+mod scene_log_budget_tests {
+    use super::{test_state::TestState, *};
 
     fn state() -> TestState {
         let mut s = TestState::default();


### PR DESCRIPTION
## Summary
#1102 stopped writing the server fake player's identity into scene crdts (presence isolation), but `op_signed_fetch_headers` still hard-requires `PLAYER_IDENTITY_DATA` — only to fill `is_guest` in the metadata. Since `commit-842b57e` every `signedFetch` from a scene on the orchestrated server fails with `no player identity!` (seen in production on flagtag and towerofmadness: SafeStorage, leaderboards, wallet balances all dead).

Fix: fall back to `is_guest: false` when identity is missing **and** the context is a server context. Truthful (the server signs with the engine wallet or a storage delegation ephemeral — never a guest key) and write-free, so #1102's isolation is untouched. The signer itself (`handle_sign_request`) never used player identity.

## What could break
- Client contexts are bit-identical: a missing identity still errors (`client_without_identity_still_errors` pins this).
- Downstream services now see `is_guest: false` from server scenes. NOTE: pre-#1102 the fake profile left `has_connected_web3` unset, so the server actually sent `is_guest: true`; `false` is a deliberate delta — truthful for the delegation-signed storage calls (root-backed key), and no known consumer gates on the field (storage accepted `true` for months).

## How to test
- `cargo test -p dcl --lib signed_fetch` — 3 regression tests. `server_without_identity_is_not_guest` fails on main before this fix (verified: reverting the fallback arm makes it FAIL) and passes after.
- End to end: deploy an orchestrated server on a build with this fix, join a world whose scene calls `signedFetch` (e.g. flagtag's leaderboard read at round end) and check the scene log no longer shows `no player identity!`.
