### PR TITLE
fix(chat): don't leak zero address as sender for system/console chat messages

### DIFF
--- a/crates/system_ui/src/chat/mod.rs
+++ b/crates/system_ui/src/chat/mod.rs
@@ -684,10 +684,14 @@ fn pipe_chats_to_scene(
             .iter()
             .any(|marker| ce.message.starts_with(*marker))
     }) {
-        let player_address = if chat_event.sender == Entity::PLACEHOLDER {
-            Some(Default::default())
+        // System/console messages (e.g. "Realm set to `...`") have no real player behind
+        // them. Previously these defaulted to the zero address, which the frontend rendered
+        // as a fake "0x0000...0000" sender bubble instead of a system message. Send the
+        // literal "system" sentinel the chat UI's `isSystem()` check recognizes instead.
+        let sender_address = if chat_event.sender == Entity::PLACEHOLDER {
+            "system".to_owned()
         } else {
-            players
+            let player_address = players
                 .get(chat_event.sender)
                 .ok()
                 .map(|fp| fp.address)
@@ -697,17 +701,19 @@ fn pipe_chats_to_scene(
                     } else {
                         None
                     }
-                })
-        };
+                });
 
-        let Some(player_address) = player_address else {
-            warn!("no player for {chat_event:?}");
-            continue;
+            let Some(player_address) = player_address else {
+                warn!("no player for {chat_event:?}");
+                continue;
+            };
+
+            format!("{player_address:#x}")
         };
 
         for sender in senders.iter() {
             let _ = sender.send(ChatMessage {
-                sender_address: format!("{player_address:#x}"),
+                sender_address: sender_address.clone(),
                 message: chat_event.message.clone(),
                 channel: chat_event.channel.clone(),
             });


### PR DESCRIPTION
## Bug

A user reported (screenshot) a fake chat message from sender `0x0000...0000` immediately followed by a debug/console line like `Realm set to \`https://peer.decentraland.org/content\``.

## Root cause

System/console lines (emitted via `PrintConsoleLine`, e.g. `"Realm set to \`{realm}\`"` in `crates/ipfs/src/lib.rs`) are pushed as `ChatEvent { sender: Entity::PLACEHOLDER, .. }`.

`pipe_chats_to_scene` (in `crates/system_ui/src/chat/mod.rs`), which bridges chat events over the `GetChatStream` RPC to the react-web frontend, defaulted `player_address` to `Address::default()` (the zero address) whenever `sender == Entity::PLACEHOLDER`, then formatted it as the message's `sender_address`.

The react-web chat UI's `isSystem()` check (`react-web/src/features/chat/Chat.tsx`) only treats an empty string or the literal `"system"` as a system message:

```ts
function isSystem(sender: string): boolean {
  return !sender || sender.toLowerCase() === 'system'
}
```

So a zero-address string didn't match, fell through to `shortAddr()`, and rendered as if a real user with address `0x0000...0000` had sent the message.

## Fix

Send the `"system"` sentinel for `Entity::PLACEHOLDER`-sourced chat events instead of a fake zero address, matching the contract `isSystem()`/`displaySender()` already expect.

## Scope note

This only touches the RPC bridge that feeds the react-web chat panel (`pipe_chats_to_scene`). There's an analogous native/dui-based chat renderer in the same file (`update_chat`/`ConversationManager::add_message`) with a similar `.or(Some(Address::zero()))` pattern, but per an in-file comment ("we're the only consumer now the SDK7 chat UI is gone") the react-web path looks like the live one, and I didn't want to touch dui-rendering behavior (bubble alignment/template selection) without being able to verify it visually in this environment. Flagging for a maintainer to confirm whether that path is still live and needs the same treatment.

I don't have a local Rust toolchain in this environment to run `cargo build`/`clippy` — please let CI confirm, and happy to address any fallout.

Requested by Gon via Slack
