### PR TITLE
Support draco-compressed gltfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,8 +4124,7 @@ source = "git+https://github.com/robtfm/winit?branch=v0.30.x#a8c6812b563f9c0974a
 [[package]]
 name = "draco-nd-vector"
 version = "0.1.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4564672e9738d0f8050b9480ec1d1ccbde72ae7e55ce925ab20b9db896ebc30"
+source = "git+https://github.com/robtfm/draco-oxide?branch=fix%2Fwasm32-rans-refill#5acfcf680d4bd17222d910b74ff8bf76a8161575"
 dependencies = [
  "quote",
  "seq-macro",
@@ -4135,8 +4134,7 @@ dependencies = [
 [[package]]
 name = "draco-oxide-core"
 version = "0.1.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0cee8775cb7c8bf283562163fee5ae1bc8448836774b615604ffce958028c5"
+source = "git+https://github.com/robtfm/draco-oxide?branch=fix%2Fwasm32-rans-refill#5acfcf680d4bd17222d910b74ff8bf76a8161575"
 dependencies = [
  "draco-nd-vector",
  "kiddo",
@@ -4151,8 +4149,7 @@ dependencies = [
 [[package]]
 name = "draco-oxide-decoder"
 version = "0.1.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f64caba64a067cfaf83d61d85dd9551482cae56670f0b1d0ac5fa0ed75eea16"
+source = "git+https://github.com/robtfm/draco-oxide?branch=fix%2Fwasm32-rans-refill#5acfcf680d4bd17222d910b74ff8bf76a8161575"
 dependencies = [
  "draco-oxide-core",
  "remain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +737,12 @@ checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "backtrace"
@@ -2596,6 +2608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4014,6 +4032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9c272297e804878a2a4b707cfcfc6d2328b5bb936944613b4fdf2b9269afdfd"
 
 [[package]]
+name = "divrem"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
+
+[[package]]
 name = "dlib"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,6 +4120,44 @@ dependencies = [
 name = "dpi"
 version = "0.1.1"
 source = "git+https://github.com/robtfm/winit?branch=v0.30.x#a8c6812b563f9c0974a17226f566705bbc9ee674"
+
+[[package]]
+name = "draco-nd-vector"
+version = "0.1.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4564672e9738d0f8050b9480ec1d1ccbde72ae7e55ce925ab20b9db896ebc30"
+dependencies = [
+ "quote",
+ "seq-macro",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "draco-oxide-core"
+version = "0.1.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0cee8775cb7c8bf283562163fee5ae1bc8448836774b615604ffce958028c5"
+dependencies = [
+ "draco-nd-vector",
+ "kiddo",
+ "paste",
+ "remain",
+ "seq-macro",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "draco-oxide-decoder"
+version = "0.1.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f64caba64a067cfaf83d61d85dd9551482cae56670f0b1d0ac5fa0ed75eea16"
+dependencies = [
+ "draco-oxide-core",
+ "remain",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "dtoa"
@@ -4694,6 +4756,19 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed"
+version = "1.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707070ccf8c4173548210893a0186e29c266901b71ed20cd9e2ca0193dfe95c3"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -6035,6 +6110,8 @@ dependencies = [
  "common",
  "console 0.1.0",
  "ddsfile",
+ "draco-oxide-core",
+ "draco-oxide-decoder",
  "futures-io",
  "futures-lite",
  "gltf",
@@ -6511,6 +6588,26 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kiddo"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5195aa4f0d1224a7baf95ce80e5a1b14e991c0eb25fa95a0c4ce81053fbcac55"
+dependencies = [
+ "aligned-vec",
+ "array-init",
+ "az",
+ "cmov",
+ "divrem",
+ "fixed",
+ "generator",
+ "num-traits",
+ "ordered-float 5.2.0",
+ "sorted-vec",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "kira"
@@ -9175,6 +9272,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "remain"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b297d1baead74bf76361e49ed016060bd829633361b68500d2e7ea3e66ab6a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10004,6 +10112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10415,6 +10529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted-vec"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238653bedf881fede50103cb7838b029e2b73d3d3d8e70d36f0a96be32a65c7b"
+
+[[package]]
 name = "sourcemap"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10778,6 +10898,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,14 @@ prost-build = "0.11.8"
 # carried on a fork branch off the 0.17.1 tag. not an upstream backport —
 # naga_oil main is 0.22; revisit only if bevy's pinned naga_oil moves.
 naga_oil = { git = "https://github.com/robtfm/naga_oil", branch = "fix/deterministic-override-emit-order" }
+# rANS refill never refills on 32-bit targets (wasm32), corrupting every stream
+# whose encoder chose the branchless refill strategy. fix PR'd upstream as
+# reearth/draco-oxide#34; drop these patches when it lands in a release.
+# core and nd-vector carry no changes but must come from the same source as the
+# decoder or the workspace resolves two copies of core and types don't unify.
+draco-oxide-decoder = { git = "https://github.com/robtfm/draco-oxide", branch = "fix/wasm32-rans-refill" }
+draco-oxide-core = { git = "https://github.com/robtfm/draco-oxide", branch = "fix/wasm32-rans-refill" }
+draco-nd-vector = { git = "https://github.com/robtfm/draco-oxide", branch = "fix/wasm32-rans-refill" }
 # mess required by ecosystem crates referencing bevy subcrates directly
 bevy = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }
 bevy_a11y = { git = "https://github.com/robtfm/bevy", branch = "release-0.16-dcl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,9 @@ async-compat = "0.2"
 async-fs = "2.0"
 base64 = "0.22"
 multihash-codetable = { version = "0.1.1", features = ["digest", "sha2"] }
+# pinned: alpha releases make no api stability promises between versions
+draco-oxide-decoder = "=0.1.0-alpha.9"
+draco-oxide-core = "=0.1.0-alpha.9"
 strum = "0.27"
 strum_macros = "0.27"
 wasm-bindgen = "0.2.92"

--- a/crates/image_processing/Cargo.toml
+++ b/crates/image_processing/Cargo.toml
@@ -38,7 +38,9 @@ block_compression = { version = "0.7", default-features = false, features = [
 image = { workspace = true }
 ddsfile = "0.5.2"
 gltf = "1.4"
-gltf-json = "1.4"
+gltf-json = { version = "1.4", features = ["extensions"] }
+draco-oxide-decoder = { workspace = true }
+draco-oxide-core = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-fs = { workspace = true }

--- a/crates/image_processing/src/engine.rs
+++ b/crates/image_processing/src/engine.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::AssetPath,
+    asset::{AssetLoadFailedEvent, AssetPath},
     diagnostic::FrameCount,
     image::TextureFormatPixelInfo,
     platform::collections::{HashMap, HashSet},
@@ -99,6 +99,7 @@ struct ImgReprocessStats {
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 fn check_assets(
     mut a: EventReader<AssetEvent<Image>>,
+    mut failed_gltfs: EventReader<AssetLoadFailedEvent<Gltf>>,
     images: Res<Assets<Image>>,
     mut w: EventWriter<AssetForProcessing>,
     ipfas: IpfsAssetServer,
@@ -190,6 +191,35 @@ fn check_assets(
 
             assets_to_process.push((ty, ipfs_path, asset_path.to_owned()));
         }
+    }
+
+    // a gltf that fails to load because it is draco-compressed (the loader
+    // rejects the extension by name, and spec-compliant draco files must list
+    // it in extensionsRequired) is run through the processor once, which
+    // decompresses and persists it. the processor independently verifies the
+    // extension against the actual bytes.
+    for ev in failed_gltfs.read() {
+        if !format!("{}", ev.error).contains("KHR_draco_mesh_compression") {
+            continue;
+        }
+        let asset_path = ev.path.clone();
+        let Ok(Some(ipfs_path)) = IpfsPath::new_from_path(asset_path.path()) else {
+            stats.skip_unknown += 1;
+            continue;
+        };
+
+        if paths_processed.contains(&ipfs_path) {
+            continue;
+        }
+        paths_processed.insert(ipfs_path.clone());
+
+        if let Ok(None) = ipfs_path.context_free_hash() {
+            stats.skip_unhashable += 1;
+            continue;
+        }
+
+        stats.total += 1;
+        assets_to_process.push((ProcessingAssetType::DracoGltf, ipfs_path, asset_path));
     }
 
     if task.is_none() && !assets_to_process.is_empty() {
@@ -310,6 +340,9 @@ fn pipe_events(
                             processing_gltfs.insert(asset_server.load(cache_path), h.id());
                         }
                     }
+                    // the original never loaded, so a plain reload picks up the
+                    // repaired cache bytes (no need for the image-swap below)
+                    ProcessingAssetType::DracoGltf => asset_server.reload(req.base_path),
                     ProcessingAssetType::Image => asset_server.reload(req.base_path),
                 };
             }

--- a/crates/image_processing/src/lib.rs
+++ b/crates/image_processing/src/lib.rs
@@ -15,6 +15,9 @@ use bevy::{asset::AssetPath, prelude::*};
 #[derive(Clone, Copy)]
 pub enum ProcessingAssetType {
     Gltf,
+    // a gltf that failed to load, presumed draco-compressed; unlike `Gltf` the
+    // original asset never loaded, so on success it is reloaded in place
+    DracoGltf,
     Image,
 }
 

--- a/crates/image_processing/src/processor/draco.rs
+++ b/crates/image_processing/src/processor/draco.rs
@@ -1,0 +1,254 @@
+// Decompresses KHR_draco_mesh_compression geometry in place: decoded attribute
+// and index data is appended to the binary chunk as new buffer views, the
+// primitives' accessors are pointed at them, and the extension is stripped, so
+// the result is a plain gltf the engine can load.
+
+use draco_oxide_core::{attribute::Attribute, mesh::Mesh};
+use gltf_json::{
+    accessor::{ComponentType, GenericComponentType, Type},
+    validation::Checked,
+    Index,
+};
+
+const DRACO_EXTENSION: &str = "KHR_draco_mesh_compression";
+
+#[derive(Debug)]
+#[allow(dead_code)] // we use the ignored debug impl
+pub enum DracoError {
+    Decode(draco_oxide_decoder::Err),
+    Malformed(&'static str),
+    Unsupported(&'static str),
+}
+
+struct PrimitiveWork {
+    view: usize,
+    // (draco attribute unique id, accessor index)
+    attributes: Vec<(usize, usize)>,
+    indices: Option<usize>,
+}
+
+/// Decodes every draco-compressed primitive, rewriting `root` and appending the
+/// decoded data to `bin`. Returns the indices of the now-dead compressed buffer
+/// views (for the caller to drop when it rebuilds the binary chunk).
+pub fn decompress(root: &mut gltf_json::Root, bin: &mut Vec<u8>) -> Result<Vec<usize>, DracoError> {
+    // gather work first: decoding mutates accessors/views/bin, which can't be
+    // borrowed while iterating primitives
+    let mut work = Vec::new();
+    for mesh in root.meshes.iter_mut() {
+        for primitive in mesh.primitives.iter_mut() {
+            let Some(ext) = primitive
+                .extensions
+                .as_mut()
+                .and_then(|e| e.others.remove(DRACO_EXTENSION))
+            else {
+                continue;
+            };
+
+            let view =
+                ext.get("bufferView")
+                    .and_then(serde_json::Value::as_u64)
+                    .ok_or(DracoError::Malformed("extension bufferView"))? as usize;
+            let ext_attributes = ext
+                .get("attributes")
+                .and_then(serde_json::Value::as_object)
+                .ok_or(DracoError::Malformed("extension attributes"))?;
+
+            let mut attributes = Vec::new();
+            for (semantic, unique_id) in ext_attributes {
+                let unique_id = unique_id
+                    .as_u64()
+                    .ok_or(DracoError::Malformed("attribute id"))?
+                    as usize;
+                let accessor = primitive
+                    .attributes
+                    .iter()
+                    .find(|(k, _)| k.to_string() == *semantic)
+                    .map(|(_, v)| v.value())
+                    .ok_or(DracoError::Malformed(
+                        "extension attribute not in primitive",
+                    ))?;
+                attributes.push((unique_id, accessor));
+            }
+
+            work.push(PrimitiveWork {
+                view,
+                attributes,
+                indices: primitive.indices.map(|i| i.value()),
+            });
+        }
+    }
+
+    let mut dead_views = Vec::new();
+    for prim in work {
+        let view = root
+            .buffer_views
+            .get(prim.view)
+            .ok_or(DracoError::Malformed("bufferView out of range"))?;
+        let start = view.byte_offset.unwrap_or_default().0 as usize;
+        let len = view.byte_length.0 as usize;
+        let compressed = bin
+            .get(start..start + len)
+            .ok_or(DracoError::Malformed("bufferView out of binary range"))?
+            .to_vec();
+
+        let mesh = draco_oxide_decoder::decode_mesh(&compressed).map_err(DracoError::Decode)?;
+
+        if let Some(acc_idx) = prim.indices {
+            write_indices(root, bin, &mesh, acc_idx)?;
+        }
+
+        for (unique_id, acc_idx) in prim.attributes {
+            let attribute = mesh
+                .get_attributes()
+                .iter()
+                .find(|a| a.get_id().as_usize() == unique_id)
+                .ok_or(DracoError::Malformed("attribute id not in draco stream"))?;
+            write_attribute(root, bin, attribute, acc_idx)?;
+        }
+
+        dead_views.push(prim.view);
+    }
+
+    if !dead_views.is_empty() {
+        root.extensions_used.retain(|e| e != DRACO_EXTENSION);
+        root.extensions_required.retain(|e| e != DRACO_EXTENSION);
+    }
+
+    dead_views.sort_unstable();
+    dead_views.dedup();
+    Ok(dead_views)
+}
+
+fn write_indices(
+    root: &mut gltf_json::Root,
+    bin: &mut Vec<u8>,
+    mesh: &Mesh,
+    acc_idx: usize,
+) -> Result<(), DracoError> {
+    let faces = mesh.get_faces();
+    let accessor = root
+        .accessors
+        .get(acc_idx)
+        .ok_or(DracoError::Malformed("indices accessor out of range"))?;
+
+    // keep the declared index width where the point count still fits, else widen
+    let max = faces
+        .iter()
+        .flatten()
+        .map(|p| usize::from(*p))
+        .max()
+        .unwrap_or(0);
+    let declared = match accessor.component_type {
+        Checked::Valid(GenericComponentType(ct)) => ct,
+        Checked::Invalid => ComponentType::U32,
+    };
+    let component_type = match declared {
+        ComponentType::U8 if max <= u8::MAX as usize => ComponentType::U8,
+        ComponentType::U16 if max <= u16::MAX as usize => ComponentType::U16,
+        _ => ComponentType::U32,
+    };
+
+    let mut data = Vec::with_capacity(faces.len() * 3 * component_type.size());
+    for index in faces.iter().flatten() {
+        let index = usize::from(*index);
+        match component_type {
+            ComponentType::U8 => data.push(index as u8),
+            ComponentType::U16 => data.extend_from_slice(&(index as u16).to_le_bytes()),
+            _ => data.extend_from_slice(&(index as u32).to_le_bytes()),
+        }
+    }
+
+    let view = push_view(root, bin, &data);
+    let accessor = &mut root.accessors[acc_idx];
+    accessor.buffer_view = Some(view);
+    accessor.byte_offset = None;
+    accessor.count = (faces.len() * 3).into();
+    accessor.component_type = Checked::Valid(GenericComponentType(component_type));
+    Ok(())
+}
+
+fn write_attribute(
+    root: &mut gltf_json::Root,
+    bin: &mut Vec<u8>,
+    attribute: &Attribute,
+    acc_idx: usize,
+) -> Result<(), DracoError> {
+    use draco_oxide_core::attribute::ComponentDataType;
+
+    let component_type = match attribute.get_component_type() {
+        ComponentDataType::F32 => ComponentType::F32,
+        ComponentDataType::U8 => ComponentType::U8,
+        ComponentDataType::U16 => ComponentType::U16,
+        ComponentDataType::U32 => ComponentType::U32,
+        ComponentDataType::I8 => ComponentType::I8,
+        ComponentDataType::I16 => ComponentType::I16,
+        _ => return Err(DracoError::Unsupported("component type")),
+    };
+
+    let accessor = root
+        .accessors
+        .get(acc_idx)
+        .ok_or(DracoError::Malformed("attribute accessor out of range"))?;
+    let multiplicity = match accessor.type_ {
+        Checked::Valid(Type::Scalar) => 1,
+        Checked::Valid(Type::Vec2) => 2,
+        Checked::Valid(Type::Vec3) => 3,
+        Checked::Valid(Type::Vec4) => 4,
+        Checked::Valid(Type::Mat2) => 4,
+        Checked::Valid(Type::Mat3) => 9,
+        Checked::Valid(Type::Mat4) => 16,
+        Checked::Invalid => return Err(DracoError::Malformed("accessor type")),
+    };
+    if attribute.get_num_components() != multiplicity {
+        return Err(DracoError::Unsupported(
+            "attribute component count mismatch",
+        ));
+    }
+
+    // flatten the unique-value buffer out to per-point values
+    let element_size = component_type.size() * multiplicity;
+    let values = attribute.get_data_as_bytes();
+    let data = match attribute.point_map_as_slice() {
+        None => values.to_vec(),
+        Some(map) => {
+            let mut data = Vec::with_capacity(map.len() * element_size);
+            for value_idx in map {
+                let offset = usize::from(*value_idx) * element_size;
+                data.extend_from_slice(&values[offset..offset + element_size]);
+            }
+            data
+        }
+    };
+
+    let view = push_view(root, bin, &data);
+    let accessor = &mut root.accessors[acc_idx];
+    accessor.buffer_view = Some(view);
+    accessor.byte_offset = None;
+    accessor.count = attribute.len().into();
+    accessor.component_type = Checked::Valid(GenericComponentType(component_type));
+    Ok(())
+}
+
+fn push_view(
+    root: &mut gltf_json::Root,
+    bin: &mut Vec<u8>,
+    data: &[u8],
+) -> Index<gltf_json::buffer::View> {
+    while !bin.len().is_multiple_of(4) {
+        bin.push(0);
+    }
+    let offset = bin.len() as u64;
+    bin.extend_from_slice(data);
+    let index = Index::new(root.buffer_views.len() as u32);
+    root.buffer_views.push(gltf_json::buffer::View {
+        buffer: gltf_json::Index::new(0),
+        byte_length: data.len().into(),
+        byte_offset: Some(offset.into()),
+        byte_stride: None,
+        name: Some("Draco_Decoded".into()),
+        target: None,
+        extensions: None,
+        extras: Default::default(),
+    });
+    index
+}

--- a/crates/image_processing/src/processor/mod.rs
+++ b/crates/image_processing/src/processor/mod.rs
@@ -1,3 +1,4 @@
+mod draco;
 #[cfg(not(target_arch = "wasm32"))]
 mod native_fs;
 #[cfg(target_arch = "wasm32")]
@@ -32,14 +33,17 @@ pub(crate) async fn process_events(
         };
 
         let data = match req.ty {
-            ProcessingAssetType::Gltf => match process_gltf(&raw_bytes) {
-                Ok(gltf) => gltf,
-                Err(e) => {
-                    error!("failed to process gltf {:?}: {:?}", req.base_path, e);
-                    let _ = resp_sx.send(Err(()));
-                    continue;
+            ProcessingAssetType::Gltf | ProcessingAssetType::DracoGltf => {
+                let expect_draco = matches!(req.ty, ProcessingAssetType::DracoGltf);
+                match process_gltf(&raw_bytes, expect_draco) {
+                    Ok(gltf) => gltf,
+                    Err(e) => {
+                        error!("failed to process gltf {:?}: {:?}", req.base_path, e);
+                        let _ = resp_sx.send(Err(()));
+                        continue;
+                    }
                 }
-            },
+            }
             ProcessingAssetType::Image => match process_image(&raw_bytes) {
                 Ok(dds) => dds,
                 Err(e) => {
@@ -150,10 +154,13 @@ fn process_image(raw_bytes: &[u8]) -> Result<Vec<u8>, ImageProcessError> {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)] // we use the ignored debug impl
 enum GltfProcessError {
-    #[allow(dead_code)] // we use the ignored debug impl
     ImageError(ImageProcessError),
     InvalidHeader,
+    ParseFailed,
+    Draco(draco::DracoError),
+    NotDraco,
 }
 
 impl From<ImageProcessError> for GltfProcessError {
@@ -162,16 +169,19 @@ impl From<ImageProcessError> for GltfProcessError {
     }
 }
 
-fn process_gltf(raw_bytes: &[u8]) -> Result<Vec<u8>, GltfProcessError> {
+fn process_gltf(raw_bytes: &[u8], expect_draco: bool) -> Result<Vec<u8>, GltfProcessError> {
+    // failed-load (draco) requests can hand us arbitrary bytes, so parse fallibly
     let (mut root, mut old_bin): (gltf_json::Root, Vec<u8>) = if raw_bytes.starts_with(b"glTF") {
-        let glb = Glb::from_slice(raw_bytes).unwrap();
+        let glb = Glb::from_slice(raw_bytes).map_err(|_| GltfProcessError::ParseFailed)?;
         (
-            gltf_json::deserialize::from_slice(&glb.json).unwrap(),
+            gltf_json::deserialize::from_slice(&glb.json)
+                .map_err(|_| GltfProcessError::ParseFailed)?,
             glb.bin.map(|b| b.into_owned()).unwrap_or_default(),
         )
     } else if raw_bytes.starts_with(b"{") {
         (
-            gltf_json::deserialize::from_slice(raw_bytes).unwrap(),
+            gltf_json::deserialize::from_slice(raw_bytes)
+                .map_err(|_| GltfProcessError::ParseFailed)?,
             Vec::default(),
         )
     } else {
@@ -186,7 +196,9 @@ fn process_gltf(raw_bytes: &[u8]) -> Result<Vec<u8>, GltfProcessError> {
                 // This is a .gltf with embedded binary.
                 // We should decode it and make it the "real" binary chunk.
                 let parts: Vec<&str> = uri.split(',').collect();
-                let decoded = general_purpose::STANDARD.decode(parts[1]).unwrap();
+                let decoded = general_purpose::STANDARD
+                    .decode(parts[1])
+                    .map_err(|_| GltfProcessError::ParseFailed)?;
 
                 // If we already had a binary chunk (from a GLB), append this.
                 // If we came from JSON, 'old_bin' was empty, so this becomes the start.
@@ -203,10 +215,31 @@ fn process_gltf(raw_bytes: &[u8]) -> Result<Vec<u8>, GltfProcessError> {
         }
     }
 
+    // decompress draco geometry before the texture pass so the rebuilt binary
+    // chunk contains the decoded accessor data
+    let draco_views = if root
+        .extensions_used
+        .iter()
+        .any(|e| e == "KHR_draco_mesh_compression")
+    {
+        draco::decompress(&mut root, &mut old_bin).map_err(GltfProcessError::Draco)?
+    } else {
+        Vec::default()
+    };
+    if expect_draco && draco_views.is_empty() {
+        // the gltf failed to load for some reason other than draco compression;
+        // there is nothing we can do to fix it
+        return Err(GltfProcessError::NotDraco);
+    }
+
     // collect all Raw Image Data first
     // store them in a temp vector so we can safely mutate the JSON later.
     let mut raw_images: Vec<Option<Vec<u8>>> = Vec::new();
     let mut zombie_views = vec![false; root.buffer_views.len()];
+    for view in draco_views {
+        // drop the compressed draco data; the decoded views replace it
+        zombie_views[view] = true;
+    }
 
     for image in &root.images {
         let pixels = extract_pixels_safe(image, &root.buffer_views, &old_bin);

--- a/crates/image_processing/src/processor/mod.rs
+++ b/crates/image_processing/src/processor/mod.rs
@@ -75,6 +75,10 @@ fn process_image(raw_bytes: &[u8]) -> Result<Vec<u8>, ImageProcessError> {
         return Err(ImageProcessError::CantLoad);
     };
 
+    compress_decoded(img)
+}
+
+fn compress_decoded(img: image::DynamicImage) -> Result<Vec<u8>, ImageProcessError> {
     let initial_width = img.width();
     let initial_height = img.height();
     let resized = if initial_width > 1024
@@ -83,8 +87,9 @@ fn process_image(raw_bytes: &[u8]) -> Result<Vec<u8>, ImageProcessError> {
         || !initial_height.is_multiple_of(4)
     {
         let downratio = (1024.0 / initial_width.max(initial_height) as f32).min(1.0);
-        let resized_width = (initial_width as f32 * downratio * 0.25).round() as u32 * 4;
-        let resized_height = (initial_height as f32 * downratio * 0.25).round() as u32 * 4;
+        // clamp to one block: extreme aspect ratios can round a dimension to zero
+        let resized_width = ((initial_width as f32 * downratio * 0.25).round() as u32).max(1) * 4;
+        let resized_height = ((initial_height as f32 * downratio * 0.25).round() as u32).max(1) * 4;
         img.resize_exact(
             resized_width,
             resized_height,
@@ -282,20 +287,42 @@ fn process_gltf(raw_bytes: &[u8], expect_draco: bool) -> Result<Vec<u8>, GltfPro
     // compress & append textures
     for (i, raw_opt) in raw_images.into_iter().enumerate() {
         if let Some(raw_pixels) = raw_opt {
-            let bc7_data = process_image(&raw_pixels)?;
+            // apply the same worth-compressing gate as engine::check_assets: bc7
+            // saves nothing on tiny images, and a 1-pixel dimension would resize
+            // to zero. tiny or undecodable images keep their original bytes
+            // instead of failing the whole gltf
+            let decoded = image::load_from_memory(&raw_pixels).ok().filter(|img| {
+                img.width() > 2
+                    && img.height() > 2
+                    && img.width() as usize * img.height() as usize * 4 > 1024
+            });
+
+            let new_data = match decoded {
+                Some(img) => {
+                    let bc7_data = compress_decoded(img)?;
+                    root.images[i].mime_type =
+                        Some(gltf_json::image::MimeType("image/vnd-ms.dds".into()));
+                    bc7_data
+                }
+                // the original view was zombied above, so carry the bytes over
+                // unchanged (mime type stays as declared)
+                None if root.images[i].buffer_view.is_some() => raw_pixels,
+                // data-uri image: the untouched json still points at it
+                None => continue,
+            };
 
             // append to new_bin
             while !new_bin.len().is_multiple_of(4) {
                 new_bin.push(0);
             }
             let offset = new_bin.len() as u64;
-            new_bin.extend_from_slice(&bc7_data);
+            new_bin.extend_from_slice(&new_data);
 
             // Create NEW BufferView
             let new_view_idx = root.buffer_views.len();
             root.buffer_views.push(gltf_json::buffer::View {
                 buffer: gltf_json::Index::new(0),
-                byte_length: bc7_data.len().into(),
+                byte_length: new_data.len().into(),
                 byte_offset: Some(offset.into()),
                 byte_stride: None,
                 name: Some("BC7_Data".into()),
@@ -307,7 +334,6 @@ fn process_gltf(raw_bytes: &[u8], expect_draco: bool) -> Result<Vec<u8>, GltfPro
             // Update Image to point to new View
             root.images[i].buffer_view = Some(gltf_json::Index::new(new_view_idx as u32));
             root.images[i].uri = None;
-            root.images[i].mime_type = Some(gltf_json::image::MimeType("image/vnd-ms.dds".into()));
         }
     }
 
@@ -398,4 +424,103 @@ pub fn write_glb<W: Write>(
     writer.write_all(&bin_data)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn png_bytes(width: u32, height: u32) -> Vec<u8> {
+        let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            width,
+            height,
+            image::Rgba([255, 255, 255, 255]),
+        ));
+        let mut out = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut out, image::ImageFormat::Png).unwrap();
+        out.into_inner()
+    }
+
+    fn parse_glb(bytes: &[u8]) -> (gltf_json::Root, Vec<u8>) {
+        let glb = Glb::from_slice(bytes).unwrap();
+        (
+            gltf_json::deserialize::from_slice(&glb.json).unwrap(),
+            glb.bin.map(|b| b.into_owned()).unwrap_or_default(),
+        )
+    }
+
+    fn view_bytes<'a>(root: &gltf_json::Root, bin: &'a [u8], image: usize) -> &'a [u8] {
+        let view = &root.buffer_views[root.images[image].buffer_view.unwrap().value()];
+        let start = view.byte_offset.unwrap_or_default().0 as usize;
+        &bin[start..start + view.byte_length.0 as usize]
+    }
+
+    #[test]
+    fn resize_never_rounds_a_dimension_to_zero() {
+        assert!(process_image(&png_bytes(1, 1)).is_ok());
+        assert!(process_image(&png_bytes(2048, 2)).is_ok());
+    }
+
+    #[test]
+    fn tiny_data_uri_image_passes_through_untouched() {
+        let json = format!(
+            r#"{{"asset":{{"version":"2.0"}},"images":[
+                {{"mimeType":"image/png","uri":"data:image/png;base64,{}"}},
+                {{"mimeType":"image/png","uri":"data:image/png;base64,{}"}}]}}"#,
+            general_purpose::STANDARD.encode(png_bytes(1, 1)),
+            general_purpose::STANDARD.encode(png_bytes(32, 32)),
+        );
+
+        let output = process_gltf(json.as_bytes(), false).unwrap();
+        let (root, bin) = parse_glb(&output);
+
+        // tiny image untouched
+        assert!(root.images[0].uri.as_ref().unwrap().starts_with("data:"));
+        assert!(root.images[0].buffer_view.is_none());
+        // large image compressed
+        assert_eq!(
+            root.images[1].mime_type.as_ref().unwrap().0,
+            "image/vnd-ms.dds"
+        );
+        assert!(view_bytes(&root, &bin, 1).starts_with(b"DDS "));
+    }
+
+    #[test]
+    fn tiny_buffer_view_image_keeps_original_bytes() {
+        let png = png_bytes(1, 1);
+        let mut root = gltf_json::Root::default();
+        root.buffers.push(gltf_json::Buffer {
+            byte_length: png.len().into(),
+            name: None,
+            uri: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        root.buffer_views.push(gltf_json::buffer::View {
+            buffer: gltf_json::Index::new(0),
+            byte_length: png.len().into(),
+            byte_offset: None,
+            byte_stride: None,
+            name: None,
+            target: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        root.images.push(gltf_json::Image {
+            buffer_view: Some(gltf_json::Index::new(0)),
+            mime_type: Some(gltf_json::image::MimeType("image/png".into())),
+            name: None,
+            uri: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        let mut input = Vec::new();
+        write_glb(&mut input, &root, &png).unwrap();
+
+        let output = process_gltf(&input, false).unwrap();
+        let (root, bin) = parse_glb(&output);
+
+        assert_eq!(root.images[0].mime_type.as_ref().unwrap().0, "image/png");
+        assert_eq!(view_bytes(&root, &bin, 0), png);
+    }
 }

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -179,6 +179,12 @@ impl Plugin for GltfDefinitionPlugin {
 
         app.init_resource::<GltfNameCache>();
         app.add_systems(Update, update_gltf.in_set(SceneSets::PostLoop));
+        app.add_systems(
+            Update,
+            retry_repaired_gltfs
+                .in_set(SceneSets::PostLoop)
+                .before(update_gltf),
+        );
         app.add_systems(Update, maintain_gltf_name_cache);
         app.add_systems(SpawnScene, update_ready_gltfs.after(scene_spawner_system));
         app.add_systems(Update, check_gltfs_ready.in_set(SceneSets::PostInit));
@@ -255,7 +261,7 @@ fn despawn_instance_non_recursive(commands: &mut Commands, entities: impl Iterat
 fn on_gltf_container_removed(trigger: Trigger<OnRemove, GltfDefinition>, mut commands: Commands) {
     commands
         .entity(trigger.target())
-        .try_remove::<(GltfLoaded, GltfProcessed, GltfReady)>();
+        .try_remove::<(GltfLoaded, GltfProcessed, GltfReady, GltfAssetFailed)>();
 }
 
 // assets are keyed by path and the first load's settings win, so every gltf that might
@@ -347,7 +353,8 @@ fn update_gltf(
         commands
             .entity(ent)
             .remove::<GltfLoaded>()
-            .remove::<GltfProcessed>();
+            .remove::<GltfProcessed>()
+            .remove::<GltfAssetFailed>();
 
         if let Some(GltfLoaded(Some(instance_id))) = maybe_loaded {
             if !has_gltf_processed {
@@ -402,7 +409,11 @@ fn update_gltf(
             bevy::asset::LoadState::Failed(e) => {
                 warn!("failed to process gltf {}: {}", def.0.src, e);
                 set_state(scene_ent, LoadingState::FinishedWithError);
-                commands.entity(ent).try_insert(GltfLoaded(None));
+                // the marker lets retry_repaired_gltfs pick this up if the asset
+                // is repaired and reloaded (see below)
+                commands
+                    .entity(ent)
+                    .try_insert((GltfLoaded(None), GltfAssetFailed));
                 continue;
             }
             bevy::asset::LoadState::Loading => continue,
@@ -456,6 +467,55 @@ fn update_gltf(
                 set_state(scene_ent, LoadingState::FinishedWithError);
                 commands.entity(ent).try_insert(GltfLoaded(None));
             }
+        }
+    }
+}
+
+// marks a container whose underlying gltf asset failed to load, so that
+// retry_repaired_gltfs watches it for a repair
+#[derive(Component)]
+struct GltfAssetFailed;
+
+// a gltf that failed to load may be repaired externally (draco-compressed
+// geometry is decompressed into the cache by the image_processing plugin,
+// which then reloads the asset). when a marked container's asset is loading
+// (or has finished loading) again, run it back through the load flow. the
+// marker is only applied when the asset itself failed, so a non-failed state
+// can only mean a repair-reload happened.
+fn retry_repaired_gltfs(
+    mut commands: Commands,
+    failed_gltfs: Query<
+        (Entity, &SceneEntity, &GltfHandle, &GltfLoaded),
+        (With<GltfDefinition>, With<GltfAssetFailed>),
+    >,
+    ipfas: IpfsAssetServer,
+    mut contexts: Query<&mut RendererSceneContext>,
+) {
+    for (ent, scene_ent, h_gltf, loaded) in failed_gltfs.iter() {
+        if loaded.0.is_some()
+            || !matches!(
+                ipfas.load_state(h_gltf.0.id()),
+                LoadState::Loading | LoadState::Loaded
+            )
+        {
+            continue;
+        }
+
+        debug!("retrying repaired gltf for {}", scene_ent.id);
+        commands
+            .entity(ent)
+            .try_remove::<(GltfLoaded, GltfProcessed, GltfReady, GltfAssetFailed)>();
+
+        if let Ok(mut context) = contexts.get_mut(scene_ent.root) {
+            context.update_crdt(
+                SceneComponentId::GLTF_CONTAINER_LOADING_STATE,
+                CrdtType::LWW_ANY,
+                scene_ent.id,
+                &PbGltfContainerLoadingState {
+                    current_state: LoadingState::Loading as i32,
+                    ..Default::default()
+                },
+            );
         }
     }
 }


### PR DESCRIPTION
Adds support for `KHR_draco_mesh_compression` gltfs by transcoding them to plain gltfs on first encounter, reusing the existing `image_processing` cache-rewrite flow.

## How it works

- Draco glbs fail bevy's loader at the `extensionsRequired` check. `check_assets` now also reads `AssetLoadFailedEvent<Gltf>` and, when the error names the draco extension, enqueues the cached bytes for processing (once per content hash per session; the processor independently verifies `extensionsUsed` against the actual bytes).
- A new draco pass in `process_gltf` (`processor/draco.rs`) runs before the BC7 texture pass: each compressed primitive's bufferView is decoded with [draco-oxide-decoder](https://github.com/reearth/draco-oxide) (pure rust, wasm32-clean, interop-tested against the reference C++ codec; pinned `=0.1.0-alpha.9` since alphas make no API-stability promises), decoded data is appended as new bufferViews, the existing accessors are pointed at them, and the extension is stripped. The JSON is otherwise untouched, and the result is persisted over the cached bytes — decode once, ever, per asset.
- On success the asset is reloaded in place (the original never loaded, so no image-swap is needed). In `gltf_container`, containers whose asset failed get a `GltfAssetFailed` marker; a small retry system re-runs marked containers through the normal load flow when their asset is loading or loaded again (a state only a repair-reload can produce).

Verified natively against gltf-pipeline-compressed models (textured + skinned): fail → transcode (~100ms) → reload → retry → spawned, including joints/weights and animator wiring; decoded positions refill the declared accessor bounds within quantization error.

## Tiny-texture passthrough

The transcoder previously BC7-compressed every embedded image, and the resize step rounds a 1-pixel dimension (or any aspect ratio over ~512:1) down to zero, failing the whole file. Harmless-but-wasteful in the normal flow; for draco content it would leave the asset permanently broken, and 1x1 textures are common. Each image is now gated with the same worth-compressing filter `check_assets` uses: tiny or undecodable images keep their original bytes, and the resize math is clamped so it can never produce a zero dimension. Covered by unit tests.

## Limitations

- Preview-server content uses `b64-` path-derived hashes, which are (correctly) excluded from the cache in both directions, so preview draco scenes are not repairable by this route — deployed content only. Preview support would need a session-scoped in-memory overlay in the ipfs reader; left as a follow-up.
- The wasm runtime path is verified end-to-end (textured, skinned, and live-scene draco content repair in the browser). Web testing surfaced an upstream decoder bug on wasm32, fixed via the pinned fork (see comments and reearth/draco-oxide#34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes #559