### PR TITLE
ci: run the package workflow's react-web build on Node 24

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -83,7 +83,7 @@ jobs:
           # react HUD (cef): node for the page + bridge-scene bundles, ninja for cef-dll-sys' cmake build
           - uses: actions/setup-node@v7
             with:
-                node-version: 20
+                node-version: 24
           # moved up from below the CEF export: the TS-bindings build compiles the bevy dep
           # graph (gilrs needs libudev) before the HUD bundle can build.
           - name: Install alsa and udev


### PR DESCRIPTION
jsdom 30 / jest-dom 7 (#1070) require Node ≥ 22, so the react-web `npm ci` in `package.yml` now warns `EBADENGINE` on Node 20. Every other workflow (`ci.yml`, both `publish-headless.yml` jobs) and `react-web/.nvmrc` already pin 24 — this brings the release build in line.

`package.yml` is dispatch-only, so this gets exercised on the next desktop release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)