### PR TITLE
Fix clippy lints for Rust 1.98

### DIFF
--- a/crates/comms/src/livekit/room/plugin.rs
+++ b/crates/comms/src/livekit/room/plugin.rs
@@ -156,6 +156,7 @@ fn poll_connecting_rooms(
     }
 }
 
+#[allow(clippy::result_large_err)] // RoomError is livekit's, and connect failures are rare
 async fn connect_to_room(
     address: String,
     token: String,

--- a/crates/nft/src/extended_image_loader.rs
+++ b/crates/nft/src/extended_image_loader.rs
@@ -64,10 +64,11 @@ impl AssetLoader for SvgLoader {
             let data = image
                 .data
                 .unwrap()
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|pair| {
-                    (u16::from_le_bytes([pair[0], pair[1]]) as f32 / u16::MAX as f32
-                        * u8::MAX as f32) as u8
+                    (u16::from_le_bytes(*pair) as f32 / u16::MAX as f32 * u8::MAX as f32) as u8
                 })
                 .collect::<Vec<_>>();
             image = Image::new(

--- a/crates/scene_runner/src/update_world/gltf_container.rs
+++ b/crates/scene_runner/src/update_world/gltf_container.rs
@@ -1344,10 +1344,12 @@ pub fn mesh_to_parry_shape(mesh_data: &Mesh) -> Option<SharedShape> {
     // trimesh_with_flags rather than erroring. drop those triangles.
     let vertex_count = positions_ref.len() as u32;
     let total_triangles = indices.len() / 3;
-    let indices_parry: Vec<_> = indices
-        .chunks_exact(3)
+    let indices_parry: Vec<[u32; 3]> = indices
+        .as_chunks::<3>()
+        .0
+        .iter()
         .filter(|chunk| chunk.iter().all(|ix| *ix < vertex_count))
-        .map(|chunk| chunk.try_into().unwrap())
+        .copied()
         .collect();
     if indices_parry.len() < total_triangles {
         warn!(

--- a/src/bin/survey_imposters.rs
+++ b/src/bin/survey_imposters.rs
@@ -167,10 +167,7 @@ fn analyse(path: &Path, level: u32) -> Result<Stats> {
         let palette_w_rgba8 = palette.width() as usize;
         let palette_h = palette.height() as usize;
         let palette_bytes = palette.into_raw();
-        let palette_entries: Vec<[u8; 8]> = palette_bytes
-            .chunks_exact(8)
-            .map(|c| c.try_into().unwrap())
-            .collect();
+        let palette_entries: Vec<[u8; 8]> = palette_bytes.as_chunks::<8>().0.to_vec();
 
         let pixels_x = palette_w_rgba8 / 2;
         let pixels_y = palette_h;
@@ -204,7 +201,7 @@ fn analyse(path: &Path, level: u32) -> Result<Stats> {
         let img =
             image::load_from_memory_with_format(&tex_png, image::ImageFormat::Png)?.into_rgba8();
         let raw = img.into_raw();
-        raw.chunks_exact(8).map(|c| c.try_into().unwrap()).collect()
+        raw.as_chunks::<8>().0.to_vec()
     };
 
     let mut full: HashSet<[u8; 8]> = HashSet::new();


### PR DESCRIPTION
**Summary**
Rust 1.98.0 stable (released 2026-08-18) landed on CI's unpinned toolchain and broke the Clippy job on main and every open PR. Two new lints fire:
- `result_large_err` on `connect_to_room` (livekit's `RoomError` is ≥136 bytes) — allowed locally, since the type is upstream's and the error path is a rare one-shot connect failure.
- `chunks_exact` with a constant size in `gltf_container.rs`, `extended_image_loader.rs`, and `survey_imposters.rs` — migrated to `as_chunks`, no behavior change (all buffers are exact multiples of the chunk size).

**What could break**
Nothing at runtime; the `as_chunks` rewrites are mechanical equivalents. `cef_offscreen` wasn't clippy-checked locally (no cmake on this machine) — CI covers it.

**How to test**
CI's Clippy job on this PR. Locally: `cargo +stable clippy --locked -- -D warnings` with rustc 1.98.