### PR TITLE
Read all four nine-slice border edges

### DIFF
--- a/crates/assets/src/assets/shaders/nineslice_material.wgsl
+++ b/crates/assets/src/assets/shaders/nineslice_material.wgsl
@@ -14,7 +14,7 @@ struct SliceData {
 fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     var uv = in.uv;
     let image_size = vec2<f32>(textureDimensions(image_texture));
-    let border_size = vec2<f32>(slice_data.bounds.x + slice_data.bounds.z, slice_data.bounds.y + slice_data.bounds.z);
+    let border_size = vec2<f32>(slice_data.bounds.x + slice_data.bounds.z, slice_data.bounds.y + slice_data.bounds.w);
     let position = in.uv * slice_data.surface.xy;
 
     if slice_data.surface.x > image_size.x {

--- a/crates/ui_core/src/nine_slice.rs
+++ b/crates/ui_core/src/nine_slice.rs
@@ -113,18 +113,18 @@ fn update_slices(
                 .unwrap_or(0.0),
             slice
                 .center_region
-                .left
+                .top
+                .resolve(image_size.y, Vec2::ZERO)
+                .unwrap_or(0.0),
+            slice
+                .center_region
+                .right
                 .resolve(image_size.x, Vec2::ZERO)
                 .unwrap_or(0.0),
             slice
                 .center_region
-                .left
-                .resolve(image_size.x, Vec2::ZERO)
-                .unwrap_or(0.0),
-            slice
-                .center_region
-                .left
-                .resolve(image_size.x, Vec2::ZERO)
+                .bottom
+                .resolve(image_size.y, Vec2::ZERO)
                 .unwrap_or(0.0),
         );
         let surface = whole_pixel_size(node);


### PR DESCRIPTION
Fixes #1076.

`update_slices` resolved `center_region.left` four times, so the GPU `bounds` vec4 carried the left border width in every lane — any `Ui9Slice` with an asymmetric rect rendered with uniform borders. This isn't only a dui-property concern: scene UIs reach the same path via `BackgroundTextureMode::NineSlices(BorderRect)`, which converts to a `UiRect` of `Val::Percent` per edge.

- read `top`/`right`/`bottom` as well, and resolve the vertical edges against `image_size.y` instead of `.x` so percentage top/bottom borders scale off the image height
- `nineslice_material.wgsl`: `border_size.y` summed `bounds.y + bounds.z` (top + right) rather than `bounds.y + bounds.w`. Harmless while all four lanes were equal, wrong the moment the CPU side is fixed, so it lands in the same change.