### PR TITLE
Use f64 clocks for long-running processes; unwrap the Pulse tick rollover; add PBEngineInfo.total_runtime_f64

### DIFF
--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -180,7 +180,7 @@ fn broadcast_emote(
                 comms::Emote {
                     urn: urn.as_str().to_owned(),
                     incremental_id: *count,
-                    timestamp: time.elapsed_secs(),
+                    timestamp: time.elapsed_secs_f64(),
                     duration_ms,
                     stopping: false,
                 },
@@ -202,7 +202,7 @@ fn broadcast_emote(
                 comms::Emote {
                     urn: urn.as_str().to_owned(),
                     incremental_id: *count,
-                    timestamp: time.elapsed_secs(),
+                    timestamp: time.elapsed_secs_f64(),
                     duration_ms: None,
                     stopping: true,
                 },
@@ -507,8 +507,8 @@ fn animate(
         // fallback for scene-driven anims (in case the URN fails to resolve) and as the
         // final default when nothing else claims the avatar.
         let time_to_peak = (jump_height * -gravity * 2.0).sqrt() / -gravity;
-        let just_jumped =
-            dynamic_state.jump_time > (time.elapsed_secs() - time_to_peak / 2.0).max(0.0);
+        let just_jumped = dynamic_state.jump_time
+            > (time.elapsed_secs_f64() - time_to_peak as f64 / 2.0).max(0.0);
         let (velocity_emote, velocity_move_kind) =
             if dynamic_state.move_kind == MoveKind::DoubleJump {
                 // Set on foreign avatars from rfc4::Movement.jump_count >= 2 (see foreign_dynamics).
@@ -551,7 +551,8 @@ fn animate(
                         urn: URN_JUMP.clone(),
                         speed: time_to_peak.recip() * 0.5,
                         repeat: true,
-                        restart: dynamic_state.jump_time > time.elapsed_secs() - time.delta_secs(),
+                        restart: dynamic_state.jump_time
+                            > time.elapsed_secs_f64() - time.delta_secs_f64(),
                         transition_seconds: 0.1,
                         initial_audio_mark: if !just_jumped { Some(0.1) } else { None },
                         ..Default::default()
@@ -678,7 +679,7 @@ struct SpawnedExtras {
     // the *start* time (rather than the raw seek) lets the deferred play resume at
     // `elapsed_secs - start` — i.e. advanced by however long the prop took to load — so a
     // slow load doesn't resume stale. Cleared when the avatar + prop finally play.
-    deferred_start: Option<f32>,
+    deferred_start: Option<f64>,
 }
 
 impl SpawnedExtras {
@@ -1030,7 +1031,7 @@ fn play_current_emote(
                 // the load duration rather than at the (now-stale) requested value.
                 extras.deferred_start = active_emote
                     .pending_seek
-                    .map(|seek| time.elapsed_secs() - seek);
+                    .map(|seek| time.elapsed_secs_f64() - seek as f64);
                 continue;
             }
         }
@@ -1193,7 +1194,7 @@ fn play_current_emote(
             spawned_extras
                 .get_mut(&entity)
                 .and_then(|extras| extras.deferred_start.take())
-                .map(|start| time.elapsed_secs() - start)
+                .map(|start| (time.elapsed_secs_f64() - start) as f32)
         });
         let elapsed = play(
             transitions,

--- a/crates/avatar/src/foreign_dynamics.rs
+++ b/crates/avatar/src/foreign_dynamics.rs
@@ -44,7 +44,7 @@ impl Plugin for PlayerMovementPlugin {
 
 #[derive(Component)]
 struct PlayerTargetPosition {
-    time: f32,
+    time: f64,
     /// The source clock of the last applied update, seconds (see `PlayerPositionEvent`).
     timestamp: Option<f64>,
     velocity: Option<Vec3>,
@@ -78,7 +78,7 @@ struct PendingSceneAnim {
     /// it also fires once `update_freq` elapses from receipt. `None` once applied.
     pending: Option<Option<SceneDrivenAnimationRequest>>,
     /// Local time the pending anim was received, for the `update_freq` backstop.
-    received_at: f32,
+    received_at: f64,
     /// Whether the next movement packet should fire `pending` (vs. merely arm it; see `pending`).
     fire_on_next_movement: bool,
     /// Render-only lean from the latest scene-anim event, composed onto the interpolated yaw each
@@ -127,7 +127,7 @@ fn update_foreign_user_target_position(
                     });
                 if is_valid {
                     const LAG_DECAY_SECS: f32 = 1.5;
-                    let delta = ev.time - pos.time;
+                    let delta = (ev.time - pos.time) as f32;
                     let update_freq = LAG_DECAY_SECS
                         / ((LAG_DECAY_SECS - delta).max(0.0) / pos.update_freq
                             + (LAG_DECAY_SECS / delta).min(1.0));
@@ -203,7 +203,7 @@ fn update_foreign_scene_anim(
     mut players: Query<&mut PendingSceneAnim>,
     time: Res<Time>,
 ) {
-    let now = time.elapsed_secs();
+    let now = time.elapsed_secs_f64();
     for ev in anim_events.read() {
         let tilt = avatar_tilt_quat(ev.tilt.0, ev.tilt.1);
         // The next movement packet arms the clip and the one after fires it (see `PendingSceneAnim`),
@@ -257,28 +257,25 @@ fn update_foreign_user_actual_position(
 
         let turn_time;
         if let Some(velocity) = target.velocity {
-            let t0 = time.elapsed_secs();
-            let t1 = target.time + target.update_freq;
+            let t0 = time.elapsed_secs_f64();
+            let t1 = target.time + target.update_freq as f64;
 
-            if t1 < t0 + time.delta_secs() * 2.0 {
+            if t1 < t0 + time.delta_secs_f64() * 2.0 {
                 // Past the goalpost: dead-reckon forward from the last observation. `stale` is
                 // unbounded while no packet arrives, so the offset is saturated rather than linear
                 // (see `COAST_SECS`) — a single missed update used to walk the peer away at full
                 // speed indefinitely. `decay` is the derivative of that offset, so the velocity we
                 // report stays consistent with the motion we render and the walk/run blend winds
                 // down with it instead of animating a sprint on a stationary avatar.
-                let stale = t0 - t1;
+                let stale = (t0 - t1) as f32;
                 let decay = (-stale / COAST_SECS).exp();
                 actual.translation = target.translation + velocity * (COAST_SECS * (1.0 - decay));
                 dynamic_state.velocity = velocity * decay;
                 turn_time = 0.0;
             } else {
                 // use some extrapolation but slow it down so we don't overcompensate for missed packets
-                let dt = if (t1 - t0) < 1.0 {
-                    t1 - t0
-                } else {
-                    (t1 - t0).sqrt()
-                };
+                let dt = (t1 - t0) as f32;
+                let dt = if dt < 1.0 { dt } else { dt.sqrt() };
 
                 let p0 = actual.translation;
                 let p1 = target.translation;
@@ -297,7 +294,7 @@ fn update_foreign_user_actual_position(
             }
         } else {
             // arrive at target position by time + 0.5
-            let walk_time_left = target.time + 0.5 - time.elapsed_secs();
+            let walk_time_left = (target.time + 0.5 - time.elapsed_secs_f64()) as f32;
             if walk_time_left <= 0.0 {
                 actual.translation = target.translation;
                 dynamic_state.velocity = Vec3::ZERO;
@@ -307,7 +304,7 @@ fn update_foreign_user_actual_position(
                 dynamic_state.velocity = delta / time.delta_secs();
                 actual.translation += dynamic_state.velocity * time.delta_secs();
             }
-            turn_time = target.time + 0.2 - time.elapsed_secs();
+            turn_time = (target.time + 0.2 - time.elapsed_secs_f64()) as f32;
         }
 
         // Compose the render-only lean onto the (yaw-only) target before interpolating, so the
@@ -332,7 +329,7 @@ fn update_foreign_user_actual_position(
         match target.remote_move_kind {
             Some(MoveKind::Jump) => {
                 if dynamic_state.jump_time == -1.0 {
-                    dynamic_state.jump_time = time.elapsed_secs();
+                    dynamic_state.jump_time = time.elapsed_secs_f64();
                 }
             }
             Some(k) => dynamic_state.move_kind = k,
@@ -391,7 +388,7 @@ fn update_foreign_user_actual_position(
         // trigger, apply it anyway rather than strand it.
         if let Some(mut pending) = maybe_pending {
             if pending.pending.is_some()
-                && time.elapsed_secs() >= pending.received_at + target.update_freq
+                && time.elapsed_secs_f64() >= pending.received_at + target.update_freq as f64
             {
                 let anim = pending.pending.take().unwrap();
                 commands

--- a/crates/avatar/src/npc_dynamics.rs
+++ b/crates/avatar/src/npc_dynamics.rs
@@ -46,7 +46,7 @@ fn update_npc_velocity(
             continue;
         }
 
-        let velocity = (current_translation - prev_translation) / scene.last_update_dt;
+        let velocity = (current_translation - prev_translation) / scene.last_update_dt as f32;
 
         commands.entity(ent).try_insert(AvatarDynamicState {
             velocity: if velocity.is_finite() {

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -1236,7 +1236,7 @@ pub struct EngineMovementControl {
     /// is received. Set by `movePlayerTo` when it imposes a facing, so the imposed
     /// orientation survives until the controller scene reads the new transform and
     /// echoes it back, rather than being clobbered by an in-flight stale tick.
-    pub accept_movement_after: f32,
+    pub accept_movement_after: f64,
 }
 
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
@@ -1264,7 +1264,7 @@ pub enum MoveKind {
 pub struct AvatarDynamicState {
     pub velocity: Vec3,
     pub ground_height: f32,
-    pub jump_time: f32,
+    pub jump_time: f64,
     pub move_kind: MoveKind,
 }
 

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -512,8 +512,8 @@ pub struct ForeignMetaData {
 #[derive(Event)]
 pub struct PlayerPositionEvent {
     pub player: Entity,
-    /// Local receive time (`time.elapsed_secs()`) — drives the interpolation catch-up window.
-    pub time: f32,
+    /// Local receive time (`time.elapsed_secs_f64()`) — drives the interpolation catch-up window.
+    pub time: f64,
     /// The source clock for this update, in seconds: the Pulse server tick, or the sender's own
     /// clock on the LiveKit path. Only ever compared against a previous value from the same
     /// source, to reject reordered/duplicate packets.
@@ -552,7 +552,7 @@ pub struct PlayerPositionEvent {
 #[derive(Event)]
 pub struct PlayerSceneAnimEvent {
     pub player: Entity,
-    pub time: f32,
+    pub time: f64,
     /// Resolved animation; `None` clears any active one.
     pub anim: Option<SceneDrivenAnimationRequest>,
     /// Render-only avatar lean (pitch, roll) in degrees, composed onto the interpolated yaw in
@@ -611,7 +611,7 @@ fn apply_foreign_movement(
     m: &rfc4::Movement,
     entity: Entity,
     scene_id: SceneEntityId,
-    now: f32,
+    now: f64,
     timestamp: f64,
     teleport: bool,
     commands: &mut Commands,
@@ -902,7 +902,7 @@ pub fn process_transport_updates(
                             &movement,
                             entity,
                             scene_id,
-                            time.elapsed_secs(),
+                            time.elapsed_secs_f64(),
                             timestamp,
                             teleport,
                             &mut commands,
@@ -949,7 +949,7 @@ pub fn process_transport_updates(
                                 );
                                 anim_events.write(PlayerSceneAnimEvent {
                                     player: entity,
-                                    time: time.elapsed_secs(),
+                                    time: time.elapsed_secs_f64(),
                                     anim,
                                     tilt,
                                 });

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -259,7 +259,7 @@ impl Broadcast for rfc4::Movement {
 pub struct Emote {
     pub urn: String,
     pub incremental_id: u32,
-    pub timestamp: f32,
+    pub timestamp: f64,
     /// `Some` for a one-shot (the Pulse server auto-completes it after the duration); `None` for a
     /// looping emote (ended by a later `stopping` send). Ignored on a stop.
     pub duration_ms: Option<u32>,
@@ -273,7 +273,7 @@ impl Broadcast for Emote {
             rfc4::PlayerEmote {
                 incremental_id: self.incremental_id,
                 urn: self.urn.clone(),
-                timestamp: self.timestamp,
+                timestamp: self.timestamp as f32,
                 is_stopping: Some(self.stopping),
             },
         )))

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -106,8 +106,8 @@ struct ProfileEntry {
     fetching: Option<ProfileSource>,
     /// when the next cascade may start; None = due now. Irrelevant once satisfied.
     next_fetch: Option<web_time::Instant>,
-    /// `time.elapsed_secs()` of the last `ProfileRequest` sent to the peer
-    last_p2p: Option<f32>,
+    /// `time.elapsed_secs_f64()` of the last `ProfileRequest` sent to the peer
+    last_p2p: Option<f64>,
 }
 
 impl ProfileEntry {
@@ -168,7 +168,7 @@ impl ProfileEntry {
     /// its own latest profile. Held back until the first cascade concludes so the
     /// authoritative sources get first go, except when we already hold (stale) data —
     /// then the request rides alongside the re-fetch.
-    fn wants_p2p(&self, now: f32) -> bool {
+    fn wants_p2p(&self, now: f64) -> bool {
         let behind = self
             .data
             .as_ref()
@@ -301,7 +301,7 @@ pub fn setup_primary_profile(
     ipfas: IpfsAssetServer,
     mut contexts: Query<&mut GlobalCrdtState>,
     mut cache: ProfileManager,
-    mut last_announce: Local<f32>,
+    mut last_announce: Local<f64>,
     time: Res<Time>,
 ) {
     // gather any event receivers
@@ -357,7 +357,7 @@ pub fn setup_primary_profile(
                     version: profile.version,
                 },
             );
-            *last_announce = time.elapsed_secs();
+            *last_announce = time.elapsed_secs_f64();
 
             // send to event receivers
             senders.retain(|sender| {
@@ -382,7 +382,7 @@ pub fn setup_primary_profile(
                 current_profile.is_deployed = true;
             }
         } else if let Some(current_profile) = current_profile.profile.as_ref() {
-            let now = time.elapsed_secs();
+            let now = time.elapsed_secs_f64();
             if now > *last_announce + 5.0 {
                 debug!("announcing profile v {}", current_profile.version);
                 // The keepalive re-announce goes the same way as the version bump above: Pulse
@@ -560,7 +560,7 @@ fn request_missing_profiles(
     transports: Query<&Transport>,
     time: Res<Time>,
 ) {
-    let now = time.elapsed_secs();
+    let now = time.elapsed_secs_f64();
 
     // resolved players: push cache movement, but diff before any push — only real
     // changes reach the entity/scenes
@@ -669,7 +669,7 @@ pub fn process_profile_events(
     mut commands: Commands,
     mut players: Query<(&mut ForeignPlayer, Option<&mut UserProfile>)>,
     mut events: EventReader<ProfileEvent>,
-    mut last_sent_request: Local<HashMap<Entity, f32>>,
+    mut last_sent_request: Local<HashMap<Entity, f64>>,
     time: Res<Time>,
     wallet: Res<Wallet>,
     transports: Query<&Transport>,
@@ -719,7 +719,7 @@ pub fn process_profile_events(
                         let _ = transport
                             .sender
                             .try_send(NetworkMessage::reliable(&response));
-                        last_sent_request.insert(*request_transport, time.elapsed_secs());
+                        last_sent_request.insert(*request_transport, time.elapsed_secs_f64());
                     }
                 }
             }
@@ -797,7 +797,7 @@ pub fn process_profile_events(
         }
     }
 
-    last_sent_request.retain(|_, req_time| *req_time > time.elapsed_secs() - 10.0);
+    last_sent_request.retain(|_, req_time| *req_time > time.elapsed_secs_f64() - 10.0);
 }
 
 #[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Default)]

--- a/crates/comms/src/pulse/mod.rs
+++ b/crates/comms/src/pulse/mod.rs
@@ -315,6 +315,11 @@ impl SubjectState {
 pub struct PulseDecoder {
     grid: PulseParcelGrid,
     subjects: HashMap<u32, Subject>,
+    /// Server ticks are `u32` milliseconds since the Pulse server started, so they roll over after
+    /// ~49.7 days of server uptime. The newest raw tick seen, and the number of milliseconds to
+    /// add to it (a multiple of 2^32) to keep the emitted timestamps monotonic across rollovers.
+    newest_tick: Option<u32>,
+    tick_epoch_ms: u64,
 }
 
 impl PulseDecoder {
@@ -322,6 +327,8 @@ impl PulseDecoder {
         Self {
             grid,
             subjects: HashMap::new(),
+            newest_tick: None,
+            tick_epoch_ms: 0,
         }
     }
 
@@ -449,7 +456,7 @@ impl PulseDecoder {
                 movement: Box::new(movement),
                 realm,
                 teleport: false,
-                timestamp: Self::tick_secs(full.server_tick),
+                timestamp: self.tick_secs(full.server_tick),
             },
         ]
     }
@@ -495,7 +502,7 @@ impl PulseDecoder {
             movement: Box::new(movement),
             realm,
             teleport,
-            timestamp: Self::tick_secs(server_tick),
+            timestamp: self.tick_secs(server_tick),
         }]
     }
 
@@ -515,6 +522,14 @@ impl PulseDecoder {
 
         // The delta is diffed from `baseline_seq`; we can only apply it if our state is exactly
         // that sequence. Otherwise we missed an intermediate delta — resync from what we have.
+        //
+        // Known gap: a delta whose baseline is AHEAD of us is dropped here even though the missing
+        // link may be a reliable full state still in flight (unreliable deltas can overtake it):
+        // full 0, delta 0→1, delta 2→3, full 2 leaves us at 2 with 3 discarded, and the resync
+        // reply (from 1) then mismatches too, so the subject stalls for two round-trips. If that
+        // shows up in practice, hold the single ahead-of-us delta per subject and chain it after
+        // the next successful apply (delta or full) instead of dropping it — still send the resync,
+        // since the gap may be genuine loss.
         if delta.baseline_seq != subject.last_seq {
             return vec![PulseEvent::Resync(pulse::ResyncRequest {
                 subject_id: delta.subject_id,
@@ -541,7 +556,7 @@ impl PulseDecoder {
             movement: Box::new(movement),
             realm,
             teleport: false,
-            timestamp: Self::tick_secs(delta.server_tick),
+            timestamp: self.tick_secs(delta.server_tick),
         }]
     }
 
@@ -560,10 +575,28 @@ impl PulseDecoder {
         self.to_movement(&self.subjects[&subject_id].baseline)
     }
 
-    /// A server tick (absolute milliseconds) as seconds. `f64` throughout — see
-    /// [`PulseEvent::Movement`]'s `timestamp`.
-    fn tick_secs(server_tick: u32) -> f64 {
-        server_tick as f64 / 1000.0
+    /// A server tick (absolute milliseconds) as seconds, unwrapped across the `u32` rollover. `f64`
+    /// throughout — see [`PulseEvent::Movement`]'s `timestamp`.
+    fn tick_secs(&mut self, server_tick: u32) -> f64 {
+        let Some(newest) = self.newest_tick else {
+            self.newest_tick = Some(server_tick);
+            return server_tick as f64 / 1000.0;
+        };
+        // Wrapping difference against the newest tick seen: anything less than half the range
+        // ahead is forward progress (including across the rollover); the rest are reordered or
+        // stale packets from before it.
+        let delta = server_tick.wrapping_sub(newest) as i32;
+        let newest = if delta >= 0 {
+            if server_tick < newest {
+                self.tick_epoch_ms += 1 << 32;
+            }
+            self.newest_tick = Some(server_tick);
+            server_tick
+        } else {
+            newest
+        };
+        let newest_ms = (self.tick_epoch_ms + newest as u64) as i64;
+        (newest_ms + delta.min(0) as i64) as f64 / 1000.0
     }
 
     /// Reconstruct an `rfc4::Movement` from a subject's float baseline. Position is parcel-decoded

--- a/crates/comms/src/pulse/test.rs
+++ b/crates/comms/src/pulse/test.rs
@@ -318,3 +318,55 @@ fn left_drops_subject_and_emits_address() {
         [PulseEvent::Resync(_)]
     ));
 }
+
+/// Server ticks are `u32` milliseconds since the Pulse server started and roll over after ~49.7
+/// days. The converted timestamps must keep increasing across the rollover, or the receiver's
+/// strictly-newer gate would drop every update after it.
+#[test]
+fn ticks_stay_monotonic_across_u32_rollover() {
+    const TICKS: [u32; 4] = [u32::MAX - 50, u32::MAX - 10, 30, 70];
+
+    let mut decoder = PulseDecoder::new(PulseParcelGrid::default());
+    decoder.handle(server_msg(pulse::server_message::Message::PlayerJoined(
+        pulse::PlayerJoined {
+            user_id: WALLET.to_string(),
+            profile_version: 7,
+            state: Some(pulse::PlayerStateFull {
+                subject_id: SUBJECT,
+                sequence: 5,
+                server_tick: u32::MAX - 100,
+                state: Some(player_state((1.0, 2.0, 3.0), 0)),
+            }),
+            realm: String::new(),
+        },
+    )));
+
+    let stamps: Vec<f64> = TICKS
+        .iter()
+        .enumerate()
+        .flat_map(|(i, tick)| {
+            let delta = pulse::PlayerStateDeltaTier0 {
+                subject_id: SUBJECT,
+                baseline_seq: 5 + i as u32,
+                new_seq: 6 + i as u32,
+                server_tick: *tick,
+                position_x: Some(128 + i as u32),
+                ..Default::default()
+            };
+            movement_timestamps(decoder.handle(server_msg(
+                pulse::server_message::Message::PlayerStateDelta(delta),
+            )))
+        })
+        .collect();
+
+    assert_eq!(stamps.len(), TICKS.len());
+    for (a, b) in stamps.iter().zip(stamps.iter().skip(1)) {
+        assert!(
+            b > a,
+            "ticks must stay increasing across the rollover, got {a} then {b}"
+        );
+    }
+    assert!((stamps[1] - stamps[0] - 0.040).abs() < 1e-6);
+    assert!((stamps[2] - stamps[1] - 0.041).abs() < 1e-6);
+    assert!((stamps[3] - stamps[2] - 0.040).abs() < 1e-6);
+}

--- a/crates/dcl/src/js/mod.rs
+++ b/crates/dcl/src/js/mod.rs
@@ -104,7 +104,7 @@ impl std::ops::Deref for SuperUserScene {
 pub struct CommunicatedWithRenderer;
 
 // scene-elapsed time (seconds) of the last SceneResponse::Stats flush
-pub struct SceneStatsFlush(pub f32);
+pub struct SceneStatsFlush(pub f64);
 
 // Count of CRDT batches sent this tick, incremented by `crdt_send_to_renderer` and cleared
 // at each tick boundary by the scene loop: a scene may send at most MAX_CRDT_SENDS_PER_TICK
@@ -308,14 +308,14 @@ pub fn op_log(state: Rc<RefCell<impl State>>, message: String) {
     debug!("op_log {}", message);
     let time = state.borrow().borrow::<SceneElapsedTime>().0;
     let mut state = state.borrow_mut();
-    push_scene_log(&mut *state, SceneLogLevel::Log, message, time as f64)
+    push_scene_log(&mut *state, SceneLogLevel::Log, message, time)
 }
 
 pub fn op_error(state: Rc<RefCell<impl State>>, message: String) {
     debug!("op_error");
     let time = state.borrow().borrow::<SceneElapsedTime>().0;
     let mut state = state.borrow_mut();
-    push_scene_log(&mut *state, SceneLogLevel::SceneError, message, time as f64)
+    push_scene_log(&mut *state, SceneLogLevel::SceneError, message, time)
 }
 
 pub fn player_identity(state: &impl State) -> Result<PbPlayerIdentityData, anyhow::Error> {

--- a/crates/dcl/src/lib.rs
+++ b/crates/dcl/src/lib.rs
@@ -27,7 +27,7 @@ pub struct SceneCensus {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SceneElapsedTime(pub f32);
+pub struct SceneElapsedTime(pub f64);
 
 // data from renderer to scene
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/engine_info.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/engine_info.proto
@@ -12,4 +12,5 @@ message PBEngineInfo {
   uint32 frame_number = 1; // frame counter of the engine
   float total_runtime = 2; // total runtime of this scene in seconds
   uint32 tick_number  = 3; // tick counter of the scene as per ADR-148
+  double total_runtime_f64 = 5; // total_runtime at f64 precision: the float field cannot resolve frame deltas past ~36h of scene uptime
 }

--- a/crates/dcl_deno/src/js/mod.rs
+++ b/crates/dcl_deno/src/js/mod.rs
@@ -377,7 +377,7 @@ pub(crate) fn scene_thread(
 
         state
             .borrow_mut()
-            .put(SceneElapsedTime(elapsed.as_secs_f32()));
+            .put(SceneElapsedTime(elapsed.as_secs_f64()));
         // tick boundary: reset the bounded per-tick send allowance
         state.borrow_mut().try_take::<CrdtSendsThisTick>();
 

--- a/crates/dcl_wasm/src/inner/mod.rs
+++ b/crates/dcl_wasm/src/inner/mod.rs
@@ -253,7 +253,7 @@ impl From<WasmError> for JsValue {
 }
 
 #[wasm_bindgen]
-pub fn op_set_elapsed(state: &WorkerContext, elapsed: f32) {
+pub fn op_set_elapsed(state: &WorkerContext, elapsed: f64) {
     let mut state = state.state.borrow_mut();
     state.put(SceneElapsedTime(elapsed));
     // tick boundary: reset the bounded per-tick send allowance

--- a/crates/imposters/src/bake_scene.rs
+++ b/crates/imposters/src/bake_scene.rs
@@ -1234,17 +1234,17 @@ fn output_progress(
     mut max_count: Local<usize>,
     config: Res<AppConfig>,
     time: Res<Time>,
-    mut last_time: Local<f32>,
+    mut last_time: Local<f64>,
     plugin: Res<DclImposterPlugin>,
 ) {
     if plugin.zip_output.is_none() {
         return;
     }
 
-    if time.elapsed_secs() < *last_time + 5.0 {
+    if time.elapsed_secs_f64() < *last_time + 5.0 {
         return;
     }
-    *last_time = time.elapsed_secs();
+    *last_time = time.elapsed_secs_f64();
 
     let max_level = config.scene_imposter_distances.len() - 1;
     let count = q.iter().filter(|i| i.level == max_level).count();

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -213,7 +213,7 @@ pub fn handle_player_move_requests(
     // Engine dispatch clock, matching RendererSceneContext::last_sent. Constant
     // within a frame, so a same-frame scene dispatch compares equal (and is treated
     // as stale by the strict `>` acceptance test in apply_movement).
-    let now = time.elapsed_secs();
+    let now = time.elapsed_secs_f64();
     let Ok((player_entity, _, _, _)) = player.single() else {
         return;
     };
@@ -350,7 +350,7 @@ fn apply_player_move(
     movement_control: &mut EngineMovementControl,
     movement_info: &mut AvatarMovementInfo,
     teleport_events: &mut EventWriter<PlayerTeleported>,
-    now: f32,
+    now: f64,
 ) {
     let (_, mut player_transform, mut dynamics, maybe_active) = player.single_mut().unwrap();
     if let Some(active) = maybe_active {
@@ -1789,11 +1789,11 @@ pub fn handle_eth_async(
             .ok()
             .and_then(|scene| scene.last_action_event)
             .unwrap_or_default();
-        if last_action_time < time.elapsed_secs() - 1.0 {
+        if last_action_time < time.elapsed_secs_f64() - 1.0 {
             response.send(Err(format!(
                 "no recent user activity (last action {}, time {}).",
                 last_action_time,
-                time.elapsed_secs()
+                time.elapsed_secs_f64()
             )));
             continue;
         }
@@ -1854,11 +1854,11 @@ pub fn handle_copy_to_clipboard(
             .ok()
             .and_then(|scene| scene.last_action_event)
             .unwrap_or_default();
-        if last_action_time < time.elapsed_secs() - 1.0 {
+        if last_action_time < time.elapsed_secs_f64() - 1.0 {
             response.send(Err(format!(
                 "no recent user activity (last action {}, time {}).",
                 last_action_time,
-                time.elapsed_secs()
+                time.elapsed_secs_f64()
             )));
             continue;
         }

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -716,7 +716,7 @@ pub(crate) fn initialize_scene(
         context.inspected = inspected;
         // set last_sent so the scene doesn't get extreme starvation priority
         // when it first becomes eligible after initialization completes
-        context.last_sent = time.elapsed_secs();
+        context.last_sent = time.elapsed_secs_f64();
         // spawn in flight so we wait for initial RPC requests
         context.state = SceneState::Live {
             handle: SceneThreadHandle {

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -186,7 +186,7 @@ impl Toaster<'_, '_> {
         let message = message.into();
         if let Some(existing) = self.toasts.0.get_mut(&key) {
             if existing.message == message {
-                existing.last_update = self.time.elapsed_secs();
+                existing.last_update = self.time.elapsed_secs_f64();
                 return;
             }
         }
@@ -195,8 +195,8 @@ impl Toaster<'_, '_> {
             key,
             Toast {
                 message,
-                time: self.time.elapsed_secs(),
-                last_update: self.time.elapsed_secs(),
+                time: self.time.elapsed_secs_f64(),
+                last_update: self.time.elapsed_secs_f64(),
                 on_click,
             },
         );
@@ -222,8 +222,8 @@ impl Toaster<'_, '_> {
 
 pub struct Toast {
     pub message: String,
-    pub time: f32,
-    pub last_update: f32,
+    pub time: f64,
+    pub last_update: f64,
     pub on_click: Option<On<Click>>,
 }
 
@@ -449,12 +449,12 @@ fn update_scene_priority(
 
     // mark scenes that have been in-flight past the timeout as broken and free their
     // slot, so a wedged scene worker can't hold a scene thread forever
-    let elapsed = time.elapsed_secs();
+    let elapsed = time.elapsed_secs_f64();
     for (ent, _, mut context, _) in scenes.iter_mut() {
         if context.in_flight()
             && !context.inspected
             && elapsed - context.last_sent
-                > renderer_context::SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f32()
+                > renderer_context::SCENE_NOT_RESPONDING_TIMEOUT.as_secs_f64()
         {
             warn!(
                 "scene {} ({} @ {}) has not responded for {:.0}s, marking broken",
@@ -515,7 +515,7 @@ fn update_scene_priority(
             } else {
                 distance
             };
-            let not_yet_run = context.last_sent < time.elapsed_secs();
+            let not_yet_run = context.last_sent < time.elapsed_secs_f64();
 
             if !context.in_flight() && !not_yet_run {
                 skipped_already_sent += 1;
@@ -523,8 +523,9 @@ fn update_scene_priority(
 
             (!context.in_flight() && not_yet_run).then(|| {
                 updates.eligible_jobs += 1;
-                let priority =
-                    FloatOrd(context.priority / (time.elapsed_secs() - context.last_sent));
+                let priority = FloatOrd(
+                    context.priority / (time.elapsed_secs_f64() - context.last_sent) as f32,
+                );
                 (ent, priority)
             })
         })
@@ -1021,8 +1022,9 @@ fn send_scene_updates(
     buf.clear();
     DclWriter::new(buf).write(&PbEngineInfo {
         frame_number: frame.0,
-        total_runtime: context.total_runtime,
+        total_runtime: context.total_runtime as f32,
         tick_number: context.tick_number,
+        total_runtime_f64: context.total_runtime,
     });
     context.crdt_store.force_update(
         SceneComponentId::ENGINE_INFO,
@@ -1052,7 +1054,7 @@ fn send_scene_updates(
         context.state = SceneState::Broken;
     } else {
         context.set_in_flight(true);
-        context.last_sent = time.elapsed_secs();
+        context.last_sent = time.elapsed_secs_f64();
         dcl_assert!(!updates.jobs_in_flight.contains(&ent));
         updates.jobs_in_flight.insert(ent);
     }
@@ -1112,7 +1114,7 @@ fn receive_scene_updates(
                     if let Some(root) = updates.scene_ids.get(&scene_id) {
                         if let Ok(mut context) = scenes.get_mut(*root) {
                             context.state = SceneState::Broken;
-                            let timestamp = context.total_runtime as f64 + 1.0;
+                            let timestamp = context.total_runtime + 1.0;
                             error!("[{scene_id:?} @ {}] error: {message}", context.tick_number);
                             context.log(SceneLogMessage {
                                 timestamp,
@@ -1351,12 +1353,12 @@ fn push_camera_fov_to_crdt(
     camera: Query<&Projection, With<PrimaryCamera>>,
     mut contexts: Query<&mut GlobalCrdtState>,
     time: Res<Time>,
-    mut last_pushed: Local<Option<(f32, f32)>>,
+    mut last_pushed: Local<Option<(f32, f64)>>,
 ) {
     let Ok(Projection::Perspective(p)) = camera.single() else {
         return;
     };
-    let now = time.elapsed_secs();
+    let now = time.elapsed_secs_f64();
     let should_push = match *last_pushed {
         None => true,
         Some((last_fov, last_time)) => last_fov != p.fov || now - last_time >= 2.0,

--- a/crates/scene_runner/src/renderer_context.rs
+++ b/crates/scene_runner/src/renderer_context.rs
@@ -84,7 +84,7 @@ pub struct RendererSceneContext {
     pub hierarchy_changed: bool,
 
     // time of last message sent to scene
-    pub last_sent: f32,
+    pub last_sent: f64,
     // last player/camera transforms sent to the scene, used to delta-check
     // without deserializing the stored crdt entry every frame
     pub last_sent_player_transform: Option<Transform>,
@@ -105,18 +105,18 @@ pub struct RendererSceneContext {
     pub blocked: HashSet<&'static str>,
 
     // total scene run time in seconds
-    pub total_runtime: f32,
+    pub total_runtime: f64,
     // scene tick number
     pub tick_number: u32,
     // last tick delta
-    pub last_update_dt: f32,
+    pub last_update_dt: f64,
 
     // message buffer
     pub logs: RingBuffer<SceneLogMessage>,
     log_to_stdout: bool,
 
     // last time a pointer event occurred
-    pub last_action_event: Option<f32>,
+    pub last_action_event: Option<f64>,
     // sdk version
     pub sdk_version: &'static str,
 

--- a/crates/scene_runner/src/update_scene/pointer_lock.rs
+++ b/crates/scene_runner/src/update_scene/pointer_lock.rs
@@ -36,7 +36,7 @@ impl Plugin for PointerLockPlugin {
 #[derive(Component)]
 pub struct CumulativePointerDelta {
     pub delta: Vec2,
-    pub since: f32,
+    pub since: f64,
 }
 
 #[derive(Component)]
@@ -51,7 +51,7 @@ impl From<PbPointerLock> for PointerLock {
 #[derive(SystemParam)]
 pub struct CameraInteractionState<'w, 's> {
     input_manager: InputManager<'w, 's>,
-    state: Local<'s, (ClickState, f32)>,
+    state: Local<'s, (ClickState, f64)>,
     time: Res<'w, Time>,
     _p: PhantomData<&'s ()>,
 }
@@ -70,14 +70,14 @@ impl CameraInteractionState<'_, '_> {
         match self.state.0 {
             ClickState::None | ClickState::Released => {
                 if self.input_manager.just_down(action, InputPriority::None) {
-                    *self.state = (ClickState::Held, self.time.elapsed_secs());
+                    *self.state = (ClickState::Held, self.time.elapsed_secs_f64());
                 } else {
                     self.state.0 = ClickState::None;
                 }
             }
             ClickState::Held => {
                 if self.input_manager.just_up(action) {
-                    if self.time.elapsed_secs() - self.state.1 > 0.25 {
+                    if self.time.elapsed_secs_f64() - self.state.1 > 0.25 {
                         self.state.0 = ClickState::Released;
                     } else {
                         self.state.0 = ClickState::Clicked;

--- a/crates/scene_runner/src/update_scene/pointer_results.rs
+++ b/crates/scene_runner/src/update_scene/pointer_results.rs
@@ -1329,7 +1329,7 @@ fn send_action_event(
             direction,
             timestamp,
         );
-        context.last_action_event = Some(time.elapsed_secs());
+        context.last_action_event = Some(time.elapsed_secs_f64());
         consumer = Some(scene);
     }
     consumer

--- a/crates/scene_runner/src/update_scene/raycast_result.rs
+++ b/crates/scene_runner/src/update_scene/raycast_result.rs
@@ -83,14 +83,14 @@ fn run_raycasts(
     debug: Res<DebugRaycast>,
     mut gizmos: Gizmos,
     time: Res<Time>,
-    mut gizmo_cache: Local<Vec<(f32, Vec3, Vec3)>>,
+    mut gizmo_cache: Local<Vec<(f64, Vec3, Vec3)>>,
     containing_scene: ContainingScene,
     su_target_res: Res<SuperUserRaycastScene>,
 ) {
     // redraw non-continuous gizmos for 1 sec
     gizmo_cache.retain(|(until, origin, end)| {
         gizmos.line(*origin, *end, basic::BLUE);
-        time.elapsed_secs() > *until
+        time.elapsed_secs_f64() > *until
     });
 
     for (e, scene_ent, mut raycast, transform) in raycast_requests.iter_mut() {
@@ -310,7 +310,7 @@ fn run_raycasts(
             let end = origin + direction * raycast.max_distance;
             gizmos.line(origin, end, basic::BLUE);
             if !continuous {
-                gizmo_cache.push((time.elapsed_secs() + 1.0, origin, end));
+                gizmo_cache.push((time.elapsed_secs_f64() + 1.0, origin, end));
             }
         }
 

--- a/crates/scene_runner/src/update_world/scene_ui/ui_dropdown.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_dropdown.rs
@@ -129,7 +129,7 @@ pub fn set_ui_dropdown(
                             value: combo.selected as i32,
                         },
                     );
-                    context.last_action_event = Some(time.elapsed_secs());
+                    context.last_action_event = Some(time.elapsed_secs_f64());
                 },
             ),
         ));

--- a/crates/scene_runner/src/update_world/scene_ui/ui_input.rs
+++ b/crates/scene_runner/src/update_world/scene_ui/ui_input.rs
@@ -94,7 +94,7 @@ pub fn set_ui_input(
                     is_submit: Some(submit),
                 },
             );
-            context.last_action_event = Some(time.elapsed_secs());
+            context.last_action_event = Some(time.elapsed_secs_f64());
         };
 
         commands.modify_component(move |style: &mut Node| {

--- a/crates/system_ui/src/chat/history.rs
+++ b/crates/system_ui/src/chat/history.rs
@@ -36,7 +36,7 @@ impl Plugin for ChatHistoryPlugin {
 
 #[derive(Component, Default)]
 pub struct ChatHistory {
-    current: VecDeque<(Entity, Entity, f32)>,
+    current: VecDeque<(Entity, Entity, f64)>,
 }
 
 fn setup_chat_history(mut commands: Commands, root: Res<SystemUiRoot>, dui: Res<DuiRegistry>) {
@@ -106,7 +106,7 @@ fn update_chat_history(
             warn!("no");
             break;
         };
-        let mut alpha = (time.elapsed_secs() - 10.0 - *exp).clamp(-1.0, 0.0) * -0.3;
+        let mut alpha = ((time.elapsed_secs_f64() - 10.0 - *exp).clamp(-1.0, 0.0) * -0.3) as f32;
         if history
             .current
             .get(1)
@@ -117,7 +117,7 @@ fn update_chat_history(
         node.0.border_color.set_alpha(alpha * 2.0);
         node.1.color.as_mut().unwrap().set_alpha(alpha);
 
-        if *exp > time.elapsed_secs() - 10.0 {
+        if *exp > time.elapsed_secs_f64() - 10.0 {
             break;
         }
 
@@ -192,7 +192,7 @@ fn update_chat_history(
         ));
         history
             .current
-            .push_back((bubble, message, time.elapsed_secs()));
+            .push_back((bubble, message, time.elapsed_secs_f64()));
     }
 
     for chat in pending_private_chats.drain(..) {
@@ -213,7 +213,7 @@ fn update_chat_history(
         ));
         history
             .current
-            .push_back((bubble, message, time.elapsed_secs()));
+            .push_back((bubble, message, time.elapsed_secs_f64()));
     }
 
     for chat in pending_nearby_chats.drain(..) {
@@ -256,6 +256,6 @@ fn update_chat_history(
         ));
         history
             .current
-            .push_back((bubble, message, time.elapsed_secs()));
+            .push_back((bubble, message, time.elapsed_secs_f64()));
     }
 }

--- a/crates/system_ui/src/emote_select.rs
+++ b/crates/system_ui/src/emote_select.rs
@@ -99,7 +99,7 @@ fn handle_emote_key(
     time: Res<Time>,
     existing: Query<&EmoteDialog>,
     buttons: Query<&EmoteButton>,
-    mut press_time: Local<f32>,
+    mut press_time: Local<f64>,
     mut lost_focus_events: EventReader<WindowFocused>,
     frame: Res<FrameCount>,
 ) {
@@ -117,10 +117,10 @@ fn handle_emote_key(
         };
 
         w.write(EmoteUiEvent::Show { coords });
-        *press_time = time.elapsed_secs();
+        *press_time = time.elapsed_secs_f64();
     }
 
-    if input_manager.just_up(SystemAction::Emote) && time.elapsed_secs() > *press_time + 0.25 {
+    if input_manager.just_up(SystemAction::Emote) && time.elapsed_secs_f64() > *press_time + 0.25 {
         w.write(EmoteUiEvent::Hide);
     }
 

--- a/crates/system_ui/src/oow.rs
+++ b/crates/system_ui/src/oow.rs
@@ -23,7 +23,7 @@ use crate::change_realm::ChangeRealmDialog;
 /// Extracts scene loading info: (title, pending_assets_count)
 fn get_scene_loading_info(
     player: Entity,
-    now: f32,
+    now: f64,
     containing_scene: &ContainingScene,
     scenes: &Query<(&RendererSceneContext, Option<&GltfLoadingCount>)>,
 ) -> (String, Option<u32>) {
@@ -41,7 +41,7 @@ fn get_scene_loading_info(
     // script is stalling. Surface a countdown to the not-responding timeout, after which
     // handle_out_of_world lets the player into the world.
     if let Some((context, _)) = scene {
-        let in_flight_for = now - context.last_sent;
+        let in_flight_for = (now - context.last_sent) as f32;
         if pending_assets.unwrap_or(0) == 0
             && context.in_flight()
             && in_flight_for >= SCENE_NOT_RESPONDING_DISPLAY_AFTER.as_secs_f32()
@@ -98,7 +98,7 @@ fn update_loading_scene_dialog(
     };
 
     let (title_text, pending_assets) =
-        get_scene_loading_info(player, time.elapsed_secs(), &containing_scene, &scenes);
+        get_scene_loading_info(player, time.elapsed_secs_f64(), &containing_scene, &scenes);
     let state_text = pending_assets
         .map(|count| format!("{} assets", count))
         .unwrap_or_else(|| "assets".to_owned());
@@ -146,7 +146,7 @@ struct LogoPulse;
 fn animate_logo_pulse(mut logos: Query<&mut ImageNode, With<LogoPulse>>, time: Res<Time>) {
     for mut img in logos.iter_mut() {
         // ping-pong opacity 0.5..1.0 over 1 second
-        let alpha = 0.75 + 0.25 * (time.elapsed_secs() * TAU).sin();
+        let alpha = (0.75 + 0.25 * (time.elapsed_secs_f64() * TAU as f64).sin()) as f32;
         img.color = img.color.with_alpha(alpha);
     }
 }
@@ -265,7 +265,7 @@ fn pipe_scene_loading_ui_stream(
 
     let current_state = if let (true, Ok(player)) = (visible, player.single()) {
         let (title, pending_assets) =
-            get_scene_loading_info(player, time.elapsed_secs(), &containing_scene, &scenes);
+            get_scene_loading_info(player, time.elapsed_secs_f64(), &containing_scene, &scenes);
         SceneLoadingUi {
             visible: true,
             realm_connected: current_realm.connected,

--- a/crates/system_ui/src/sysinfo.rs
+++ b/crates/system_ui/src/sysinfo.rs
@@ -235,7 +235,7 @@ fn update_scene_load_state(
     player: Query<(Entity, &GlobalTransform), With<PrimaryUser>>,
     debug_info: Res<DebugInfo>,
 ) {
-    let tick = (time.elapsed_secs() * 10.0) as u32;
+    let tick = (time.elapsed_secs_f64() * 10.0) as u32;
     if tick == *last_update {
         return;
     }

--- a/crates/system_ui/src/toasts.rs
+++ b/crates/system_ui/src/toasts.rs
@@ -58,7 +58,7 @@ fn update_toasts(
         };
 
         if let Some(ent) = maybe_ent {
-            if toast.time < time.elapsed_secs() - 5.0 {
+            if toast.time < time.elapsed_secs_f64() - 5.0 {
                 commands.entity(ent).despawn();
                 displays.insert(key.clone(), None);
                 continue;
@@ -78,5 +78,5 @@ fn update_toasts(
 
     toasts
         .0
-        .retain(|_, toast| toast.last_update > time.elapsed_secs() - 5.0);
+        .retain(|_, toast| toast.last_update > time.elapsed_secs_f64() - 5.0);
 }

--- a/crates/tween/src/lib.rs
+++ b/crates/tween/src/lib.rs
@@ -579,7 +579,7 @@ pub struct SystemTween {
 #[derive(Component)]
 pub struct SystemTweenData {
     start_pos: Transform,
-    start_time: f32,
+    start_time: f64,
 }
 
 pub fn update_system_tween(
@@ -602,12 +602,12 @@ pub fn update_system_tween(
                     debug!("system tween starting {} @ {:?}", tween.time, tween.target);
                     commands.entity(ent).try_insert(SystemTweenData {
                         start_pos: *transform,
-                        start_time: time.elapsed_secs(),
+                        start_time: time.elapsed_secs_f64(),
                     });
                 }
             }
             (false, Some(data)) => {
-                let elapsed = time.elapsed_secs() - data.start_time;
+                let elapsed = (time.elapsed_secs_f64() - data.start_time) as f32;
                 if elapsed >= tween.time {
                     debug!("system tween complete @ {:?}", tween.target);
                     *transform = tween.target;

--- a/crates/ui_core/src/spinner.rs
+++ b/crates/ui_core/src/spinner.rs
@@ -30,7 +30,7 @@ fn setup(
 
 fn spin_spinners(mut q: Query<&mut ImageNode, With<Spinner>>, time: Res<Time>) {
     for mut t in q.iter_mut() {
-        t.texture_atlas.as_mut().unwrap().index = (time.elapsed_secs() * 8.0) as usize % 8;
+        t.texture_atlas.as_mut().unwrap().index = (time.elapsed_secs_f64() * 8.0) as usize % 8;
     }
 }
 

--- a/crates/user_input/src/avatar_movement.rs
+++ b/crates/user_input/src/avatar_movement.rs
@@ -293,7 +293,7 @@ pub struct ActivePlayerComponent<C: Component> {
     /// Engine dispatch time (`RendererSceneContext::last_sent`) of the scene tick
     /// that produced `component`. Used to reject AvatarMovement that was initiated
     /// before a `movePlayerTo`-imposed facing (and so read a stale transform).
-    initiated_at: f32,
+    initiated_at: f64,
     pub component: C,
 }
 
@@ -660,7 +660,7 @@ pub fn apply_movement(
     dynamic_state.velocity = velocity;
     if movement.component.velocity.y > 10.0 {
         if !*jumping {
-            dynamic_state.jump_time = time_res.elapsed_secs();
+            dynamic_state.jump_time = time_res.elapsed_secs_f64();
             *jumping = true;
         }
     } else {

--- a/crates/user_input/src/point_at.rs
+++ b/crates/user_input/src/point_at.rs
@@ -43,13 +43,13 @@ fn capture_point_at(
     pointer_ray: Res<PointerRay>,
     time: Res<Time>,
     mut player: Query<(&mut PointAtSync, &AvatarDynamicState, &GlobalTransform), With<PrimaryUser>>,
-    mut latch_until: Local<f32>,
+    mut latch_until: Local<f64>,
     mut press_origin_dir: Local<Option<Vec3>>,
 ) {
     let Ok((mut sync, dynamics, player_global)) = player.single_mut() else {
         return;
     };
-    let now = time.elapsed_secs();
+    let now = time.elapsed_secs_f64();
     let idle = dynamics.move_kind == MoveKind::Idle;
 
     // Drop the latch the moment we leave idle — pointing while running looks
@@ -132,7 +132,7 @@ fn capture_point_at(
             let dcl = DclTranslation::from_bevy_translation(target_bevy);
             sync.target_world = Vec3::new(dcl.0[0], dcl.0[1], dcl.0[2]);
             sync.is_pointing = true;
-            *latch_until = now + POINT_AT_DURATION;
+            *latch_until = now + POINT_AT_DURATION as f64;
             return;
         }
     }

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -716,7 +716,7 @@ fn supervisor(
     orchestrated: Option<Res<OrchestratedScenes>>,
     updates: Res<scene_runner::SceneUpdates>,
 ) {
-    let elapsed = time.elapsed_secs();
+    let elapsed = time.elapsed_secs_f64();
 
     for e in errors.read() {
         error!("[headless] scene error: {e:?}");
@@ -851,7 +851,7 @@ fn request_delegation_renewals(
         .duration_since(web_time::UNIX_EPOCH)
         .unwrap()
         .as_millis() as i64;
-    let elapsed = time.elapsed_secs();
+    let elapsed = time.elapsed_secs_f64();
 
     // drop throttle state for scenes no longer holding a delegation (removed scenes),
     // so this map doesn't grow unbounded over the engine's lifetime
@@ -1200,7 +1200,7 @@ fn emit_scene_status(
         }
     }
 
-    let elapsed = time.elapsed_secs();
+    let elapsed = time.elapsed_secs_f64();
     if elapsed - *last > 5.0 {
         *last = elapsed;
         for ctx in scenes.iter() {
@@ -1221,7 +1221,7 @@ fn emit_scene_stats(
     mut last: Local<f32>,
     mut prev: Local<std::collections::HashMap<String, (SceneResourceCounters, f32)>>,
 ) {
-    let elapsed = time.elapsed_secs();
+    let elapsed = time.elapsed_secs_f64();
     if elapsed - *last <= 10.0 {
         return;
     }

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -712,7 +712,7 @@ fn supervisor(
     mut errors: EventReader<AppError>,
     mut exit: EventWriter<AppExit>,
     mut announced: Local<bool>,
-    mut last_report: Local<f32>,
+    mut last_report: Local<f64>,
     orchestrated: Option<Res<OrchestratedScenes>>,
     updates: Res<scene_runner::SceneUpdates>,
 ) {
@@ -757,7 +757,7 @@ fn supervisor(
     // wall-clock timeout: graceful success exit for smoke tests
     // (checked in main via arg-injected resource below)
     if let Some(limit) = TIMEOUT.get().copied().flatten() {
-        if elapsed > limit {
+        if elapsed > limit as f64 {
             println!("[headless] timeout {limit}s reached, exiting");
             exit.write_default();
         }
@@ -842,10 +842,10 @@ fn reap_terminal_scene_rooms(
 fn request_delegation_renewals(
     delegations: Res<StorageDelegations>,
     time: Res<Time>,
-    mut last_request: Local<std::collections::HashMap<String, f32>>,
+    mut last_request: Local<std::collections::HashMap<String, f64>>,
 ) {
     const REFRESH_BUFFER_MS: i64 = 5 * 60 * 1000;
-    const REQUEST_THROTTLE_SECS: f32 = 30.0;
+    const REQUEST_THROTTLE_SECS: f64 = 30.0;
 
     let now_ms = web_time::SystemTime::now()
         .duration_since(web_time::UNIX_EPOCH)
@@ -1175,7 +1175,7 @@ fn emit_scene_log(hash: &str, log: &SceneLogMessage) {
 fn emit_scene_status(
     time: Res<Time>,
     scenes: Query<&RendererSceneContext>,
-    mut last: Local<f32>,
+    mut last: Local<f64>,
     mut live: Local<std::collections::HashSet<String>>,
     mut broken: Local<std::collections::HashSet<String>>,
 ) {
@@ -1218,8 +1218,8 @@ fn emit_scene_status(
 fn emit_scene_stats(
     time: Res<Time>,
     scenes: Query<&RendererSceneContext>,
-    mut last: Local<f32>,
-    mut prev: Local<std::collections::HashMap<String, (SceneResourceCounters, f32)>>,
+    mut last: Local<f64>,
+    mut prev: Local<std::collections::HashMap<String, (SceneResourceCounters, f64)>>,
 ) {
     let elapsed = time.elapsed_secs_f64();
     if elapsed - *last <= 10.0 {


### PR DESCRIPTION
The headless authoritative server runs for weeks, and the engine kept every clock as f32 seconds since process start. At a 30 Hz tick the f32 resolution reaches the tick period after ~3 days and exceeds it after ~6 days, at which point the scene scheduler's `last_sent < elapsed` gate reads false on repeated frames and its priority divides by zero, and the foreign-avatar interpolation windows degrade the same way.

**Changes**

- Every `Time::elapsed_secs()` read becomes `elapsed_secs_f64()`, and the fields those reads land in are widened (scene dispatch/runtime stamps, foreign-avatar target and receipt times, jump time, emote timestamp, toasts, chat history, pointer lock, gizmo cache, ...). Intervals stay f32 and deltas are cast at the point of use, so the Vec3 math is unchanged. Time-of-day (seconds since midnight, bounded) is deliberately left f32.
- `SceneElapsedTime` crosses the scene IPC as f64 (native and wasm). The message-pack channel is positional, so **the two native binaries must ship together**.
- Pulse `server_tick` is u32 milliseconds since the Pulse server started and rolls over after ~49.7 days; the receiver's strictly-newer gate would then drop every update. The decoder unwraps it with a wrapping half-range test, adding 2^32 ms per rollover. Numerically identical to the old value until the first rollover. A comment in `on_delta` records a known (self-healing) two-round-trip stall when an unreliable delta overtakes a reliable full state, to revisit if it shows up in practice.
- `double total_runtime_f64 = 5` on PBEngineInfo, written alongside the float. The float can't be widened in place: the SDK's generated decoder guards the wire type and would skip the field, so existing scenes would read 0. Protocol PR: https://github.com/decentraland/protocol/pull/476

Verified locally: clippy `-D warnings` clean, comms Pulse unit tests (incl. a new rollover test), wasm build, and the react-web real-engine e2e suite (23/23 excluding the mic test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

