### PR TITLE
Accept content-versioned b64 preview ids when decoding local-scene hashes

### DIFF
--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -1981,15 +1981,23 @@ impl Drop for DeferredDropper {
     }
 }
 
-/// Splits a dev server's b64 hash payload — `"{projectRoot}{sep}{key}-{machineId}"` — at its
-/// `/{key}-` marker into (projectRoot, machineId), both in their original case and separators.
-/// The marker is matched case-insensitively (collection keys are lowercased while the encoded
-/// path keeps its casing) and separator-insensitively (a Windows dev server encodes backslash
-/// paths); both normalizations are byte-for-byte over the ASCII they rewrite, so an index found
-/// in the normalized copy still slices `decoded` itself.
+/// Splits a dev server's b64 hash payload — plain `"{projectRoot}{sep}{key}-{machineId}"` or
+/// content-versioned `"{projectRoot}{sep}{key}\0{mtime}-{machineId}"` (sdk-commands embeds the
+/// file's mtime after a NUL byte so the id changes when the file does; paths can't contain NUL,
+/// so the forms are unambiguous) — at its `/{key}` marker into (projectRoot, machineId), both in
+/// their original case and separators. The marker is matched case-insensitively (collection keys
+/// are lowercased while the encoded path keeps its casing) and separator-insensitively (a Windows
+/// dev server encodes backslash paths); both normalizations are byte-for-byte over the ASCII they
+/// rewrite, so an index found in the normalized copy still slices `decoded` itself.
 fn b64_split_at_key<'a>(decoded: &'a str, key: &str) -> Option<(&'a str, &'a str)> {
+    let normalized = decoded.replace('\\', "/").to_lowercase();
+    if let Some(idx) = normalized.rfind(&format!("/{key}\u{0}")) {
+        // mtime is digits only, so the first '-' after the NUL starts the machineId
+        let (_mtime, machine_id) = decoded[idx + key.len() + 2..].split_once('-')?;
+        return Some((&decoded[..idx], machine_id));
+    }
     let marker = format!("/{key}-");
-    let idx = decoded.replace('\\', "/").to_lowercase().rfind(&marker)?;
+    let idx = normalized.rfind(&marker)?;
     Some((&decoded[..idx], &decoded[idx + marker.len()..]))
 }
 
@@ -2017,5 +2025,19 @@ mod tests {
             b64_split_at_key(r"C:\Users\bob\scene\models\Tree.glb-pc", "scene.json"),
             None
         );
+    }
+
+    #[test]
+    fn splits_content_versioned_path() {
+        let decoded = "/Users/bob/scene/models/Tree.glb\u{0}1786032377138-my-mac";
+        let split = b64_split_at_key(decoded, "models/tree.glb");
+        assert_eq!(split, Some(("/Users/bob/scene", "my-mac")));
+    }
+
+    #[test]
+    fn splits_content_versioned_windows_path() {
+        let decoded = "C:\\Users\\bob\\scene\\models\\Tree.glb\u{0}1786032377138-my-pc";
+        let split = b64_split_at_key(decoded, "models/tree.glb");
+        assert_eq!(split, Some((r"C:\Users\bob\scene", "my-pc")));
     }
 }


### PR DESCRIPTION
decentraland/js-sdk-toolchain#1529 proposes embedding a file's mtime in `dcl start` preview content ids — `b64-<base64(path \0 truncatedMtimeMs -machineId)>` — so ids become self-invalidating cache keys. Paths can't contain NUL, so the versioned form is unambiguously distinguishable from the current plain `path-machineId` form, and the sdk decoder accepts both.

Our content pipeline treats these ids as opaque and never disk-caches `b64-` hashes, so serving is unaffected — but `b64_split_at_key` (the shared key-anchored decode behind `local_project_root` and `local_b64_hash_for`) anchors on `/{key}-`, which the NUL breaks. Against a versioned server every collection entry would fail to decode: the editor would treat local scenes as deployed (save/import disabled), `refresh_scene_collection` would no-op, and imported assets would fall back to source-CID hashes and 404 until reload.

This teaches `b64_split_at_key` to recognise the NUL-terminated form first (machineId starts at the first `-` after the NUL — mtime is digits only, so hyphen-containing machine ids still split correctly), falling back to the existing plain-form logic unchanged. Composes with the Windows separator handling from #1121. Minted ids stay plain, which the new server decoder explicitly accepts, so no mtime knowledge is needed on our side.

Works against both current and versioned sdk-commands servers; draft until the sdk PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)