### PR TITLE
fix cinematic look-at rotation lagging translation by one frame

### DIFF
--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -249,10 +249,7 @@ pub fn update_camera_position(
             .and_then(|e| gt_helper.compute_global_transform(e).ok())
         {
             Transform::IDENTITY
-                .looking_at(
-                    look_at_transform.translation() - camera_transform.translation,
-                    Vec3::Y,
-                )
+                .looking_at(look_at_transform.translation() - translation, Vec3::Y)
                 .rotation
         } else {
             let yaw = cine


### PR DESCRIPTION
When a cinematic/virtual camera has a `lookAtEntity`, the look direction was computed from the camera's previous-frame position (`camera_transform.translation`), while the camera translation was set from the current-frame origin. The rendered rotation was therefore always one frame stale relative to position, which shows up as visible judder when a scene orbits a virtual camera around the player (e.g. the match-game win animation in `monsterrecon.dcl.eth`).

Compute the look direction from the same frame's target translation instead, so rotation and position are consistent within each frame. This also makes the transition tween's target rotation consistent with its target position, rather than aiming from wherever the camera currently is mid-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)