### PR TITLE
fix: a cached getPlayerData drops the rest of the frame's user-data requests

### DIFF
--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -1216,7 +1216,7 @@ fn get_user_data(
                     fp.context == scene_context && *address == format!("{:#x}", fp.address)
                 }) {
                     response.send(Ok(profile.content.clone()));
-                    return;
+                    continue;
                 }
 
                 if let Some(my_address) = me.address() {


### PR DESCRIPTION
## Why

`get_user_data` answers a `GetUserData` naming a player it already holds as a `ForeignPlayer` straight from the component, then **returns from the system** rather than continuing the event loop. The two sibling branches right beside it both `continue`.

Everything queued behind that request pays for it:

- the rest of the frame's `GetUserData` events go unread;
- both pending drains at the foot of the system are skipped — `pending_primary_requests`, which is what lifts a scene's `get_user_data` block, and `pending_remote_requests`, which is the profile-cache drain.

Progress is one cached hit per frame, and `RpcCall` is an ordinary double-buffered event, so two cached hits in a frame's worth of requests is enough for everything behind them to expire unread: their senders drop and the scene gets an error instead of an answer.

Asking about one player at a time hides this — the loop has nothing left to skip. It shows up when a scene asks about many at once, which is what the communities members tab is about to do: ~120 addresses in a tick, some of them players standing nearby.

## What

`return` → `continue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
