### PR TITLE
bridge-scene: move to the experimental-bevy SDK build

### DIFF
--- a/react-web/bridge-scene/package-lock.json
+++ b/react-web/bridge-scene/package-lock.json
@@ -8,11 +8,11 @@
       "name": "bevy-ui-scene",
       "version": "1.0.0",
       "devDependencies": {
-        "@dcl/ecs": "7.22.6-25007982108.commit-83012ab",
-        "@dcl/js-runtime": "7.22.6-25007982108.commit-83012ab",
-        "@dcl/react-ecs": "7.22.6-25007982108.commit-83012ab",
-        "@dcl/sdk": "7.22.6-25007982108.commit-83012ab",
-        "@dcl/sdk-commands": "7.22.6-25007982108.commit-83012ab",
+        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
+        "@dcl/js-runtime": "7.27.1-33247605236.commit-732120a",
+        "@dcl/react-ecs": "7.27.1-33247605236.commit-732120a",
+        "@dcl/sdk": "7.27.1-33247605236.commit-732120a",
+        "@dcl/sdk-commands": "7.27.1-33247605236.commit-732120a",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "eslint": "^8.53.0",
@@ -24,7 +24,7 @@
         "prettier": "3.0.3"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=22.0.0",
         "npm": ">=6.0.0"
       }
     },
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -101,6 +101,15 @@
       "integrity": "sha512-gJZo3IB8U+jhBJWR0DgoLS+zaUDIb/u79e7Rp+MEM78uH3bvC19S3Dd8lxWEbPXNKlCB0saUptfK/Buw0c1y2Q==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@dcl/core-commons": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.11.0.tgz",
