### PR TITLE
Fix local-scene detection for Windows dev servers

### DIFF
--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -224,8 +224,12 @@ impl AssetLoader for SceneJsLoader {
 pub struct ContentMap(pub HashMap<String, String>);
 
 impl ContentMap {
+    // keys are stored lowercase with '/' separators (the dev server normalizes the
+    // same way); lookups mirror that so backslashed srcs still resolve
     pub fn hash<'a>(&'a self, file: &str) -> Option<Cow<'a, str>> {
-        self.0.get(file.to_lowercase().as_str()).map(Into::into)
+        self.0
+            .get(file.replace('\\', "/").to_lowercase().as_str())
+            .map(Into::into)
     }
 
     pub fn files(&self) -> impl Iterator<Item = &String> {
@@ -241,7 +245,7 @@ impl ContentMap {
     }
 
     pub fn with(mut self, file: String, hash: String) -> Self {
-        self.0.insert(file.to_lowercase(), hash);
+        self.0.insert(file.replace('\\', "/").to_lowercase(), hash);
         self
     }
 }
@@ -1276,14 +1280,9 @@ impl IpfsIo {
             let Ok(decoded) = String::from_utf8(decoded) else {
                 continue;
             };
-            // decoded == "{projectRoot}/{key-original-case}-{machineId}"; the key is lowercased, so
-            // locate "/{key}-" case-insensitively, then slice the original to keep the real casing.
-            let marker = format!("/{key}-");
-            let Some(idx) = decoded.to_lowercase().rfind(&marker) else {
+            let Some((project_root, machine_id)) = b64_split_at_key(&decoded, key) else {
                 continue;
             };
-            let project_root = &decoded[..idx];
-            let machine_id = &decoded[idx + marker.len()..];
             let abs = format!("{project_root}/{rel}-{machine_id}");
             return Some(format!("b64-{}", BASE64_STANDARD.encode(abs.as_bytes())));
         }
@@ -1309,9 +1308,8 @@ impl IpfsIo {
             let Ok(decoded) = String::from_utf8(decoded) else {
                 continue;
             };
-            let marker = format!("/{key}-");
-            if let Some(idx) = decoded.to_lowercase().rfind(&marker) {
-                return Some(decoded[..idx].to_string());
+            if let Some((project_root, _)) = b64_split_at_key(&decoded, key) {
+                return Some(project_root.to_string());
             }
         }
         None
@@ -1980,5 +1978,44 @@ impl DeferredDropper {
 impl Drop for DeferredDropper {
     fn drop(&mut self) {
         self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Splits a dev server's b64 hash payload — `"{projectRoot}{sep}{key}-{machineId}"` — at its
+/// `/{key}-` marker into (projectRoot, machineId), both in their original case and separators.
+/// The marker is matched case-insensitively (collection keys are lowercased while the encoded
+/// path keeps its casing) and separator-insensitively (a Windows dev server encodes backslash
+/// paths); both normalizations are byte-for-byte over the ASCII they rewrite, so an index found
+/// in the normalized copy still slices `decoded` itself.
+fn b64_split_at_key<'a>(decoded: &'a str, key: &str) -> Option<(&'a str, &'a str)> {
+    let marker = format!("/{key}-");
+    let idx = decoded.replace('\\', "/").to_lowercase().rfind(&marker)?;
+    Some((&decoded[..idx], &decoded[idx + marker.len()..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::b64_split_at_key;
+
+    #[test]
+    fn splits_unix_path() {
+        let decoded = "/Users/bob/scene/models/Tree.glb-my-mac";
+        let split = b64_split_at_key(decoded, "models/tree.glb");
+        assert_eq!(split, Some(("/Users/bob/scene", "my-mac")));
+    }
+
+    #[test]
+    fn splits_windows_path() {
+        let decoded = r"C:\Users\bob\scene\models\Tree.glb-my-pc";
+        let split = b64_split_at_key(decoded, "models/tree.glb");
+        assert_eq!(split, Some((r"C:\Users\bob\scene", "my-pc")));
+    }
+
+    #[test]
+    fn no_split_for_other_key() {
+        assert_eq!(
+            b64_split_at_key(r"C:\Users\bob\scene\models\Tree.glb-pc", "scene.json"),
+            None
+        );
     }
 }

--- a/crates/platform/src/web_save.js
+++ b/crates/platform/src/web_save.js
@@ -98,7 +98,7 @@ function sceneMatches(sceneJson, target) {
 // project path as suffixes — handle == project root (empty suffix) first, then handle == its parent,
 // grandparent, … — and matching scene.json. Returns the dir handle, or null.
 async function findProjectDir(handle, target) {
-  const segs = (target.root || '').split('/').filter(Boolean)
+  const segs = (target.root || '').split(/[\\/]/).filter(Boolean)
   for (let i = segs.length; i >= 0; i--) {
     let dir
     try {


### PR DESCRIPTION
**Summary**
On Windows, models imported from the editor's asset catalog never rendered: the dev server encodes backslashed absolute paths into its `b64-` content hashes, and the `/{key}-` marker match that recovers the project root only understood forward slashes. The engine then treated the scene as non-local, skipped the `/scene_content` content-map refresh, and the freshly written file stayed unresolvable. The fix matches the marker separator-insensitively (new `b64_split_at_key` helper), mirrors the dev server's separator normalization in `ContentMap` lookups, and splits the recovered root on either separator in `web_save`'s folder matching.

**What could break**
`ContentMap` keys/lookups now also normalize `\` to `/` — a content map that intentionally used literal backslashes in filenames would collide, but the dev server and deployments already forbid/normalize those. Recovered project roots on Windows keep their native backslashes, as before (they were previously just never recovered).

**How to test**
`cargo test -p ipfs` — `splits_windows_path` fails on main and passes here (repro of the exact decode). End to end on Windows: run a `dcl start --data-layer` scene in the editor, click any asset-catalog model — before the fix the entity appears in the hierarchy but never renders; after, it renders without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRfGfjcRmehJZq5oMS6Q8g