### PR TITLE
fix: align FOREIGN_PLAYER_RANGE with ADR-245

### DIFF
--- a/crates/dcl_component/src/lib.rs
+++ b/crates/dcl_component/src/lib.rs
@@ -132,7 +132,8 @@ impl SceneEntityId {
     pub const CAMERA: SceneEntityId = Self::reserved(2);
     pub const WORLD_ORIGIN: SceneEntityId = Self::reserved(5);
 
-    pub const FOREIGN_PLAYER_RANGE: RangeInclusive<u16> = 6..=405;
+    /// ADR-245 reserves entity numbers 32..256 for player data components.
+    pub const FOREIGN_PLAYER_RANGE: RangeInclusive<u16> = 32..=255;
 
     /// size for a table indexed by `id`: both 0 and 65535 are valid indexes
     pub const LIVE_TABLE_LEN: usize = u16::MAX as usize + 1;

--- a/docs/PRESENCE_ISOLATION.md
+++ b/docs/PRESENCE_ISOLATION.md
@@ -32,7 +32,7 @@ bound, so an (unexpected) roomless scene sees nobody.
 `ForeignPlayer` entities belong to a context (`ForeignPlayer.context`). The same wallet
 connected to two rooms is simply **two entities**, one per context, each with its own
 `scene_id` allocated from its context's `PlayerIdAllocator` (over
-`SceneEntityId::FOREIGN_PLAYER_RANGE`, so each room hosts the full ~400-player range;
+`SceneEntityId::FOREIGN_PLAYER_RANGE`, so each room hosts the full 224-player range;
 freed ids are re-issued with a bumped generation so scenes see a recycled id as a fresh
 entity). Per-room connect/disconnect therefore falls out of ordinary entity lifecycle:
 joining a second room creates a player entity in that context (identity write + profile


### PR DESCRIPTION
## What

`SceneEntityId::FOREIGN_PLAYER_RANGE` becomes `32..=255`, matching the band [ADR-245](https://adr.decentraland.org/adr/ADR-245) reserves for player data components.

## Why

The old `6..=405` predates the ADR. It landed in the first Comms PR (#18, May 2023); ADR-245 is dated August 2023 and the constant was never reconciled. An accident of chronology rather than a deliberate deviation — but it leaves bevy the only host allocating player entities outside the reserved band. `hammurabi-headless`, `godot-explorer` and `unity-explorer` all use `[32, 256)`.

## What the mismatch can cause

**Scenes that identify players by entity number see the wrong set.** Checking `n >= 32 && n < 256` is a common shortcut for "is this a player entity", and on bevy it misses ids `6..31` and `256..405` — 176 of the 400 slots.

**The misses are concentrated where they hurt most.** `PlayerIdAllocator` starts at the bottom of the range, so the **first 26 players to join a room get ids `6..31`**, entirely below the band. A room with fewer than 26 concurrent players can have *every* player invisible to such a check; a busier room has some work and some not, depending on join order. Because freed ids are re-issued LIFO, churn keeps reusing those low numbers rather than moving past them.

Nothing errors in any of this. The same scene bundle behaves differently on bevy than on every other host, silently.

**It also occupies space the reserved block has not allocated yet.** ADR-219 reserves `[0, 512)` and names only 0/1/2; `6..31` sits directly above the named statics, which is where future static entities are most likely to be assigned. Live player entities there would collide with any such assignment.

Test fixtures, dashboards and log tooling keyed to `32..255` under-report on bevy for the same reason.

## Impact

Capacity per crdt context goes from 400 to 224 slots — the figure the ADR sizes for (224 × 65536 = the 14,680,064 unique players it cites). With presence isolated per room, each room still gets the full band.

Entity ids are per-session and host-assigned, and the SDK's comms filter drops `entityId < 512`, so they never cross the peer wire. Nothing to migrate.

## Notes

`WORLD_ORIGIN = 5` is left alone here. It is a bevy-only claim on the same unallocated reserved space and worth standardising, but that needs an ADR-219 conversation rather than a code change.

`cargo check` and `cargo test` pass for `dcl_component`. No test or fixture referenced the old bounds.