### PR TITLE
fix nametag/world-ui flicker when a render target grows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "bevy"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_internal",
  "tracing",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.2"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "quote",
@@ -1090,7 +1090,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "encase_derive_impl",
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -1285,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1331,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "glam 0.29.3",
 ]
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1554,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1571,12 +1571,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1614,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "async-channel 2.5.0",
  "bevy_app",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1732,7 +1732,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_macro_utils 0.16.1 (git+https://github.com/robtfm/bevy?branch=release-0.16-dcl)",
  "proc-macro2",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1835,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.1"
-source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#c690bcf9b8f86153fe651ac2352b12adf6590b44"
+source = "git+https://github.com/robtfm/bevy?branch=release-0.16-dcl#5097f8301c57602f55e28e7e5f96ce0a34ddd2d9"
 dependencies = [
  "accesskit",
  "accesskit_winit",

--- a/crates/scene_runner/src/update_world/scene_ui/mod.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/mod.rs
@@ -872,6 +872,7 @@ fn update_canvas_atlas(
     mut outputs: Query<&mut UiTextureOutput>,
     mut atlases: ResMut<SceneCanvasAtlases>,
     mut images: ResMut<Assets<Image>>,
+    mut cameras: Query<(&mut Camera, &mut Projection)>,
     // absent in headless tests (no render plugin); without a gpu there is nothing to overflow
     render_device: Option<Res<RenderDevice>>,
 ) {
@@ -917,6 +918,9 @@ fn update_canvas_atlas(
                 height: new_size.y,
                 depth_or_array_layers: 1,
             };
+            if let Ok((mut camera, mut projection)) = cameras.get_mut(atlas.camera) {
+                world_ui::set_camera_target_size(&mut camera, &mut projection, new_size);
+            }
             atlas.size = new_size;
         } else {
             atlas.size = current;

--- a/crates/world_ui/src/lib.rs
+++ b/crates/world_ui/src/lib.rs
@@ -6,7 +6,7 @@ use bevy::{
     platform::collections::{HashMap, HashSet},
     prelude::*,
     render::{
-        camera::RenderTarget,
+        camera::{CameraProjection, RenderTarget, RenderTargetInfo},
         primitives::Aabb,
         render_asset::RenderAssetUsages,
         render_resource::{
@@ -147,6 +147,27 @@ pub fn spawn_world_ui_view(
     (camera, image)
 }
 
+/// Point a camera's computed target at `size` now, as bevy's `camera_system` would next frame.
+/// Render targets grow after ui layout, and `camera_system` runs before it, so without this
+/// the frame that first renders into the grown image has its main texture, ui projection and
+/// final blit sized to the old image, and everything sampling the image sees a stretched frame.
+pub fn set_camera_target_size(camera: &mut Camera, projection: &mut Projection, size: UVec2) {
+    let scale_factor = match &camera.target {
+        RenderTarget::Image(target) => target.scale_factor.0,
+        _ => 1.0,
+    };
+    camera.computed.target_info = Some(RenderTargetInfo {
+        physical_size: size,
+        scale_factor,
+    });
+    if let Some(size) = camera.logical_viewport_size() {
+        if size.x != 0.0 && size.y != 0.0 {
+            projection.update(size.x, size.y);
+            camera.computed.clip_from_view = projection.get_clip_from_view();
+        }
+    }
+}
+
 #[derive(Component)]
 pub struct WorldUiMaterialRef(AssetId<TextShapeMaterial>, AssetId<Image>);
 
@@ -239,6 +260,7 @@ pub fn update_worldui_materials(
     mut quads: Query<(&MeshMaterial3d<TextShapeMaterial>, &mut Aabb)>,
     mut mats: ResMut<Assets<TextShapeMaterial>>,
     mut images: ResMut<Assets<Image>>,
+    mut cameras: Query<(&mut Camera, &mut Projection, &WorldUiRenderTarget)>,
     frame: Res<FrameCount>,
     render_device: Res<RenderDevice>,
     mut prev_changed_targets: Local<HashSet<AssetId<Image>>>,
@@ -318,6 +340,11 @@ pub fn update_worldui_materials(
                     height: req_size.y,
                     depth_or_array_layers: 1,
                 };
+                for (mut camera, mut projection, target) in cameras.iter_mut() {
+                    if target.0.id() == id {
+                        set_camera_target_size(&mut camera, &mut projection, req_size);
+                    }
+                }
             }
 
             Some(id)


### PR DESCRIPTION
## Problem

World-ui text quads and the scene ui-canvas atlas (which the system ui scene uses for player nametags) render into a grow-only image. Growth happens after ui layout, but bevy's `camera_system` runs before layout, so the camera only learned the new image size the following frame. The frame that first rendered into the grown image had its main texture, ui projection and final upscaling blit sized to the old image, stretching the old content over the new texture.

The atlas stores normalized uvs, so every canvas material is rewritten (and re-bound to the new texture) on growth — so every nametag sampled that stretched frame. Net effect: a one-frame flicker of all nametags whenever a player spawned in.

## Fix

Update the camera's computed target size directly when we resize the image (`world_ui::set_camera_target_size`, mirroring the image-target branch of `camera_system`), so the same frame renders at the right size. Used by both `update_worldui_materials` and `update_canvas_atlas`.

Bumps the bevy fork (robtfm/bevy@5097f83) to make `ComputedCameraValues`' fields public, as they already are upstream.

Reproduced and verified with a standalone scene that churns `UiCanvas` nametag planes (append / same-tick remove+append / resize) against a persistent row — flicker gone with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)