### PR TITLE
fix cinematic pitch/roll clamps reading yaw_range

### DIFF
--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -260,11 +260,11 @@ pub fn update_camera_position(
                 .map(|r| options.yaw.clamp(-r, r))
                 .unwrap_or(options.yaw);
             let pitch = cine
-                .yaw_range
+                .pitch_range
                 .map(|r| options.pitch.clamp(-r, r))
                 .unwrap_or(options.pitch);
             let roll = cine
-                .yaw_range
+                .roll_range
                 .map(|r| options.roll.clamp(-r, r))
                 .unwrap_or(options.roll);
             rotation * Quat::from_euler(EulerRot::YXZ, yaw, pitch, roll)


### PR DESCRIPTION
Copy-paste error in `update_camera_position`: the pitch and roll clamps both read `cine.yaw_range` instead of `pitch_range`/`roll_range`, so a cinematic camera with distinct rotation ranges had its pitch and roll clamped to the yaw limits. No effect on cameras using `lookAtEntity` (that branch bypasses the clamps) or with all ranges equal/unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)