### PR TITLE
Start fresh profiles at version 0 so the first edit is a new version

### DIFF
--- a/crates/common/src/profile.rs
+++ b/crates/common/src/profile.rs
@@ -138,7 +138,7 @@ impl Default for SerializedProfile {
         Self {
             user_id: Default::default(),
             name: "Bevy_User".to_string(),
-            version: 1,
+            version: 0,
             eth_address: "0x0000000000000000000000000000000000000000".to_owned(),
             has_claimed_name: Default::default(),
             has_connected_web3: Default::default(),


### PR DESCRIPTION
A fresh profile (guest login, new web3 account) is built as `UserProfile { version: 0 }` with `SerializedProfile::default()`, whose `version` was 1 — so `profile.version` and `content.version` start out disagreeing.

The two fields travel different paths: the owner's version announcements carry `profile.version`, while peers resolving the profile p2p derive the version from the serialized content. A peer that resolves a fresh guest therefore caches the profile as v1. The owner's first edit bumps `profile.version` 0 → 1 (syncing `content.version`), so the announced version is exactly what peers already hold — they never refetch, and the first profile change is invisible until a second edit pushes the version to 2.

Zero the content default so both fields start at 0 and the first edit announces a genuinely new version.

Web3 users with an existing catalyst profile were unaffected (their loaded profile is internally consistent), which is why this only showed up for guests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkfpispXnwJv8WpbbYvK3G