### PR TITLE
Fix remote profile resolution on .zone environments

### DIFF
--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -72,8 +72,12 @@ impl Plugin for UserProfilePlugin {
 enum ProfileDisplayState {
     Loaded(Box<UserProfile>),
     Loading(Task<Result<Option<UserProfile>, anyhow::Error>>),
-    Failed,
+    Failed(web_time::Instant),
 }
+
+/// Failures are cached, so without a retry one transient error (timeout, dns, registry
+/// lag) would leave the address unresolvable for the engine's whole uptime.
+const PROFILE_FETCH_RETRY: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Resource, Default)]
 pub struct ProfileCache(HashMap<Address, ProfileDisplayState>);
@@ -101,6 +105,13 @@ impl ProfileManager<'_, '_> {
         &mut self,
         address: Address,
     ) -> Result<Option<&UserProfile>, ProfileMissingError> {
+        // dropping the expired failure makes the entry below re-spawn the fetch
+        if let Some(ProfileDisplayState::Failed(at)) = self.cache.0.get(&address) {
+            if at.elapsed() >= PROFILE_FETCH_RETRY {
+                self.cache.0.remove(&address);
+            }
+        }
+
         let state = self.cache.0.entry(address).or_insert_with(|| {
             ProfileDisplayState::Loading(IoTaskPool::get().spawn_compat(get_remote_profile(
                 address,
@@ -112,7 +123,14 @@ impl ProfileManager<'_, '_> {
         if let ProfileDisplayState::Loading(task) = state {
             match task.complete() {
                 Some(Ok(Some(profile))) => *state = ProfileDisplayState::Loaded(Box::new(profile)),
-                Some(Ok(None)) | Some(Err(_)) => *state = ProfileDisplayState::Failed,
+                Some(Ok(None)) => {
+                    debug!("registry has no profile for {address:#x}");
+                    *state = ProfileDisplayState::Failed(web_time::Instant::now());
+                }
+                Some(Err(e)) => {
+                    warn!("profile fetch failed for {address:#x}: {e}");
+                    *state = ProfileDisplayState::Failed(web_time::Instant::now());
+                }
                 None => (),
             }
         }
@@ -120,7 +138,7 @@ impl ProfileManager<'_, '_> {
         Ok(match state {
             ProfileDisplayState::Loaded(data) => Some(data),
             ProfileDisplayState::Loading(_) => None,
-            ProfileDisplayState::Failed => return Err(ProfileMissingError),
+            ProfileDisplayState::Failed(_) => return Err(ProfileMissingError),
         })
     }
 
@@ -353,34 +371,35 @@ fn request_missing_profiles(
 
         let dbb = manager.meta_cache.0.get(&player.address).cloned();
         match manager.get_data(player.address) {
-            Ok(Some(profile)) => {
+            Ok(Some(profile)) if profile.version >= player.profile_version => {
                 // catalyst fetch complete
-                if profile.version >= player.profile_version {
-                    if let Ok(mut global_crdt) = contexts.get_mut(player.context) {
-                        global_crdt.update_crdt(
-                            SceneComponentId::PLAYER_IDENTITY_DATA,
-                            CrdtType::LWW_ANY,
-                            player.scene_id,
-                            &PbPlayerIdentityData {
-                                address: format!("{:#x}", player.address),
-                                is_guest: !(profile.content.has_connected_web3.unwrap_or(false)),
-                            },
-                        );
-                    }
-
-                    commands.entity(ent).try_insert(profile.clone());
-                } else {
-                    warn!(
-                        "removing stale profile {} != {} (meta = {:?})",
-                        profile.version, player.profile_version, dbb,
+                if let Ok(mut global_crdt) = contexts.get_mut(player.context) {
+                    global_crdt.update_crdt(
+                        SceneComponentId::PLAYER_IDENTITY_DATA,
+                        CrdtType::LWW_ANY,
+                        player.scene_id,
+                        &PbPlayerIdentityData {
+                            address: format!("{:#x}", player.address),
+                            is_guest: !(profile.content.has_connected_web3.unwrap_or(false)),
+                        },
                     );
-                    manager.remove(player.address);
-                    // debounce the re-fetch: remove() cleared the cache, so without
-                    // this the next frame would re-spawn the catalyst request (and
-                    // its POST) every tick until the registry serves the new version.
-                    requested.insert(player.address, time.elapsed_secs());
                 }
+
+                commands.entity(ent).try_insert(profile.clone());
                 continue;
+            }
+            Ok(Some(profile)) => {
+                warn!(
+                    "removing stale profile {} != {} (meta = {:?})",
+                    profile.version, player.profile_version, dbb,
+                );
+                manager.remove(player.address);
+                // debounce the re-fetch: remove() cleared the cache, so without
+                // this the next frame would re-spawn the catalyst request (and
+                // its POST) every tick until the registry serves the new version.
+                requested.insert(player.address, time.elapsed_secs());
+                // fall through to the comms profile request: the announcing peer is the
+                // authority on its own latest profile, so a lagging registry can't deadlock us
             }
             Ok(None) => {
                 // catalyst fetch in progress
@@ -693,11 +712,18 @@ pub async fn get_remote_profile(
         Some(endpoint) => endpoint,
         None => ipfs.lambda_endpoint().ok_or(anyhow!("not connected"))?,
     };
-    debug!("requesting profile from {}", endpoint);
+    // the .zone and .org registries hold separate profile namespaces, so the registry
+    // must match the peer's environment
+    let registry_url = if endpoint.contains(".decentraland.zone") {
+        "https://asset-bundle-registry.decentraland.zone/profiles"
+    } else {
+        "https://asset-bundle-registry.decentraland.org/profiles"
+    };
+    debug!("requesting profile for {address:#x} from {registry_url} (endpoint {endpoint})");
 
     let response = ipfs
         .client()
-        .post("https://asset-bundle-registry.decentraland.org/profiles")
+        .post(registry_url)
         .timeout(std::time::Duration::from_secs(10))
         .body(format!("{{ \"ids\": [\"{:#x}\"] }}", address))
         .header("content-type", "application/json")


### PR DESCRIPTION
## Summary

Authoritative servers on .zone realms could never resolve most players' profiles, so scenes saw truncated addresses instead of names (`AvatarBase` never populated). Three compounding causes in `get_remote_profile` / `ProfileManager`:

- The asset-bundle-registry host is hardcoded to **.org** (since #568), but the .zone and .org registries hold **separate profile namespaces** — the .org registry returns nothing (or an unrelated profile) for .zone players.
- A failed fetch was cached as `Failed` **forever**, silently — one timeout poisoned the address for the engine's whole uptime, even across rejoins.
- A stale registry answer (version older than announced) looped on refetch without ever falling back to asking the peer directly.

This PR picks the registry host from the peer's announced lambdas endpoint (realm fallback), retries failed fetches after 30s, logs fetch failures, and falls through to the comms `ProfileRequest` on stale answers.

## What could break

- Unresolvable addresses now retry every 30s instead of going quiet — slightly more registry traffic (one POST/30s per unresolved player, incl. guests until the comms fallback answers).
- Any environment whose lambdas endpoint doesn't contain `.decentraland.zone` still uses the .org registry (unchanged behavior).

## How to test

Namespace divergence repro (address from a live .zone session where the server logged a truncated name):

```bash
curl -s -X POST https://asset-bundle-registry.decentraland.org/profiles  -H 'content-type: application/json' -d '{"ids":["0x1d485820aea7ae6d090c5901fbaf69be224c1b76"]}'   # -> []
curl -s -X POST https://asset-bundle-registry.decentraland.zone/profiles -H 'content-type: application/json' -d '{"ids":["0x1d485820aea7ae6d090c5901fbaf69be224c1b76"]}'   # -> profile "vitZone"
```

End to end: run a headless authoritative server on a .zone realm, join with a desktop client, and watch the scene's `getPlayer()` name. Before this change it stays a truncated address forever; after, the real .zone name appears. For the retry fix: block `asset-bundle-registry.decentraland.zone` in /etc/hosts while the client joins, then unblock — before, the name never recovers; after, it resolves within ~30s (and the failure now shows as a `warn` in engine logs).