### PR TITLE
deps: patch rustls-webpki 0.103.13, rand 0.9.3 / 0.10.1 (advisories)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8874,7 +8874,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
@@ -9084,9 +9084,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -9094,9 +9094,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -9247,7 +9247,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -9797,7 +9797,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -9889,9 +9889,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -12317,7 +12317,7 @@ checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]


### PR DESCRIPTION
Hand-edited `Cargo.lock` (version + checksum only — the dependency lists are identical across each bump, verified against crates.io), validated with `cargo metadata --locked`.

| Package | Bump | Advisory | Reached via |
|---|---|---|---|
| rustls-webpki | 0.103.10 → 0.103.13 | GHSA-82j2-j2ch-gfr8 (high) — panic on malformed CRL BIT STRING | rustls 0.23 ← `deno_tls` (scene TLS / WebSocket) |
| rand | 0.9.2 → 0.9.3 | GHSA-cq8v-f236-94qc (low) | rav1e ← ravif ← image |
| rand | 0.10.0 → 0.10.1 | GHSA-cq8v-f236-94qc (low) | uuid |

Closes Dependabot alerts #40, #33, #29. The older `rustls-webpki` 0.101/0.102 copies (ethers/livekit-api's reqwest 0.11 line, and the deno fork) are unchanged here — those are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)