### PR TITLE
Bound new_in_range to its range instead of walking past the end

### DIFF
--- a/crates/dcl/src/interface/crdt_context.rs
+++ b/crates/dcl/src/interface/crdt_context.rs
@@ -141,11 +141,21 @@ impl CrdtContext {
     }
 
     pub fn new_in_range(&mut self, range: &RangeInclusive<u16>) -> Option<SceneEntityId> {
-        let mut next_new = self.last_new.wrapping_add(1);
-        if !range.contains(&self.last_new) {
-            self.last_new = *range.end();
-            next_new = *range.start();
+        if range.is_empty() {
+            return None;
         }
+        let (start, end) = (*range.start(), *range.end());
+
+        let mut next_new = if range.contains(&self.last_new) {
+            if self.last_new == end {
+                start
+            } else {
+                self.last_new + 1
+            }
+        } else {
+            self.last_new = end;
+            start
+        };
 
         while next_new != self.last_new {
             if !self.entity_entry(next_new).1 {
@@ -154,10 +164,7 @@ impl CrdtContext {
                 self.last_new = next_new;
                 return Some(new_id);
             }
-            next_new += 1;
-            if !range.contains(&self.last_new) {
-                self.last_new = *range.start();
-            }
+            next_new = if next_new == end { start } else { next_new + 1 };
         }
 
         None


### PR DESCRIPTION
Fixes #1107. 

The first half (the duplicate `FOREIGN_PLAYER_RANGE` constants) was already resolved by #1102, which removed the module-level copy in `global_crdt.rs` and left `SceneEntityId::FOREIGN_PLAYER_RANGE = 6..=405` as the single definition.

`CrdtContext::new_in_range` tested `self.last_new` in its wrap guard, but the loop only ever advances `next_new`. So the guard never fired, `next_new` incremented past `*range.end()` unchecked, and since `entity_entry` accepts any `u16` the scan kept walking and returned ids outside the requested range. `next_new += 1` also overflow-panics once the walk reaches 65535 — or wraps to 0 in release and starts handing out the reserved static ids (`ROOT`, `PLAYER`, `CAMERA`).

The fix tests the variable that moves, in both the entry and the advance step. The advance step is the one-liner the issue suggests; the entry step needs it too, because with `last_new == *range.end()` the range still contains `last_new`, so no reset fires and `next_new` starts one past the end — putting the very first `entity_entry` call out of range.

Empty ranges return `None` up front. With wrapping in the loop a reversed range would otherwise spin forever rather than walk off the end as it did before.

### Reachability

Lower than when the issue was filed. The foreign-player allocator that motivated it no longer calls `new_in_range` at all — #1102 replaced it with `PlayerIdAllocator`, a free-list plus cursor already bounded by `checked_add` and an explicit end check. The only remaining caller is the inspector's `AllocateEntity` path (`crates/dcl/src/js/engine.rs`) over `512..=u16::MAX - 1`, so it takes ~65k simultaneously-live entities in one scene context to reach. Worth fixing anyway: the range currently documents an invariant it doesn't enforce, and the failure mode when crossed is silent cross-wiring rather than a clean `None`.

### Not included

- No unit test — the `dcl` crate has no test module anywhere, and adding the infrastructure felt out of scope for a focused fix. Happy to add one if you'd rather have it.
- A one-element range (`7..=7`) still yields `None`; `last_new` acts as an exclusive sentinel so there's nothing to scan. Pre-existing and unchanged here, and no caller uses such a range.