+      "integrity": "sha512-VJ6FgMQoF242slJy1EDJkfkOqYKrywSKJf/ZNg5buGsZj2CAc+RLyBnp0XSl/iCp3VJfpJA3lm5yuKCqWralCA==",
+      "dev": true,
+      "dependencies": {
+        "@well-known-components/interfaces": "^1.5.2"
+      }
     },
     "node_modules/@dcl/crypto": {
       "version": "3.7.0",
@@ -131,9 +140,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.22.6-25007982108.commit-83012ab",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.22.6-25007982108.commit-83012ab.tgz",
-      "integrity": "sha512-kfUI0g63+QslPq10msMYj7jzNPnFVjs2wIDdfkrBpjy490YZzsyvrGlFRoE9FGqqYRQmp6tyV156PJFFnevsoQ==",
+      "version": "7.27.1-33247605236.commit-732120a",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.27.1-33247605236.commit-732120a.tgz",
+      "integrity": "sha512-cUrLWiZhZbvHGcD+hYzKZM+lp1WDq4WiikuO1jYf3+oeCqQhHvXMr8i9oG8wwFjV2VkgniJATCqg/tgdZt83hA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -144,12 +153,14 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@dcl/explorer": {
-      "version": "1.0.164509-20240802172549.commit-fb95b9b",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.164509-20240802172549.commit-fb95b9b.tgz",
-      "integrity": "sha512-R+vmK+rdxjKJ7s3/1nNdefEG5tCyB1Z8VZH+s6EvV9mMwMXpiI4hFUAZ0gSCEQz9D2P7clern9E95AajWzbeIQ==",
+    "node_modules/@dcl/fetch-component": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@dcl/fetch-component/-/fetch-component-1.1.2.tgz",
+      "integrity": "sha512-AzryeK3QwE13NgszhvIx9mib/S5+r3yZOiltFha/4rtJ27cs5TBf+jzQZKDFyhqDFEGBcEqOrJNAKYXCemp85Q==",
       "dev": true,
-      "license": "Apache-2.0"
+      "dependencies": {
+        "@dcl/core-commons": "0.11.0"
+      }
     },
     "node_modules/@dcl/gltf-validator-ts": {
       "version": "1.0.14",
@@ -235,20 +246,20 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.25.0.tgz",
-      "integrity": "sha512-TDpU0hUx6CbxM7jPET3t1L1w2JWbmKpzNSxmoqe+OWjmiopNhZQyBuldSEbjf7eUR4ZBijMAcYfMy3EOoDgKiQ==",
+      "version": "7.36.3",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.36.3.tgz",
+      "integrity": "sha512-EwvXoZlXvDKZsK2qrRYG+Yia7qKHWgQUqbWY7e6zSVMffRDhhjVyS2FEipgrLqL0YMrTkJcfAsHaNnZgZsnP4A==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "7.28.5",
-        "@dcl/asset-packs": "^2.10.0",
+        "@dcl/asset-packs": "^2.17.0",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.16.2.tgz",
-      "integrity": "sha512-ewSqwbpneK/EQGRH1w8P1XlZywSgBLcThvrUv53C/2adbwSoTLzB8gc3is2lKpkDnM5XCdpOJUGmX/KuK43xXg==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.18.1.tgz",
+      "integrity": "sha512-BJwLqAg2AGzSWLuAbWkxVBlwx9AA0FJNLdUDhaPTsTFjp9uvbKYT8RQ247LjDp1E+TgV/dh9AInsUpk1LZpwrg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -261,9 +272,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/ecs": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.24.3.tgz",
-      "integrity": "sha512-nYZEuEYEzOOmIfx0foiku2NVSoPwci2F5tGDbyi7uNn1hCwkTG8z+gcWqsfg9VBqSCR0ikBW6aP9Y3ukib8Nnw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.27.0.tgz",
+      "integrity": "sha512-fVLbrTWC2F56iKnTbTM8vFUta/v6yMc6R6SBfwJdRHmd7CoKPI/pAfkmOozwOkj2pWZhUe+ggAKFnCUdh36meQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -279,16 +290,16 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@dcl/inspector/node_modules/glob": {
@@ -316,51 +327,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@dcl/inspector/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@dcl/inspector/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@dcl/inspector/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@dcl/inspector/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -370,16 +344,16 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.22.6-25007982108.commit-83012ab",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.22.6-25007982108.commit-83012ab.tgz",
-      "integrity": "sha512-b/g1uJpOWM64pYSZy5T+uIgxjsC+9Ix3qA3Iqxx3/F23o4N6Zi2/aajzQCh47vtDMDx4LKiXvLbj8jg6W2W3yQ==",
+      "version": "7.27.1-33247605236.commit-732120a",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.27.1-33247605236.commit-732120a.tgz",
+      "integrity": "sha512-lrHqhNBdAkKJXLs2o3/gnysVpkuaCyCp5dRNZTnqjhpVbitjhEOEx0R/lkiXGFWrrZTmJ3ItQTNlMPgWtKl5rQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.14.2.tgz",
-      "integrity": "sha512-Sq3ziGZUN/fXpSZ0+y7ngdS8WbHuinuJKJeNm81izDH7qo/viToDcnKMNX3lqgGqZqtDes604QxBhehJ0MhsRQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.15.2.tgz",
+      "integrity": "sha512-aYUCfcQp0eMCZfDt+iV2wMBl3oVMsl68uMz6jSVpnfTFqEqMlCmfeh0uZTr/eVMkSvQl8JUSrsKE1aGSE//bNw==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -416,9 +390,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-25001674716.commit-044c893",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
-      "integrity": "sha512-CbOb1SRTxNDa1uvc4lXLpyYXvWAK5/D8yh9Sxy/OMEpYrWaApD4RN4H/rRaRi7l+HI0p/0b1WZ045izBhv/8XQ==",
+      "version": "1.0.0-33247403125.commit-6e4ee4a",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33247403125.commit-6e4ee4a.tgz",
+      "integrity": "sha512-FmR3J9QaK0VJUJRiDHwGoX9k1Fj24Isnx0k3/Ob102Bp8qdHr3BMkIiRK4z/6pR9QHUgrBobCNfXY3Qy/QbYnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -447,13 +421,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.22.6-25007982108.commit-83012ab",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.22.6-25007982108.commit-83012ab.tgz",
-      "integrity": "sha512-Hq9AV1wKkV1Wf0Yb3az32tZgWl1ffPVUXYmTZs+FtAtf6MoYQdHoeZtvdDL1PJeJAvmbsMODpiGtL0z9jQwNGQ==",
+      "version": "7.27.1-33247605236.commit-732120a",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.27.1-33247605236.commit-732120a.tgz",
+      "integrity": "sha512-B+4+WbuccDsFNhfNIEiFHqSRDFcmLdKogkzjNhHv4Bu3bTFKwVMiUqNmShN26VPWVHkez1VHVn4K6KhmqQJWsA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.22.6-25007982108.commit-83012ab",
+        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -482,70 +456,62 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.22.6-25007982108.commit-83012ab",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.22.6-25007982108.commit-83012ab.tgz",
-      "integrity": "sha512-0ca3Zjq0FEmImqcd+w0Gl5GWEHRhNTmyF/JU80Ot/bJcA0WjsYoSLKjC8EynvqJOEMcEDMcGo0xqHWTJ1/vXqA==",
+      "version": "7.27.1-33247605236.commit-732120a",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.27.1-33247605236.commit-732120a.tgz",
+      "integrity": "sha512-VbYK6Cet+De6aIMobm34xjDYaho9LNLJBr6ApHYniBr9E8jQYgc9I7Ly79qJrxf3XC/sh7Au6LtSWPcSIGcGSA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.22.6-25007982108.commit-83012ab",
+        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
         "@dcl/ecs-math": "2.1.0",
-        "@dcl/explorer": "1.0.164509-20240802172549.commit-fb95b9b",
-        "@dcl/js-runtime": "7.22.6-25007982108.commit-83012ab",
-        "@dcl/react-ecs": "7.22.6-25007982108.commit-83012ab",
-        "@dcl/sdk-commands": "7.22.6-25007982108.commit-83012ab",
-        "text-encoding": "0.7.0"
+        "@dcl/js-runtime": "7.27.1-33247605236.commit-732120a",
+        "@dcl/react-ecs": "7.27.1-33247605236.commit-732120a",
+        "@dcl/sdk-commands": "7.27.1-33247605236.commit-732120a"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.22.6-25007982108.commit-83012ab",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.22.6-25007982108.commit-83012ab.tgz",
-      "integrity": "sha512-t9mpi2mV9GpflWOqcHdJquxAhchGYnFqGDKA0mmtFOldfz40OsJ09j1e8G4iy08BGNt/DYiV9DKacLDyXd47UA==",
+      "version": "7.27.1-33247605236.commit-732120a",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.27.1-33247605236.commit-732120a.tgz",
+      "integrity": "sha512-gsxGB4HbFE+/+pGPyV/GKTcgk1PtVb8yXKr4fL4k2nk3vIdBQkjNIOYm+YXe17ZiurXH7y/ZOHKHPp3Wwb2aqg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.22.6-25007982108.commit-83012ab",
+        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.25.0",
-        "@dcl/linker-dapp": "^0.14.2",
+        "@dcl/inspector": "7.36.3",
+        "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
+        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
-        "@segment/analytics-node": "^1.1.3",
+        "@segment/analytics-node": "^3.1.0",
         "@well-known-components/env-config-provider": "^1.2.0",
-        "@well-known-components/fetch-component": "^3.0.0",
         "@well-known-components/http-server": "^2.0.0-20230501134558.commit-be9a25d",
         "@well-known-components/logger": "^3.1.2",
         "@well-known-components/metrics": "^2.0.1",
         "archiver": "^5.3.1",
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
-        "colorette": "^2.0.19",
-        "dcl-catalyst-client": "^21.6.1",
+        "dcl-catalyst-client": "^22.0.0",
         "esbuild": "^0.18.17",
         "extract-zip": "2.0.1",
-        "fp-future": "^1.0.1",
-        "glob": "^9.3.2",
-        "i18next": "^25.2.1",
-        "i18next-fs-backend": "^2.6.0",
+        "i18next": "^25.8.4",
+        "i18next-fs-backend": "^2.6.1",
         "ignore": "^5.2.4",
-        "node-fetch": "^2.7.0",
-        "open": "^8.4.0",
-        "portfinder": "^1.0.32",
-        "prompts": "^2.4.2",
         "qrcode": "^1.5.4",
         "typescript": "^5.0.2",
-        "undici": "^5.19.1",
-        "uuid": "^9.0.1"
+        "undici": "^7.16.0"
       },
       "bin": {
         "sdk-commands": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/typescript": {
@@ -1026,9 +992,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1066,16 +1032,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1093,9 +1049,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1310,13 +1266,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -1332,9 +1281,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1385,22 +1334,22 @@
       }
     },
     "node_modules/@segment/analytics-core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.4.1.tgz",
-      "integrity": "sha512-kV0Pf33HnthuBOVdYNani21kYyj118Fn+9757bxqoksiXoZlYvBsFq6giNdCsKcTIE1eAMqNDq3xE1VQ0cfsHA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.3.tgz",
+      "integrity": "sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-generic-utils": "1.1.1",
-        "dset": "^3.1.2",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
         "tslib": "^2.4.1"
       }
     },
     "node_modules/@segment/analytics-generic-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.1.1.tgz",
