### PR TITLE
fix(web-hud): withdraw queued permission prompts the engine has already resolved

### DIFF
--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -17,7 +17,7 @@ use system_bridge::{
     settings::SettingInfo, AvatarModifierState, BlockUpdateData, BlockedUserData,
     BlockingStatusData, ChatMessage, FriendConnectivityEvent, FriendData, FriendRequestData,
     FriendStatusData, FriendshipEventUpdate, HomeScene, HoverEvent, LiveSceneInfo,
-    PermanentPermissionItem, PermissionRequest, ProximityEvent, SceneLoadingUi, SetAvatarData,
+    PermanentPermissionItem, PermissionRequestEvent, ProximityEvent, SceneLoadingUi, SetAvatarData,
     SetPermanentPermission, SetSinglePermission, SystemApi, VoiceMessage,
 };
 
@@ -525,11 +525,11 @@ pub async fn op_get_permission_request_stream(state: Rc<RefCell<impl State>>) ->
 pub async fn op_read_permission_request_stream(
     state: Rc<RefCell<impl State>>,
     _rid: u32,
-) -> Result<Option<PermissionRequest>, anyhow::Error> {
+) -> Result<Option<PermissionRequestEvent>, anyhow::Error> {
     debug!("op_read_permission_request_stream");
     let Some(mut receiver) = state
         .borrow_mut()
-        .try_take::<RpcStreamReceiver<PermissionRequest>>()
+        .try_take::<RpcStreamReceiver<PermissionRequestEvent>>()
     else {
         return Ok(None);
     };

--- a/crates/dcl_deno/src/js/op_wrappers/system_api.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/system_api.rs
@@ -11,7 +11,7 @@ use system_bridge::{
     settings::SettingInfo, AvatarModifierState, BlockUpdateData, BlockedUserData,
     BlockingStatusData, ChatMessage, FriendConnectivityEvent, FriendData, FriendRequestData,
     FriendStatusData, FriendshipEventUpdate, HomeScene, HoverEvent, LiveSceneInfo,
-    PermanentPermissionItem, PermissionRequest, ProximityEvent, SceneLoadingUi, SetAvatarData,
+    PermanentPermissionItem, PermissionRequestEvent, ProximityEvent, SceneLoadingUi, SetAvatarData,
     VoiceMessage,
 };
 
@@ -336,7 +336,7 @@ pub async fn op_get_permission_request_stream(state: Rc<RefCell<OpState>>) -> u3
 pub async fn op_read_permission_request_stream(
     state: Rc<RefCell<OpState>>,
     rid: u32,
-) -> Result<Option<PermissionRequest>, deno_core::anyhow::Error> {
+) -> Result<Option<PermissionRequestEvent>, deno_core::anyhow::Error> {
     dcl::js::system_api::op_read_permission_request_stream(state, rid).await
 }
 

--- a/crates/system_api_types/src/lib.rs
+++ b/crates/system_api_types/src/lib.rs
@@ -356,6 +356,18 @@ pub struct PermissionRequest {
     pub id: usize,
 }
 
+#[derive(Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(tag = "type")]
+#[ts(export)]
+pub enum PermissionRequestEvent {
+    #[serde(rename = "request")]
+    Request(PermissionRequest),
+    // a streamed request no longer needs a decision: the engine resolved it itself (e.g. a
+    // permanent rule set for an earlier request now covers it, or the scene went away)
+    #[serde(rename = "cancelled")]
+    Cancelled { id: usize },
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export)]
 pub struct SetSinglePermission {

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -113,7 +113,7 @@ pub enum SystemApi {
     GetBridgeStream(RpcStreamSender<String>),
     SendChat(String, String),
     Quit,
-    GetPermissionRequestStream(RpcStreamSender<PermissionRequest>),
+    GetPermissionRequestStream(RpcStreamSender<PermissionRequestEvent>),
     SetSinglePermission(SetSinglePermission),
     SetPermanentPermission(SetPermanentPermission),
     GetPermissionUsedStream(RpcStreamSender<PermissionUsed>),

--- a/crates/system_ui/src/permission_manager.rs
+++ b/crates/system_ui/src/permission_manager.rs
@@ -17,7 +17,7 @@ use scene_runner::{
     renderer_context::RendererSceneContext,
     ContainingScene, Toaster,
 };
-use system_bridge::{NativeUi, PermanentPermissionItem, SystemApi};
+use system_bridge::{NativeUi, PermanentPermissionItem, PermissionRequestEvent, SystemApi};
 use tokio::sync::oneshot::error::TryRecvError;
 use ui_core::{
     button::DuiButton,
@@ -340,10 +340,10 @@ pub fn handle_scene_permissions(
     mut manager: ResMut<PermissionManager>,
     mut config: ResMut<AppConfig>,
     mut system_events: EventReader<SystemApi>,
-    mut requests_streams: Local<Vec<RpcStreamSender<system_bridge::PermissionRequest>>>,
+    mut requests_streams: Local<Vec<RpcStreamSender<PermissionRequestEvent>>>,
     mut used_streams: Local<Vec<RpcStreamSender<PermissionUsed>>>,
-    // corresponds to the items in the manager deque
-    mut permission_ids: Local<Vec<usize>>,
+    // corresponds to the items in the manager deque (None = never streamed)
+    mut permission_ids: Local<Vec<Option<usize>>>,
     mut inc: Local<usize>,
     scenes: Query<&RendererSceneContext>,
     current_realm: Res<CurrentRealm>,
@@ -359,16 +359,20 @@ pub fn handle_scene_permissions(
             SystemApi::GetPermissionRequestStream(stream) => {
                 // send any current outstanding requests when a new stream is attached
                 for (handle, req) in permission_ids.iter().zip(manager.pending.iter()) {
-                    let Ok(hash) = scenes.get(req.scene).map(|ctx| &ctx.hash) else {
+                    let (Some(handle), Ok(hash)) =
+                        (handle, scenes.get(req.scene).map(|ctx| &ctx.hash))
+                    else {
                         continue;
                     };
 
-                    let _ = stream.send(system_bridge::PermissionRequest {
-                        ty: req.ty,
-                        additional: req.additional.clone(),
-                        scene: hash.clone(),
-                        id: *handle,
-                    });
+                    let _ = stream.send(PermissionRequestEvent::Request(
+                        system_bridge::PermissionRequest {
+                            ty: req.ty,
+                            additional: req.additional.clone(),
+                            scene: hash.clone(),
+                            id: *handle,
+                        },
+                    ));
                 }
 
                 requests_streams.push(stream.clone())
@@ -378,7 +382,7 @@ pub fn handle_scene_permissions(
                 let Some((index, _)) = permission_ids
                     .iter()
                     .enumerate()
-                    .find(|(_, id)| **id == result.id)
+                    .find(|(_, id)| **id == Some(result.id))
                 else {
                     warn!("permission request with id {} not found", result.id);
                     continue;
@@ -454,6 +458,7 @@ pub fn handle_scene_permissions(
 
         let Ok(hash) = scenes.get(req.scene).map(|ctx| &ctx.hash) else {
             resolved.insert(i, false);
+            permission_ids.push(None);
             continue;
         };
 
@@ -470,19 +475,23 @@ pub fn handle_scene_permissions(
             PermissionValue::Ask => true,
         };
 
-        let next_id = *inc;
-        if needs_request {
+        let next_id = needs_request.then(|| {
+            let next_id = *inc;
             *inc += 1;
 
             for req_stream in requests_streams.iter() {
-                let _ = req_stream.send(system_bridge::PermissionRequest {
-                    ty: req.ty,
-                    additional: req.additional.clone(),
-                    scene: hash.clone(),
-                    id: next_id,
-                });
+                let _ = req_stream.send(PermissionRequestEvent::Request(
+                    system_bridge::PermissionRequest {
+                        ty: req.ty,
+                        additional: req.additional.clone(),
+                        scene: hash.clone(),
+                        id: next_id,
+                    },
+                ));
             }
-        }
+
+            next_id
+        });
 
         permission_ids.push(next_id);
     }
@@ -498,11 +507,17 @@ pub fn handle_scene_permissions(
     requests_streams.retain(|s| !s.is_closed());
     used_streams.retain(|s| !s.is_closed());
 
-    // send out resolved items
+    // send out resolved items, and tell the streams any request they were shown is no longer open
     for (index, result) in resolved.iter().rev() {
-        permission_ids.remove(*index);
+        let id = permission_ids.remove(*index);
         let perm = manager.pending.remove(*index).unwrap();
         perm.sender.send(*result);
+
+        if let Some(id) = id {
+            for req_stream in requests_streams.iter() {
+                let _ = req_stream.send(PermissionRequestEvent::Cancelled { id });
+            }
+        }
     }
 
     // send out uses

--- a/react-web/bridge-scene/src/bevy-api.ts
+++ b/react-web/bridge-scene/src/bevy-api.ts
@@ -13,7 +13,7 @@ import type {
   HoverAction,
   HoverEvent,
   LiveSceneInfo,
-  PermissionRequest,
+  PermissionRequestEvent,
   ProximityEvent,
   SceneLoadingUi,
   SetAvatarData,
@@ -74,9 +74,10 @@ export type KernelFetchRequest = {
 }
 export type KernelFetchResponse = { ok: boolean; status: number; statusText?: string; body: string }
 
-// A scene's pending permission request (e.g. ChangeRealm). `ty` is the serde enum name
-// (e.g. 'ChangeRealm'); `scene` is the scene HASH — resolve its title via liveSceneInfo().
-export type PermissionRequestRaw = PermissionRequest
+// A scene's pending permission request (`type: 'request'`; `ty` is the serde enum name, e.g.
+// 'ChangeRealm'; `scene` is the scene HASH — resolve its title via liveSceneInfo()), or
+// `type: 'cancelled'` when the engine resolved an earlier request itself.
+export type PermissionRequestRaw = PermissionRequestEvent
 // Persist a permission at a level. `value` is the scene hash (Scene) or realm url (Realm),
 // unused for Global. `allow: null` clears the stored value.
 export type SetPermanentPermissionBody = {

--- a/react-web/bridge-scene/src/domains/permissions.ts
+++ b/react-web/bridge-scene/src/domains/permissions.ts
@@ -10,6 +10,11 @@ export function registerPermissions(ctx: Ctx): void {
     try {
       const stream = await BevyApi.getPermissionRequestStream()
       for await (const req of stream) {
+        if (req.type === 'cancelled') {
+          // resolved engine-side (an "Always …" answer to an earlier prompt covers it): drop the prompt
+          ctx.send({ kind: 'permissionWithdrawn', id: req.id })
+          continue
+        }
         // The engine's request only carries the scene HASH. Resolve the title (hash→title) and the
         // current realm from the existing SystemApi — same as the SDK7 scene, so no Rust change.
         // Both are best-effort: a failure must never drop the request (else no dialog ever shows).

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -489,6 +489,13 @@ export interface PermissionRequestMessage {
   additional?: string
 }
 
+/** A queued permission prompt the engine has already resolved (a permanent rule set for an earlier
+ *  prompt now covers it) — the HUD drops it without asking. */
+export interface PermissionWithdrawnMessage {
+  kind: 'permissionWithdrawn'
+  id: number
+}
+
 /** Which scope an Allow/Deny applies to. `once` = just this request; the rest persist a rule. */
 export type PermissionLevelChoice = 'once' | 'scene' | 'realm' | 'global'
 
@@ -995,6 +1002,7 @@ export type SceneToPage =
   | GalleryMessage
   | GalleryPhotoMessage
   | PermissionRequestMessage
+  | PermissionWithdrawnMessage
 
 // ---- envelope --------------------------------------------------------------
 

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -703,6 +703,9 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
         case 'permissionRequest':
           setPermissionQueue((q) => (q.some((r) => r.id === msg.id) ? q : [...q, msg]))
           break
+        case 'permissionWithdrawn':
+          setPermissionQueue((q) => q.filter((r) => r.id !== msg.id))
+          break
       }
     })
 

--- a/react-web/src/test/permissions.test.tsx
+++ b/react-web/src/test/permissions.test.tsx
@@ -50,6 +50,16 @@ describe('permissions domain', () => {
     expect(h.session().permissions.pending).toHaveLength(0)
   })
 
+  it('a withdrawn request is dropped from the queue without a decision', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    h.driver.emit(REQ)
+    h.driver.emit({ ...REQ, id: 8 })
+    h.driver.emit({ kind: 'permissionWithdrawn', id: 8 })
+    expect(h.session().permissions.pending.map((r) => r.id)).toEqual([7])
+    expect(h.driver.last('permissionResolve')).toBeUndefined()
+  })
+
   it('a permanent-level deny carries the chosen scope back', async () => {
     const h = renderSession()
     await enterAsGuest(h)


### PR DESCRIPTION
Closes #1113.

Answering one queued permission prompt with an "Always …" level makes the engine resolve the other queued requests itself, but the request stream never told the HUD, so the react HUD kept showing prompts that were already closed.

- `system_api_types`: the request stream item becomes a tagged enum `PermissionRequestEvent` — `{ type: "request", ...PermissionRequest }` or `{ type: "cancelled", id }`.
- `handle_scene_permissions`: `permission_ids` is now `Vec<Option<usize>>` (`None` = resolved on the spot, never streamed); a `cancelled` is sent only for entries the HUD was actually shown, so auto-allowed requests (e.g. a fetch-heavy scene with an existing rule) produce no HUD traffic.
- bridge scene maps `cancelled` → a new `permissionWithdrawn` page message; the HUD drops the matching queued prompt.

Note: this changes the wire shape of `getPermissionRequestStream`. The legacy `bevy-ui-scene` still reads the flat struct and will need a matching tweak if it's still used with `--ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
