### PR TITLE
dependabot: ignore tracing-appender 0.2.5 (breaks wasm build)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     # but is breaking); cargo's caret semantics encode compatibility correctly, so the
     # manifest ranges are the policy. Crossing a range boundary is deliberate manual work.
     versioning-strategy: lockfile-only
+    ignore:
+      # 0.2.5 pulls in `symlink`, which has no wasm32 impl — breaks the web build.
+      # Fixed upstream in tokio-rs/tracing#3568 (unreleased); drop once 0.2.6 ships.
+      - dependency-name: tracing-appender
+        versions: ['0.2.5']
     groups:
       cargo-deps:
         patterns: ['*']


### PR DESCRIPTION
`tracing-appender` 0.2.5 pulls in the `symlink` crate, which has no wasm32 implementation, so the web build in #1142 fails with `error[E0425]: cannot find function 'symlink_file' in crate 'symlink'`. Upstream: tokio-rs/tracing#3536, fix tokio-rs/tracing#3568 (unreleased).

The other 30 bumps in #1142 build for wasm with only tracing-appender held at 0.2.4, so this adds a dependabot `ignore` pinned to `0.2.5` exactly — the fixed release will be proposed automatically and the rule can be dropped then.

After merge, `@dependabot rebase` on #1142 should re-resolve without 0.2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)