-      "integrity": "sha512-THTIzBPHnvu1HYJU3fARdJ3qIkukO3zDXsmDm+kAeUks5R9CBXOQ6rPChiASVzSmwAIIo5uFIXXnCraojlq/Gw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1408,21 +1357,21 @@
       }
     },
     "node_modules/@segment/analytics-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.3.0.tgz",
-      "integrity": "sha512-lRLz1WZaDokMoUe299yP5JkInc3OgJuqNNlxb6j0q22umCiq6b5iDo2gRmFn93reirIvJxWIicQsGrHd93q8GQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-3.1.0.tgz",
+      "integrity": "sha512-F3pJmzUxmWZFV2wxJfuGvjLViCrQBFpxLLp4++fkoDsohWwS89T7n0M5nW1zxeYc2X2rA/v7q5ou3JZIw9bl3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.4.1",
-        "@segment/analytics-generic-utils": "1.1.1",
+        "@segment/analytics-core": "1.8.3",
+        "@segment/analytics-generic-utils": "1.2.0",
         "buffer": "^6.0.3",
-        "node-fetch": "^2.6.7",
+        "jose": "^5.1.0",
         "tslib": "^2.4.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/@types/glob": {
@@ -1457,13 +1406,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -1472,9 +1414,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1681,6 +1623,45 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
@@ -1743,17 +1724,6 @@
       },
       "peerDependencies": {
         "@well-known-components/interfaces": "^1.0.0"
-      }
-    },
-    "node_modules/@well-known-components/fetch-component": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@well-known-components/fetch-component/-/fetch-component-3.0.0.tgz",
-      "integrity": "sha512-ycIaojkwLJvhpicdPsmsEzA9qPbV7voAjrRcVE7+n7UNctIQC8ppymapj0UQ3FFpdEWWVSzjoo33H0BW+sD8eg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@well-known-components/interfaces": "^1.4.1",
-        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@well-known-components/http-server": {
@@ -1976,58 +1946,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/archiver-utils/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -2354,9 +2278,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2619,13 +2543,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2663,9 +2580,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2704,16 +2621,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2793,20 +2700,21 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/dcl-catalyst-client": {
-      "version": "21.11.0",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.11.0.tgz",
-      "integrity": "sha512-6BgOCz4aYnMGtuIkXTLP3hjoZHLwoScTLvs73U4R8Um6lIsnKNsbn5UyaocVNpkgrzZWaTGHDsv36OZJNH3XTQ==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-22.0.0.tgz",
+      "integrity": "sha512-K2cjYR5RZcdH6YNC7YjQMmZd4fhlE7zGyc79sYWvJGgofjO8TxAJ7CCNahqqllzMrdnxidFFGOWXTYJMJmOdqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/catalyst-contracts": "^4.4.0",
         "@dcl/crypto": "^3.4.0",
