### PR TITLE
Re-enable engine console commands from the React HUD, preview-gate the dev/cheat ones

### DIFF
--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -1330,7 +1330,10 @@ fn play_current_emote(
 #[derive(clap::Parser, ConsoleCommand)]
 #[command(name = "/emote")]
 struct EmoteConsoleCommand {
+    /// Emote urn, or a profile emote slot number
     urn: String,
+    #[arg(long, default_value_t = false)]
+    r#loop: bool,
 }
 
 fn emote_console_command(
@@ -1354,15 +1357,17 @@ fn emote_console_command(
             }
 
             info!("anim {} -> {}", command.urn, urn);
-            let timestamp = maybe_prev.map(|p| p.timestamp).unwrap_or_default();
+            let timestamp = maybe_prev.map(|p| p.timestamp + 1).unwrap_or_default();
 
             commands.entity(player).try_insert(EmoteCommand {
                 urn: urn.clone(),
                 timestamp,
-                r#loop: false,
+                r#loop: command.r#loop,
             });
-        };
-        input.ok();
+            input.reply_ok(format!("playing emote {urn}"));
+        } else {
+            input.reply_failed("player not found");
+        }
     }
 }
 

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -148,7 +148,7 @@ impl Plugin for AvatarPlugin {
             ComponentPosition::Any,
         );
 
-        app.add_console_command::<DebugDumpAvatar, _>(debug_dump_avatar);
+        app.add_preview_console_command::<DebugDumpAvatar, _>(debug_dump_avatar);
 
         app.add_observer(add_attach_points_to_avatar_shape);
         app.add_observer(remove_attach_points_from_avatar_shape);

--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -4,7 +4,7 @@ use bevy_console::{
     ConsoleSet, PrintConsoleLine,
 };
 use clap::Parser;
-use common::{rpc::RpcResultReceiver, sets::SceneSets};
+use common::{rpc::RpcResultReceiver, sets::SceneSets, structs::PreviewMode};
 use std::sync::Mutex;
 
 pub trait DoAddConsoleCommand {
@@ -12,6 +12,17 @@ pub trait DoAddConsoleCommand {
         &mut self,
         system: impl IntoScheduleConfigs<ScheduleSystem, U>,
     ) -> &mut Self;
+
+    /// Register a command only when running in preview mode. Outside preview the command is
+    /// not registered at all, so it is absent from `/help` and rejected as unrecognised.
+    fn add_preview_console_command<T: Command, U>(
+        &mut self,
+        system: impl IntoScheduleConfigs<ScheduleSystem, U>,
+    ) -> &mut Self;
+}
+
+fn is_preview(preview: Option<Res<PreviewMode>>) -> bool {
+    preview.is_some_and(|p| p.is_preview)
 }
 
 // hook console commands
@@ -23,11 +34,39 @@ impl DoAddConsoleCommand for App {
     ) -> &mut Self {
         bevy_console::AddConsoleCommand::add_console_command::<T, U>(self, system)
     }
+
+    fn add_preview_console_command<T: bevy_console::Command, U>(
+        &mut self,
+        system: impl IntoScheduleConfigs<ScheduleSystem, U>,
+    ) -> &mut Self {
+        let register = |mut config: ResMut<ConsoleConfiguration>| {
+            config
+                .commands
+                .insert(T::name(), T::command().no_binary_name(true));
+        };
+
+        self.add_systems(
+            Startup,
+            register.in_set(ConsoleSet::Startup).run_if(is_preview),
+        )
+        .add_systems(
+            Update,
+            system.in_set(ConsoleSet::Commands).run_if(is_preview),
+        )
+    }
 }
 
 #[cfg(test)]
 impl DoAddConsoleCommand for App {
     fn add_console_command<T: bevy_console::Command, U>(
+        &mut self,
+        _: impl IntoScheduleConfigs<ScheduleSystem, U>,
+    ) -> &mut Self {
+        // do nothing
+        self
+    }
+
+    fn add_preview_console_command<T: bevy_console::Command, U>(
         &mut self,
         _: impl IntoScheduleConfigs<ScheduleSystem, U>,
     ) -> &mut Self {

--- a/crates/image_processing/src/engine.rs
+++ b/crates/image_processing/src/engine.rs
@@ -45,7 +45,7 @@ impl Plugin for ImageProcessingPlugin {
 
         app.init_resource::<ImgReprocessStats>();
         app.init_resource::<DebugProcessingEnabled>();
-        app.add_console_command::<DebugProcessingCommand, _>(toggle_debug_processing);
+        app.add_preview_console_command::<DebugProcessingCommand, _>(toggle_debug_processing);
     }
 }
 

--- a/crates/imposters/src/lib.rs
+++ b/crates/imposters/src/lib.rs
@@ -22,9 +22,9 @@ pub struct DclImposterPlugin {
 impl Plugin for DclImposterPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((DclImposterBakeScenePlugin, DclImposterRenderPlugin))
-            .add_console_command::<ImpostDistanceCommand, _>(set_impost_distance)
-            .add_console_command::<ImpostMultisampleCommand, _>(set_impost_multi)
-            .add_console_command::<DebugImpostersCommand, _>(toggle_debug_imposters);
+            .add_preview_console_command::<ImpostDistanceCommand, _>(set_impost_distance)
+            .add_preview_console_command::<ImpostMultisampleCommand, _>(set_impost_multi)
+            .add_preview_console_command::<DebugImpostersCommand, _>(toggle_debug_imposters);
         app.insert_resource(self.clone());
     }
 }

