### PR TITLE
Isolate the CEF profile per client, and handle shutdown signals on linux

### DIFF
--- a/crates/cef_offscreen/Cargo.toml
+++ b/crates/cef_offscreen/Cargo.toml
@@ -17,4 +17,6 @@ raw-window-handle = "0.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
+
+[target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/cef_offscreen/src/message_loop.rs
+++ b/crates/cef_offscreen/src/message_loop.rs
@@ -15,6 +15,7 @@ use cef::{Settings, api_hash, execute_process, initialize, shutdown, sys};
 ///   the main thread the CEF UI thread, so browsers are driven directly.
 pub struct MessageLoopPlugin {
     _app: Box<cef::App>,
+    cache_dir: std::path::PathBuf,
     #[cfg(target_os = "macos")]
     _loader: Box<DebugLibraryLoader>,
 }
@@ -22,6 +23,7 @@ pub struct MessageLoopPlugin {
 impl Plugin for MessageLoopPlugin {
     fn build(&self, app: &mut App) {
         app.insert_non_send_resource(RunOnMainThread)
+            .insert_resource(CefCacheDir(self.cache_dir.clone()))
             .add_systems(Update, cef_shutdown.run_if(on_event::<AppExit>));
 
         #[cfg(target_os = "macos")]
@@ -56,6 +58,9 @@ impl Default for MessageLoopPlugin {
         );
         assert_eq!(ret, -1, "cannot execute browser process");
 
+        reap_abandoned_cache_dirs();
+        let cache_dir = cef_cache_dir();
+
         let settings = Settings {
             #[cfg(target_os = "macos")]
             framework_dir_path: bundled_framework_dir()
@@ -71,19 +76,7 @@ impl Default for MessageLoopPlugin {
             // AppImage — with the sandbox left on, the zygote host FATALs at startup:
             // zygote_host_impl_linux.cc "Check failed: . : No such file or directory").
             no_sandbox: true as _,
-            // A per-executable cache dir: the default (shared) path triggers Chromium's process
-            // singleton across different host apps, which can strand/kill renderer subprocesses.
-            root_cache_path: std::env::temp_dir()
-                .join(format!(
-                    "cef-cache-{}",
-                    std::env::current_exe()
-                        .ok()
-                        .and_then(|p| p.file_name().map(|f| f.to_string_lossy().into_owned()))
-                        .unwrap_or_else(|| "app".to_string())
-                ))
-                .to_str()
-                .unwrap_or_default()
-                .into(),
+            root_cache_path: cache_dir.to_str().unwrap_or_default().into(),
             windowless_rendering_enabled: true as _,
             #[cfg(any(target_os = "windows", target_os = "linux"))]
             multi_threaded_message_loop: true as _,
@@ -105,11 +98,67 @@ impl Default for MessageLoopPlugin {
 
         Self {
             _app: Box::new(app),
+            cache_dir,
             #[cfg(target_os = "macos")]
             _loader: Box::new(_loader),
         }
     }
 }
+
+/// The CEF profile lives at `$TMPDIR/cef-cache-<exe>-<pid>`, one dir per running client.
+/// A shared path puts every client on the same Chromium process singleton (and, on macos, the
+/// same mach service name, hashed from the path), so a second client - or a stuck one still
+/// holding the lock - fails to start: `bootstrap_check_in: Permission denied` and
+/// `Failed to open UKM database: database is locked`. Nothing in the profile has to outlive the
+/// run, so the dir is removed again in `cef_shutdown`.
+#[derive(Resource)]
+struct CefCacheDir(std::path::PathBuf);
+
+fn cef_cache_dir() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("{}{}", cef_cache_prefix(), std::process::id()))
+}
+
+fn cef_cache_prefix() -> String {
+    format!(
+        "cef-cache-{}-",
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_name().map(|f| f.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "app".to_string())
+    )
+}
+
+/// A client that dies without running `cef_shutdown` (`kill -9`, a crash) strands its profile,
+/// ~70MB a time. Drop the ones whose owning process is gone before adding another.
+#[cfg(unix)]
+fn reap_abandoned_cache_dirs() {
+    let prefix = cef_cache_prefix();
+    let Ok(entries) = std::fs::read_dir(std::env::temp_dir()) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.strip_prefix(&prefix))
+            .and_then(|pid| pid.parse::<libc::pid_t>().ok())
+            .filter(|pid| *pid > 0)
+        else {
+            continue;
+        };
+        // signal 0 only probes: ESRCH means the owner is gone, so nothing is still writing there
+        // (EPERM - a live process we don't own - leaves it alone).
+        let gone = unsafe { libc::kill(pid, 0) } == -1
+            && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH);
+        if gone {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+// No cheap liveness probe without libc; stray profiles wait for %TEMP% to be cleared.
+#[cfg(not(unix))]
+fn reap_abandoned_cache_dirs() {}
 
 // The packaged layout: <exe>/../Frameworks/Chromium Embedded Framework.framework.
 #[cfg(target_os = "macos")]
@@ -162,8 +211,9 @@ fn exit_on_shutdown_signal(mut sent: Local<bool>, mut exit: EventWriter<AppExit>
     }
 }
 
-fn cef_shutdown(_: NonSend<RunOnMainThread>) {
+fn cef_shutdown(_: NonSend<RunOnMainThread>, cache_dir: Res<CefCacheDir>) {
     shutdown();
+    let _ = std::fs::remove_dir_all(&cache_dir.0);
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/cef_offscreen/src/message_loop.rs
+++ b/crates/cef_offscreen/src/message_loop.rs
@@ -30,7 +30,7 @@ impl Plugin for MessageLoopPlugin {
         app.add_systems(Main, cef_do_message_loop_work);
         // .before so cef_shutdown's on_event condition sees the AppExit written here in the
         // same frame — the runner exits right after it, so a lost race skips cef shutdown
-        #[cfg(target_os = "macos")]
+        #[cfg(unix)]
         app.add_systems(Update, exit_on_shutdown_signal.before(cef_shutdown));
     }
 }
@@ -93,8 +93,8 @@ impl Default for MessageLoopPlugin {
             ),
             1
         );
-        #[cfg(target_os = "macos")]
-        macos::install_shutdown_signal_handlers();
+        #[cfg(unix)]
+        unix::install_shutdown_signal_handlers();
 
         Self {
             _app: Box::new(app),
@@ -203,9 +203,9 @@ fn cef_do_message_loop_work(_: NonSend<RunOnMainThread>) {
     cef::do_message_loop_work();
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(unix)]
 fn exit_on_shutdown_signal(mut sent: Local<bool>, mut exit: EventWriter<AppExit>) {
-    if !*sent && macos::shutdown_signal_received() {
+    if !*sent && unix::shutdown_signal_received() {
         *sent = true;
         exit.write_default();
     }
@@ -214,6 +214,41 @@ fn exit_on_shutdown_signal(mut sent: Local<bool>, mut exit: EventWriter<AppExit>
 fn cef_shutdown(_: NonSend<RunOnMainThread>, cache_dir: Res<CefCacheDir>) {
     shutdown();
     let _ = std::fs::remove_dir_all(&cache_dir.0);
+}
+
+#[cfg(unix)]
+mod unix {
+    use core::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    static SHUTDOWN_SIGNAL: AtomicBool = AtomicBool::new(false);
+
+    pub fn shutdown_signal_received() -> bool {
+        SHUTDOWN_SIGNAL.load(Ordering::Relaxed)
+    }
+
+    extern "C" fn flag_shutdown_signal(signal: libc::c_int) {
+        if SHUTDOWN_SIGNAL.swap(true, Ordering::Relaxed) {
+            // a repeated signal means the graceful exit isn't getting there; bail out hard
+            unsafe { libc::_exit(128 + signal) };
+        }
+    }
+
+    /// Chromium installs SIGINT/SIGTERM/SIGHUP handlers during cef initialize, and they tear the
+    /// process down through Chromium's own quit path rather than ours, so ctrl+c never reaches
+    /// bevy: cef shutdown doesn't run, and on macos it wedges outright. There the handler calls
+    /// -[NSApplication terminate:] from the message pump, re-entering winit's
+    /// applicationWillTerminate delegate from inside cef_do_message_loop_work (itself inside a
+    /// winit event-loop callback); it panics across a cannot-unwind boundary and the abort()
+    /// hangs in __pthread_kill, leaving an unkillable zombie. Replace the handlers: flag the
+    /// signal and let the app wind down through AppExit, which already runs cef shutdown.
+    pub fn install_shutdown_signal_handlers() {
+        unsafe {
+            for sig in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+                libc::signal(sig, flag_shutdown_signal as *const () as libc::sighandler_t);
+            }
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -242,34 +277,6 @@ mod macos {
 
     extern "C" fn set_handling_send_event(_: &Object, _: Sel, flag: bool) {
         IS_HANDLING_SEND_EVENT.swap(flag, Ordering::Relaxed);
-    }
-
-    static SHUTDOWN_SIGNAL: AtomicBool = AtomicBool::new(false);
-
-    pub fn shutdown_signal_received() -> bool {
-        SHUTDOWN_SIGNAL.load(Ordering::Relaxed)
-    }
-
-    extern "C" fn flag_shutdown_signal(signal: libc::c_int) {
-        if SHUTDOWN_SIGNAL.swap(true, Ordering::Relaxed) {
-            // a repeated signal means the graceful exit isn't getting there; bail out hard
-            unsafe { libc::_exit(128 + signal) };
-        }
-    }
-
-    /// Chromium installs SIGINT/SIGTERM/SIGHUP handlers during cef initialize that call
-    /// -[NSApplication terminate:] from the message pump. winit's applicationWillTerminate
-    /// delegate is then re-entered from inside cef_do_message_loop_work (itself inside a winit
-    /// event-loop callback) and panics across a cannot-unwind boundary; the abort() wedges in
-    /// __pthread_kill, leaving an unkillable zombie that still holds the CEF cache singleton
-    /// and blocks every relaunch. Replace the handlers: flag the signal and let the app wind
-    /// down through AppExit, which already runs cef shutdown.
-    pub fn install_shutdown_signal_handlers() {
-        unsafe {
-            for sig in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
-                libc::signal(sig, flag_shutdown_signal as *const () as libc::sighandler_t);
-            }
-        }
     }
 
     pub fn install_cef_app_protocol() {


### PR DESCRIPTION
Two related CEF shutdown/startup fixes.

**Per-client CEF profile.** `root_cache_path` was `$TMPDIR/cef-cache-<exe>`, shared by every instance of the executable, so a second native client contended on Chromium's process singleton there — and on macos on the mach service name, which hashes that path. The second client failed with `bootstrap_check_in .apps.<md5>: Permission denied (1100)` and `Failed to open UKM database: database is locked`. The same contention is what made a wedged client block every relaunch until reboot.

The dir is now keyed on the pid and removed again in `cef_shutdown`. Nothing in the profile needs to outlive the run — the identity is stored engine-side. A client that dies without running `cef_shutdown` strands ~70MB, so startup reaps the profiles whose owning pid is gone (`kill(pid, 0)` → `ESRCH`); no cheap liveness probe on windows, so stray dirs there wait for `%TEMP%` to be cleared.

**Shutdown signals on linux.** Chromium installs SIGINT/SIGTERM/SIGHUP handlers during cef initialize and tears the process down through its own quit path, so ctrl+c never reaches bevy and cef shutdown doesn't run. Only macos overrode them (#980, where the handler additionally wedged in `-[NSApplication terminate:]` re-entering winit's `applicationWillTerminate`). The override moves into a `cfg(unix)` module so linux gets it too; the ObjC `isHandlingSendEvent` shim stays macos-only. Behaviour on macos is unchanged — same handler, same atomic, same `AppExit` path.