### PR TITLE
fix(react-web e2e): passport assertion + Playwright teardown hang

### DIFF
--- a/react-web/e2e/README.md
+++ b/react-web/e2e/README.md
@@ -27,8 +27,9 @@ npm run test:e2e
 ```
 
 `playwright.config.ts` starts both servers automatically (Vite dev on :5173 + the
-bridge scene on :8100) and reuses them if already running. To point at an
-already-running app, set `E2E_URL=http://localhost:5173`.
+bridge scene on :8100, with `BRIDGE_SCENE_PREVIEW=0` so Vite doesn't also start its
+own) and reuses them if already running. To point at an already-running app, set
+`E2E_URL=http://localhost:5173`.
 
 List the tests without launching the engine:
 

--- a/react-web/e2e/engine.spec.ts
+++ b/react-web/e2e/engine.spec.ts
@@ -89,8 +89,11 @@ test.describe('react HUD ↔ real engine', () => {
   // --- profile: passport relayed --------------------------------------------
   test('profile: the passport is relayed to the page', async () => {
     await expectBridge(page, 'page', 'profile')
+    // The sidebar's Profile icon opens the local player's passport popup (App's viewMyProfile,
+    // reading the relayed profile) — it never toggles the small profile panel, so the button has
+    // no pressed state.
     await sidebar(page, 'Profile')
-    await expect(page.getByRole('button', { name: 'Profile', exact: true })).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('button', { name: 'OVERVIEW', exact: true })).toBeVisible()
   })
 
   // --- notifications: open → fetch -------------------------------------------

--- a/react-web/playwright.config.ts
+++ b/react-web/playwright.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
     {
       command: 'npm run dev',
       url: 'http://localhost:5173',
+      // :8100 is OUR webServer below — stop vite's own bridge-scene auto-start (vite.config.ts) from
+      // racing it (EADDRINUSE) and, worse, outliving the run: the runner waits for each server's
+      // stdio to close, and vite's detached sdk-commands child keeps them open after vite is killed.
+      env: { BRIDGE_SCENE_PREVIEW: '0' },
       reuseExistingServer: true,
       timeout: 120_000
     },

--- a/react-web/vite.config.ts
+++ b/react-web/vite.config.ts
@@ -10,12 +10,15 @@ import react from '@vitejs/plugin-react'
 // default systemScene in dev, with scene hot-reload) alongside vite, so `npm run dev` is the ONE
 // command. If :8100 is already serving (your own terminal, or Playwright's webServer), leave it
 // alone. The child is killed with the dev server (detached group so sdk-commands' own children
-// don't survive as orphans).
+// don't survive as orphans). BRIDGE_SCENE_PREVIEW=0 disables the auto-start entirely — Playwright
+// sets it because it runs :8100 as its own webServer, and a child spawned from here would outlive
+// its SIGKILL of the vite process group (own group, inherited stdio) and hang the test run's exit.
 function bridgeScenePreview(): Plugin {
   return {
     name: 'bridge-scene-preview',
     apply: 'serve',
     configureServer(server) {
+      if (process.env.BRIDGE_SCENE_PREVIEW === '0') return
       const probe = createConnection({ port: 8100, host: '127.0.0.1' })
       probe.once('connect', () => probe.destroy()) // already running — reuse it
       probe.once('error', () => {


### PR DESCRIPTION
Two pre-existing failures in the tier-2 (real engine) Playwright suite, both harness-side — no HUD/engine behaviour changes.

**`profile: the passport is relayed to the page` always failed.** It asserted the sidebar's Profile button gets `aria-pressed="true"`, but that button's `onClick` is App's `viewMyProfile`, which opens the passport popup and never toggles `session.profile.open` — so the assertion was unreachable. It now asserts the passport is shown (its `OVERVIEW` tab). Because the suite is serial, this also un-skips the eight tests after it.

**Playwright never printed its summary or exited.** It `SIGKILL`s the `npm run dev` process group and then waits for the child's stdio to close. `vite.config.ts`'s bridge-scene auto-start spawns `sdk-commands` `detached` with inherited stdio, so the orphan outlives the kill and holds the pipes open forever. The same spawn raced Playwright's own `:8100` webServer (`EADDRINUSE`). Fix: a `BRIDGE_SCENE_PREVIEW=0` opt-out in the vite plugin, set via `env` on the vite `webServer` entry. `npm run dev` on its own is unchanged.

Full headed run against a main-built engine: 24 passed, 2 skipped (tier-1 placeholders), exit 0, no listeners or processes left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)