--- a/crates/restricted_actions/src/agent_commands.rs
+++ b/crates/restricted_actions/src/agent_commands.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_console::ConsoleCommand;
 use common::{
     rpc::{RpcCall, RpcResultSender, SpawnResponse},
-    structs::{EmoteCommand, PrimaryUser},
+    structs::PrimaryUser,
 };
 use console::{DoAddConsoleCommand, PendingConsoleResponses};
 use dcl_component::transform_and_parent::DclTranslation;
@@ -16,7 +16,6 @@ impl Plugin for AgentCommandsPlugin {
         app.add_console_command::<PlayerPositionCommand, _>(player_position_cmd);
         app.add_console_command::<ListPortablesCommand, _>(list_portables_cmd);
         app.add_console_command::<ConnectedPlayersCommand, _>(connected_players_cmd);
-        app.add_console_command::<TriggerEmoteCommand, _>(trigger_emote_cmd);
         app.add_console_command::<GetUserDataCommand, _>(get_user_data_cmd);
     }
 }
@@ -209,38 +208,6 @@ fn connected_players_cmd(
             },
             responder,
         );
-    }
-}
-
-// --- /emote ---
-
-#[derive(clap::Parser, ConsoleCommand)]
-#[command(name = "/emote")]
-struct TriggerEmoteCommand {
-    urn: String,
-    #[arg(long, default_value_t = false)]
-    r#loop: bool,
-}
-
-fn trigger_emote_cmd(
-    mut input: ConsoleCommand<TriggerEmoteCommand>,
-    mut player: Query<(Entity, Option<&EmoteCommand>), With<PrimaryUser>>,
-    mut commands: Commands,
-) {
-    if let Some(Ok(command)) = input.take() {
-        match player.single_mut() {
-            Ok((entity, maybe_prev)) => {
-                commands.entity(entity).try_insert(EmoteCommand {
-                    urn: command.urn.clone(),
-                    r#loop: command.r#loop,
-                    timestamp: maybe_prev
-                        .map(|prev| prev.timestamp + 1)
-                        .unwrap_or_default(),
-                });
-                input.reply_ok(format!("playing emote {}", command.urn));
-            }
-            Err(_) => input.reply_failed("player not found"),
-        }
     }
 }
 

--- a/crates/restricted_actions/src/agent_commands.rs
+++ b/crates/restricted_actions/src/agent_commands.rs
@@ -11,7 +11,7 @@ pub struct AgentCommandsPlugin;
 
 impl Plugin for AgentCommandsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_console_command::<MovePlayerToCommand, _>(move_player_to_cmd);
+        app.add_preview_console_command::<MovePlayerToCommand, _>(move_player_to_cmd);
         app.add_console_command::<WalkPlayerToCommand, _>(walk_player_to_cmd);
         app.add_console_command::<PlayerPositionCommand, _>(player_position_cmd);
         app.add_console_command::<ListPortablesCommand, _>(list_portables_cmd);

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -137,7 +137,7 @@ impl Plugin for PointerResultPlugin {
                 .chain()
                 .in_set(SceneSets::Input),
         );
-        app.add_console_command::<DebugPointerCommand, _>(debug_pointer_command);
+        app.add_preview_console_command::<DebugPointerCommand, _>(debug_pointer_command);
     }
 }
 

--- a/crates/scene_runner/src/update_scene/raycast_result.rs
+++ b/crates/scene_runner/src/update_scene/raycast_result.rs
@@ -40,7 +40,7 @@ impl Plugin for RaycastResultPlugin {
         app.add_systems(Update, run_raycasts.in_set(SceneSets::Input));
         app.init_resource::<DebugRaycast>();
         app.init_resource::<SuperUserRaycastScene>();
-        app.add_console_command::<DebugRaycastCommand, _>(debug_raycast);
+        app.add_preview_console_command::<DebugRaycastCommand, _>(debug_raycast);
     }
 }
 