+        "@dcl/fetch-component": "^1.0.1",
         "@dcl/hashing": "^3.0.0",
         "@dcl/schemas": "^23.0.0",
-        "@well-known-components/fetch-component": "^2.0.0",
-        "cookie": "^0.5.0",
-        "cross-fetch": "^3.1.5",
-        "form-data": "^4.0.0"
+        "cookie": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/dcl-catalyst-client/node_modules/@dcl/hashing": {
@@ -2827,17 +2735,6 @@
         "ajv-errors": "^3.0.0",
         "ajv-keywords": "^5.1.0",
         "mitt": "^3.0.1"
-      }
-    },
-    "node_modules/dcl-catalyst-client/node_modules/@well-known-components/fetch-component": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@well-known-components/fetch-component/-/fetch-component-2.0.2.tgz",
-      "integrity": "sha512-LdY+6n9kuyACg3fcU4qMrNhLZuG7eqPxLSqzDgQyoHKeNjlzggoUqTVJKtIyi6vjPs8pSQ/Fx1xdLuBhOKCgww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@well-known-components/interfaces": "^1.4.1",
-        "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/debug": {
@@ -2891,16 +2788,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -3570,9 +3457,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3656,9 +3543,9 @@
       }
     },
     "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3752,9 +3639,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3846,9 +3733,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4033,9 +3920,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {
