### PR TITLE
Silence missing image-loader errors in headless

### DIFF
--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -341,7 +341,8 @@ fn main() {
     // and TextShape plugins below.
     app.init_asset::<Shader>()
         .init_asset::<AnimationClip>()
-        .init_asset::<Image>();
+        .init_asset::<Image>()
+        .register_asset_loader(StubImageLoader);
 
     // Skip the render-only scene plugins (scene UI, TextShape, scene materials, billboards,
     // lights, visibility, pointer results). Must precede SceneRunnerPlugin: the gates are
@@ -485,6 +486,42 @@ fn main() {
         .ok();
 
     app.run();
+}
+
+/// Stands in for the render-only `ImageLoader`: without it the asset server errors
+/// per gltf texture. Nothing samples textures here, so don't decode them.
+struct StubImageLoader;
+
+impl bevy::asset::AssetLoader for StubImageLoader {
+    type Asset = Image;
+    type Settings = bevy::image::ImageLoaderSettings;
+    type Error = std::convert::Infallible;
+
+    async fn load(
+        &self,
+        _reader: &mut dyn bevy::asset::io::Reader,
+        _settings: &Self::Settings,
+        _load_context: &mut bevy::asset::LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        use bevy::asset::RenderAssetUsages;
+        use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
+
+        Ok(Image::new_fill(
+            Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            TextureDimension::D2,
+            &[255, 255, 255, 255],
+            TextureFormat::Rgba8UnormSrgb,
+            RenderAssetUsages::empty(),
+        ))
+    }
+
+    fn extensions(&self) -> &[&str] {
+        bevy::image::ImageLoader::SUPPORTED_FILE_EXTENSIONS
+    }
 }
 
 /// GLTF scenes are written into the world via bevy's SceneSpawner, which reflects


### PR DESCRIPTION
## Summary
The headless binary omits `ImagePlugin` (render-only), so the asset server logged `Could not find an asset loader` for every external gltf texture at scene load. Register a stub `Image` loader that returns a 1x1 placeholder without decoding — nothing samples textures without a renderer, and this also skips the pointless fetch+decode per texture.

## What could break
Only the headless binary is touched. Any headless code path that actually needs decoded pixels would now get a 1x1 white placeholder — none exists today (material plugins are skipped headless).

## How to test
```bash
cargo build --bin headless --no-default-features --features headless,livekit
# in a scene whose gltfs reference external textures (e.g. any scene using asset-packs):
npx @dcl/sdk-commands start --port 8021 --no-browser &
target/debug/headless --realm http://localhost:8021 --preview --server-mode
```
Before: one `Could not find an asset loader ... .png` error per texture at scene load. After: none, and the scene boots identically (verified against the flagtag preview — same entity/coin registry as before the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014coQ4mpQQh4CZrfrEXrFV5