--- a/crates/scene_runner/src/update_world/mesh_collider.rs
+++ b/crates/scene_runner/src/update_world/mesh_collider.rs
@@ -180,7 +180,7 @@ impl Plugin for MeshColliderPlugin {
         add_collider_systems::<CtCollider>(app);
 
         app.init_resource::<DebugColliders>();
-        app.add_console_command::<DebugColliderCommand, _>(debug_colliders);
+        app.add_preview_console_command::<DebugColliderCommand, _>(debug_colliders);
     }
 }
 

--- a/crates/scene_runner/src/util.rs
+++ b/crates/scene_runner/src/util.rs
@@ -33,9 +33,9 @@ impl Plugin for SceneUtilPlugin {
     fn build(&self, app: &mut App) {
         let (send, recv) = tokio::sync::mpsc::unbounded_channel();
         app.insert_resource(ConsoleRelay { send, recv });
-        app.add_console_command::<DebugDumpScene, _>(debug_dump_scene);
+        app.add_preview_console_command::<DebugDumpScene, _>(debug_dump_scene);
         app.add_console_command::<ReloadCommand, _>(reload_command);
-        app.add_console_command::<ClearStoreCommand, _>(clear_store_command);
+        app.add_preview_console_command::<ClearStoreCommand, _>(clear_store_command);
         app.add_systems(Update, (console_relay, handle_preview_command));
     }
 }

--- a/crates/social/src/lib.rs
+++ b/crates/social/src/lib.rs
@@ -67,7 +67,7 @@ impl Plugin for SocialPlugin {
         {
             app.init_resource::<DebugSocialEnabled>();
             app.init_resource::<RestartSocialRequested>();
-            app.add_console_command::<DebugSocialCommand, _>(toggle_debug_social);
+            app.add_preview_console_command::<DebugSocialCommand, _>(toggle_debug_social);
             app.add_console_command::<RestartSocialCommand, _>(restart_social);
             app.add_systems(
                 PostUpdate,

--- a/crates/system_ui/src/chat/mod.rs
+++ b/crates/system_ui/src/chat/mod.rs
@@ -63,7 +63,7 @@ impl Plugin for ChatPanelPlugin {
             );
             app.add_systems(Update, keyboard_popup);
         }
-        app.add_console_command::<Rechat, _>(debug_chat);
+        app.add_preview_console_command::<Rechat, _>(debug_chat);
         app.add_event::<PrivateChatEntered>();
         app.add_plugins((FriendsPlugin, ChatHistoryPlugin));
     }

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -72,7 +72,7 @@ impl Plugin for SysInfoPanelPlugin {
         app.add_console_command::<SysinfoCommand, _>(set_sysinfo);
 
         app.add_systems(First, (entity_count, display_tracked_components));
-        app.add_console_command::<TrackComponentCommand, _>(set_track_components);
+        app.add_preview_console_command::<TrackComponentCommand, _>(set_track_components);
     }
 }
 

--- a/crates/user_input/src/lib.rs
+++ b/crates/user_input/src/lib.rs
@@ -47,9 +47,9 @@ impl Plugin for UserInputPlugin {
         );
         app.init_resource::<EngineMovementControl>()
             .init_resource::<CursorLocks>();
-        app.add_console_command::<NoClipCommand, _>(no_clip);
-        app.add_console_command::<SpeedCommand, _>(speed_cmd);
-        app.add_console_command::<JumpCommand, _>(jump_cmd);
+        app.add_preview_console_command::<NoClipCommand, _>(no_clip);
+        app.add_preview_console_command::<SpeedCommand, _>(speed_cmd);
+        app.add_preview_console_command::<JumpCommand, _>(jump_cmd);
     }
 }
 

--- a/react-web/bridge-scene/src/domains/world.ts
+++ b/react-web/bridge-scene/src/domains/world.ts
@@ -89,18 +89,23 @@ export function registerWorld(ctx: Ctx): void {
       })
   })
 
