### PR TITLE
feat: base domain

### DIFF
--- a/crates/collectibles/src/base_wearables.rs
+++ b/crates/collectibles/src/base_wearables.rs
@@ -307,8 +307,12 @@ pub fn default_bodyshape_instance() -> WearableInstance {
     .unwrap()
 }
 
-pub const CONTENT_URL: &str = "https://peer.decentraland.org/content/contents/";
-pub const BASE_URL: &str = "https://peer.decentraland.org/content";
+pub fn content_url() -> String {
+    common::base_domain::https_url_from_path("peer", "/content/contents/")
+}
+pub fn base_url() -> String {
+    common::base_domain::https_url_from_path("peer", "/content")
+}
 
 pub fn default_wearables(body_shape: &WearableUrn) -> impl Iterator<Item = WearableInstance> {
     match body_shape.as_str() {

--- a/crates/collectibles/src/base_wearables.rs
+++ b/crates/collectibles/src/base_wearables.rs
@@ -308,10 +308,10 @@ pub fn default_bodyshape_instance() -> WearableInstance {
 }
 
 pub fn content_url() -> String {
-    common::base_domain::https_url_from_path("peer", "/content/contents/")
+    common::base_domain::https("peer", "/content/contents/")
 }
 pub fn base_url() -> String {
-    common::base_domain::https_url_from_path("peer", "/content")
+    common::base_domain::https("peer", "/content")
 }
 
 pub fn default_wearables(body_shape: &WearableUrn) -> impl Iterator<Item = WearableInstance> {

--- a/crates/collectibles/src/lib.rs
+++ b/crates/collectibles/src/lib.rs
@@ -310,7 +310,7 @@ pub fn request_collectibles<T: CollectibleType>(
                         entity.id.clone(),
                         collection,
                         Some(IpfsModifier {
-                            base_url: Some(base_wearables::CONTENT_URL.to_owned()),
+                            base_url: Some(base_wearables::content_url()),
                         }),
                         entity.metadata.as_ref().map(ToString::to_string),
                     );

--- a/crates/collectibles/src/wearables.rs
+++ b/crates/collectibles/src/wearables.rs
@@ -97,10 +97,7 @@ fn load_collections(
             let t: Task<Result<Collections, anyhow::Error>> =
                 IoTaskPool::get().spawn_compat(async move {
                     let response = client
-                        .get(common::base_domain::https(
-                            "realm-provider",
-                            "/lambdas/collections",
-                        ))
+                        .get(common::base_domain::https("peer", "/lambdas/collections"))
                         .timeout(std::time::Duration::from_secs(10))
                         .send()
                         .await

--- a/crates/collectibles/src/wearables.rs
+++ b/crates/collectibles/src/wearables.rs
@@ -97,7 +97,7 @@ fn load_collections(
             let t: Task<Result<Collections, anyhow::Error>> =
                 IoTaskPool::get().spawn_compat(async move {
                     let response = client
-                        .get(common::base_domain::https_url_from_path(
+                        .get(common::base_domain::https(
                             "realm-provider",
                             "/lambdas/collections",
                         ))

--- a/crates/collectibles/src/wearables.rs
+++ b/crates/collectibles/src/wearables.rs
@@ -97,7 +97,10 @@ fn load_collections(
             let t: Task<Result<Collections, anyhow::Error>> =
                 IoTaskPool::get().spawn_compat(async move {
                     let response = client
-                        .get("https://realm-provider.decentraland.org/lambdas/collections")
+                        .get(common::base_domain::https_url_from_path(
+                            "realm-provider",
+                            "/lambdas/collections",
+                        ))
                         .timeout(std::time::Duration::from_secs(10))
                         .send()
                         .await

--- a/crates/common/src/base_domain.rs
+++ b/crates/common/src/base_domain.rs
@@ -39,7 +39,7 @@ pub fn is_custom() -> bool {
     )
 }
 
-pub fn https_url_from_path(sub: &str, path: &str) -> String {
+pub fn https(sub: &str, path: &str) -> String {
     format!("https://{}{path}", host(sub))
 }
 
@@ -48,28 +48,26 @@ pub fn wss(sub: &str, path: &str) -> String {
 }
 
 pub fn host(sub: &str) -> String {
-    if sub.is_empty() {
-        get().to_owned()
-    } else {
-        format!("{sub}.{}", get())
-    }
+    format!("{sub}.{}", get())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // NOTE: asserts literal URLs, so no test in this crate may set() a custom domain —
+    // tests share the process-wide OnceLock.
     #[test]
     fn default_composition_targets_decentraland() {
         assert_eq!(
-            https_url_from_path("auth-api", "/requests"),
-            format!("https://auth-api.{}/requests", get())
+            https("auth-api", "/requests"),
+            "https://auth-api.decentraland.org/requests"
         );
         assert_eq!(
             wss("rpc-social-service-ea", ""),
-            format!("wss://rpc-social-service-ea.{}", get())
+            "wss://rpc-social-service-ea.decentraland.org"
         );
-        assert_eq!(host(""), get());
+        assert_eq!(host("pulse-server"), "pulse-server.decentraland.org");
     }
 
     #[test]

--- a/crates/common/src/base_domain.rs
+++ b/crates/common/src/base_domain.rs
@@ -1,0 +1,91 @@
+//! The base domain every backend host is composed from; set once via --base-domain.
+
+use std::sync::OnceLock;
+
+pub const DEFAULT: &str = "decentraland.org";
+
+static BASE_DOMAIN: OnceLock<String> = OnceLock::new();
+
+pub fn set(domain: &str) -> Result<(), String> {
+    let d = domain.trim().to_ascii_lowercase();
+    if d.contains("://")
+        || ['/', ':'].iter().any(|c| d.contains(*c))
+        || d.chars().any(char::is_whitespace)
+    {
+        return Err(format!(
+            "--base-domain must be a bare domain (no scheme, path or port): `{d}`"
+        ));
+    }
+    if !d.contains('.') || d.starts_with('.') || d.ends_with('.') {
+        return Err(format!("--base-domain is not a valid domain: `{d}`"));
+    }
+    if BASE_DOMAIN.set(d.clone()).is_err() && get() != d {
+        return Err(format!(
+            "base domain already resolved to `{}`; `--base-domain {d}` came too late",
+            get()
+        ));
+    }
+    Ok(())
+}
+
+pub fn get() -> &'static str {
+    BASE_DOMAIN.get().map(String::as_str).unwrap_or(DEFAULT)
+}
+
+pub fn is_custom() -> bool {
+    !matches!(
+        get(),
+        "decentraland.org" | "decentraland.zone" | "decentraland.today"
+    )
+}
+
+pub fn https_url_from_path(sub: &str, path: &str) -> String {
+    format!("https://{}{path}", host(sub))
+}
+
+pub fn wss(sub: &str, path: &str) -> String {
+    format!("wss://{}{path}", host(sub))
+}
+
+pub fn host(sub: &str) -> String {
+    if sub.is_empty() {
+        get().to_owned()
+    } else {
+        format!("{sub}.{}", get())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_composition_targets_decentraland() {
+        assert_eq!(
+            https_url_from_path("auth-api", "/requests"),
+            format!("https://auth-api.{}/requests", get())
+        );
+        assert_eq!(
+            wss("rpc-social-service-ea", ""),
+            format!("wss://rpc-social-service-ea.{}", get())
+        );
+        assert_eq!(host(""), get());
+    }
+
+    #[test]
+    fn rejects_non_bare_domains() {
+        for bad in [
+            "",
+            "https://interconnected.online",
+            "interconnected.online/",
+            "interconnected.online/path",
+            "interconnected.online:443",
+            "dcl one",
+            "localhost",
+            ".interconnected.online",
+            "interconnected.online.",
+        ] {
+            assert!(set(bad).is_err(), "`{bad}` should be refused");
+        }
+    }
+}

--- a/crates/common/src/base_domain.rs
+++ b/crates/common/src/base_domain.rs
@@ -9,16 +9,14 @@ static BASE_DOMAIN: OnceLock<String> = OnceLock::new();
 
 pub fn set(domain: &str) -> Result<(), String> {
     let d = domain.trim().to_ascii_lowercase();
-    if d.contains("://")
-        || ['/', ':'].iter().any(|c| d.contains(*c))
-        || d.chars().any(char::is_whitespace)
-    {
+    // ascii labels only: the value is spliced into http::Uri authorities, which reject
+    // anything else (unwrapped at the composition sites, so a bad value must stop here)
+    let label_ok =
+        |l: &str| !l.is_empty() && l.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-');
+    if !d.contains('.') || !d.split('.').all(label_ok) {
         return Err(format!(
-            "--base-domain must be a bare domain (no scheme, path or port): `{d}`"
+            "--base-domain must be a bare ascii domain (no scheme, path or port): `{d}`"
         ));
-    }
-    if !d.contains('.') || d.starts_with('.') || d.ends_with('.') {
-        return Err(format!("--base-domain is not a valid domain: `{d}`"));
     }
     if BASE_DOMAIN.set(d.clone()).is_err() && get() != d {
         return Err(format!(
@@ -34,10 +32,7 @@ pub fn get() -> &'static str {
 }
 
 pub fn is_custom() -> bool {
-    !matches!(
-        get(),
-        "decentraland.org" | "decentraland.zone" | "decentraland.today"
-    )
+    !matches!(get(), DEFAULT | "decentraland.zone")
 }
 
 pub fn https(sub: &str, path: &str) -> String {
@@ -83,6 +78,8 @@ mod tests {
             "localhost",
             ".interconnected.online",
             "interconnected.online.",
+            "interconnected..online",
+            "münchen.de",
         ] {
             assert!(set(bad).is_err(), "`{bad}` should be refused");
         }

--- a/crates/common/src/base_domain.rs
+++ b/crates/common/src/base_domain.rs
@@ -1,4 +1,5 @@
-//! The base domain every backend host is composed from; set once via --base-domain.
+//! The base domain every backend host is composed from; set once via --base-domain
+//! (native) or the ?baseDomain= entry param (web, via boot.js + src/web.rs).
 
 use std::sync::OnceLock;
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod asset_cache;
+pub mod base_domain;
 pub mod bounds_calc;
 pub mod dynamics;
 pub mod inputs;

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -474,28 +474,19 @@ pub struct PreviousLogin {
 fn default_home_realm() -> String {
     crate::base_domain::https("realm-provider-ea", "/main")
 }
-#[allow(clippy::ptr_arg)]
-fn is_default_home_realm(realm: &String) -> bool {
-    *realm == default_home_realm()
-}
-fn is_default_home_location(location: &IVec2) -> bool {
-    *location == IVec2::ZERO
-}
-
 // app configuration
 #[derive(Serialize, Deserialize, Resource, Clone)]
 #[serde(default)]
 pub struct AppConfig {
-    /// The pinned home scene. Written ONLY by SetHomeScene, and serialized only when it
-    /// differs from the derived default, so un-pinned installs keep tracking the
-    /// base-domain default. --server / --location are startup params (like the web's
-    /// ?realm= / ?position=) and are deliberately never merged in here — the config file
-    /// is rewritten wholesale on any settings change, which would silently persist a
+    /// The pinned home scene. Written ONLY by SetHomeScene; None = never pinned, so the
+    /// home keeps tracking the base-domain-derived default. A pinned home persists (and
+    /// survives switching base domains) even when it happens to equal some domain's
+    /// default. --server / --location are startup params (like the web's ?realm= /
+    /// ?position=) and are deliberately never merged in here — the config file is
+    /// rewritten wholesale on any settings change, which would silently persist a
     /// one-off CLI target as home.
-    #[serde(alias = "server", skip_serializing_if = "is_default_home_realm")]
-    pub home_realm: String,
-    #[serde(alias = "location", skip_serializing_if = "is_default_home_location")]
-    pub home_location: IVec2,
+    pub home_realm: Option<String>,
+    pub home_location: Option<IVec2>,
     pub previous_login: Option<PreviousLogin>,
     pub graphics: GraphicsSettings,
     pub audio: AudioSettings,
@@ -541,8 +532,8 @@ pub const INPUTS_GENERATION: u32 = 1;
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            home_realm: default_home_realm(),
-            home_location: IVec2::ZERO,
+            home_realm: None,
+            home_location: None,
             previous_login: None,
             graphics: Default::default(),
             audio: Default::default(),
@@ -578,13 +569,14 @@ impl Default for AppConfig {
 impl AppConfig {
     /// one-time forced reinitialization: configs saved with an older generation get the
     /// current defaults for the preset-managed settings, keeping everything else
-    /// Every pre-home-realm config file froze the then-stock default into `server` on any
-    /// settings write. Treat that literal as "never pinned" so those installs follow the
-    /// derived default (and any --base-domain) instead of staying nailed to it.
-    pub fn migrate_home(&mut self) {
-        if self.home_realm == "https://realm-provider-ea.decentraland.org/main" {
-            self.home_realm = default_home_realm();
-        }
+    /// The effective home realm: the pinned value, else the base-domain-derived default.
+    pub fn home_realm(&self) -> String {
+        self.home_realm.clone().unwrap_or_else(default_home_realm)
+    }
+
+    /// The effective home parcel: the pinned value, else 0,0.
+    pub fn home_location(&self) -> IVec2 {
+        self.home_location.unwrap_or(IVec2::ZERO)
     }
 
     pub fn reset_outdated_settings(&mut self) {

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -522,7 +522,7 @@ pub const INPUTS_GENERATION: u32 = 1;
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            server: "https://realm-provider-ea.decentraland.org/main".to_owned(),
+            server: crate::base_domain::https_url_from_path("realm-provider-ea", "/main"),
             location: IVec2::new(0, 0),
             previous_login: None,
             graphics: Default::default(),

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -471,12 +471,31 @@ pub struct PreviousLogin {
     pub auth: Vec<ChainLink>,
 }
 
+fn default_home_realm() -> String {
+    crate::base_domain::https("realm-provider-ea", "/main")
+}
+#[allow(clippy::ptr_arg)]
+fn is_default_home_realm(realm: &String) -> bool {
+    *realm == default_home_realm()
+}
+fn is_default_home_location(location: &IVec2) -> bool {
+    *location == IVec2::ZERO
+}
+
 // app configuration
 #[derive(Serialize, Deserialize, Resource, Clone)]
 #[serde(default)]
 pub struct AppConfig {
-    pub server: String,
-    pub location: IVec2,
+    /// The pinned home scene. Written ONLY by SetHomeScene, and serialized only when it
+    /// differs from the derived default, so un-pinned installs keep tracking the
+    /// base-domain default. --server / --location are startup params (like the web's
+    /// ?realm= / ?position=) and are deliberately never merged in here — the config file
+    /// is rewritten wholesale on any settings change, which would silently persist a
+    /// one-off CLI target as home.
+    #[serde(alias = "server", skip_serializing_if = "is_default_home_realm")]
+    pub home_realm: String,
+    #[serde(alias = "location", skip_serializing_if = "is_default_home_location")]
+    pub home_location: IVec2,
     pub previous_login: Option<PreviousLogin>,
     pub graphics: GraphicsSettings,
     pub audio: AudioSettings,
@@ -522,8 +541,8 @@ pub const INPUTS_GENERATION: u32 = 1;
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            server: crate::base_domain::https("realm-provider-ea", "/main"),
-            location: IVec2::new(0, 0),
+            home_realm: default_home_realm(),
+            home_location: IVec2::ZERO,
             previous_login: None,
             graphics: Default::default(),
             audio: Default::default(),
@@ -559,6 +578,15 @@ impl Default for AppConfig {
 impl AppConfig {
     /// one-time forced reinitialization: configs saved with an older generation get the
     /// current defaults for the preset-managed settings, keeping everything else
+    /// Every pre-home-realm config file froze the then-stock default into `server` on any
+    /// settings write. Treat that literal as "never pinned" so those installs follow the
+    /// derived default (and any --base-domain) instead of staying nailed to it.
+    pub fn migrate_home(&mut self) {
+        if self.home_realm == "https://realm-provider-ea.decentraland.org/main" {
+            self.home_realm = default_home_realm();
+        }
+    }
+
     pub fn reset_outdated_settings(&mut self) {
         if self.settings_generation >= SETTINGS_GENERATION {
             return;

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -471,7 +471,7 @@ pub struct PreviousLogin {
     pub auth: Vec<ChainLink>,
 }
 
-fn default_home_realm() -> String {
+pub fn default_home_realm() -> String {
     crate::base_domain::https("realm-provider-ea", "/main")
 }
 // app configuration
@@ -567,8 +567,6 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    /// one-time forced reinitialization: configs saved with an older generation get the
-    /// current defaults for the preset-managed settings, keeping everything else
     /// The effective home realm: the pinned value, else the base-domain-derived default.
     pub fn home_realm(&self) -> String {
         self.home_realm.clone().unwrap_or_else(default_home_realm)
@@ -579,6 +577,8 @@ impl AppConfig {
         self.home_location.unwrap_or(IVec2::ZERO)
     }
 
+    /// one-time forced reinitialization: configs saved with an older generation get the
+    /// current defaults for the preset-managed settings, keeping everything else
     pub fn reset_outdated_settings(&mut self) {
         if self.settings_generation >= SETTINGS_GENERATION {
             return;

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -522,7 +522,7 @@ pub const INPUTS_GENERATION: u32 = 1;
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            server: crate::base_domain::https_url_from_path("realm-provider-ea", "/main"),
+            server: crate::base_domain::https("realm-provider-ea", "/main"),
             location: IVec2::new(0, 0),
             previous_login: None,
             graphics: Default::default(),

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -58,15 +58,20 @@ use self::{
 #[cfg(feature = "livekit")]
 use self::livekit::{plugin::LivekitPlugin, StartLivekit};
 
-const GATEKEEPER_URL: &str = "https://comms-gatekeeper.decentraland.org/get-scene-adapter";
-const PREVIEW_GATEKEEPER_URL: &str =
-    "https://comms-gatekeeper-local.decentraland.org/get-scene-adapter";
+fn gatekeeper_url() -> String {
+    common::base_domain::https_url_from_path("comms-gatekeeper", "/get-scene-adapter")
+}
+fn preview_gatekeeper_url() -> String {
+    common::base_domain::https_url_from_path("comms-gatekeeper-local", "/get-scene-adapter")
+}
 // Authoritative-server endpoints: yield a token with the LiveKit identity
 // `authoritative-server`, which clients target for authoritative-scene traffic.
-const SERVER_GATEKEEPER_URL: &str =
-    "https://comms-gatekeeper.decentraland.org/get-server-scene-adapter";
-const PREVIEW_SERVER_GATEKEEPER_URL: &str =
-    "https://comms-gatekeeper-local.decentraland.org/get-server-scene-adapter";
+fn server_gatekeeper_url() -> String {
+    common::base_domain::https_url_from_path("comms-gatekeeper", "/get-server-scene-adapter")
+}
+fn preview_server_gatekeeper_url() -> String {
+    common::base_domain::https_url_from_path("comms-gatekeeper-local", "/get-server-scene-adapter")
+}
 
 pub mod chat_marker_things {
     pub const EMOTE: char = '␐';
@@ -583,10 +588,10 @@ fn connect_scene_room(
             let wallet = wallet.clone();
             let preview = ev.scene_id.starts_with("b64-");
             let url = match (common::structs::server_mode(), preview) {
-                (true, true) => PREVIEW_SERVER_GATEKEEPER_URL,
-                (true, false) => SERVER_GATEKEEPER_URL,
-                (false, true) => PREVIEW_GATEKEEPER_URL,
-                (false, false) => GATEKEEPER_URL,
+                (true, true) => preview_server_gatekeeper_url(),
+                (true, false) => server_gatekeeper_url(),
+                (false, true) => preview_gatekeeper_url(),
+                (false, false) => gatekeeper_url(),
             };
             let uri = Uri::try_from(url).unwrap();
             let client = ipfs.ipfs().client();

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -59,18 +59,18 @@ use self::{
 use self::livekit::{plugin::LivekitPlugin, StartLivekit};
 
 fn gatekeeper_url() -> String {
-    common::base_domain::https_url_from_path("comms-gatekeeper", "/get-scene-adapter")
+    common::base_domain::https("comms-gatekeeper", "/get-scene-adapter")
 }
 fn preview_gatekeeper_url() -> String {
-    common::base_domain::https_url_from_path("comms-gatekeeper-local", "/get-scene-adapter")
+    common::base_domain::https("comms-gatekeeper-local", "/get-scene-adapter")
 }
 // Authoritative-server endpoints: yield a token with the LiveKit identity
 // `authoritative-server`, which clients target for authoritative-scene traffic.
 fn server_gatekeeper_url() -> String {
-    common::base_domain::https_url_from_path("comms-gatekeeper", "/get-server-scene-adapter")
+    common::base_domain::https("comms-gatekeeper", "/get-server-scene-adapter")
 }
 fn preview_server_gatekeeper_url() -> String {
-    common::base_domain::https_url_from_path("comms-gatekeeper-local", "/get-server-scene-adapter")
+    common::base_domain::https("comms-gatekeeper-local", "/get-server-scene-adapter")
 }
 
 pub mod chat_marker_things {

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -927,19 +927,20 @@ const REGISTRY_ZONE: &str = "https://asset-bundle-registry.decentraland.zone/pro
 
 /// The .zone and .org registries hold separate profile namespaces, so the registry must
 /// match the profile owner's environment, judged by their announced lambdas endpoint:
-/// a host under the zone tld uses the zone registry.
+/// a host under the custom base domain uses that domain's registry, else a host under
+/// the zone tld uses the zone registry.
 fn registry_url(endpoint: Option<&str>) -> String {
     let host = endpoint
         .and_then(|e| reqwest::Url::parse(e).ok())
         .and_then(|url| url.host_str().map(str::to_owned));
     if let Some(host) = host {
-        if host.rsplit('.').next() == Some("zone") {
-            return REGISTRY_ZONE.to_owned();
-        }
         let base = common::base_domain::get();
         if common::base_domain::is_custom() && (host == base || host.ends_with(&format!(".{base}")))
         {
             return common::base_domain::https("asset-bundle-registry", "/profiles");
+        }
+        if host.rsplit('.').next() == Some("zone") {
+            return REGISTRY_ZONE.to_owned();
         }
     }
     REGISTRY_ORG.to_owned()

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -525,7 +525,7 @@ fn drive_profile_fetches(mut manager: ProfileManager) {
 
     // collect due entries into registry batches, one set per registry host
     let now = web_time::Instant::now();
-    let mut wants: HashMap<&'static str, Vec<Address>> = HashMap::default();
+    let mut wants: HashMap<String, Vec<Address>> = HashMap::default();
     for (address, entry) in entries.iter_mut() {
         if entry.wants_fetch(now) {
             entry.fetching = Some(ProfileSource::Registry);
@@ -543,7 +543,7 @@ fn drive_profile_fetches(mut manager: ProfileManager) {
     for (url, addresses) in wants {
         for chunk in addresses.chunks(PROFILE_REQUEST_BATCH) {
             registry_batches.push(IoTaskPool::get().spawn_compat(fetch_registry_profiles(
-                url,
+                url.clone(),
                 chunk.to_vec(),
                 ipfs.ipfs().clone(),
             )));
@@ -928,15 +928,21 @@ const REGISTRY_ZONE: &str = "https://asset-bundle-registry.decentraland.zone/pro
 /// The .zone and .org registries hold separate profile namespaces, so the registry must
 /// match the profile owner's environment, judged by their announced lambdas endpoint:
 /// a host under the zone tld uses the zone registry.
-fn registry_url(endpoint: Option<&str>) -> &'static str {
-    let is_zone = endpoint
+fn registry_url(endpoint: Option<&str>) -> String {
+    let host = endpoint
         .and_then(|e| reqwest::Url::parse(e).ok())
-        .is_some_and(|url| url.host_str().and_then(|host| host.rsplit('.').next()) == Some("zone"));
-    if is_zone {
-        REGISTRY_ZONE
-    } else {
-        REGISTRY_ORG
+        .and_then(|url| url.host_str().map(str::to_owned));
+    if let Some(host) = host {
+        if host.rsplit('.').next() == Some("zone") {
+            return REGISTRY_ZONE.to_owned();
+        }
+        let base = common::base_domain::get();
+        if common::base_domain::is_custom() && (host == base || host.ends_with(&format!(".{base}")))
+        {
+            return common::base_domain::https_url_from_path("asset-bundle-registry", "/profiles");
+        }
     }
+    REGISTRY_ORG.to_owned()
 }
 
 /// One registry POST for a chunk of ids, reported per item: Ok(Some) found, Ok(None)
@@ -944,7 +950,7 @@ fn registry_url(endpoint: Option<&str>) -> &'static str {
 /// the addresses that were asked for — the response identifies each profile by its
 /// deployed metadata, which is written by whoever deployed it.
 async fn fetch_registry_profiles(
-    registry_url: &'static str,
+    registry_url: String,
     addresses: Vec<Address>,
     ipfs: std::sync::Arc<IpfsIo>,
 ) -> Vec<(Address, Result<Option<UserProfile>, anyhow::Error>)> {
@@ -958,7 +964,7 @@ async fn fetch_registry_profiles(
     let outcome: Result<Vec<LambdaProfiles>, anyhow::Error> = async {
         let response = ipfs
             .client()
-            .post(registry_url)
+            .post(&registry_url)
             .timeout(std::time::Duration::from_secs(10))
             .body(serde_json::json!({ "ids": ids }).to_string())
             .header("content-type", "application/json")

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -939,7 +939,7 @@ fn registry_url(endpoint: Option<&str>) -> String {
         let base = common::base_domain::get();
         if common::base_domain::is_custom() && (host == base || host.ends_with(&format!(".{base}")))
         {
-            return common::base_domain::https_url_from_path("asset-bundle-registry", "/profiles");
+            return common::base_domain::https("asset-bundle-registry", "/profiles");
         }
     }
     REGISTRY_ORG.to_owned()

--- a/crates/comms/src/pulse/plugin.rs
+++ b/crates/comms/src/pulse/plugin.rs
@@ -484,9 +484,13 @@ impl Plugin for PulsePlugin {
 /// WebTransport on 7743. Override with the `PULSE_SERVER=host:port` env var — e.g.
 /// `pulse-server.decentraland.zone` for dev, or a local instance.
 #[cfg(not(target_arch = "wasm32"))]
-const DEFAULT_PULSE_SERVER: &str = "pulse-server.decentraland.org:7777";
+fn default_pulse_server() -> String {
+    format!("{}:7777", common::base_domain::host("pulse-server"))
+}
 #[cfg(target_arch = "wasm32")]
-const DEFAULT_PULSE_SERVER: &str = "pulse-server.decentraland.org:7743";
+fn default_pulse_server() -> String {
+    format!("{}:7743", common::base_domain::host("pulse-server"))
+}
 
 /// SHA-256 to pin the server's TLS cert via WebTransport's `serverCertificateHashes`. Production is
 /// CA-signed → `None` (default trust); native (ENet) never needs one.
@@ -496,7 +500,7 @@ fn dev_cert_hash() -> Option<Vec<u8>> {
 }
 #[cfg(target_arch = "wasm32")]
 fn dev_cert_hash() -> Option<Vec<u8>> {
-    // To test against a local self-signed dev server, point DEFAULT_PULSE_SERVER at it and return the
+    // To test against a local self-signed dev server, point default_pulse_server at it and return the
     // SHA-256 of its cert (e.g. claude-work/pulse-dev-cert/cert.pem — regenerate + refresh if expired,
     // `openssl x509 -outform DER | openssl dgst -sha256`):
     // Some(vec![
@@ -510,14 +514,14 @@ fn dev_cert_hash() -> Option<Vec<u8>> {
 /// Insert the [`PulseConfig`] that activates the transport, on clients and servers alike — a server
 /// joins as a scene listener rather than a subject (see [`ListenerRole`]). Targets, in order of
 /// precedence, [`PulseEndpointOverride`] (a startup param), the `PULSE_SERVER` env var, then
-/// [`DEFAULT_PULSE_SERVER`]. The grid is the Decentraland Genesis City `ParcelEncoder` from the
+/// [`default_pulse_server`]. The grid is the Decentraland Genesis City `ParcelEncoder` from the
 /// server's appsettings ([`PulseParcelGrid::default`]).
 fn configure_pulse(mut commands: Commands, endpoint: Option<Res<PulseEndpointOverride>>) {
     let (endpoint, source) = match endpoint {
         Some(endpoint) => (endpoint.0.clone(), "startup param"),
         None => match std::env::var("PULSE_SERVER") {
             Ok(endpoint) => (endpoint, "PULSE_SERVER"),
-            Err(_) => (DEFAULT_PULSE_SERVER.to_owned(), "default"),
+            Err(_) => (default_pulse_server(), "default"),
         },
     };
     let Some((host, port)) = endpoint.rsplit_once(':') else {
@@ -1639,7 +1643,7 @@ async fn build_auth_chain(wallet: &Wallet, server_id: &str) -> Result<Vec<u8>, S
 #[cfg(test)]
 mod tests {
     use super::{
-        configure_pulse, lsd_realm_key, PulseConfig, PulseEndpointOverride, DEFAULT_PULSE_SERVER,
+        configure_pulse, default_pulse_server, lsd_realm_key, PulseConfig, PulseEndpointOverride,
     };
     use bevy::prelude::*;
 
@@ -1668,7 +1672,7 @@ mod tests {
             "startup:1"
         );
         assert_eq!(configured_endpoint(None, Some("env:2")), "env:2");
-        assert_eq!(configured_endpoint(None, None), DEFAULT_PULSE_SERVER);
+        assert_eq!(configured_endpoint(None, None), default_pulse_server());
         std::env::remove_var("PULSE_SERVER");
     }
 

--- a/crates/dcl/src/js/ethereum_controller.rs
+++ b/crates/dcl/src/js/ethereum_controller.rs
@@ -9,7 +9,9 @@ use crate::{interface::crdt_context::CrdtContext, RpcCalls};
 
 use super::State;
 
-const PROVIDER_URL: &str = "wss://rpc.decentraland.org/mainnet?project=kernel-local";
+fn provider_url() -> String {
+    common::base_domain::wss("rpc", "/mainnet?project=kernel-local")
+}
 
 pub async fn op_send_async(
     state: Rc<RefCell<impl State>>,
@@ -89,7 +91,7 @@ impl EthereumProvider {
 
         let provider = match &*this_provider {
             Some(p) => p,
-            None => this_provider.insert(Provider::<Ws>::connect(PROVIDER_URL).await?),
+            None => this_provider.insert(Provider::<Ws>::connect(provider_url()).await?),
         };
 
         let result = provider.request(method, params).await;

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -684,7 +684,10 @@ pub fn change_realm(
 
 pub fn map_realm_name(request: &str) -> String {
     if request.ends_with(".dcl.eth") && !request.starts_with("https://") {
-        format!("https://worlds-content-server.decentraland.org/world/{request}")
+        format!(
+            "{}/world/{request}",
+            common::base_domain::https_url_from_path("worlds-content-server", "")
+        )
     } else {
         request.to_owned()
     }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -684,10 +684,7 @@ pub fn change_realm(
 
 pub fn map_realm_name(request: &str) -> String {
     if request.ends_with(".dcl.eth") && !request.starts_with("https://") {
-        format!(
-            "{}/world/{request}",
-            common::base_domain::https_url_from_path("worlds-content-server", "")
-        )
+        common::base_domain::https("worlds-content-server", &format!("/world/{request}"))
     } else {
         request.to_owned()
     }

--- a/crates/nft/src/asset_source.rs
+++ b/crates/nft/src/asset_source.rs
@@ -82,9 +82,9 @@ impl AssetReader for NftReader {
                 ))));
             }
 
-            let remote = format!(
-                "{}/api/v2/chain/{chain}/contract/{address}/nfts/{token}",
-                common::base_domain::https_url_from_path("opensea", "")
+            let remote = common::base_domain::https(
+                "opensea",
+                &format!("/api/v2/chain/{chain}/contract/{address}/nfts/{token}"),
             );
 
             let token = path;

--- a/crates/nft/src/asset_source.rs
+++ b/crates/nft/src/asset_source.rs
@@ -82,7 +82,10 @@ impl AssetReader for NftReader {
                 ))));
             }
 
-            let remote = format!("https://opensea.decentraland.org/api/v2/chain/{chain}/contract/{address}/nfts/{token}");
+            let remote = format!(
+                "{}/api/v2/chain/{chain}/contract/{address}/nfts/{token}",
+                common::base_domain::https_url_from_path("opensea", "")
+            );
 
             let token = path;
 
@@ -136,7 +139,8 @@ impl AssetReader for NftReader {
 
             let reader = AsyncCursor::new(data);
             Ok(reader)
-        }).await
+        })
+        .await
     }
 
     async fn read_meta<'a>(

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -680,7 +680,10 @@ pub async fn lookup_ens(
     } else {
         lookup_portable(
             parent_scene,
-            format!("https://worlds-content-server.decentraland.org/world/{ens}"),
+            format!(
+                "{}/world/{ens}",
+                common::base_domain::https_url_from_path("worlds-content-server", "")
+            ),
             super_user,
             ipfs,
         )

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -680,10 +680,7 @@ pub async fn lookup_ens(
     } else {
         lookup_portable(
             parent_scene,
-            format!(
-                "{}/world/{ens}",
-                common::base_domain::https_url_from_path("worlds-content-server", "")
-            ),
+            common::base_domain::https("worlds-content-server", &format!("/world/{ens}")),
             super_user,
             ipfs,
         )

--- a/crates/scene_inspector/src/asset_commands.rs
+++ b/crates/scene_inspector/src/asset_commands.rs
@@ -12,6 +12,7 @@ use platform::AsyncRwLock;
 
 use crate::active_scene::SceneResolver;
 
+// deliberately not base_domain-derived: builder-items is only deployed on decentraland.org
 const CATALOG_URL: &str = "https://builder-items.decentraland.org/asset-packs/latest/catalog.json";
 const CONTENTS_BASE: &str = "https://builder-items.decentraland.org/contents/";
 

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -363,9 +363,10 @@ pub(crate) fn load_scene_javascript(
                 }
             }
         } else {
-            ipfas.load_url_uncached(
-                "https://renderer-artifacts.decentraland.org/sdk6-adaption-layer/main/index.min.js",
-            )
+            ipfas.load_url_uncached(&common::base_domain::https_url_from_path(
+                "renderer-artifacts",
+                "/sdk6-adaption-layer/main/index.min.js",
+            ))
         };
 
         let crdt_component_interfaces = CrdtComponentInterfaces(HashMap::from_iter(

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -363,10 +363,11 @@ pub(crate) fn load_scene_javascript(
                 }
             }
         } else {
-            ipfas.load_url_uncached(&common::base_domain::https(
-                "renderer-artifacts",
-                "/sdk6-adaption-layer/main/index.min.js",
-            ))
+            // deliberately not base_domain-derived: renderer-artifacts is only deployed
+            // on decentraland.org (no zone or custom-domain equivalents)
+            ipfas.load_url_uncached(
+                "https://renderer-artifacts.decentraland.org/sdk6-adaption-layer/main/index.min.js",
+            )
         };
 
         let crdt_component_interfaces = CrdtComponentInterfaces(HashMap::from_iter(

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -363,7 +363,7 @@ pub(crate) fn load_scene_javascript(
                 }
             }
         } else {
-            ipfas.load_url_uncached(&common::base_domain::https_url_from_path(
+            ipfas.load_url_uncached(&common::base_domain::https(
                 "renderer-artifacts",
                 "/sdk6-adaption-layer/main/index.min.js",
             ))

--- a/crates/social/src/client.rs
+++ b/crates/social/src/client.rs
@@ -466,7 +466,9 @@ fn dbgerr<E: std::fmt::Debug>(e: E) -> anyhow::Error {
     anyhow!(format!("{e:?}"))
 }
 
-const SOCIAL_URL: &str = "wss://rpc-social-service-ea.decentraland.org";
+fn social_url() -> String {
+    common::base_domain::wss("rpc-social-service-ea", "")
+}
 
 const PAGE_SIZE: i32 = 100;
 
@@ -518,14 +520,17 @@ async fn run_one_connection(
     response_sx: &UnboundedSender<FriendData>,
 ) -> Result<(), anyhow::Error> {
     // Connect WebSocket
-    info!("[social] Connecting to social service at {SOCIAL_URL}");
-    let (ws, ws_closed) = PlatformRpcWebSocket::connect(SOCIAL_URL)
+    info!("[social] Connecting to social service at {}", social_url());
+    let (ws, ws_closed) = PlatformRpcWebSocket::connect(&social_url())
         .await
         .map_err(dbgerr)?;
-    info!("[social] Successfully connected to social service at {SOCIAL_URL}");
+    info!(
+        "[social] Successfully connected to social service at {}",
+        social_url()
+    );
 
     // V2 auth: send signed headers as first WS message
-    let uri: http::Uri = SOCIAL_URL.parse().map_err(dbgerr)?;
+    let uri: http::Uri = social_url().parse().map_err(dbgerr)?;
     let signed_headers = wallet::sign_request("get", &uri, wallet, "{}".to_owned())
         .await
         .map_err(dbgerr)?;

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -230,12 +230,12 @@ fn handle_home_scene(mut ev: EventReader<SystemApi>, mut config: ResMut<AppConfi
     for ev in ev.read() {
         match ev {
             SystemApi::GetHomeScene(rpc_result_sender) => rpc_result_sender.send(HomeScene {
-                realm: config.home_realm.clone(),
-                parcel: config.home_location.as_vec2().into(),
+                realm: config.home_realm(),
+                parcel: config.home_location().as_vec2().into(),
             }),
             SystemApi::SetHomeScene(home_scene) => {
-                config.home_realm = home_scene.realm.clone();
-                config.home_location = bevy::math::Vec2::from(&home_scene.parcel).as_ivec2();
+                config.home_realm = Some(home_scene.realm.clone());
+                config.home_location = Some(bevy::math::Vec2::from(&home_scene.parcel).as_ivec2());
                 platform::write_config_file(&*config);
             }
             _ => (),

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -230,12 +230,12 @@ fn handle_home_scene(mut ev: EventReader<SystemApi>, mut config: ResMut<AppConfi
     for ev in ev.read() {
         match ev {
             SystemApi::GetHomeScene(rpc_result_sender) => rpc_result_sender.send(HomeScene {
-                realm: config.server.clone(),
-                parcel: config.location.as_vec2().into(),
+                realm: config.home_realm.clone(),
+                parcel: config.home_location.as_vec2().into(),
             }),
             SystemApi::SetHomeScene(home_scene) => {
-                config.server = home_scene.realm.clone();
-                config.location = bevy::math::Vec2::from(&home_scene.parcel).as_ivec2();
+                config.home_realm = home_scene.realm.clone();
+                config.home_location = bevy::math::Vec2::from(&home_scene.parcel).as_ivec2();
                 platform::write_config_file(&*config);
             }
             _ => (),

--- a/crates/system_ui/src/change_realm.rs
+++ b/crates/system_ui/src/change_realm.rs
@@ -76,7 +76,7 @@ fn change_realm_dialog(
     // let target_url = format!("{endpoint}/explore/realms");
 
     // hard coded since the other doesn't list main
-    let target_url = common::base_domain::https("realm-provider", "/realms");
+    let target_url = common::base_domain::https("realm-provider-ea", "/realms");
 
     let client = ipfas.ipfs().client();
     let task: Task<Result<Vec<ServerDesc>, anyhow::Error>> =

--- a/crates/system_ui/src/change_realm.rs
+++ b/crates/system_ui/src/change_realm.rs
@@ -76,7 +76,7 @@ fn change_realm_dialog(
     // let target_url = format!("{endpoint}/explore/realms");
 
     // hard coded since the other doesn't list main
-    let target_url = common::base_domain::https_url_from_path("realm-provider", "/realms");
+    let target_url = common::base_domain::https("realm-provider", "/realms");
 
     let client = ipfas.ipfs().client();
     let task: Task<Result<Vec<ServerDesc>, anyhow::Error>> =

--- a/crates/system_ui/src/change_realm.rs
+++ b/crates/system_ui/src/change_realm.rs
@@ -76,7 +76,7 @@ fn change_realm_dialog(
     // let target_url = format!("{endpoint}/explore/realms");
 
     // hard coded since the other doesn't list main
-    let target_url = "https://realm-provider.decentraland.org/realms";
+    let target_url = common::base_domain::https_url_from_path("realm-provider", "/realms");
 
     let client = ipfas.ipfs().client();
     let task: Task<Result<Vec<ServerDesc>, anyhow::Error>> =

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -203,11 +203,10 @@ impl DiscoverSettings {
 
     fn request(&mut self) {
         let mut url = if self.worlds {
-            "https://places.decentraland.org/api/worlds/?limit=50"
+            common::base_domain::https_url_from_path("places", "/api/worlds/?limit=50")
         } else {
-            "https://places.decentraland.org/api/places/?limit=50"
-        }
-        .to_string();
+            common::base_domain::https_url_from_path("places", "/api/places/?limit=50")
+        };
 
         url = format!("{url}&offset={}", self.data.len());
 
@@ -433,7 +432,10 @@ impl DiscoverPage {
         Self {
             title: format!("({}, {})", coords.x, coords.y),
             base_position: format!("{},{}", coords.x, coords.y),
-            image: "https://realm-provider.decentraland.org/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y".to_owned(),
+            image: common::base_domain::https_url_from_path(
+                "realm-provider",
+                "/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y",
+            ),
             ..Default::default()
         }
     }
@@ -624,10 +626,11 @@ pub fn spawn_discover_popup(
 ) {
     let url = match &item.world_name {
         Some(name) => format!(
-            "https://worlds-content-server.decentraland.org/world/{}",
+            "{}/world/{}",
+            common::base_domain::https_url_from_path("worlds-content-server", ""),
             name.clone()
         ),
-        None => "https://realm-provider-ea.decentraland.org/main".to_owned(),
+        None => common::base_domain::https_url_from_path("realm-provider-ea", "/main"),
     };
 
     let Ok(to) = IVec2Arg::from_str(&item.base_position) else {

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -203,9 +203,9 @@ impl DiscoverSettings {
 
     fn request(&mut self) {
         let mut url = if self.worlds {
-            common::base_domain::https_url_from_path("places", "/api/worlds/?limit=50")
+            common::base_domain::https("places", "/api/worlds/?limit=50")
         } else {
-            common::base_domain::https_url_from_path("places", "/api/places/?limit=50")
+            common::base_domain::https("places", "/api/places/?limit=50")
         };
 
         url = format!("{url}&offset={}", self.data.len());
@@ -432,7 +432,7 @@ impl DiscoverPage {
         Self {
             title: format!("({}, {})", coords.x, coords.y),
             base_position: format!("{},{}", coords.x, coords.y),
-            image: common::base_domain::https_url_from_path(
+            image: common::base_domain::https(
                 "realm-provider",
                 "/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y",
             ),
@@ -625,12 +625,10 @@ pub fn spawn_discover_popup(
     item: &DiscoverPage,
 ) {
     let url = match &item.world_name {
-        Some(name) => format!(
-            "{}/world/{}",
-            common::base_domain::https_url_from_path("worlds-content-server", ""),
-            name.clone()
-        ),
-        None => common::base_domain::https_url_from_path("realm-provider-ea", "/main"),
+        Some(name) => {
+            common::base_domain::https("worlds-content-server", &format!("/world/{name}"))
+        }
+        None => common::base_domain::https("realm-provider-ea", "/main"),
     };
 
     let Ok(to) = IVec2Arg::from_str(&item.base_position) else {

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -433,7 +433,7 @@ impl DiscoverPage {
             title: format!("({}, {})", coords.x, coords.y),
             base_position: format!("{},{}", coords.x, coords.y),
             image: common::base_domain::https(
-                "realm-provider",
+                "peer",
                 "/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y",
             ),
             ..Default::default()

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -628,7 +628,7 @@ pub fn spawn_discover_popup(
         Some(name) => {
             common::base_domain::https("worlds-content-server", &format!("/world/{name}"))
         }
-        None => common::base_domain::https("realm-provider-ea", "/main"),
+        None => common::structs::default_home_realm(),
     };
 
     let Ok(to) = IVec2Arg::from_str(&item.base_position) else {

--- a/crates/system_ui/src/map.rs
+++ b/crates/system_ui/src/map.rs
@@ -193,8 +193,10 @@ fn set_map_content(
                     debug!("click parcel {}", parcel);
 
                     let url = format!(
-                        "https://places.decentraland.org/api/places?positions={},{}",
-                        parcel.x, parcel.y
+                        "{}/api/places?positions={},{}",
+                        common::base_domain::https_url_from_path("places", ""),
+                        parcel.x,
+                        parcel.y
                     );
 
                     let client = ipfas.ipfs().client();

--- a/crates/system_ui/src/map.rs
+++ b/crates/system_ui/src/map.rs
@@ -192,11 +192,9 @@ fn set_map_content(
                     let parcel = cursor_parcel.floor().as_ivec2() + IVec2::Y;
                     debug!("click parcel {}", parcel);
 
-                    let url = format!(
-                        "{}/api/places?positions={},{}",
-                        common::base_domain::https_url_from_path("places", ""),
-                        parcel.x,
-                        parcel.y
+                    let url = common::base_domain::https(
+                        "places",
+                        &format!("/api/places?positions={},{}", parcel.x, parcel.y),
                     );
 
                     let client = ipfas.ipfs().client();

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -709,7 +709,10 @@ fn update_map_visibilty(
         };
         *init = true;
         // todo this is really bad
-        if realm.about_url.ends_with("decentraland.org/main/about") {
+        if realm
+            .about_url
+            .ends_with(&format!("{}/main/about", common::base_domain::get()))
+        {
             style.display = Display::Flex;
         } else {
             style.display = Display::None;

--- a/crates/wallet/src/browser_auth.rs
+++ b/crates/wallet/src/browser_auth.rs
@@ -41,8 +41,12 @@ struct ServerResponseError {
     message: String,
 }
 
-const AUTH_FRONT_URL: &str = "https://decentraland.org/auth/requests";
-const AUTH_SERVER_ENDPOINT_URL: &str = "https://auth-api.decentraland.org/requests";
+fn auth_front_url() -> String {
+    common::base_domain::https_url_from_path("", "/auth/requests")
+}
+fn auth_server_endpoint_url() -> String {
+    common::base_domain::https_url_from_path("auth-api", "/requests")
+}
 const AUTH_SERVER_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const AUTH_SERVER_TIMEOUT: Duration = Duration::from_secs(600);
 
@@ -60,7 +64,7 @@ async fn fetch_server(req_id: String) -> Result<(H160, serde_json::Value), anyho
         }
         attempt += 1;
 
-        let url = format!("{AUTH_SERVER_ENDPOINT_URL}/{req_id}");
+        let url = format!("{}/{req_id}", auth_server_endpoint_url());
         let response = reqwest::Client::builder()
             .use_native_tls()
             .build()
@@ -124,7 +128,7 @@ async fn init_request(request: CreateRequest) -> Result<InitializedRequest, anyh
         .use_native_tls()
         .build()
         .unwrap()
-        .post(AUTH_SERVER_ENDPOINT_URL)
+        .post(auth_server_endpoint_url())
         .header("Content-Type", "application/json")
         .timeout(AUTH_SERVER_TIMEOUT)
         .body(body)
@@ -142,7 +146,10 @@ async fn init_request(request: CreateRequest) -> Result<InitializedRequest, anyh
 }
 
 async fn finish_request(request_id: String) -> Result<(H160, serde_json::Value), anyhow::Error> {
-    let url = format!("{AUTH_FRONT_URL}/{request_id}?targetConfigId=alternative");
+    let url = format!(
+        "{}/{request_id}?targetConfigId=alternative",
+        auth_front_url()
+    );
     opener::open_browser(url)?;
 
     fetch_server(request_id).await

--- a/crates/wallet/src/browser_auth.rs
+++ b/crates/wallet/src/browser_auth.rs
@@ -42,10 +42,10 @@ struct ServerResponseError {
 }
 
 fn auth_front_url() -> String {
-    common::base_domain::https_url_from_path("", "/auth/requests")
+    format!("https://{}/auth/requests", common::base_domain::get())
 }
 fn auth_server_endpoint_url() -> String {
-    common::base_domain::https_url_from_path("auth-api", "/requests")
+    common::base_domain::https("auth-api", "/requests")
 }
 const AUTH_SERVER_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const AUTH_SERVER_TIMEOUT: Duration = Duration::from_secs(600);

--- a/crates/wallet/src/delegation.rs
+++ b/crates/wallet/src/delegation.rs
@@ -15,16 +15,7 @@ use serde::Deserialize;
 
 use crate::Wallet;
 
-pub fn storage_hosts() -> Vec<String> {
-    let mut hosts = vec![
-        "storage.decentraland.org".to_owned(),
-        "storage.decentraland.zone".to_owned(),
-    ];
-    if common::base_domain::is_custom() {
-        hosts.push(common::base_domain::host("storage"));
-    }
-    hosts
-}
+pub const STORAGE_HOSTS: [&str; 2] = ["storage.decentraland.org", "storage.decentraland.zone"];
 
 #[derive(Deserialize)]
 struct DelegationEnvelope {
@@ -163,9 +154,11 @@ impl StorageDelegations {
 /// exact-match world-storage hosts, https only (the claim must never go out in cleartext).
 pub fn is_storage_request(uri: &http::Uri) -> bool {
     uri.scheme_str() == Some("https")
-        && uri
-            .host()
-            .is_some_and(|h| storage_hosts().contains(&h.to_lowercase()))
+        && uri.host().is_some_and(|h| {
+            let h = h.to_lowercase();
+            STORAGE_HOSTS.contains(&h.as_str())
+                || (common::base_domain::is_custom() && h == common::base_domain::host("storage"))
+        })
 }
 
 #[cfg(test)]

--- a/crates/wallet/src/delegation.rs
+++ b/crates/wallet/src/delegation.rs
@@ -15,7 +15,16 @@ use serde::Deserialize;
 
 use crate::Wallet;
 
-pub const STORAGE_HOSTS: [&str; 2] = ["storage.decentraland.org", "storage.decentraland.zone"];
+pub fn storage_hosts() -> Vec<String> {
+    let mut hosts = vec![
+        "storage.decentraland.org".to_owned(),
+        "storage.decentraland.zone".to_owned(),
+    ];
+    if common::base_domain::is_custom() {
+        hosts.push(common::base_domain::host("storage"));
+    }
+    hosts
+}
 
 #[derive(Deserialize)]
 struct DelegationEnvelope {
@@ -156,7 +165,7 @@ pub fn is_storage_request(uri: &http::Uri) -> bool {
     uri.scheme_str() == Some("https")
         && uri
             .host()
-            .is_some_and(|h| STORAGE_HOSTS.contains(&h.to_lowercase().as_str()))
+            .is_some_and(|h| storage_hosts().contains(&h.to_lowercase()))
 }
 
 #[cfg(test)]

--- a/deploy/headless/launcher/README.md
+++ b/deploy/headless/launcher/README.md
@@ -21,6 +21,7 @@ enabled; you rarely need to run it by hand.
 | `--tick-hz <n>` | Scene tick rate. Defaults to 30. |
 | `--pulse-realm <key>` | Pulse realm to announce verbatim — the key sdk-commands mints for a local preview. Standalone only; an orchestrated engine takes one per scene on `add-scene`. |
 | `--pulse-server <host:port>` | Pulse server to join. Defaults to the production server; a zone deployment passes the zone one. |
+| `--base-domain <domain>` | Deployment domain the backend hosts (comms gatekeeper, worlds, ...) are composed from. Defaults to `decentraland.org`; a zone deployment passes `decentraland.zone`. |
 | `--timeout <secs>` | Exit cleanly after N seconds. |
 
 `--scene-id`, `--private-key` and `--env` are accepted for hammurabi compatibility and ignored.

--- a/deploy/headless/launcher/bin/cli.js
+++ b/deploy/headless/launcher/bin/cli.js
@@ -48,7 +48,7 @@ function translate(argv) {
   let position = null
   let production = false
   let orchestrated = false
-  const passthrough = { '--tick-hz': true, '--timeout': true, '--scene-threads': true, '--pulse-realm': true, '--pulse-server': true }
+  const passthrough = { '--tick-hz': true, '--timeout': true, '--scene-threads': true, '--pulse-realm': true, '--pulse-server': true, '--base-domain': true }
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -15,8 +15,9 @@
 //     __onEngineCrash(message, source) — OPTIONAL host callback; the watchdog calls it instead of
 //       rendering any overlay (React owns the error UI)
 //     window.engine / engine_console_command — the console RPC (built by engine.js post-launch)
-//     __baseDomain() — the ?baseDomain= entry param (or the decentraland.org default); the wasm
-//       reads it before composing any backend URL (parity with native --base-domain)
+//     __baseDomain() — HOST-PROVIDED (react-web/src/lib/baseDomain.ts, defined before this module
+//       is injected): the deployment domain every backend host is composed from; the wasm reads
+//       it before composing any backend URL (parity with native --base-domain)
 //     __bevyHomeScene() — the persisted home scene { realm, parcel: "x,y" } (or the derived
 //       defaults), for the host's "Skip to Home"; set alongside __bevyReadyToLaunch
 import { initEngine, start, engine_home_scene, gpu_cache_hash, initGpuCache } from './engine.js'
@@ -262,16 +263,10 @@ window.addEventListener('wheel', forwardWheelToEngine)
 // ---- URL sync (CALLED BY THE WASM — src/web.rs set_url_params) -----------------------------------
 // Keeps the browser URL in step with the player's realm/position so a reload/share lands back at
 // the same place. Defaults are omitted so the canonical entry URL stays clean.
-// Entry-URL base domain (web parity with the native --base-domain flag): the ?baseDomain=
-// param, else derived from the hosting origin (the decentraland.zone staging deployment keys
-// to zone backends; prod to org), else org. Read once here; the wasm latches it too (web.rs
-// apply_base_domain via window.__baseDomain), and set_url_params below preserves unknown
+// The base domain is the HUD's call (see the __baseDomain contract above): the ?baseDomain=
+// entry param, else the hosting origin's apex, else org. set_url_params below preserves unknown
 // params, so the param form survives URL syncs.
-// MIRROR: react-web/src/lib/baseDomain.ts derives the same value the same way for the HUD.
-const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain')
-  ?? ['decentraland.org', 'decentraland.zone'].find((apex) => location.hostname === apex || location.hostname.endsWith(`.${apex}`))
-  ?? 'decentraland.org'
-window.__baseDomain = () => BASE_DOMAIN
+const BASE_DOMAIN = window.__baseDomain()
 const DEFAULT_SERVER = `https://realm-provider-ea.${BASE_DOMAIN}/main`
 const DEFAULT_PORTABLES = 'basiccontroller.dcl.eth'
 // The engine connects to the EXPANDED world url (ipfs map_realm_name turns `name.dcl.eth` into

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -15,6 +15,8 @@
 //     __onEngineCrash(message, source) — OPTIONAL host callback; the watchdog calls it instead of
 //       rendering any overlay (React owns the error UI)
 //     window.engine / engine_console_command — the console RPC (built by engine.js post-launch)
+//     __baseDomain() — the ?baseDomain= entry param (or the decentraland.org default); the wasm
+//       reads it before composing any backend URL (parity with native --base-domain)
 import { initEngine, start, gpu_cache_hash, initGpuCache } from './engine.js'
 
 // ---- boot progress (replaces ui.js's DOM loading steps) -----------------------------------------
@@ -258,12 +260,17 @@ window.addEventListener('wheel', forwardWheelToEngine)
 // ---- URL sync (CALLED BY THE WASM — src/web.rs set_url_params) -----------------------------------
 // Keeps the browser URL in step with the player's realm/position so a reload/share lands back at
 // the same place. Defaults are omitted so the canonical entry URL stays clean.
-const DEFAULT_SERVER = 'https://realm-provider-ea.decentraland.org/main'
+// Entry-URL base domain (web parity with the native --base-domain flag). Read once here;
+// the wasm latches it too (web.rs apply_base_domain via window.__baseDomain), and
+// set_url_params below preserves unknown params, so ?baseDomain= survives URL syncs.
+const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain') || 'decentraland.org'
+window.__baseDomain = () => BASE_DOMAIN
+const DEFAULT_SERVER = `https://realm-provider-ea.${BASE_DOMAIN}/main`
 const DEFAULT_PORTABLES = 'basiccontroller.dcl.eth'
 // The engine connects to the EXPANDED world url (ipfs map_realm_name turns `name.dcl.eth` into
 // worlds-content-server…/world/name.dcl.eth) and echoes that back here. Reverse it so the address
 // bar keeps the short name the user typed; a reload re-expands it the same way.
-const WORLDS_PREFIX = 'https://worlds-content-server.decentraland.org/world/'
+const WORLDS_PREFIX = `https://worlds-content-server.${BASE_DOMAIN}/world/`
 // captured from the ENTRY url (later syncs rewrite location.search)
 const explicitSystemScene = new URLSearchParams(window.location.search).has('systemScene')
 window.set_url_params = (position, server, system_scene, portables, preview, editor) => {

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -17,7 +17,9 @@
 //     window.engine / engine_console_command — the console RPC (built by engine.js post-launch)
 //     __baseDomain() — the ?baseDomain= entry param (or the decentraland.org default); the wasm
 //       reads it before composing any backend URL (parity with native --base-domain)
-import { initEngine, start, gpu_cache_hash, initGpuCache } from './engine.js'
+//     __bevyHomeScene() — the persisted home scene { realm, parcel: "x,y" } (or the derived
+//       defaults), for the host's "Skip to Home"; set alongside __bevyReadyToLaunch
+import { initEngine, start, engine_home_scene, gpu_cache_hash, initGpuCache } from './engine.js'
 
 // ---- boot progress (replaces ui.js's DOM loading steps) -----------------------------------------
 // Weight of each step in the overall bar (sums to 100). Step ids are read by the React login bar
@@ -322,6 +324,9 @@ initEngine()
     // Deferred launch: the host calls this once the user picks a destination — avoiding a wasted
     // default-realm load. One engine per page (see start()'s __bevyStarted guard).
     window.__bevyLaunch = (realm, position) => start({ realm, position, systemScene: config.systemScene, portables: config.portables, preview: config.preview, editor: config.editor, pulseServer: config.pulseServer })
+    // The persisted home scene ({ realm, parcel: "x,y" }), valid once engine_init has loaded the
+    // config — the host's places picker targets it from "Skip to Home" before launching.
+    window.__bevyHomeScene = () => { try { return JSON.parse(engine_home_scene()) } catch { return null } }
     window.__bevyReadyToLaunch = true
   })
   .catch((e) => {

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -262,10 +262,15 @@ window.addEventListener('wheel', forwardWheelToEngine)
 // ---- URL sync (CALLED BY THE WASM — src/web.rs set_url_params) -----------------------------------
 // Keeps the browser URL in step with the player's realm/position so a reload/share lands back at
 // the same place. Defaults are omitted so the canonical entry URL stays clean.
-// Entry-URL base domain (web parity with the native --base-domain flag). Read once here;
-// the wasm latches it too (web.rs apply_base_domain via window.__baseDomain), and
-// set_url_params below preserves unknown params, so ?baseDomain= survives URL syncs.
-const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain') || 'decentraland.org'
+// Entry-URL base domain (web parity with the native --base-domain flag): the ?baseDomain=
+// param, else derived from the hosting origin (the decentraland.zone staging deployment keys
+// to zone backends; prod to org), else org. Read once here; the wasm latches it too (web.rs
+// apply_base_domain via window.__baseDomain), and set_url_params below preserves unknown
+// params, so the param form survives URL syncs.
+// MIRROR: react-web/src/lib/baseDomain.ts derives the same value the same way for the HUD.
+const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain')
+  ?? ['decentraland.org', 'decentraland.zone'].find((apex) => location.hostname === apex || location.hostname.endsWith(`.${apex}`))
+  ?? 'decentraland.org'
 window.__baseDomain = () => BASE_DOMAIN
 const DEFAULT_SERVER = `https://realm-provider-ea.${BASE_DOMAIN}/main`
 const DEFAULT_PORTABLES = 'basiccontroller.dcl.eth'

--- a/deploy/web/engine/engine.js
+++ b/deploy/web/engine/engine.js
@@ -1,11 +1,11 @@
 // Engine logic - ES module
 // Handles WASM/WebGPU initialization and game execution
 
-import init, { engine_init, engine_run, engine_console_command, gpu_cache_hash } from "./pkg/webgpu_build.js";
+import init, { engine_init, engine_run, engine_console_command, engine_home_scene, gpu_cache_hash } from "./pkg/webgpu_build.js";
 import { initGpuCache } from "./gpu_cache.js";
 
 // Re-export for main.js
-export { gpu_cache_hash, initGpuCache };
+export { engine_home_scene, gpu_cache_hash, initGpuCache };
 
 /**
  * Records an uncaught worker error as context for the crash watchdog. A worker

--- a/react-web/e2e/helpers.ts
+++ b/react-web/e2e/helpers.ts
@@ -121,8 +121,8 @@ export async function enterAsGuest(page: Page): Promise<void> {
   await installBridgeSpy(page)
   await page.goto(APP_URL)
   await page.getByRole('button', { name: /EXPLORE AS GUEST/i }).click({ timeout: 90000 })
-  // Entry now goes through the destination picker — skip it (default spawn → Genesis Plaza).
-  await page.getByRole('button', { name: /SKIP TO GENESIS PLAZA/i }).click({ timeout: 60000 })
+  // Entry now goes through the destination picker — skip to home (default spawn → Genesis Plaza on a fresh profile).
+  await page.getByRole('button', { name: /SKIP TO HOME/i }).click({ timeout: 60000 })
   // World-ready: the React sidebar nav mounts once phase === 'world'.
   await page.waitForSelector('nav[aria-label="Main navigation"]', { timeout: 180000 })
 }

--- a/react-web/e2e/visual.spec.ts
+++ b/react-web/e2e/visual.spec.ts
@@ -42,7 +42,7 @@ async function enterWorld(page: Page): Promise<void> {
   await page.goto('/?mock=1')
   await page.getByRole('button', { name: /EXPLORE AS GUEST/i }).click()
   // Entry now goes through the destination picker; skip it (default spawn) to reach the world HUD.
-  await page.getByRole('button', { name: /SKIP TO GENESIS PLAZA/i }).click()
+  await page.getByRole('button', { name: /SKIP TO HOME/i }).click()
   await page.waitForSelector('nav[aria-label="Main navigation"]')
 }
 
@@ -125,7 +125,7 @@ test.describe('visual — mock HUD', () => {
   test('permission dialog', async ({ page }) => {
     await page.goto('/?mock=1&perm=1')
     await page.getByRole('button', { name: /EXPLORE AS GUEST/i }).click()
-    await page.getByRole('button', { name: /SKIP TO GENESIS PLAZA/i }).click()
+    await page.getByRole('button', { name: /SKIP TO HOME/i }).click()
     await page.getByRole('alertdialog').waitFor()
     await settle(page)
     await expect(page).toHaveScreenshot('permission-dialog.png')
@@ -184,7 +184,7 @@ test.describe('visual — mock HUD', () => {
   test('hover tooltips (radial)', async ({ page }) => {
     await page.goto('/?mock=1&simhover=7')
     await page.getByRole('button', { name: /EXPLORE AS GUEST/i }).click()
-    await page.getByRole('button', { name: /SKIP TO GENESIS PLAZA/i }).click()
+    await page.getByRole('button', { name: /SKIP TO HOME/i }).click()
     await page.waitForSelector('nav[aria-label="Main navigation"]')
     await page.getByText('Show Profile').waitFor() // the seeded hover arrives ~1.5s after entry
     const vp = page.viewportSize()

--- a/react-web/package.json
+++ b/react-web/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "bundle:native": "tsc --noEmit && vite build --base ./ --outDir ../assets/react-hud --emptyOutDir && npm --prefix bridge-scene run export-native",
+    "bundle:native": "tsc --noEmit && vite build --mode native --base ./ --outDir ../assets/react-hud --emptyOutDir && npm --prefix bridge-scene run export-native",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -41,6 +41,7 @@ import { hasUsableGpu } from './lib/gpu'
 import { MobileGate, GateChecking } from './features/gate/MobileGate'
 import { UntrustedLaunchGate } from './features/gate/UntrustedLaunchGate'
 import { isTrustedSystemScene } from './lib/systemScene'
+import { BASE_DOMAIN, isTrustedBaseDomain } from './lib/baseDomain'
 import { ErrorBoundary } from './features/error/ErrorBoundary'
 import { CrashModal } from './features/error/CrashModal'
 import { openRealmError } from './features/error/RealmErrorModal'
@@ -86,6 +87,9 @@ const GATE_REASON = gateReason()
 const SYSTEM_SCENE_OVERRIDE = bootMode().systemScene
 const UNTRUSTED_SYSTEM_SCENE =
   SYSTEM_SCENE_OVERRIDE != null && !isTrustedSystemScene(SYSTEM_SCENE_OVERRIDE) ? SYSTEM_SCENE_OVERRIDE : null
+// `?baseDomain=` likewise: it points every backend at another deployment. Native is exempt —
+// there the shell injects it from the user's own --base-domain flag, not from a link.
+const UNTRUSTED_BASE_DOMAIN = MODE !== 'native' && !isTrustedBaseDomain(BASE_DOMAIN) ? BASE_DOMAIN : null
 
 export function App(): React.JSX.Element {
   useHudScale() // keep --ui-scale in sync with the viewport (DPI-correct, like Unity)
@@ -98,8 +102,14 @@ export function App(): React.JSX.Element {
   // Ahead of every other gate: returning here is what keeps EngineHost unmounted, and EngineHost is
   // what injects boot.js and starts the scene.
   const [trustUntrusted, setTrustUntrusted] = useState(false)
-  if (UNTRUSTED_SYSTEM_SCENE != null && !trustUntrusted) {
-    return <UntrustedLaunchGate systemScene={UNTRUSTED_SYSTEM_SCENE} onProceed={() => setTrustUntrusted(true)} />
+  if ((UNTRUSTED_SYSTEM_SCENE != null || UNTRUSTED_BASE_DOMAIN != null) && !trustUntrusted) {
+    return (
+      <UntrustedLaunchGate
+        systemScene={UNTRUSTED_SYSTEM_SCENE ?? undefined}
+        baseDomain={UNTRUSTED_BASE_DOMAIN ?? undefined}
+        onProceed={() => setTrustUntrusted(true)}
+      />
+    )
   }
   if (GATE_REASON) return <MobileGate reason={GATE_REASON} />
   if (gpu === 'checking') return <GateChecking />

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -52,7 +52,7 @@ const params = new URLSearchParams(location.search)
 // NATIVE (?native=1): HUD in a CEF offscreen webview over the native bevy engine — a JS shim
 // bridges this app's BroadcastChannel to the engine's native relay (no iframe, no mock).
 const MODE: 'mock' | 'engine' | 'native' =
-  params.get('mock') === '1' ? 'mock' : params.get('native') === '1' ? 'native' : 'engine'
+  params.get('mock') === '1' ? 'mock' : __NATIVE_HUD__ && params.get('native') === '1' ? 'native' : 'engine'
 const SHOWCASE = params.get('showcase') === '1'
 // Embedded/debug mode (?hud=0 or ?systemScene= — see lib/bootMode.ts): render ONLY the
 // engine — no React HUD at all (no sidebar, chat, pointer, panels, or the sign-in /

--- a/react-web/src/components/WorldVisitModal.tsx
+++ b/react-web/src/components/WorldVisitModal.tsx
@@ -4,10 +4,11 @@
 // image. Confirm → onConfirm (the caller calls the engine's changeRealm via the bridge).
 
 import { useEffect, useState } from 'react'
+import { serviceUrl } from '../lib/baseDomain'
 import { openPopup } from '../design'
 import styles from './WorldVisitModal.module.css'
 
-const WORLDS_API = 'https://places.decentraland.org/api/worlds'
+const WORLDS_API = `${serviceUrl('places')}/api/worlds`
 
 /** The bits of a places-API world entry this prompt shows. All optional — a world may have none. */
 interface WorldInfo {

--- a/react-web/src/engine/EngineDriver.ts
+++ b/react-web/src/engine/EngineDriver.ts
@@ -130,6 +130,10 @@ export class EngineDriver implements LoginDriver {
     this.rpc.launch(realm, position)
   }
 
+  homeScene(): { realm: string; parcel: string } | null {
+    return this.rpc.homeScene()
+  }
+
   private emit(msg: SceneToPage): void {
     this.listeners.forEach((fn) => fn(msg))
   }

--- a/react-web/src/engine/driver.ts
+++ b/react-web/src/engine/driver.ts
@@ -56,7 +56,11 @@ export interface LoginDriver {
    *  flag so a second genuine crash still shows). Optional — the mock has no engine. */
   rearmCrashWatchdog?(): void
   /** Boot the engine at a chosen realm/position (deferred-start: nothing loads until the user picks
-   *  a destination). A parcel passes `position` "x,y"; a world passes `realm`; skip passes "0,0".
-   *  Optional — the mock has no engine to launch. */
+   *  a destination). A parcel passes `position` "x,y"; a world passes `realm`; skip passes the
+   *  home scene. Optional — the mock has no engine to launch. */
   launch?(realm?: string, position?: string): void
+  /** The engine's persisted home scene — the Skip target. Available pre-launch; null until the
+   *  engine module is up. Optional — the mock has no engine (and native skips keep the engine's
+   *  own start realm, which already IS home). */
+  homeScene?(): { realm: string; parcel: string } | null
 }

--- a/react-web/src/engine/engineRpc.ts
+++ b/react-web/src/engine/engineRpc.ts
@@ -9,6 +9,7 @@ type EngineWindow = Window & {
   engine_console_command?: (line: string) => Promise<string>
   __bevyReadyToLaunch?: boolean
   __bevyLaunch?: (realm?: string, position?: string) => void
+  __bevyHomeScene?: () => { realm: string; parcel: string } | null
   __bevyLoadProgress?: number
   __bevyLoadStep?: string | null
   __bevyPanic?: { message: string }
@@ -58,6 +59,13 @@ export class EngineRpc {
   /** Boot the bevy app at a realm/position (only valid in manualParams mode, after readyToLaunch). */
   launch(realm?: string, position?: string): void {
     this.win?.__bevyLaunch?.(realm, position)
+  }
+
+  /** The engine's persisted home scene (realm + "x,y" parcel, or the engine's derived defaults).
+   *  Available alongside readyToLaunch — i.e. BEFORE launch, which is what lets the places
+   *  picker's Skip target home. Null until the engine module is up. */
+  homeScene(): { realm: string; parcel: string } | null {
+    return this.win?.__bevyHomeScene?.() ?? null
   }
 
   ready(): boolean {

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -7,6 +7,7 @@
 import { useEffect } from 'react'
 import type { EngineRpc } from '../../engine/engineRpc'
 import { bridgeChannelName } from '../../engine/protocol'
+import { serviceUrl } from '../../lib/baseDomain'
 import { bootMode } from '../../lib/bootMode'
 import { PAGE_DIR } from '../../lib/publicUrl'
 // Moved to lib/systemScene.ts, which also decides whether a link is allowed to override it.
@@ -16,8 +17,7 @@ import { SYSTEM_SCENE } from '../../lib/systemScene'
 // engine's own derived default). Exported: parcel launches pass it EXPLICITLY so a ?realm
 // override — possibly an invalid world — never leaks into a Places pick (always a Genesis
 // coordinate).
-const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain') ?? 'decentraland.org'
-export const DEFAULT_REALM = `https://realm-provider-ea.${BASE_DOMAIN}/main`
+export const DEFAULT_REALM = `${serviceUrl('realm-provider-ea')}/main`
 
 // Engine media libs the wasm expects as globals (LivekitClient, Hls) — loaded from CDNs like the
 // old boot page did.

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -12,10 +12,12 @@ import { PAGE_DIR } from '../../lib/publicUrl'
 // Moved to lib/systemScene.ts, which also decides whether a link is allowed to override it.
 import { SYSTEM_SCENE } from '../../lib/systemScene'
 
-// The main (Genesis City) realm. Exported: parcel launches pass it EXPLICITLY so a ?realm
+// The main (Genesis City) realm, on the ?baseDomain= entry param when present (parity with the
+// engine's own derived default). Exported: parcel launches pass it EXPLICITLY so a ?realm
 // override — possibly an invalid world — never leaks into a Places pick (always a Genesis
 // coordinate).
-export const DEFAULT_REALM = 'https://realm-provider-ea.decentraland.org/main'
+const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain') ?? 'decentraland.org'
+export const DEFAULT_REALM = `https://realm-provider-ea.${BASE_DOMAIN}/main`
 
 // Engine media libs the wasm expects as globals (LivekitClient, Hls) — loaded from CDNs like the
 // old boot page did.

--- a/react-web/src/features/gallery/PhotoDetail.tsx
+++ b/react-web/src/features/gallery/PhotoDetail.tsx
@@ -8,6 +8,7 @@
 // next press to close the gallery.
 
 import { useEffect, useRef, useState } from 'react'
+import { serviceUrl } from '../../lib/baseDomain'
 import { Avatar, Button } from '../../design'
 import { useWindowKeyDown } from '../../lib/useWindowKeyDown'
 import { registerCancelLayer } from '../../lib/cancelLayers'
@@ -16,7 +17,7 @@ import type { GalleryPhoto, GalleryPhotoMeta } from '../../engine/protocol'
 import type { ChatUser } from '../chat/ProfileCardPresentation'
 import styles from './GalleryPage.module.css'
 
-const REELS_BASE = 'https://reels.decentraland.org'
+const REELS_BASE = serviceUrl('reels')
 
 function formatDate(dateTime: string): string {
   const ms = photoTime(dateTime)

--- a/react-web/src/features/gate/UntrustedLaunchGate.tsx
+++ b/react-web/src/features/gate/UntrustedLaunchGate.tsx
@@ -1,5 +1,6 @@
-// Interstitial for a link that picks its own super-user scene (`?systemScene=`) — see
-// lib/systemScene.ts for why that parameter is worth stopping on.
+// Interstitial for a link that carries an infrastructure-pointing parameter: its own super-user
+// scene (`?systemScene=` — see lib/systemScene.ts for why that is worth stopping on) and/or its
+// own backend deployment (`?baseDomain=` — see lib/baseDomain.ts).
 //
 // Not dismissible: ModalShell is scrimless (its host owns the overlay, Escape and focus — see
 // design/Modal.tsx), so this gate draws its own inert full-screen layer and `closeButton={false}`
@@ -24,9 +25,11 @@ const TITLE = 'This Launch Link Is Not Trusted'
 
 export function UntrustedLaunchGate({
   systemScene,
+  baseDomain,
   onProceed
 }: {
-  systemScene: string
+  systemScene?: string
+  baseDomain?: string
   onProceed: () => void
 }): React.JSX.Element {
   const [advanced, setAdvanced] = useState(false)
@@ -71,18 +74,33 @@ export function UntrustedLaunchGate({
       >
         <p className={styles.lead}>Someone may be trying to change how your Explorer behaves.</p>
         <p className={styles.lead}>
-          This link carries a parameter the Explorer does not accept from links, because it replaces the
-          interface with code that runs as you:
+          This link carries {systemScene != null && baseDomain != null ? 'parameters' : 'a parameter'} the
+          Explorer does not accept from links:
         </p>
 
         <dl className={styles.params}>
-          <dt>
-            systemScene = <span className={styles.paramValue}>{systemScene}</span>
-          </dt>
-          <dd className={styles.paramDesc}>
-            Replaces the Explorer&apos;s interface with a scene loaded from this address. It can move
-            your avatar, change your profile, and answer permission prompts on your behalf.
-          </dd>
+          {systemScene != null && (
+            <>
+              <dt>
+                systemScene = <span className={styles.paramValue}>{systemScene}</span>
+              </dt>
+              <dd className={styles.paramDesc}>
+                Replaces the Explorer&apos;s interface with a scene loaded from this address. It can move
+                your avatar, change your profile, and answer permission prompts on your behalf.
+              </dd>
+            </>
+          )}
+          {baseDomain != null && (
+            <>
+              <dt>
+                baseDomain = <span className={styles.paramValue}>{baseDomain}</span>
+              </dt>
+              <dd className={styles.paramDesc}>
+                Points every backend service — sign-in, content, comms — at servers under this domain.
+                Whoever runs them would see your session and control what you play.
+              </dd>
+            </>
+          )}
         </dl>
 
         <p className={styles.lead}>Unless you built this link yourself, the safe choice is to exit.</p>

--- a/react-web/src/features/login/LoadingAndLogin.tsx
+++ b/react-web/src/features/login/LoadingAndLogin.tsx
@@ -4,6 +4,7 @@
 // identity straight to the engine. No verification-code / secure-step screen anymore.
 
 import { useEffect, useState } from 'react'
+import { serviceUrl } from '../../lib/baseDomain'
 import { Button } from '../../design'
 import { prefetchPlaces } from '../places/placesApi'
 import type { LoginFlow, LoginStatus } from '../session/useEngineSession'
@@ -71,7 +72,7 @@ function useProfile(address?: string): { name?: string; body?: string } {
       return
     }
     let cancelled = false
-    fetch(`https://peer.decentraland.org/lambdas/profiles/${address}`)
+    fetch(`${serviceUrl('peer')}/lambdas/profiles/${address}`)
       .then((r) => r.json() as Promise<ProfileResponse>)
       .then((j) => {
         const a = j.avatars?.[0]

--- a/react-web/src/features/map/MapPage.tsx
+++ b/react-web/src/features/map/MapPage.tsx
@@ -5,6 +5,7 @@
 // panel (places.decentraland.org/api/places) when a parcel/pin is clicked. Teleport via the bridge.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { serviceUrl } from '../../lib/baseDomain'
 import { MainMenuShell } from '../menu/MainMenuShell'
 import { CAT_ICONS, CAT_PINS, WORLD_ICON } from './mapArt'
 import { GRID, ORIGIN_X, ORIGIN_Y, PARCELS_PER_TILE, SIZE, SPAN, tileUrl } from './atlas'
@@ -13,8 +14,8 @@ import { openWorldVisit } from '../../components/WorldVisitModal'
 import { isCancelKey } from '../../lib/bindingLabels'
 import styles from './MapPage.module.css'
 
-const PLACES_API = 'https://places.decentraland.org/api/places'
-const WORLDS_API = 'https://places.decentraland.org/api/worlds'
+const PLACES_API = `${serviceUrl('places')}/api/places`
+const WORLDS_API = `${serviceUrl('places')}/api/worlds`
 
 // Category chips. `api` is the lowercase value the places API expects under `categories`
 // (null = no filter / "All"); icons + pins are the unity-explorer textures under /assets/map.

--- a/react-web/src/features/map/atlas.ts
+++ b/react-web/src/features/map/atlas.ts
@@ -11,6 +11,8 @@
 // world z increase in the same direction, while screen y grows downward — hence the flip in
 // `atlasPx`. "Atlas px" is the untransformed tile-grid space, before any pan/zoom/rotation.
 
+import { serviceUrl } from '../../lib/baseDomain'
+
 export const PARCEL_METERS = 16
 
 // ---- satellite atlas -------------------------------------------------------
@@ -89,7 +91,7 @@ export function parcelTileFor(worldX: number, worldZ: number): ParcelTile {
   const centerParcelY = chunkY * PARCEL_TILE_CHUNK + PARCEL_TILE_CHUNK / 2
   const px = PARCEL_TILE_PARCELS * PARCEL_TILE_PX_PER_PARCEL
   return {
-    url: `https://api.decentraland.org/v1/map.png?center=${centerParcelX},${centerParcelY}&width=${px}&height=${px}&size=${PARCEL_TILE_PX_PER_PARCEL}`,
+    url: `${serviceUrl('api')}/v1/map.png?center=${centerParcelX},${centerParcelY}&width=${px}&height=${px}&size=${PARCEL_TILE_PX_PER_PARCEL}`,
     centerX: centerParcelX * PARCEL_METERS,
     centerZ: centerParcelY * PARCEL_METERS,
     meters: PARCEL_TILE_PARCELS * PARCEL_METERS

--- a/react-web/src/features/places/PlacesPicker.tsx
+++ b/react-web/src/features/places/PlacesPicker.tsx
@@ -1,6 +1,7 @@
 // PlacesPicker — shown right after Jump In (phase 'picking') so the user chooses where to spawn
-// instead of dropping straight into Genesis Plaza. Reuses the exact in-world Places browser; a card
-// click resolves a destination (parcel teleport / world realm) and a Skip button takes the default.
+// instead of dropping straight into their home scene. Reuses the exact in-world Places browser; a
+// card click resolves a destination (parcel teleport / world realm) and a Skip button takes home
+// (the default realm at 0,0 — Genesis Plaza — unless the user pinned one).
 
 import { Button } from '../../design'
 import { PlacesBrowser } from './PlacesBrowser'
@@ -19,7 +20,7 @@ export function PlacesPicker({ onPick }: { onPick: (dest: Destination) => void }
               <h1 className={styles.title}>Where do you want to go?</h1>
             </div>
             <Button variant="secondary" size="md" className={styles.skip} onClick={() => onPick(null)}>
-              Skip to Genesis Plaza
+              Skip to Home
             </Button>
           </div>
           <PlacesBrowser onPick={(place: DiscoverPlace) => onPick(placeTeleport(place))} />

--- a/react-web/src/features/places/placesApi.ts
+++ b/react-web/src/features/places/placesApi.ts
@@ -2,7 +2,9 @@
 // Plain fetch; the pure helpers below derive card fields from a DiscoverPlace and
 // are kept side-effect free so they're unit-testable.
 
-const API_BASE = 'https://places.decentraland.org/api'
+import { serviceUrl } from '../../lib/baseDomain'
+
+const API_BASE = `${serviceUrl('places')}/api`
 
 export interface DiscoverPlace {
   id: string
@@ -103,7 +105,7 @@ export function fetchWorlds(args: FetchPlacesArgs = {}): Promise<PlacesResponse>
 // only covers Genesis City, and /worlds user counts lag behind live presence. We fetch the
 // live counts and resolve card metadata for those names in one batch.
 
-const WORLDS_LIVE_URL = 'https://worlds-content-server.decentraland.org/live-data'
+const WORLDS_LIVE_URL = `${serviceUrl('worlds-content-server')}/live-data`
 
 type LiveWorldEntry = { worldName: string; users: number }
 

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -2,6 +2,7 @@
 // Owns the driver and exposes the login flow + scene-loading state + phase.
 
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { serviceUrl } from '../../lib/baseDomain'
 import { clearStoredLogins, getStoredLogin, redirectToAuth, rootAddress, type StoredLogin } from '../auth/sso'
 import type { LoginDriver } from '../../engine/driver'
 import type { FatalError } from '../error/fatalError'
@@ -1131,7 +1132,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       validatingRealm.current = true
       const base =
         dest.realm.endsWith('.dcl.eth') && !dest.realm.startsWith('https://')
-          ? `https://worlds-content-server.decentraland.org/world/${dest.realm}`
+          ? `${serviceUrl('worlds-content-server')}/world/${dest.realm}`
           : dest.realm
       // Launching against an unreachable realm strands the engine in a cryptic login failure, so
       // block up front: 404 → not found, no/failed answer (incl. timeout) → unreachable.

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -1050,8 +1050,12 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       // override (possibly an invalid world after a failed validation), and inheriting it would
       // strand a Genesis pick "Reconnecting to the realm" forever.
       try {
-        if (dest == null) driver.launch?.(DEFAULT_REALM, '0,0')
-        else if (dest.kind === 'world') driver.launch?.(dest.realm, dest.position)
+        if (dest == null) {
+          // Skip goes HOME — the engine's persisted home scene (the derived default realm at
+          // 0,0 unless the user pinned one), not a hardcoded Genesis Plaza.
+          const home = driver.homeScene?.()
+          driver.launch?.(home?.realm ?? DEFAULT_REALM, home?.parcel ?? '0,0')
+        } else if (dest.kind === 'world') driver.launch?.(dest.realm, dest.position)
         else driver.launch?.(DEFAULT_REALM, `${dest.x},${dest.y}`)
       } catch (e) {
         // A boot-time engine panic throws synchronously out of launch() (a generic "unreachable"

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -9,3 +9,11 @@ export const BASE_DOMAIN = new URLSearchParams(window.location.search).get('base
 export function serviceUrl(sub: string): string {
   return `https://${sub}.${BASE_DOMAIN}`
 }
+
+// Decentraland's own deployments. Any other domain arriving by LINK points the whole session's
+// backends — sign-in, content, comms — at someone else's servers, so App.tsx stops on it with the
+// UntrustedLaunchGate before anything boots. The native shell injects the param from the user's
+// own --base-domain flag (App runs in native mode there), which needs no gate.
+export function isTrustedBaseDomain(domain: string): boolean {
+  return domain === 'decentraland.org' || domain === 'decentraland.zone'
+}

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -5,9 +5,10 @@
 //      keys to zone backends, prod to org
 //   3. else decentraland.org (localhost dev, the native CEF page, everything else)
 // Captured once from the entry URL; the engine's URL syncs preserve unknown params so the
-// param form survives realm/position rewrites.
-// MIRROR: deploy/web/engine/boot.js derives the same value the same way for the engine side,
-// and crates/common/src/base_domain.rs is the engine-internal equivalent.
+// param form survives realm/position rewrites. This module is the single source: it publishes
+// the value as window.__baseDomain() for the engine loader (deploy/web/engine/boot.js) and the
+// wasm (src/web.rs apply_base_domain → crates/common/src/base_domain.rs), both of which run
+// only after the HUD has mounted EngineHost.
 
 /** The apex deployment domain a hosting origin implies, or null for unrecognised hosts. */
 export function hostBaseDomain(hostname: string): string | null {
@@ -17,10 +18,27 @@ export function hostBaseDomain(hostname: string): string | null {
   return null
 }
 
+/**
+ * The ?baseDomain= value the engine will accept (crates/common/src/base_domain.rs `set`):
+ * lowercased, bare ascii labels, at least one dot. Anything else is null so the HUD and the
+ * engine fall back to the same derived default instead of splitting across two domains.
+ */
+export function normaliseBaseDomain(raw: string | null): string | null {
+  const d = raw?.trim().toLowerCase() ?? ''
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+$/.test(d) ? d : null
+}
+
 export const BASE_DOMAIN =
-  new URLSearchParams(window.location.search).get('baseDomain') ??
+  normaliseBaseDomain(new URLSearchParams(window.location.search).get('baseDomain')) ??
   hostBaseDomain(window.location.hostname) ??
   'decentraland.org'
+
+declare global {
+  interface Window {
+    __baseDomain?: () => string
+  }
+}
+window.__baseDomain = () => BASE_DOMAIN
 
 /** https origin for a service subdomain, e.g. serviceUrl('places') → "https://places.decentraland.org". */
 export function serviceUrl(sub: string): string {

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -1,9 +1,26 @@
-// The base domain every HUD backend host is composed from — the ?baseDomain= entry param
-// (set by hand on web, injected by the native shell from --base-domain), defaulting to
-// decentraland.org. Captured once from the entry URL; the engine's URL syncs preserve unknown
-// params so it survives realm/position rewrites. Mirrors the engine's common::base_domain
-// (crates/common/src/base_domain.rs).
-export const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain') ?? 'decentraland.org'
+// The base domain every HUD backend host is composed from:
+//   1. the ?baseDomain= entry param (set by hand on web, injected by the native shell from
+//      --base-domain; non-decentraland values are stopped by the UntrustedLaunchGate)
+//   2. else derived from the hosting origin — the staging deployment at decentraland.zone/bevy-web
+//      keys to zone backends, prod to org
+//   3. else decentraland.org (localhost dev, the native CEF page, everything else)
+// Captured once from the entry URL; the engine's URL syncs preserve unknown params so the
+// param form survives realm/position rewrites.
+// MIRROR: deploy/web/engine/boot.js derives the same value the same way for the engine side,
+// and crates/common/src/base_domain.rs is the engine-internal equivalent.
+
+/** The apex deployment domain a hosting origin implies, or null for unrecognised hosts. */
+export function hostBaseDomain(hostname: string): string | null {
+  for (const apex of ['decentraland.org', 'decentraland.zone']) {
+    if (hostname === apex || hostname.endsWith(`.${apex}`)) return apex
+  }
+  return null
+}
+
+export const BASE_DOMAIN =
+  new URLSearchParams(window.location.search).get('baseDomain') ??
+  hostBaseDomain(window.location.hostname) ??
+  'decentraland.org'
 
 /** https origin for a service subdomain, e.g. serviceUrl('places') → "https://places.decentraland.org". */
 export function serviceUrl(sub: string): string {

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -1,0 +1,11 @@
+// The base domain every HUD backend host is composed from — the ?baseDomain= entry param
+// (set by hand on web, injected by the native shell from --base-domain), defaulting to
+// decentraland.org. Captured once from the entry URL; the engine's URL syncs preserve unknown
+// params so it survives realm/position rewrites. Mirrors the engine's common::base_domain
+// (crates/common/src/base_domain.rs).
+export const BASE_DOMAIN = new URLSearchParams(window.location.search).get('baseDomain') ?? 'decentraland.org'
+
+/** https origin for a service subdomain, e.g. serviceUrl('places') → "https://places.decentraland.org". */
+export function serviceUrl(sub: string): string {
+  return `https://${sub}.${BASE_DOMAIN}`
+}

--- a/react-web/src/lib/identity.ts
+++ b/react-web/src/lib/identity.ts
@@ -1,6 +1,8 @@
 // Shared player-identity helpers (name color, #tag split, short address). Used by
 // the chat, members, and friends UIs so the rarity-colored naming is consistent.
 
+import { serviceUrl } from './baseDomain'
+
 const ADDRESS_RE = /^0x[0-9a-fA-F]{6,}$/
 
 // DCL rarity name colors — stable per seed (address) so each player keeps a color.
@@ -29,7 +31,7 @@ export function rarityColor(rarity?: string): string {
 
 // Catalyst thumbnail for an emote URN — derived client-side so the wheel shows previews
 // even if the scene relay didn't send a thumbnail. Strips a trailing `:tokenId` (on-chain NFTs).
-const CATALYST_CONTENTS = 'https://peer.decentraland.org/lambdas/collections/contents'
+const CATALYST_CONTENTS = `${serviceUrl('peer')}/lambdas/collections/contents`
 
 // Direct catalyst thumbnail URL — used straight as an <img>/<image> src. The catalyst sends
 // no Cross-Origin-Resource-Policy header, but the page runs COEP `credentialless`, under which

--- a/react-web/src/lib/systemScene.ts
+++ b/react-web/src/lib/systemScene.ts
@@ -6,6 +6,7 @@
 // Anything not on the list below gets the interstitial in features/gate/UntrustedLaunchGate.
 
 import { PAGE_DIR } from './publicUrl'
+import { serviceUrl } from './baseDomain'
 
 // Our super-user bridge scene. It relays the scene-loading stream + player-ready over
 // BroadcastChannel and renders no UI.
@@ -26,7 +27,7 @@ export const SYSTEM_SCENE =
 // the engine's ipfs layer expands `name.dcl.eth` into the latter, and boot.js reverses it for the
 // address bar, so both spellings reach users.
 const TRUSTED_WORLDS = ['tortilla.dcl.eth', 'sceneviewer.dcl.eth']
-const WORLDS_PREFIX = 'https://worlds-content-server.decentraland.org/world/'
+const WORLDS_PREFIX = `${serviceUrl('worlds-content-server')}/world/`
 
 // A scene served from the developer's own machine. `sdk-commands start` is the whole point of the
 // parameter, and a link can't make someone else's machine serve it.

--- a/react-web/src/lib/useHudScale.ts
+++ b/react-web/src/lib/useHudScale.ts
@@ -15,7 +15,7 @@ const MIN = 0.6
 const MAX = 1.3
 
 type ScaleWindow = Window & { __nativeUiHeight?: number }
-const IS_NATIVE = new URLSearchParams(location.search).get('native') === '1'
+const IS_NATIVE = __NATIVE_HUD__ && new URLSearchParams(location.search).get('native') === '1'
 
 export function useHudScale(): void {
   useEffect(() => {

--- a/react-web/src/main.tsx
+++ b/react-web/src/main.tsx
@@ -14,7 +14,7 @@ installLocalNetworkFetch()
 // NATIVE (?native=1): bevy renders the 3D world *behind* this transparent webview, so the page must
 // be transparent (in web mode the engine canvas lives in this document at z-0, so the body
 // background is fine).
-if (new URLSearchParams(location.search).get('native') === '1') {
+if (__NATIVE_HUD__ && new URLSearchParams(location.search).get('native') === '1') {
   document.documentElement.style.background = 'transparent'
   document.body.style.background = 'transparent'
   // No webview context menu (Back/Reload) on right-click — that gesture is the engine's camera.

--- a/react-web/src/test/baseDomain.test.ts
+++ b/react-web/src/test/baseDomain.test.ts
@@ -1,0 +1,22 @@
+// DOMAIN: base-domain derivation (lib/baseDomain.ts) — which deployment the HUD keys its
+// backend hosts to. The trust side (isTrustedBaseDomain + the launch gate) is covered in
+// systemScene.test.tsx.
+
+import { describe, expect, it } from 'vitest'
+import { hostBaseDomain } from '../lib/baseDomain'
+
+describe('hostBaseDomain', () => {
+  it('derives the apex from decentraland deployments, bare or subdomain', () => {
+    expect(hostBaseDomain('decentraland.org')).toBe('decentraland.org')
+    expect(hostBaseDomain('play.decentraland.org')).toBe('decentraland.org')
+    expect(hostBaseDomain('decentraland.zone')).toBe('decentraland.zone')
+    expect(hostBaseDomain('cdn.decentraland.zone')).toBe('decentraland.zone')
+  })
+
+  it('derives nothing from unrecognised hosts — the param or the org default decide instead', () => {
+    expect(hostBaseDomain('localhost')).toBe(null)
+    expect(hostBaseDomain('interconnected.online')).toBe(null)
+    expect(hostBaseDomain('decentraland.org.evil.example')).toBe(null)
+    expect(hostBaseDomain('evil-decentraland.org')).toBe(null)
+  })
+})

--- a/react-web/src/test/baseDomain.test.ts
+++ b/react-web/src/test/baseDomain.test.ts
@@ -3,7 +3,7 @@
 // systemScene.test.tsx.
 
 import { describe, expect, it } from 'vitest'
-import { hostBaseDomain } from '../lib/baseDomain'
+import { hostBaseDomain, normaliseBaseDomain } from '../lib/baseDomain'
 
 describe('hostBaseDomain', () => {
   it('derives the apex from decentraland deployments, bare or subdomain', () => {
@@ -18,5 +18,18 @@ describe('hostBaseDomain', () => {
     expect(hostBaseDomain('interconnected.online')).toBe(null)
     expect(hostBaseDomain('decentraland.org.evil.example')).toBe(null)
     expect(hostBaseDomain('evil-decentraland.org')).toBe(null)
+  })
+})
+
+describe('normaliseBaseDomain', () => {
+  it('lowercases a bare domain, as the engine does', () => {
+    expect(normaliseBaseDomain('Decentraland.org')).toBe('decentraland.org')
+    expect(normaliseBaseDomain(' interconnected.online ')).toBe('interconnected.online')
+  })
+
+  it('refuses what the engine refuses — a split-brain session otherwise', () => {
+    for (const bad of [null, '', 'https://x.io', 'x.io/path', 'x.io:443', 'x io', 'localhost', '.x.io', 'x.io.', 'x..io', 'münchen.de']) {
+      expect(normaliseBaseDomain(bad)).toBe(null)
+    }
   })
 })

--- a/react-web/src/test/systemScene.test.tsx
+++ b/react-web/src/test/systemScene.test.tsx
@@ -1,13 +1,16 @@
-// DOMAIN: the `?systemScene=` launch gate (lib/systemScene.ts + features/gate/UntrustedLaunchGate).
+// DOMAIN: the untrusted-launch gate (lib/systemScene.ts, lib/baseDomain.ts +
+// features/gate/UntrustedLaunchGate).
 //
-// The parameter picks the super-user scene, which permissions.rs waves through every permission
+// `?systemScene=` picks the super-user scene, which permissions.rs waves through every permission
 // check and hands the whole SystemApi — so an unrecognised one is a session takeover delivered as a
-// link. These cover the allowlist itself and the near-misses an attacker would actually reach for.
+// link. `?baseDomain=` points every backend at another deployment — a phishing lever in a link.
+// These cover the allowlists themselves and the near-misses an attacker would actually reach for.
 
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { isTrustedSystemScene, SYSTEM_SCENE } from '../lib/systemScene'
+import { isTrustedBaseDomain } from '../lib/baseDomain'
 import { UntrustedLaunchGate } from '../features/gate/UntrustedLaunchGate'
 
 describe('isTrustedSystemScene', () => {
@@ -58,6 +61,20 @@ describe('isTrustedSystemScene', () => {
   })
 })
 
+describe('isTrustedBaseDomain', () => {
+  it("accepts decentraland's own deployments", () => {
+    expect(isTrustedBaseDomain('decentraland.org')).toBe(true)
+    expect(isTrustedBaseDomain('decentraland.zone')).toBe(true)
+  })
+
+  it('rejects other domains, including lookalikes built on the trusted names', () => {
+    expect(isTrustedBaseDomain('interconnected.online')).toBe(false)
+    expect(isTrustedBaseDomain('decentraland.org.evil.example')).toBe(false)
+    expect(isTrustedBaseDomain('evil-decentraland.org')).toBe(false)
+    expect(isTrustedBaseDomain('decentraland.today')).toBe(false)
+  })
+})
+
 describe('UntrustedLaunchGate', () => {
   it('names the offending value and leads with the safe action', () => {
     render(<UntrustedLaunchGate systemScene="https://example.com/evil" onProceed={vi.fn()} />)
@@ -65,6 +82,21 @@ describe('UntrustedLaunchGate', () => {
     expect(screen.getByText('https://example.com/evil')).toBeInTheDocument()
     // Proceeding is not reachable in one click — it sits behind Advanced.
     expect(screen.queryByRole('button', { name: /continue anyway/i })).not.toBeInTheDocument()
+  })
+
+  it('names an untrusted base domain the same way', () => {
+    render(<UntrustedLaunchGate baseDomain="interconnected.online" onProceed={vi.fn()} />)
+    expect(screen.getByText(/not trusted/i)).toBeInTheDocument()
+    expect(screen.getByText('interconnected.online')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /continue anyway/i })).not.toBeInTheDocument()
+  })
+
+  it('names both parameters when a link carries both', () => {
+    render(
+      <UntrustedLaunchGate systemScene="https://example.com/evil" baseDomain="interconnected.online" onProceed={vi.fn()} />
+    )
+    expect(screen.getByText('https://example.com/evil')).toBeInTheDocument()
+    expect(screen.getByText('interconnected.online')).toBeInTheDocument()
   })
 
   it('only proceeds after Advanced, and only on the explicit confirm', async () => {

--- a/react-web/src/vite-env.d.ts
+++ b/react-web/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+// Build-time constant (vite.config.ts `define`): true in the native HUD bundle
+// (`bundle:native`, --mode native) and on the dev server; FALSE in deployed web builds,
+// where the minifier deletes every ?native=1 branch — a link must not be able to put a
+// web deployment into native mode (it would skip the launch gates).
+declare const __NATIVE_HUD__: boolean

--- a/react-web/vite.config.ts
+++ b/react-web/vite.config.ts
@@ -131,7 +131,12 @@ function coiHeadersExceptAuth(): Plugin {
   }
 }
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command, mode }) => ({
+  // ?native=1 (CEF HUD mode) is honoured only where it's legitimate: the bundle:native build
+  // (--mode native) that CEF loads from disk, and the dev server (react_hud_cef.rs supports
+  // REACT_HUD_URL at a vite dev server). Deployed web builds compile it FALSE so a crafted
+  // link can't switch them into native mode and skip the launch gates (see src/App.tsx MODE).
+  define: { __NATIVE_HUD__: JSON.stringify(command === 'serve' || mode === 'native') },
   // Production is served from a VERSIONED CDN subpath (cdn.decentraland.org/<pkg>/<version>/ —
   // see deploy/web/scripts/prebuild.js), so built asset URLs can't be origin-absolute. CI passes
   // PUBLIC_URL for an absolute CDN base; otherwise './' (relative → works from any path, e.g. a

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,12 @@ just native-release            # bundles the HUD if stale, then builds + runs ev
 just native-release --server https://realm-provider.decentraland.org/main --location 52,-52
 ```
 
+`--base-domain` retargets every backend host (auth, comms, places, worlds, social, ...) at another deployment's domain:
+
+```bash
+just native-release --base-domain interconnected.online --location 0,0
+```
+
 Doing it by hand instead of via `just`:
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ just native-release            # bundles the HUD if stale, then builds + runs ev
 just native-release --server https://realm-provider-ea.decentraland.org/main --location 52,-52
 ```
 
-`--base-domain` retargets every backend host (auth, comms, places, worlds, social, ...) at another deployment's domain:
+`--base-domain` retargets the backend hosts (auth, comms, places, worlds, social, ...) at another deployment's domain. `renderer-artifacts` (sdk6 adaption layer) and `builder-items` (inspector asset catalog) stay on decentraland.org — they have no other deployment:
 
 ```bash
 just native-release --base-domain interconnected.online --location 0,0

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ just native-release            # bundles the HUD if stale, then builds + runs ev
 `just native-debug` is the same in debug. Both pass extra arguments through:
 
 ```bash
-just native-release --server https://realm-provider.decentraland.org/main --location 52,-52
+just native-release --server https://realm-provider-ea.decentraland.org/main --location 52,-52
 ```
 
 `--base-domain` retargets every backend host (auth, comms, places, worlds, social, ...) at another deployment's domain:

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,8 @@ just native-release --server https://realm-provider.decentraland.org/main --loca
 just native-release --base-domain interconnected.online --location 0,0
 ```
 
+On web the same thing is the `?baseDomain=` query param, e.g. `?baseDomain=interconnected.online`.
+
 Doing it by hand instead of via `just`:
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ just native-release --server https://realm-provider.decentraland.org/main --loca
 just native-release --base-domain interconnected.online --location 0,0
 ```
 
-On web the same thing is the `?baseDomain=` query param, e.g. `?baseDomain=interconnected.online`.
+On web the same thing is the `?baseDomain=` query param, e.g. `?baseDomain=interconnected.online`. Without the param, the hosting origin decides: a page served under decentraland.zone keys to zone backends, anything else to org.
 
 Doing it by hand instead of via `just`:
 

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -1064,11 +1064,11 @@ fn drain_control_commands(
                     let client = ipfs.ipfs().client();
                     let sid = scene_id.clone();
                     let task = IoTaskPool::get().spawn_compat(async move {
-                        let url = common::base_domain::https_url_from_path(
+                        let url = common::base_domain::https(
                             "comms-gatekeeper-local",
                             "/get-server-scene-adapter",
                         );
-                        let uri = http::Uri::try_from(url)?;
+                        let uri = http::Uri::try_from(url.as_str())?;
                         let meta = serde_json::json!({
                             "intent": "dcl:explorer:comms-handshake",
                             "signer": "dcl:explorer",

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -285,8 +285,8 @@ fn main() {
     );
 
     let config = AppConfig {
-        server: args.realm.clone(),
-        location: args.location,
+        home_realm: Some(args.realm.clone()),
+        home_location: Some(args.location),
         graphics: GraphicsSettings {
             vsync: false,
             log_fps: false,
@@ -615,9 +615,9 @@ fn setup(
     // and PrimaryEntities::player() panics without the marker. Placed at the scene
     // location so position-based loading picks up the parcel scene.
     let player_pos = Vec3::new(
-        8.0 + PARCEL_SIZE * config.location.x as f32,
+        8.0 + PARCEL_SIZE * config.home_location().x as f32,
         0.0,
-        -8.0 + -PARCEL_SIZE * config.location.y as f32,
+        -8.0 + -PARCEL_SIZE * config.home_location().y as f32,
     );
     // NOT OutOfWorld: the player must count as "inside" the scene parcel so
     // update_scene_room fires the authoritative scene-room connection.

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -901,7 +901,7 @@ fn drain_control_commands(
     >,
 ) {
     let store_delegation = |scene_id: &str, encoded: &str, delegations: &mut StorageDelegations| {
-        match StorageDelegation::parse(encoded, &map_realm_name(&config.server)) {
+        match StorageDelegation::parse(encoded, &map_realm_name(&config.home_realm)) {
             Ok(delegation) => {
                 // reject a renewal that rebinds to another scene's credential
                 // (hammurabi's same-scene guard)

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -1064,8 +1064,10 @@ fn drain_control_commands(
                     let client = ipfs.ipfs().client();
                     let sid = scene_id.clone();
                     let task = IoTaskPool::get().spawn_compat(async move {
-                        let url =
-                            "https://comms-gatekeeper-local.decentraland.org/get-server-scene-adapter";
+                        let url = common::base_domain::https_url_from_path(
+                            "comms-gatekeeper-local",
+                            "/get-server-scene-adapter",
+                        );
                         let uri = http::Uri::try_from(url)?;
                         let meta = serde_json::json!({
                             "intent": "dcl:explorer:comms-handshake",

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -901,7 +901,7 @@ fn drain_control_commands(
     >,
 ) {
     let store_delegation = |scene_id: &str, encoded: &str, delegations: &mut StorageDelegations| {
-        match StorageDelegation::parse(encoded, &map_realm_name(&config.home_realm)) {
+        match StorageDelegation::parse(encoded, &map_realm_name(&config.home_realm())) {
             Ok(delegation) => {
                 // reject a renewal that rebinds to another scene's credential
                 // (hammurabi's same-scene guard)

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -90,6 +90,15 @@ struct Args {
 
 fn parse_args() -> Args {
     let mut args = pico_args::Arguments::from_env();
+    // latch first: everything below that composes a backend host reads it
+    if let Err(e) = args
+        .opt_value_from_str::<_, String>("--base-domain")
+        .map_err(|e| e.to_string())
+        .and_then(|domain| domain.map_or(Ok(()), |d| common::base_domain::set(&d)))
+    {
+        eprintln!("{e}");
+        std::process::exit(2);
+    }
     let realm: String = args
         .value_from_str("--realm")
         .unwrap_or_else(|_| "http://localhost:8000".to_owned());

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -106,11 +106,11 @@ fn main() {
         .unwrap_or(IVec2::ZERO);
 
     let final_config = AppConfig {
-        server: args
+        home_realm: args
             .value_from_str("--server")
             .ok()
-            .unwrap_or(base_config.server),
-        location,
+            .unwrap_or(base_config.home_realm),
+        home_location: location,
         graphics: GraphicsSettings {
             vsync: false,
             log_fps: false,
@@ -211,7 +211,7 @@ fn main() {
             })
             .add_before::<bevy::asset::AssetPlugin>(IpfsIoPlugin {
                 preview: false,
-                starting_realm: Some(map_realm_name(&final_config.server)),
+                starting_realm: Some(map_realm_name(&final_config.home_realm)),
                 content_server_override,
                 assets_root: Default::default(),
                 num_slots: final_config.max_concurrent_remotes,
@@ -336,7 +336,7 @@ fn check_done(
     }
 
     // wait for pointers
-    if pointers.get(config.location).is_none() {
+    if pointers.get(config.home_location).is_none() {
         *counter = 0;
         return;
     }
@@ -387,9 +387,9 @@ fn setup(
     let player_id = commands
         .spawn((
             Transform::from_translation(Vec3::new(
-                8.0 + 16.0 * config.location.x as f32,
+                8.0 + 16.0 * config.home_location.x as f32,
                 8.0,
-                -8.0 + -16.0 * config.location.y as f32,
+                -8.0 + -16.0 * config.home_location.y as f32,
             )),
             Visibility::default(),
             config.player_settings.clone(),
@@ -410,9 +410,9 @@ fn setup(
             Camera3d::default(),
             PrimaryCamera::default(),
             Transform::from_translation(Vec3::new(
-                8.0 + 16.0 * config.location.x as f32,
+                8.0 + 16.0 * config.home_location.x as f32,
                 8.0,
-                -8.0 + -16.0 * config.location.y as f32,
+                -8.0 + -16.0 * config.home_location.y as f32,
             )),
         ))
         .id();

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -107,10 +107,10 @@ fn main() {
 
     let final_config = AppConfig {
         home_realm: args
-            .value_from_str("--server")
+            .value_from_str::<_, String>("--server")
             .ok()
-            .unwrap_or(base_config.home_realm),
-        home_location: location,
+            .or(base_config.home_realm),
+        home_location: Some(location),
         graphics: GraphicsSettings {
             vsync: false,
             log_fps: false,
@@ -211,7 +211,7 @@ fn main() {
             })
             .add_before::<bevy::asset::AssetPlugin>(IpfsIoPlugin {
                 preview: false,
-                starting_realm: Some(map_realm_name(&final_config.home_realm)),
+                starting_realm: Some(map_realm_name(&final_config.home_realm())),
                 content_server_override,
                 assets_root: Default::default(),
                 num_slots: final_config.max_concurrent_remotes,
@@ -336,7 +336,7 @@ fn check_done(
     }
 
     // wait for pointers
-    if pointers.get(config.home_location).is_none() {
+    if pointers.get(config.home_location()).is_none() {
         *counter = 0;
         return;
     }
@@ -387,9 +387,9 @@ fn setup(
     let player_id = commands
         .spawn((
             Transform::from_translation(Vec3::new(
-                8.0 + 16.0 * config.home_location.x as f32,
+                8.0 + 16.0 * config.home_location().x as f32,
                 8.0,
-                -8.0 + -16.0 * config.home_location.y as f32,
+                -8.0 + -16.0 * config.home_location().y as f32,
             )),
             Visibility::default(),
             config.player_settings.clone(),
@@ -410,9 +410,9 @@ fn setup(
             Camera3d::default(),
             PrimaryCamera::default(),
             Transform::from_translation(Vec3::new(
-                8.0 + 16.0 * config.home_location.x as f32,
+                8.0 + 16.0 * config.home_location().x as f32,
                 8.0,
-                -8.0 + -16.0 * config.home_location.y as f32,
+                -8.0 + -16.0 * config.home_location().y as f32,
             )),
         ))
         .id();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@ impl DecentralandAppConfig {
     ) -> Self {
         update_app_config_from_arguments(&mut app_config, &arguments);
         app_config.migrate_inputs();
-        app_config.migrate_home();
 
         Self {
             app_config,
@@ -131,11 +130,11 @@ impl DecentralandAppConfig {
     /// The realm the engine boots into: an explicit --server, else the home realm.
     /// --server is a startup param (like the web's ?realm=) and is deliberately NOT
     /// merged into the AppConfig — see the home_realm field docs.
-    pub fn boot_server(&self) -> &str {
+    pub fn boot_server(&self) -> String {
         self.arguments
             .server
-            .as_deref()
-            .unwrap_or(&self.app_config.home_realm)
+            .clone()
+            .unwrap_or_else(|| self.app_config.home_realm())
     }
 
     /// The parcel the player spawns at: an explicit --location, else the home parcel.
@@ -143,7 +142,7 @@ impl DecentralandAppConfig {
     pub fn boot_location(&self) -> IVec2 {
         self.arguments
             .location
-            .unwrap_or(self.app_config.home_location)
+            .unwrap_or_else(|| self.app_config.home_location())
     }
 }
 
@@ -247,8 +246,9 @@ impl DecentralandApp {
                 // its places picker (parity with ?realm= on web). On the stock default the
                 // param is omitted so the picker shows — and the HUD's own default-realm
                 // assumption then matches the realm the engine actually booted.
-                server: (decentraland_app_config.boot_server() != AppConfig::default().home_realm)
-                    .then(|| decentraland_app_config.boot_server().to_owned()),
+                server: (decentraland_app_config.boot_server()
+                    != AppConfig::default().home_realm())
+                .then(|| decentraland_app_config.boot_server()),
             });
         }
 
@@ -257,7 +257,7 @@ impl DecentralandApp {
 
         info!("Bevy-Explorer version {}", version);
 
-        let boot_server = map_realm_name(decentraland_app_config.boot_server());
+        let boot_server = map_realm_name(&decentraland_app_config.boot_server());
         // computed here too: scene_params is partially moved out of the arguments below
         let boot_location = BootLocation(decentraland_app_config.boot_location());
         // Show out-of-bounds geometry in preview, on a loopback realm (local dev) and in
@@ -691,7 +691,7 @@ fn desktop_default_plugins(decentraland_app_config: &DecentralandAppConfig) -> P
         .build()
         .add_before::<bevy::asset::AssetPlugin>(IpfsIoPlugin {
             preview: decentraland_app_config.arguments.is_preview,
-            starting_realm: Some(map_realm_name(decentraland_app_config.boot_server())),
+            starting_realm: Some(map_realm_name(&decentraland_app_config.boot_server())),
             content_server_override: decentraland_app_config
                 .arguments
                 .content_server_override
@@ -726,7 +726,7 @@ fn wasm_default_plugins(decentraland_app_config: &DecentralandAppConfig) -> Plug
         .disable::<LogPlugin>()
         .add_before::<AssetPlugin>(IpfsIoPlugin {
             preview: decentraland_app_config.arguments.is_preview,
-            starting_realm: Some(map_realm_name(decentraland_app_config.boot_server())),
+            starting_realm: Some(map_realm_name(&decentraland_app_config.boot_server())),
             content_server_override: decentraland_app_config
                 .arguments
                 .content_server_override

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ impl DecentralandAppConfig {
     ) -> Self {
         update_app_config_from_arguments(&mut app_config, &arguments);
         app_config.migrate_inputs();
+        app_config.migrate_home();
 
         Self {
             app_config,
@@ -127,17 +128,30 @@ impl DecentralandAppConfig {
         }
     }
 
-    /// The realm the engine boots into: an explicit --server, else the configured server.
-    /// --server is deliberately NOT merged into the AppConfig: the config file is rewritten
-    /// wholesale on any settings change, which would silently persist a one-off CLI realm
-    /// as the configured (home) server.
+    /// The realm the engine boots into: an explicit --server, else the home realm.
+    /// --server is a startup param (like the web's ?realm=) and is deliberately NOT
+    /// merged into the AppConfig — see the home_realm field docs.
     pub fn boot_server(&self) -> &str {
         self.arguments
             .server
             .as_deref()
-            .unwrap_or(&self.app_config.server)
+            .unwrap_or(&self.app_config.home_realm)
+    }
+
+    /// The parcel the player spawns at: an explicit --location, else the home parcel.
+    /// Same contract as [`Self::boot_server`].
+    pub fn boot_location(&self) -> IVec2 {
+        self.arguments
+            .location
+            .unwrap_or(self.app_config.home_location)
     }
 }
+
+/// The spawn parcel resolved by [`DecentralandAppConfig::boot_location`] — a distinct
+/// resource so the AppConfig resource (rewritten wholesale to disk on settings changes)
+/// never carries a one-off --location as home.
+#[derive(Resource)]
+pub struct BootLocation(pub IVec2);
 
 pub struct DecentralandArguments {
     pub server: Option<String>,
@@ -233,7 +247,7 @@ impl DecentralandApp {
                 // its places picker (parity with ?realm= on web). On the stock default the
                 // param is omitted so the picker shows — and the HUD's own default-realm
                 // assumption then matches the realm the engine actually booted.
-                server: (decentraland_app_config.boot_server() != AppConfig::default().server)
+                server: (decentraland_app_config.boot_server() != AppConfig::default().home_realm)
                     .then(|| decentraland_app_config.boot_server().to_owned()),
             });
         }
@@ -244,6 +258,8 @@ impl DecentralandApp {
         info!("Bevy-Explorer version {}", version);
 
         let boot_server = map_realm_name(decentraland_app_config.boot_server());
+        // computed here too: scene_params is partially moved out of the arguments below
+        let boot_location = BootLocation(decentraland_app_config.boot_location());
         // Show out-of-bounds geometry in preview, on a loopback realm (local dev) and in
         // the editor, never on a public realm. Computed before boot_server moves.
         let editor_mode = decentraland_app_config.arguments.editor;
@@ -424,6 +440,7 @@ impl DecentralandApp {
         // and add AppConfig as a resource
         let graphics_config = decentraland_app_config.app_config.graphics.clone();
         app.insert_resource(decentraland_app_config.app_config.audio.clone());
+        app.insert_resource(boot_location);
         app.insert_resource(decentraland_app_config.app_config);
 
         // Plugins
@@ -515,6 +532,7 @@ fn setup(
     mut player_resource: ResMut<PrimaryPlayerRes>,
     mut cam_resource: ResMut<PrimaryCameraRes>,
     config: Res<AppConfig>,
+    boot_location: Res<BootLocation>,
     #[cfg(target_arch = "wasm32")] render_device: ResMut<RenderDevice>,
 ) {
     #[cfg(target_arch = "wasm32")]
@@ -529,9 +547,9 @@ fn setup(
     let player_id = commands
         .spawn((
             Transform::from_translation(Vec3::new(
-                8.0 + 16.0 * config.location.x as f32,
+                8.0 + 16.0 * boot_location.0.x as f32,
                 8.0,
-                -8.0 + -16.0 * config.location.y as f32,
+                -8.0 + -16.0 * boot_location.0.y as f32,
             )),
             Visibility::default(),
             config.player_settings.clone(),
@@ -570,8 +588,6 @@ fn update_app_config_from_arguments(
     base_app_config: &mut AppConfig,
     arguments: &DecentralandArguments,
 ) {
-    base_app_config.location.replace_if_some(arguments.location);
-
     base_app_config
         .graphics
         .vsync

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,8 @@ fn main() {
 }
 
 fn decentraland_app_config() -> Result<DecentralandAppConfig, UserError> {
-    let app_config = decentraland_serialized_app_config();
     let arguments = decentraland_app_arguments()?;
+    let app_config = decentraland_serialized_app_config();
     let crash_file = decentraland_crash_file();
 
     Ok(DecentralandAppConfig::new(
@@ -96,6 +96,13 @@ fn decentraland_serialized_app_config() -> AppConfig {
 
 fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
     let mut args = pico_args::Arguments::from_env();
+
+    if let Ok(domain) = args.value_from_str::<_, String>("--base-domain") {
+        common::base_domain::set(&domain).map_err(|e| {
+            error!("{e}");
+            UserError(true)
+        })?;
+    }
 
     let test_scenes = args.value_from_str("--test_scenes").ok();
     let startup_scenes_preview = args.contains("--ui-preview");

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,13 @@ fn decentraland_serialized_app_config() -> AppConfig {
 fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
     let mut args = pico_args::Arguments::from_env();
 
-    if let Ok(domain) = args.value_from_str::<_, String>("--base-domain") {
+    if let Some(domain) = args
+        .opt_value_from_str::<_, String>("--base-domain")
+        .map_err(|e| {
+            error!("{e}");
+            UserError(true)
+        })?
+    {
         common::base_domain::set(&domain).map_err(|e| {
             error!("{e}");
             UserError(true)

--- a/src/react_hud_cef.rs
+++ b/src/react_hud_cef.rs
@@ -173,6 +173,13 @@ fn spawn_hud(
         url.push_str("realm=");
         url.push_str(&urlencoding::encode(server));
     }
+    // A non-default --base-domain reaches the HUD the same way it reaches the web page: as the
+    // ?baseDomain= param the page composes all its backend fetch hosts from.
+    if common::base_domain::get() != common::base_domain::DEFAULT {
+        url.push_str(if url.contains('?') { "&" } else { "?" });
+        url.push_str("baseDomain=");
+        url.push_str(&urlencoding::encode(common::base_domain::get()));
+    }
 
     let (w, h) = windows
         .single()

--- a/src/web.rs
+++ b/src/web.rs
@@ -130,6 +130,22 @@ pub async fn engine_init() -> Result<JsValue, JsValue> {
     Ok("Config loaded".into())
 }
 
+/// The persisted home scene — realm + "x,y" parcel — as a JSON string, falling back to the
+/// derived defaults. Valid after [`engine_init`] (it reads the loaded config); exposed so the
+/// HUD's places picker can target home from "Skip" BEFORE the engine is launched.
+#[wasm_bindgen]
+pub fn engine_home_scene() -> String {
+    let (realm, parcel) = INIT_DATA
+        .get()
+        .map(|config| (config.home_realm.clone(), config.home_location))
+        .unwrap_or_else(|| {
+            let config = AppConfig::default();
+            (config.home_realm, config.home_location)
+        });
+    serde_json::json!({ "realm": realm, "parcel": format!("{},{}", parcel.x, parcel.y) })
+        .to_string()
+}
+
 #[expect(clippy::too_many_arguments)]
 #[wasm_bindgen]
 pub fn engine_run(

--- a/src/web.rs
+++ b/src/web.rs
@@ -72,6 +72,24 @@ extern "C" {
     /// leave keys alone while the user types into scene UI.
     #[wasm_bindgen(js_name = "__setEngineTextFocus")]
     fn set_engine_text_focus(focused: bool);
+
+    /// The ?baseDomain= entry param, captured by boot.js (web parity with --base-domain).
+    /// `catch` so a host page without boot.js just falls through to the default domain.
+    #[wasm_bindgen(js_name = "__baseDomain", catch)]
+    fn base_domain_param() -> Result<String, JsValue>;
+}
+
+/// Latch the base domain before any backend URL is composed. Called at the top of BOTH wasm
+/// entry points: engine_init's config deserialization already materializes
+/// `AppConfig::default()` fields, so engine_run alone would be too late.
+fn apply_base_domain() {
+    if let Ok(domain) = base_domain_param() {
+        if !domain.is_empty() {
+            if let Err(e) = common::base_domain::set(&domain) {
+                warn!("ignoring baseDomain param: {e}");
+            }
+        }
+    }
 }
 
 /// call from a separate worker to initialize a channel for asset load processing
@@ -86,6 +104,7 @@ pub fn init_asset_load_thread() {
 #[wasm_bindgen]
 pub async fn engine_init() -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
+    apply_base_domain();
 
     let mut file = match web_fs::File::open("config.json").await {
         Ok(f) => f,
@@ -126,6 +145,7 @@ pub fn engine_run(
     params: &str,
     pulse_server: &str,
 ) {
+    apply_base_domain();
     init_runtime();
 
     let default_filter = "symphonia=warn";

--- a/src/web.rs
+++ b/src/web.rs
@@ -137,10 +137,10 @@ pub async fn engine_init() -> Result<JsValue, JsValue> {
 pub fn engine_home_scene() -> String {
     let (realm, parcel) = INIT_DATA
         .get()
-        .map(|config| (config.home_realm.clone(), config.home_location))
+        .map(|config| (config.home_realm(), config.home_location()))
         .unwrap_or_else(|| {
             let config = AppConfig::default();
-            (config.home_realm, config.home_location)
+            (config.home_realm(), config.home_location())
         });
     serde_json::json!({ "realm": realm, "parcel": format!("{},{}", parcel.x, parcel.y) })
         .to_string()


### PR DESCRIPTION
`unity-explorer` recently gained the ability to define a 'base domain' that is not decentraland.{ENV} -- this closes that gap https://github.com/decentraland/unity-explorer/pull/9826