@@ -4371,20 +4258,22 @@
       }
     },
     "node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4403,20 +4292,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
-      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -4673,9 +4570,9 @@
       }
     },
     "node_modules/i18next-fs-backend": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.6.tgz",
-      "integrity": "sha512-mYGu6Nt8RIp3X/U8Y+Gej1wo5xmYWmGKLqBGMCC2OCAou5rW5epeHgHmVcw20mJs9Z9+DAPHIxQPNCgFyPRMeg==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.7.tgz",
+      "integrity": "sha512-nN2TIycyR/d+OVuLm1ugPyOlMprqPRnQ7QktBgn44F3H8l7TeTH4ffHJ7nUsd4QVJfetWW7/VZ3s+4g7FoAZUA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4826,40 +4723,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipfs-unixfs/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/ipfs-unixfs/node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/ipld-dag-pb": {
       "version": "0.22.3",
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.22.3.tgz",
@@ -4879,40 +4742,6 @@
       "engines": {
         "node": ">=6.0.0",
         "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/ipld-dag-pb/node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5077,22 +4906,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-document.all": {
@@ -5398,19 +5211,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -5488,6 +5288,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-sha3": {
@@ -5585,16 +5395,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/lazystream": {
@@ -5743,11 +5543,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -5820,19 +5623,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
     "node_modules/minimist": {
@@ -5846,13 +5646,13 @@
       }
     },
     "node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -6208,24 +6008,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6362,30 +6144,20 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-to-regexp": {
@@ -6435,20 +6207,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/portfinder": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
-      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.6",
-        "debug": "^4.3.6"
-      },
-      "engines": {
-        "node": ">= 10.12"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6496,6 +6254,7 @@
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
       "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "deprecated": "prom-client has been replaced by @prometheus-io/client",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6504,20 +6263,6 @@
       },
       "engines": {
         "node": "^16 || ^18 || >=20"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/prop-types": {
@@ -6533,25 +6278,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6695,19 +6439,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -6864,52 +6595,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/run-parallel": {
@@ -7210,13 +6895,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7507,22 +7185,14 @@
       }
     },
     "node_modules/tdigest": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
-      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.3.tgz",
+      "integrity": "sha512-zbRt+lT+/H4fRItHshczHErVCQnitJk8MfMT24MqFJf3YL7SJJPqGIGeuOdvxXxM/AHFzKBl7WoyaYwqO9s3Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
       }
-    },
-    "node_modules/text-encoding": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
-      "deprecated": "no longer maintained",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -7797,16 +7467,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7832,21 +7499,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/varint": {
       "version": "6.0.0",
@@ -8018,9 +7670,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8198,52 +7850,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/zip-stream/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/zip-stream/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     }
   }

--- a/react-web/bridge-scene/package.json
+++ b/react-web/bridge-scene/package.json
@@ -13,14 +13,14 @@
     "lint:fix": "eslint --fix \"./src/**/*.{ts,tsx}\"",
     "format": "prettier --config .prettierrc -c \"./src/**/*.{ts,tsx}\"",
     "format:fix": "prettier -w --config .prettierrc \"./src/**/*.{ts,tsx}\"",
-    "upgrade-sdk": "npm install @dcl/sdk@protocol-squad @dcl/js-runtime@protocol-squad @dcl/react-ecs@protocol-squad @dcl/sdk-commands@protocol-squad @dcl/ecs@protocol-squad --save-exact"
+    "upgrade-sdk": "npm install @dcl/sdk@experimental-bevy @dcl/js-runtime@experimental-bevy @dcl/react-ecs@experimental-bevy @dcl/sdk-commands@experimental-bevy @dcl/ecs@experimental-bevy --save-exact"
   },
   "devDependencies": {
-    "@dcl/ecs": "7.22.6-25007982108.commit-83012ab",
-    "@dcl/js-runtime": "7.22.6-25007982108.commit-83012ab",
-    "@dcl/react-ecs": "7.22.6-25007982108.commit-83012ab",
-    "@dcl/sdk": "7.22.6-25007982108.commit-83012ab",
-    "@dcl/sdk-commands": "7.22.6-25007982108.commit-83012ab",
+    "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
+    "@dcl/js-runtime": "7.27.1-33247605236.commit-732120a",
+    "@dcl/react-ecs": "7.27.1-33247605236.commit-732120a",
+    "@dcl/sdk": "7.27.1-33247605236.commit-732120a",
+    "@dcl/sdk-commands": "7.27.1-33247605236.commit-732120a",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",
@@ -32,7 +32,12 @@
     "prettier": "3.0.3"
   },
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=22.0.0",
     "npm": ">=6.0.0"