-  // `/commands` — surface the engine console's own command list. Run its `help`; if `help` isn't a
-  // registered command the engine rejects with "Recognized commands: [...]" — exactly the list we
-  // want — so relay either the successful output or the rejection text.
+  // Engine console passthrough (`/commands` → `help`, and any chat `/command` the page forwards).
+  // The output — or the rejection text (unknown command, usage error) — goes back as a
+  // `consoleReply`; the page decides how to render it (it filters its own hidden commands).
   ctx.on('consoleCommand', (msg) => {
     const op = BevyApi.consoleCommand
     if (op == null) {
       pushSystem(ctx, 'Engine console is not available.')
       return
     }
-    op(msg.command, msg.args ?? [])
-      .then((out) => pushSystem(ctx, out.trim() || `(no output for ${msg.command})`))
-      .catch((e: unknown) => pushSystem(ctx, e instanceof Error ? e.message : String(e)))
+    const args = msg.args ?? []
+    op(msg.command, args)
+      .then((output) => {
+        ctx.send({ kind: 'consoleReply', command: msg.command, args, ok: true, output })
+      })
+      .catch((e: unknown) => {
+        ctx.send({ kind: 'consoleReply', command: msg.command, args, ok: false, output: e instanceof Error ? e.message : String(e) })
+      })
   })
 
   ctx.on('setMic', (msg) => {

--- a/react-web/e2e/README.md
+++ b/react-web/e2e/README.md
@@ -3,7 +3,7 @@
 Per-domain tests that drive the **live** app — the React HUD, the bevy engine (in a
 same-origin iframe), and the super-user bridge scene — and assert each API call
 round-trips over the bridge. The player is driven with **bevy console commands**
-(`move_player_to`, `teleport`, `player_position`); panels are opened with real DOM
+(`walk_player_to`, `teleport`, `player_position`); panels are opened with real DOM
 clicks; the bridge is observed via a `BroadcastChannel` spy.
 
 This complements the deterministic **tier 1** suite (`src/test/*.test.tsx`, run with
@@ -43,7 +43,7 @@ One test per domain, in `engine.spec.ts` (boots the world once, serial):
 | Domain | Driven by | Asserts (bridge) |
 |---|---|---|
 | session | enter as guest | `getProfile`, `getNotifications` sent on entry |
-| world (move) | `move_player_to` | `player_position` changes |
+| world (move) | `walk_player_to` | `player_position` changes |
 | chat | type + Enter | `sendChat` |
 | settings | click Settings | `getSettings` → `settings` |
 | emotes | click Emotes | `getEmotes` → `emotes` |

--- a/react-web/e2e/engine-clicks.spec.ts
+++ b/react-web/e2e/engine-clicks.spec.ts
@@ -11,7 +11,7 @@ import {
   enterAsGuest,
   sidebar,
   expectBridge,
-  movePlayerTo,
+  walkNearby,
   position,
   getUserData,
   profileVersion,
@@ -42,13 +42,13 @@ test.describe('react HUD ↔ engine — in-panel clicks (console-verified)', () 
   })
 
   // --- movement lands EXACTLY where asked (strong console round-trip) ----------
-  test('console: move_player_to lands at the requested position', async () => {
-    await movePlayerTo(page, 12, 1, 7)
+  test('console: walk_player_to lands at the requested position', async () => {
+    const to = await walkNearby(page)
     await expect
       .poll(
         async () => {
           const p = await position(page)
-          return Math.abs(p.x - 12) < 1 && Math.abs(p.z - 7) < 1
+          return Math.abs(p.x - to.x) < 1 && Math.abs(p.z - to.z) < 1
         },
         { timeout: 15_000 }
       )

--- a/react-web/e2e/engine.spec.ts
+++ b/react-web/e2e/engine.spec.ts
@@ -4,7 +4,7 @@
 // Requires a real GPU (WebGPU) + the bridge scene on :8100 — see e2e/README.md.
 
 import { test, expect, type Page } from '@playwright/test'
-import { enterAsGuest, sidebar, cmd, movePlayerTo, teleport, playerPosition, expectBridge, bridgeKinds } from './helpers'
+import { enterAsGuest, sidebar, cmd, walkNearby, teleport, playerPosition, expectBridge, bridgeKinds } from './helpers'
 
 test.describe.configure({ mode: 'serial' })
 
@@ -27,9 +27,9 @@ test.describe('react HUD ↔ real engine', () => {
   })
 
   // --- world: bevy player movement (deterministic console command) -----------
-  test('world: move_player_to relocates the avatar', async () => {
+  test('world: walk_player_to relocates the avatar', async () => {
     const before = await playerPosition(page)
-    await movePlayerTo(page, 8, 1, 24)
+    await walkNearby(page)
     await expect.poll(async () => playerPosition(page)).not.toBe(before)
     expect(await playerPosition(page)).toMatch(/-?\d/)
   })

--- a/react-web/e2e/helpers.ts
+++ b/react-web/e2e/helpers.ts
@@ -34,8 +34,32 @@ export async function cmd(page: Page, line: string): Promise<string> {
 }
 
 // --- bevy world driving (deterministic — prefer these over synthetic input) ------
-export const movePlayerTo = (page: Page, x: number, y: number, z: number): Promise<string> =>
-  cmd(page, `move_player_to ${x} ${y} ${z}`)
+/** Walk the avatar to a world position via the movement controller (`move_player_to` is
+ *  preview-only). Resolves on arrival (0.5 m stop threshold) or rejects after `timeout` s. */
+export const walkPlayerTo = (page: Page, x: number, y: number, z: number, timeout = 20): Promise<string> =>
+  cmd(page, `walk_player_to ${x} ${y} ${z} ${timeout}`)
+/** Walk a short hop from where the avatar stands, trying each cardinal direction until one
+ *  arrives — the walk respects colliders and the spawn has steps/props nearby, so any fixed
+ *  target can be blocked. Returns the target reached. */
+export async function walkNearby(page: Page, dist = 3): Promise<{ x: number; y: number; z: number }> {
+  const from = await position(page)
+  const errors: string[] = []
+  for (const [dx, dz] of [
+    [dist, 0],
+    [-dist, 0],
+    [0, dist],
+    [0, -dist]
+  ]) {
+    const to = { x: from.x + dx, y: from.y, z: from.z + dz }
+    try {
+      await walkPlayerTo(page, to.x, to.y, to.z, 10)
+      return to
+    } catch (e) {
+      errors.push(`(${to.x}, ${to.z}): ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }
+  throw new Error(`walk_player_to blocked in every direction from (${from.x}, ${from.z}): ${errors.join('; ')}`)
+}
 export const teleport = (page: Page, x: number, y: number): Promise<string> => cmd(page, `teleport ${x} ${y}`)
 export const playerPosition = (page: Page): Promise<string> => cmd(page, 'player_position')
 

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -726,7 +726,12 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
       return
     }
     if (msg.kind === 'consoleCommand') {
-      reply({ kind: 'chat', chat: { sender: '', message: 'Console commands: reload, help, show_ui, noclip, speed, jump', channel: 'Nearby' } })
+      const args = msg.args ?? []
+      const output =
+        msg.command === 'help' && args.length === 0
+          ? 'Available commands:\n  /help     - List available commands\n  /teleport - set location\n  /crdt_snapshot - (hidden by the HUD)'
+          : `(mock) ran /${msg.command} ${args.join(' ')}`.trim()
+      reply({ kind: 'consoleReply', command: msg.command, args, ok: true, output })
       return
     }
 

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -73,12 +73,22 @@ export interface ReloadSceneRequest {
   kind: 'reloadScene'
 }
 
-/** Run an engine console command (the `/commands` chat command → `help`); the scene relays the
- *  console's text output back as a system chat message. */
+/** Run an engine console command (chat `/commands` → `help`, or any passed-through `/command`);
+ *  the scene answers with a `consoleReply`. */
 export interface ConsoleCommandRequest {
   kind: 'consoleCommand'
   command: string
   args?: string[]
+}
+
+/** The console's reply to a `consoleCommand` (scene → page): its text output, or the failure
+ *  text (`ok: false`, e.g. the engine's unknown-command rejection or a clap usage error). */
+export interface ConsoleReplyMessage {
+  kind: 'consoleReply'
+  command: string
+  args: string[]
+  ok: boolean
+  output: string
 }
 
 /** Sidebar nav actions the React sidebar triggers in the scene (open a menu/popup,
@@ -970,6 +980,7 @@ export type SceneToPage =
   | LoginCodeMessage
   | SceneLoadingMessage
   | ChatRelayMessage
+  | ConsoleReplyMessage
   | ChatVisibilityMessage
   | FocusChatMessage
   | MembersMessage

--- a/react-web/src/features/chat/chatCommands.test.ts
+++ b/react-web/src/features/chat/chatCommands.test.ts
@@ -65,7 +65,7 @@ describe('parseChatCommand', () => {
   })
 
   it('HUD-hidden engine commands → the unknown-command hint, never the console', () => {
-    for (const name of ['crdt_snapshot', 'set_component', 'lock_preview', 'logout', 'exit']) {
+    for (const name of ['crdt_snapshot', 'screenshot', 'set_component', 'lock_preview', 'logout', 'exit']) {
       expect(HUD_HIDDEN_COMMANDS.has(name)).toBe(true)
       const r = parseChatCommand(`/${name} 1 2`)
       expect(r.kind).toBe('system')

--- a/react-web/src/features/chat/chatCommands.test.ts
+++ b/react-web/src/features/chat/chatCommands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseChatCommand, HELP_TEXT } from './chatCommands'
+import { formatConsoleReply, HUD_HIDDEN_COMMANDS, parseChatCommand, splitArgs, HELP_TEXT } from './chatCommands'
 
 describe('parseChatCommand', () => {
   it('passes a normal message through as send (trimmed)', () => {
@@ -52,9 +52,58 @@ describe('parseChatCommand', () => {
     expect(parseChatCommand('/goto 1 2 3').kind).toBe('system')
   })
 
-  it('an unknown /command → a system hint, not a broadcast', () => {
-    const r = parseChatCommand('/dance')
-    expect(r.kind).toBe('system')
-    expect((r as { message: string }).message).toContain('/help')
+  it('any other /command passes through to the engine console with split args', () => {
+    expect(parseChatCommand('/dance')).toEqual({ kind: 'console', command: 'dance', args: [] })
+    expect(parseChatCommand('/Emote 3')).toEqual({ kind: 'console', command: 'emote', args: ['3'] })
+    expect(parseChatCommand('/changerealm boedo.dcl.eth "https://x.y/content"')).toEqual({
+      kind: 'console',
+      command: 'changerealm',
+      args: ['boedo.dcl.eth', 'https://x.y/content']
+    })
+    // A bare slash is not a command.
+    expect(parseChatCommand('/').kind).toBe('system')
+  })
+
+  it('HUD-hidden engine commands → the unknown-command hint, never the console', () => {
+    for (const name of ['crdt_snapshot', 'set_component', 'lock_preview', 'logout', 'exit']) {
+      expect(HUD_HIDDEN_COMMANDS.has(name)).toBe(true)
+      const r = parseChatCommand(`/${name} 1 2`)
+      expect(r.kind).toBe('system')
+      expect((r as { message: string }).message).toContain('/help')
+    }
+  })
+
+  it('/reload <hash> and /help <command> go to the engine; the bare forms stay local', () => {
+    expect(parseChatCommand('/reload bafyabc')).toEqual({ kind: 'console', command: 'reload', args: ['bafyabc'] })
+    expect(parseChatCommand('/help teleport')).toEqual({ kind: 'console', command: 'help', args: ['/teleport'] })
+    expect(parseChatCommand('/help /teleport')).toEqual({ kind: 'console', command: 'help', args: ['/teleport'] })
+    expect(parseChatCommand('/help').kind).toBe('system')
+  })
+
+  it('splitArgs honours quotes', () => {
+    expect(splitArgs(`a "b c" 'd e' f`)).toEqual(['a', 'b c', 'd e', 'f'])
+    expect(splitArgs('')).toEqual([])
+  })
+})
+
+describe('formatConsoleReply', () => {
+  it('drops HUD-hidden commands from the bare help listing', () => {
+    const out = ['Available commands:', '  /teleport      - set location', '  /crdt_snapshot - Return the full live CRDT state', '  /emote         - emote'].join('\n')
+    const shown = formatConsoleReply('help', [], out)
+    expect(shown).toContain('/teleport')
+    expect(shown).toContain('/emote')
+    expect(shown).not.toContain('/crdt_snapshot')
+    // Per-command help is passed through untouched.
+    expect(formatConsoleReply('help', ['/teleport'], 'set location\n\nUsage: /teleport <X> <Y>')).toContain('Usage:')
+  })
+
+  it("trims the engine's unknown-command rejection to one sentence", () => {
+    const rejection = 'Command not recognized: `/dance`. Recognized commands: ["/clear", "/emote", "/exit"]'
+    expect(formatConsoleReply('dance', [], rejection)).toBe('Command not recognized: `/dance`. Type /commands for the list.')
+  })
+
+  it('reports empty output explicitly', () => {
+    expect(formatConsoleReply('fps', ['60'], '  ')).toBe('(no output for /fps)')
+    expect(formatConsoleReply('fps', ['60'], 'fps set to 60\n')).toBe('fps set to 60')
   })
 })

--- a/react-web/src/features/chat/chatCommands.ts
+++ b/react-web/src/features/chat/chatCommands.ts
@@ -63,6 +63,7 @@ export const HUD_HIDDEN_COMMANDS: ReadonlySet<string> = new Set([
   'component_names',
   'component_default',
   'component_schema',
+  'screenshot',
   // scene inspector — write / assets
   'set_component',
   'set_component_raw',

--- a/react-web/src/features/chat/chatCommands.ts
+++ b/react-web/src/features/chat/chatCommands.ts
@@ -3,8 +3,10 @@
 // dispatches (teleport / changeRealm / reload / console) or a system message to echo in chat.
 //
 // `/goto` and `/world` reuse the existing teleport/changeRealm bridge plumbing; `/reload` and
-// `/commands` go through new thin bridge handlers (reloadScene / consoleCommand). `/help` is a
+// `/commands` go through thin bridge handlers (reloadScene / consoleCommand). `/help` is a
 // client-rendered system message; `/commands` surfaces the engine's own console command list.
+// Any other `/word args` is passed through to the engine console (`consoleCommand`), except the
+// HUD_HIDDEN_COMMANDS below; the engine itself only registers dev/cheat commands in preview mode.
 
 /** The DCL default (Genesis) realm — `/goto genesis` / `/goto main` target this. */
 const GENESIS_ALIASES = new Set(['genesis', 'main'])
@@ -22,6 +24,8 @@ export type ChatCommand =
   | { kind: 'reload' }
   /** `/commands` — list the engine console commands. */
   | { kind: 'commands' }
+  /** Any other `/command args` — run it on the engine console (no leading slash, args pre-split). */
+  | { kind: 'console'; command: string; args: string[] }
   /** `/help` (and invalid usage) — echo this text as a system message. */
   | { kind: 'system'; message: string }
 
@@ -35,7 +39,86 @@ export const HELP_TEXT = [
   '/world <world> — jump to a world (alias of /goto <world>)',
   '/reload — reload the current scene',
   '/commands — list the engine console commands',
+  '/<command> [args] — run any engine console command (see /commands; /help <command> for its usage)',
 ].join('\n')
+
+/** Engine console commands the HUD never runs from chat, and drops from `/commands`, even though
+ *  the engine registers them: the scene-inspector/editor set serves other HUDs (the editor and
+ *  component-inspector system scenes) through the same console op and dumps whole-scene JSON;
+ *  lock/unlock_preview and show_ui are preview-scene tooling; the login/logout/chat set are
+ *  agent-harness commands that would desync this HUD's own session state; clear/exit are a
+ *  console no-op and a native quit. */
+export const HUD_HIDDEN_COMMANDS: ReadonlySet<string> = new Set([
+  // scene inspector — read
+  'set_scene',
+  'scene_stats',
+  'scene_target',
+  'scene_logs',
+  'scene_entities',
+  'entity_components',
+  'inspect_component',
+  'scene_tree',
+  'crdt_snapshot',
+  'crdt_initial',
+  'component_names',
+  'component_default',
+  'component_schema',
+  // scene inspector — write / assets
+  'set_component',
+  'set_component_raw',
+  'new_entity',
+  'save_composite',
+  'delete_component',
+  'delete_entity',
+  'freeze_scene',
+  'unfreeze_scene',
+  'tick_scene',
+  'highlight',
+  'scene_content',
+  'asset_catalog',
+  'init_asset',
+  // preview-scene tooling
+  'lock_preview',
+  'unlock_preview',
+  'show_ui',
+  // session / agent harness
+  'login_guest',
+  'login_previous',
+  'login_identity',
+  'logout',
+  'chat',
+  // console no-op / native quit
+  'clear',
+  'exit',
+])
+
+/** Split a console argument string on whitespace, honouring "double" and 'single' quotes. */
+export function splitArgs(rest: string): string[] {
+  const out: string[] = []
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(rest)) != null) out.push(m[1] ?? m[2] ?? m[3])
+  return out
+}
+
+/** Render an engine console reply as a chat system line. A bare `help` (`/commands`) drops the
+ *  HUD-hidden commands; the engine's unknown-command rejection is cut to its first sentence (its
+ *  "Recognized commands: [...]" tail is the whole registry). */
+export function formatConsoleReply(command: string, args: string[], output: string): string {
+  if (command === 'help' && args.length === 0) {
+    return output
+      .split('\n')
+      .filter((line) => {
+        const m = line.match(/^\s*\/(\S+)/)
+        return m == null || !HUD_HIDDEN_COMMANDS.has(m[1])
+      })
+      .join('\n')
+      .trim()
+  }
+  const unknown = output.match(/^Command not recognized: `[^`]*`/)
+  if (unknown != null) return `${unknown[0]}. Type /commands for the list.`
+  return output.trim() || `(no output for /${command})`
+}
 
 /** Normalize a world token to its ENS realm: `boedo` → `boedo.dcl.eth`; `foo.eth` stays. */
 function toRealm(token: string): string {
@@ -63,20 +146,29 @@ export function parseChatCommand(input: string): ChatCommand {
 
   const [word, ...restParts] = text.split(/\s+/)
   const rest = text.slice(word.length).trim()
-  switch (word.toLowerCase()) {
-    case '/help':
+  const name = word.slice(1).toLowerCase()
+  switch (name) {
+    case 'help':
+      // `/help <command>` → the engine's per-command usage (its registry keys carry the slash).
+      if (restParts.length > 0) return { kind: 'console', command: 'help', args: [`/${restParts[0].replace(/^\//, '')}`] }
       return { kind: 'system', message: HELP_TEXT }
-    case '/commands':
+    case 'commands':
       return { kind: 'commands' }
-    case '/reload':
+    case 'reload':
+      // Bare `/reload` targets the player's scene (the engine's bare `/reload` reloads every scene,
+      // this HUD's bridge included); with a hash it is the engine command.
+      if (restParts.length > 0) return { kind: 'console', command: 'reload', args: splitArgs(rest) }
       return { kind: 'reload' }
-    case '/goto':
+    case 'goto':
       return parseGoto(rest, true)
-    case '/world':
+    case 'world':
       return restParts.length === 0
         ? { kind: 'system', message: 'Usage: /world <world>' }
         : parseGoto(rest, false)
     default:
-      return { kind: 'system', message: `Unknown command ${word}. Type /help for the list.` }
+      if (name === '' || HUD_HIDDEN_COMMANDS.has(name)) {
+        return { kind: 'system', message: `Unknown command ${word}. Type /help for the list.` }
+      }
+      return { kind: 'console', command: name, args: splitArgs(rest) }
   }
 }

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -14,7 +14,7 @@ import { isInputLocked, subscribeInputLock } from '../../lib/inputLock'
 import { useWindowKeyDown } from '../../lib/useWindowKeyDown'
 import { getCursor } from '../pointer/cursorStore'
 import { openProfileCard } from '../profileCard/ProfileCard'
-import { parseChatCommand } from '../chat/chatCommands'
+import { formatConsoleReply, parseChatCommand } from '../chat/chatCommands'
 import type {
   AppNotification,
   BindingEntry,
@@ -686,6 +686,15 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           // it from a RAF loop, so it must not drive React renders.
           poseRef.current = { x: msg.x, z: msg.z, yaw: msg.yaw, camYaw: msg.camYaw }
           break
+        case 'consoleReply':
+          // Command feedback: a local "DCL System" line, never broadcast (same shape as pushSystemMessage).
+          setMessages((prev) =>
+            [
+              ...prev,
+              { sender: '', message: formatConsoleReply(msg.command, msg.args, msg.output), channel: 'Nearby', id: chatId.current++, ts: Date.now() }
+            ].slice(-MAX_CHAT_LINES)
+          )
+          break
         case 'realmInfo':
           setIsWorld(msg.isWorld)
           break
@@ -824,6 +833,9 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           break
         case 'commands':
           driverRef.current?.send({ kind: 'consoleCommand', command: 'help' })
+          break
+        case 'console':
+          driverRef.current?.send({ kind: 'consoleCommand', command: cmd.command, args: cmd.args })
           break
         case 'system':
           pushSystemMessage(cmd.message)


### PR DESCRIPTION
The engine registers ~90 console commands, but the React HUD's chat parser was a hard whitelist of five (`/help`, `/commands`, `/reload`, `/goto`, `/world`) — everything else got "Unknown command". The old bevy-ui-scene forwarded every `/` line to the engine. This restores that, with a tiering so dev/cheat commands don't leak into production play.

### Engine
- New `add_preview_console_command` on `DoAddConsoleCommand`: registers the command only when `PreviewMode.is_preview`, so outside preview it never enters the registry — absent from `/help`, rejected on every dispatch path — rather than sitting behind a deny list.
- Moved onto it (17): `idnoclip`, `speed`, `jump`, `move_player_to`, `debug_colliders`/`raycast`/`pointer`/`imposters`/`social`/`processing`, `track_components`, `debug_dump_scene`/`avatar`, `clear_store`, `impost`, `impost_multisample`, `cdb`.
- Stays public: navigation (`teleport`, `changerealm`), read-only info, client perf settings, visual tuning, `emote`, `reset_controls`, `restart_social`, `sysinfo`, `walk_player_to` (respects colliders), `spawn`/`kill`.
- `/emote` was registered twice (avatar + agent-commands batch); both handlers fired. Kept the avatar one and folded in the other's `--loop`, timestamp bump and reply.

### React HUD
- Any other `/command args` is passed through the existing `consoleCommand` bridge op (quote-aware arg split). `/reload <hash>` and `/help <command>` are forwarded; the bare forms stay HUD-local (the engine's bare `/reload` reloads the bridge scene too).
- `HUD_HIDDEN_COMMANDS`: the scene-inspector/editor set (used by the editor and component-inspector system scenes through the same op), `lock`/`unlock_preview`, `show_ui`, the `login*`/`logout`/`chat` agent commands (would desync HUD session state), `clear`, `exit`. Hidden from chat and filtered out of `/commands`.
- New `consoleReply` bridge message so the page renders console output itself (hidden-command filtering, and the engine's unknown-command rejection is trimmed instead of dumping the whole registry into chat).

### e2e
`move_player_to` is preview-only now, so the specs drive the avatar with `walk_player_to` via a `walkNearby` helper that probes a short hop in each cardinal direction. Both spec files pass against the real engine (the pre-existing `profile: the passport is relayed` failure and the Playwright teardown hang are unrelated and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
