### PR TITLE
fix: answer the authoritative server's direct profile request

### DIFF
--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -969,32 +969,47 @@ pub fn process_transport_updates(
                         continue;
                     }
 
-                    let Message::Scene(scene) = update.message else {
-                        warn!(
-                            "skipping unexpected update from {}: {:?}",
-                            update.address, update.message
-                        );
-                        continue;
-                    };
+                    match update.message {
+                        Message::Scene(scene) => {
+                            // same cross-room guard as the Player arm: the message may only
+                            // address the scene owning this context's room
+                            if let Some(room_hash) = &state.room {
+                                if scene.scene_id != *room_hash {
+                                    debug!(
+                                        "dropping cross-room message from {}: declared scene {} != room {room_hash}",
+                                        update.address, scene.scene_id
+                                    );
+                                    continue;
+                                }
+                            }
 
-                    // same cross-room guard as the Player arm: the message may only
-                    // address the scene owning this context's room
-                    if let Some(room_hash) = &state.room {
-                        if scene.scene_id != *room_hash {
-                            debug!(
-                                "dropping cross-room message from {}: declared scene {} != room {room_hash}",
-                                update.address, scene.scene_id
+                            process_messagebus(
+                                scene,
+                                update.address,
+                                &mut string_senders,
+                                &mut binary_senders,
                             );
-                            continue;
+                        }
+                        // a server resolving a guest profile asks the guest directly — the
+                        // only source there is. The request handler reads the requested
+                        // address and the reply transport, never the sender entity, so the
+                        // transport entity stands in for the (playerless) server.
+                        Message::ProfileRequest(request) => {
+                            profile_events.write(ProfileEvent {
+                                sender: update.transport_id,
+                                event: ProfileEventType::Request {
+                                    request,
+                                    transport: update.transport_id,
+                                },
+                            });
+                        }
+                        message => {
+                            warn!(
+                                "skipping unexpected update from {}: {:?}",
+                                update.address, message
+                            );
                         }
                     }
-
-                    process_messagebus(
-                        scene,
-                        update.address,
-                        &mut string_senders,
-                        &mut binary_senders,
-                    );
                 }
                 NetworkUpdate::PlayerLeft {
                     transport_id,

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -1033,7 +1033,20 @@ async fn fetch_catalyst_profile(
         );
     }
 
-    let content = response.json::<LambdaProfiles>().await?;
+    let body = response.text().await?;
+    let content = match serde_json::from_str::<LambdaProfiles>(&body) {
+        Ok(content) => content,
+        Err(e) => {
+            // the sdk preview server reports a missing profile as a 200 with an
+            // `{"error": ...}` body rather than a 404; treat it as authoritatively absent
+            if serde_json::from_str::<serde_json::Value>(&body)
+                .is_ok_and(|value| value.get("error").is_some())
+            {
+                return Ok(None);
+            }
+            return Err(anyhow!("catalyst fetch from {url}: {e}"));
+        }
+    };
     let base_url = ipfs.contents_endpoint().unwrap_or_default();
     Ok(content
         .avatars


### PR DESCRIPTION
An authoritative server resolving a guest's profile runs its fetch cascade — profile registry, then the peer's declared catalyst — and, both exhausted, asks the guest directly with a targeted rfc4 `ProfileRequest` over the scene room. The client received this as a NonPlayer update (the server's participant identity, `authoritative-server`, is not an address) and dropped it, since that arm only forwarded messagebus traffic. Guests therefore never resolved server-side: `onEnterScene` never fired for them in server scenes, and the server re-sent the request every 10s indefinitely.

This forwards the server's `ProfileRequest` to the existing profile handler, which only answers requests for our own address and replies on the arrival transport (the handler never reads the sender entity, so the transport entity stands in for the playerless server).

Also:
- the sdk preview server reports a missing profile as a 200 with an `{"error": ...}` body rather than a 404; `fetch_catalyst_profile` now treats that as "authoritatively no profile" instead of failing with a decode error every retry
- catalyst decode errors now include the URL (the bare `error decoding response body` gave no hint which endpoint misbehaved)

Verified against a local-scene-development rig (auth-server scene + zone Pulse): the client answers the request one second after connecting, the server's `onEnterScene` fires for the guest, and the request loop is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)