+  },
+  "overrides": {
+    "protobufjs": "^7.5.6",
+    "minimatch@9.0.3": "9.0.7",
+    "cookie": "^0.7.2"
   }
 }

--- a/react-web/playwright.config.ts
+++ b/react-web/playwright.config.ts
@@ -35,9 +35,12 @@ export default defineConfig({
       timeout: 120_000
     },
     {
-      command: 'npx sdk-commands start --no-browser --port 8100',
+      // --no-client: sdk-commands >= 7.27 auto-launches the desktop Explorer unless told not to
+      command: 'npx sdk-commands start --no-client --port 8100',
       cwd: 'bridge-scene',
-      url: 'http://localhost:8100',
+      // 127.0.0.1, not localhost: sdk-commands binds IPv4 only and Node >= 22 resolves localhost to ::1
+      // first. /about, not /: sdk-commands >= 7.27 no longer serves a page at / (404 = never ready).
+      url: 'http://127.0.0.1:8100/about',
       reuseExistingServer: true,
       timeout: 120_000
     }

--- a/react-web/vite.config.ts
+++ b/react-web/vite.config.ts
@@ -25,7 +25,7 @@ function bridgeScenePreview(): Plugin {
         console.log('[bridge-scene] starting live preview on :8100')
         // --no-install: only run the locally-installed @dcl/sdk-commands bin. Without it, a stale
         // bridge-scene/node_modules makes npx fetch the UNRELATED registry package "sdk-commands".
-        const child = spawn('npx', ['--no-install', 'sdk-commands', 'start', '--no-browser', '--port', '8100'], {
+        const child = spawn('npx', ['--no-install', 'sdk-commands', 'start', '--no-client', '--port', '8100'], {
           cwd: fileURLToPath(new URL('./bridge-scene', import.meta.url)),
           stdio: ['ignore', 'inherit', 'inherit'],
           detached: true


### PR DESCRIPTION
Moves `react-web/bridge-scene` off the `protocol-squad` SDK pin (`7.22.6-…commit-83012ab`, April) onto `7.27.1-33247605236.commit-732120a`, the `experimental-bevy` build from decentraland/js-sdk-toolchain#1564 — the squad-track features rebuilt on SDK `main` against decentraland/protocol#472 (npm tag `experimental-bevy` on both; no CDN tarballs anywhere in the tree). `upgrade-sdk` now targets that tag.

Dependabot: sdk-commands 7.27.x brings undici 7 and drops uuid, which clears the 10 undici/uuid/cookie alerts that were pinned by the old build. `overrides` handle what no SDK version can: `protobufjs ^7.5.6` (pinned exactly to 7.2.4 by `@dcl/protocol`; 2 criticals), `minimatch@9.0.3 → 9.0.7` (typescript-estree 6), `cookie ^0.7.2` (an old `dcl-catalyst-client` under `@dcl/quests-client`). Left: `esbuild` (every sdk-commands pins `^0.18`), `extract-zip` (no patched version), `ts-deepmerge` via `@dcl/inspector` — none have a fix upstream.

sdk-commands 7.27.x needs Node >= 22 (`fs.globSync`), so `engines.node` is `>=22`; `ci.yml` already builds on 24, `package.yml` still on 20 (fixed by #1157, merged).

Its `start` command also changed behaviour in ways the react-web dev/e2e setup has to account for: it auto-launches the desktop Explorer unless `--no-client` (`--no-browser` no longer covers it), it binds IPv4 only while Node >= 22 resolves `localhost` to `::1` first, and it no longer serves anything at `/`. Hence `--no-client` in `vite.config.ts` and `playwright.config.ts`, and the Playwright readiness probe moving to `http://127.0.0.1:8100/about`.

Verified locally: `sdk-commands build` + `bundle` on Node 24, the nametags (UiCanvas texture renderer) and the movement scene in the native explorer, and the react-web e2e suite (24/24).
