### PR TITLE
Teleport requests carry their realm; explicit boot location lands in a World

### DIFF
--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -139,7 +139,8 @@ pub enum RpcCall {
     },
     TeleportPlayer {
         scene: Option<Entity>,
-        to: IVec2,
+        /// The parcel to land on; `None` (with a realm) is the realm's default spawn.
+        to: Option<IVec2>,
         /// The realm `to` belongs to: a realm change (a full reconnect, as for `ChangeRealm`) happens first.
         realm: Option<String>,
         response: RpcResultSender<Result<(), String>>,

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -140,6 +140,8 @@ pub enum RpcCall {
     TeleportPlayer {
         scene: Option<Entity>,
         to: IVec2,
+        /// The realm `to` belongs to: a realm change (a full reconnect, as for `ChangeRealm`) happens first.
+        realm: Option<String>,
         response: RpcResultSender<Result<(), String>>,
     },
     MoveCamera {

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -18,7 +18,7 @@ module.exports.walkPlayerTo = async function (body) {
 }
 
 module.exports.teleportTo = async function (body) {
-    await Deno.core.ops.op_teleport_to(Number(body.worldCoordinates.x), Number(body.worldCoordinates.y));
+    await Deno.core.ops.op_teleport_to(Number(body.worldCoordinates.x), Number(body.worldCoordinates.y), body.realm ?? null);
     return {} 
 }
 

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -18,7 +18,8 @@ module.exports.walkPlayerTo = async function (body) {
 }
 
 module.exports.teleportTo = async function (body) {
-    await Deno.core.ops.op_teleport_to(Number(body.worldCoordinates.x), Number(body.worldCoordinates.y), body.realm ?? null);
+    const parcel = body.worldCoordinates;
+    await Deno.core.ops.op_teleport_to(parcel ? Number(parcel.x) : null, parcel ? Number(parcel.y) : null, body.realm ?? null);
     return {} 
 }
 

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -28,25 +28,28 @@ module.exports.triggerEmote = async function (body) {
     return {} 
 }
 
-module.exports.triggerSceneEmote = async function (body) { 
+module.exports.triggerSceneEmote = async function (body) {
     Deno.core.ops.op_scene_emote(body.src, body.loop)
-    return {} 
+    return { success: true }
 }
 
-module.exports.changeRealm = async function (body) { 
-    return await Deno.core.ops.op_change_realm(body.realm, body.message);
+module.exports.changeRealm = async function (body) {
+    const success = await Deno.core.ops.op_change_realm(body.realm, body.message);
+    return { success }
 }
 
-module.exports.openExternalUrl = async function (body) { 
-    return await Deno.core.ops.op_external_url(body.url);
+module.exports.openExternalUrl = async function (body) {
+    const success = await Deno.core.ops.op_external_url(body.url);
+    return { success }
 }
 
-module.exports.openNftDialog = async function (body) { 
-    return await Deno.core.ops.op_open_nft_dialog(body.urn) 
+module.exports.openNftDialog = async function (body) {
+    await Deno.core.ops.op_open_nft_dialog(body.urn)
+    return { success: true }
 }
 module.exports.setCommunicationsAdapter = async function (body) { 
     console.error("RestrictedActions::setCommunicationsAdapter not implemented");
-    return {} 
+    return { success: false }
 }
 module.exports.setUiFocus = async function(body) {
     return await Deno.core.ops.op_ui_focus(true, body.elementId);
@@ -58,5 +61,6 @@ module.exports.getUiFocus = async function() {
     return await Deno.core.ops.op_ui_focus(false);
 }
 module.exports.copyToClipboard = async function(body) {
-    return await Deno.core.ops.op_copy_to_clipboard(body.text);
+    await Deno.core.ops.op_copy_to_clipboard(body.text);
+    return {}
 }

--- a/crates/dcl/src/js/modules/UserActionModule.js
+++ b/crates/dcl/src/js/modules/UserActionModule.js
@@ -1,7 +1,7 @@
 module.exports.requestTeleport = async function (body) {
     const { destination } = body;
     if (destination === 'magic' || destination === 'crowd') {
-        return await Deno.core.ops.op_teleport_to(0, 0);
+        return await Deno.core.ops.op_teleport_to(0, 0, null);
     } else if (!/^\-?\d+\,\-?\d+$/.test(destination)) {
         return await Promise.reject(`teleportTo: invalid destination ${destination}`)
     }
@@ -12,5 +12,5 @@ module.exports.requestTeleport = async function (body) {
     let x = parseInt(coords[0], 10);
     let y = parseInt(coords[1], 10);
 
-    return await Deno.core.ops.op_teleport_to(x, y);
+    return await Deno.core.ops.op_teleport_to(x, y, null);
 }

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -97,8 +97,8 @@ pub async fn op_walk_player_to(
 
 pub async fn op_teleport_to(
     state: Rc<RefCell<impl State>>,
-    position_x: i32,
-    position_y: i32,
+    position_x: Option<i32>,
+    position_y: Option<i32>,
     realm: Option<String>,
 ) -> Result<bool, anyhow::Error> {
     debug!("op_teleport_to");
@@ -109,7 +109,7 @@ pub async fn op_teleport_to(
         .borrow_mut::<RpcCalls>()
         .push(RpcCall::TeleportPlayer {
             scene: Some(scene),
-            to: IVec2::new(position_x, position_y),
+            to: position_x.zip(position_y).map(|(x, y)| IVec2::new(x, y)),
             realm,
             response: sx,
         })?;

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -99,6 +99,7 @@ pub async fn op_teleport_to(
     state: Rc<RefCell<impl State>>,
     position_x: i32,
     position_y: i32,
+    realm: Option<String>,
 ) -> Result<bool, anyhow::Error> {
     debug!("op_teleport_to");
     let (sx, rx) = RpcResultSender::<Result<(), String>>::channel();
@@ -109,6 +110,7 @@ pub async fn op_teleport_to(
         .push(RpcCall::TeleportPlayer {
             scene: Some(scene),
             to: IVec2::new(position_x, position_y),
+            realm,
             response: sx,
         })?;
 

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -114,7 +114,11 @@ pub async fn op_teleport_to(
             response: sx,
         })?;
 
-    Ok(matches!(rx.await, Ok(Ok(_))))
+    match rx.await {
+        Ok(Ok(())) => Ok(true),
+        Ok(Err(e)) => Err(anyhow::anyhow!(e)),
+        Err(_) => Err(anyhow::anyhow!("teleport request dropped")),
+    }
 }
 
 pub async fn op_change_realm(

--- a/crates/dcl_component/src/proto/decentraland/kernel/apis/restricted_actions.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/apis/restricted_actions.proto
@@ -12,6 +12,10 @@ message MovePlayerToRequest {
 
 message TeleportToRequest {
   decentraland.common.Vector2 world_coordinates = 1;
+  // The realm the parcel belongs to: a world name (`foo.dcl.eth`) or a realm url. When set, the
+  // client changes realm (as for ChangeRealm — a full reconnect, even to the realm the player is
+  // in) and lands on the parcel there. Omitted: the parcel is in the player's current realm.
+  optional string realm = 2;
 }
 
 message TriggerEmoteRequest {

--- a/crates/dcl_component/src/proto/decentraland/kernel/apis/restricted_actions.proto
+++ b/crates/dcl_component/src/proto/decentraland/kernel/apis/restricted_actions.proto
@@ -11,10 +11,11 @@ message MovePlayerToRequest {
 }
 
 message TeleportToRequest {
-  decentraland.common.Vector2 world_coordinates = 1;
+  // The parcel to land on. Omitted: the realm's default spawn (only meaningful with `realm`).
+  optional decentraland.common.Vector2 world_coordinates = 1;
   // The realm the parcel belongs to: a world name (`foo.dcl.eth`) or a realm url. When set, the
-  // client changes realm (as for ChangeRealm — a full reconnect, even to the realm the player is
-  // in) and lands on the parcel there. Omitted: the parcel is in the player's current realm.
+  // client changes realm (a full reconnect, even to the realm the player is in) and lands on the
+  // parcel there. Omitted: the parcel is in the player's current realm.
   optional string realm = 2;
 }
 
@@ -70,6 +71,7 @@ service RestrictedActionsService {
   // TriggerEmote will trigger an emote in this current user
   rpc TriggerEmote(TriggerEmoteRequest) returns (TriggerEmoteResponse) {}
 
+  // @deprecated, use TeleportTo with `realm` (and no `world_coordinates` for the realm's default spawn)
   // ChangeRealm prompts the user to change to a specific realm
   rpc ChangeRealm(ChangeRealmRequest) returns (SuccessResponse) {}
 

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -50,8 +50,8 @@ async fn op_walk_player_to(
 #[op2(async)]
 async fn op_teleport_to(
     state: Rc<RefCell<OpState>>,
-    position_x: i32,
-    position_y: i32,
+    position_x: Option<i32>,
+    position_y: Option<i32>,
     #[string] realm: Option<String>,
 ) -> Result<bool, anyhow::Error> {
     dcl::js::restricted_actions::op_teleport_to(state, position_x, position_y, realm).await

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -52,8 +52,9 @@ async fn op_teleport_to(
     state: Rc<RefCell<OpState>>,
     position_x: i32,
     position_y: i32,
+    #[string] realm: Option<String>,
 ) -> Result<bool, anyhow::Error> {
-    dcl::js::restricted_actions::op_teleport_to(state, position_x, position_y).await
+    dcl::js::restricted_actions::op_teleport_to(state, position_x, position_y, realm).await
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -42,8 +42,9 @@ pub async fn op_teleport_to(
     state: &WorkerContext,
     position_x: i32,
     position_y: i32,
+    realm: Option<String>,
 ) -> Result<bool, WasmError> {
-    dcl::js::restricted_actions::op_teleport_to(state.rc(), position_x, position_y)
+    dcl::js::restricted_actions::op_teleport_to(state.rc(), position_x, position_y, realm)
         .await
         .map_err(WasmError::from)
 }

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -40,8 +40,8 @@ pub async fn op_walk_player_to(
 #[wasm_bindgen]
 pub async fn op_teleport_to(
     state: &WorkerContext,
-    position_x: i32,
-    position_y: i32,
+    position_x: Option<i32>,
+    position_y: Option<i32>,
     realm: Option<String>,
 ) -> Result<bool, WasmError> {
     dcl::js::restricted_actions::op_teleport_to(state.rc(), position_x, position_y, realm)

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -574,6 +574,8 @@ impl Plugin for IpfsIoPlugin {
 pub enum RealmInitialLocation {
     None,
     Base,
+    /// Land on this parcel of the new realm (a teleport that named its realm).
+    Parcel(IVec2),
 }
 
 /// Switch to a new realm

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -609,7 +609,10 @@ fn change_realm(
             PermissionType::ChangeRealm,
             *scene,
             (to.clone(), response.clone()),
-            message.clone(),
+            Some(match message {
+                Some(message) => format!("{to}: {message}"),
+                None => to.clone(),
+            }),
             false,
         );
     }

--- a/crates/restricted_actions/src/teleport.rs
+++ b/crates/restricted_actions/src/teleport.rs
@@ -17,7 +17,11 @@ use scene_runner::{
 };
 use wallet::Wallet;
 
-type TeleportAction = (IVec2, Option<String>, RpcResultSender<Result<(), String>>);
+type TeleportAction = (
+    Option<IVec2>,
+    Option<String>,
+    RpcResultSender<Result<(), String>>,
+);
 
 pub fn teleport_player(
     mut commands: Commands,
@@ -37,16 +41,21 @@ pub fn teleport_player(
         } => Some((*scene, *to, realm.clone(), response.clone())),
         _ => None,
     }) {
+        let parcel = to.map(|to| format!("({},{})", to.x, to.y));
+        let (ty, detail) = match (&realm, parcel) {
+            (Some(realm), Some(parcel)) => {
+                (PermissionType::ChangeRealm, format!("{realm} {parcel}"))
+            }
+            (Some(realm), None) => (PermissionType::ChangeRealm, realm.clone()),
+            (None, Some(parcel)) => (PermissionType::Teleport, parcel),
+            (None, None) => {
+                response.send(Err("teleport needs a parcel or a realm".to_owned()));
+                continue;
+            }
+        };
         let Some(scene) = scene else {
             actions.push((to, realm, response));
             continue;
-        };
-        let (ty, detail) = match &realm {
-            Some(realm) => (
-                PermissionType::ChangeRealm,
-                format!("{realm} ({},{})", to.x, to.y),
-            ),
-            None => (PermissionType::Teleport, format!("({},{})", to.x, to.y)),
         };
         perms.check(ty, scene, (to, realm, response), Some(detail), false);
     }
@@ -57,10 +66,14 @@ pub fn teleport_player(
     for (to, realm, response) in actions {
         if let Some(realm) = realm {
             // A realm change (a full reconnect, even to the realm we are in — same as changeRealm),
-            // landing on the parcel once it is live. It can't be applied now: it would resolve
-            // against the parcel grid of the realm being left.
-            debug!("teleport -> parcel {to} in {realm}");
-            *realm_target = RealmInitialLocation::Parcel(to);
+            // landing on the parcel once it is live, or on the realm's default spawn without one.
+            // The parcel can't be applied now: it would resolve against the parcel grid of the
+            // realm being left.
+            debug!("teleport -> {to:?} in {realm}");
+            *realm_target = match to {
+                Some(to) => RealmInitialLocation::Parcel(to),
+                None => RealmInitialLocation::Base,
+            };
             commands.send_event(ChangeRealmEvent {
                 new_realm: realm,
                 content_server_override: None,
@@ -68,6 +81,12 @@ pub fn teleport_player(
             response.send(Ok(()));
             continue;
         }
+
+        // Neither: already answered above (a system request without a scene is never built that way).
+        let Some(to) = to else {
+            response.send(Err("teleport needs a parcel or a realm".to_owned()));
+            continue;
+        };
 
         let Ok((ent, mut transform, mut dynamic_state)) = player.single_mut() else {
             warn!("player doesn't exist?!");

--- a/crates/restricted_actions/src/teleport.rs
+++ b/crates/restricted_actions/src/teleport.rs
@@ -5,7 +5,7 @@ use common::{
 };
 use comms::global_crdt::ForeignPlayer;
 use ethers_core::rand::{seq::SliceRandom, thread_rng, Rng};
-use ipfs::RealmInitialLocation;
+use ipfs::{ChangeRealmEvent, RealmInitialLocation};
 use scene_runner::{
     initialize_scene::{
         LiveScenes, PointerResult, SceneHash, SceneLoading, ScenePointers, PARCEL_SIZE,
@@ -17,18 +17,62 @@ use scene_runner::{
 };
 use wallet::Wallet;
 
+type TeleportAction = (IVec2, Option<String>, RpcResultSender<Result<(), String>>);
+
 pub fn teleport_player(
     mut commands: Commands,
     mut events: EventReader<RpcCall>,
     mut player: Query<(Entity, &mut Transform, &mut AvatarDynamicState), With<PrimaryUser>>,
-    mut perms: Permission<(IVec2, RpcResultSender<Result<(), String>>)>,
+    mut perms: Permission<TeleportAction>,
     mut realm_target: ResMut<RealmInitialLocation>,
 ) {
-    let mut do_teleport = |to: IVec2, response: RpcResultSender<Result<(), String>>| {
+    let mut actions: Vec<TeleportAction> = Vec::new();
+
+    for (scene, to, realm, response) in events.read().filter_map(|ev| match ev {
+        RpcCall::TeleportPlayer {
+            scene,
+            to,
+            realm,
+            response,
+        } => Some((*scene, *to, realm.clone(), response.clone())),
+        _ => None,
+    }) {
+        let Some(scene) = scene else {
+            actions.push((to, realm, response));
+            continue;
+        };
+        let (ty, detail) = match &realm {
+            Some(realm) => (
+                PermissionType::ChangeRealm,
+                format!("{realm} ({},{})", to.x, to.y),
+            ),
+            None => (PermissionType::Teleport, format!("({},{})", to.x, to.y)),
+        };
+        perms.check(ty, scene, (to, realm, response), Some(detail), false);
+    }
+
+    actions.extend(perms.drain_success(PermissionType::Teleport));
+    actions.extend(perms.drain_success(PermissionType::ChangeRealm));
+
+    for (to, realm, response) in actions {
+        if let Some(realm) = realm {
+            // A realm change (a full reconnect, even to the realm we are in — same as changeRealm),
+            // landing on the parcel once it is live. It can't be applied now: it would resolve
+            // against the parcel grid of the realm being left.
+            debug!("teleport -> parcel {to} in {realm}");
+            *realm_target = RealmInitialLocation::Parcel(to);
+            commands.send_event(ChangeRealmEvent {
+                new_realm: realm,
+                content_server_override: None,
+            });
+            response.send(Ok(()));
+            continue;
+        }
+
         let Ok((ent, mut transform, mut dynamic_state)) = player.single_mut() else {
             warn!("player doesn't exist?!");
             response.send(Err("Something went wrong".into()));
-            return;
+            continue;
         };
 
         transform.translation.x = to.x as f32 * 16.0 + 8.0;
@@ -43,34 +87,12 @@ pub fn teleport_player(
 
         response.send(Ok(()));
         info!("teleported to {to}");
-    };
-
-    for (scene, to, response) in events.read().filter_map(|ev| match ev {
-        RpcCall::TeleportPlayer {
-            scene,
-            to,
-            response,
-        } => Some((*scene, *to, response.clone())),
-        _ => None,
-    }) {
-        if let Some(scene) = scene {
-            perms.check(
-                PermissionType::Teleport,
-                scene,
-                (to, response.clone()),
-                Some(format!("({},{})", to.x, to.y)),
-                false,
-            );
-        } else {
-            do_teleport(to, response);
-        }
     }
 
-    for (to, response) in perms.drain_success(PermissionType::Teleport) {
-        do_teleport(to, response);
+    for (_, _, response) in perms.drain_fail(PermissionType::Teleport) {
+        response.send(Err("User declined".to_owned()))
     }
-
-    for (_, response) in perms.drain_fail(PermissionType::Teleport) {
+    for (_, _, response) in perms.drain_fail(PermissionType::ChangeRealm) {
         response.send(Err("User declined".to_owned()))
     }
 }

--- a/crates/scene_runner/src/automatic_testing/mod.rs
+++ b/crates/scene_runner/src/automatic_testing/mod.rs
@@ -371,7 +371,7 @@ fn automatic_testing(
         commands.queue(move |w: &mut World| {
             w.send_event(RpcCall::TeleportPlayer {
                 scene: None,
-                to,
+                to: Some(to),
                 realm: None,
                 response: RpcResultSender::default(),
             });

--- a/crates/scene_runner/src/automatic_testing/mod.rs
+++ b/crates/scene_runner/src/automatic_testing/mod.rs
@@ -372,6 +372,7 @@ fn automatic_testing(
             w.send_event(RpcCall::TeleportPlayer {
                 scene: None,
                 to,
+                realm: None,
                 response: RpcResultSender::default(),
             });
         });

--- a/crates/scene_runner/src/initialize_scene.rs
+++ b/crates/scene_runner/src/initialize_scene.rs
@@ -1202,6 +1202,20 @@ fn load_active_entities(
             context.set_bounds(bounds_min, bounds_max);
         }
 
+        // A teleport that named this realm: land on its parcel now that the realm is live. The
+        // out-of-world sweep holds the player until the parcel resolves against the new realm.
+        if let RealmInitialLocation::Parcel(parcel) = *teleport_target {
+            if !current_realm.about_url.is_empty() {
+                if let Ok((player_entity, _)) = player.single() {
+                    if let Ok(mut commands) = commands.get_entity(player_entity) {
+                        commands.try_insert(teleport_components(parcel));
+                        debug!("change to realm with target parcel -> none ({parcel})");
+                        *teleport_target = RealmInitialLocation::None;
+                    }
+                }
+            }
+        }
+
         if !current_realm.about_url.is_empty() && *teleport_target == RealmInitialLocation::Base {
             let has_scene_urns = !current_realm
                 .config
@@ -1244,7 +1258,7 @@ fn load_active_entities(
     };
 
     let teleport_on_resolve = match *teleport_target {
-        RealmInitialLocation::None => {
+        RealmInitialLocation::None | RealmInitialLocation::Parcel(_) => {
             *pending_teleport = false;
             None
         }

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -642,7 +642,7 @@ pub fn spawn_discover_popup(
         };
         let rpc_ev = RpcCall::TeleportPlayer {
             scene: None,
-            to: to.0,
+            to: Some(to.0),
             realm: None,
             response: Default::default(),
         };

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -643,6 +643,7 @@ pub fn spawn_discover_popup(
         let rpc_ev = RpcCall::TeleportPlayer {
             scene: None,
             to: to.0,
+            realm: None,
             response: Default::default(),
         };
 

--- a/react-web/bridge-scene/package-lock.json
+++ b/react-web/bridge-scene/package-lock.json
@@ -8,11 +8,11 @@
       "name": "bevy-ui-scene",
       "version": "1.0.0",
       "devDependencies": {
-        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
-        "@dcl/js-runtime": "7.27.1-33669021544.commit-a6216ed",
-        "@dcl/react-ecs": "7.27.1-33669021544.commit-a6216ed",
-        "@dcl/sdk": "7.27.1-33669021544.commit-a6216ed",
-        "@dcl/sdk-commands": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/ecs": "7.27.1-33674365269.commit-d8b9341",
+        "@dcl/js-runtime": "7.27.1-33674365269.commit-d8b9341",
+        "@dcl/react-ecs": "7.27.1-33674365269.commit-d8b9341",
+        "@dcl/sdk": "7.27.1-33674365269.commit-d8b9341",
+        "@dcl/sdk-commands": "7.27.1-33674365269.commit-d8b9341",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "eslint": "^8.53.0",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.27.1-33669021544.commit-a6216ed",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.27.1-33669021544.commit-a6216ed.tgz",
-      "integrity": "sha512-BE1YEG/3WFzvbN4Fj+xPDS7h/dxgJ11Nw7YrM1z8nNGWJYBhZdueJrCA5l/AsbXvpGeahWpJR27gbmCwh60Edg==",
+      "version": "7.27.1-33674365269.commit-d8b9341",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.27.1-33674365269.commit-d8b9341.tgz",
+      "integrity": "sha512-ruaj1JSS+RFSCITsisFg46kNKP/7J+e45b0KxzFc6FB1uA1yDy4eGmIXmr/zXkEaQsMFmbeViuUx77nbvgk5SQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.27.1-33669021544.commit-a6216ed",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.27.1-33669021544.commit-a6216ed.tgz",
-      "integrity": "sha512-A4oKBITJ9/l2ddDT1vJSSA8hlQydIpuCj7lzxK3K94JDIepdYXTTH+PXugMVEms8dnF1o8ooYMTgsk1Gqk0VJA==",
+      "version": "7.27.1-33674365269.commit-d8b9341",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.27.1-33674365269.commit-d8b9341.tgz",
+      "integrity": "sha512-bATA3bNHcaU0kf4p5yjpswNVJh7vkjlNpYZm2GSPMnByLL2tU9EfmszmInhLStGrE48kUyCru6Pk8Tun0U3kwg==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -390,9 +390,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33668585153.commit-4a844e9",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33668585153.commit-4a844e9.tgz",
-      "integrity": "sha512-I5cSEq7GA3QANs7xG8CWhUheSw1kC/3JA3OYHK82KNxF6YdpOdLFI82t9yraVwWb3+FaE3yYtlPW2Nf8abDIHA==",
+      "version": "1.0.0-33674022401.commit-882d4ee",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33674022401.commit-882d4ee.tgz",
+      "integrity": "sha512-+gFspUQ/HSt4oqjjWuoSuftp3u6ab3VbCB+nhA8QMlmgabqNNT5XfX87q1u/NCQLHhg61my7y9We656TYl/4cw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -421,13 +421,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.27.1-33669021544.commit-a6216ed",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.27.1-33669021544.commit-a6216ed.tgz",
-      "integrity": "sha512-6FNC0534CPj6GEgLqNAQQxX+hpHBAk4fsUKbrPepbahKu2GAqca9lH3JalxDqktPVnfWtRQ412nK4jcpqLkHag==",
+      "version": "7.27.1-33674365269.commit-d8b9341",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.27.1-33674365269.commit-d8b9341.tgz",
+      "integrity": "sha512-Oavg2KWQb2Z1/aD/duX1xF+NzaOLSZA5TOBu+cIZFCJOeTNIbbD0Z1UUIIvGcZ3OzDA7Hu3s69XhWIobChYvMA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/ecs": "7.27.1-33674365269.commit-d8b9341",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -456,35 +456,35 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.27.1-33669021544.commit-a6216ed",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.27.1-33669021544.commit-a6216ed.tgz",
-      "integrity": "sha512-gYn9mZC37f/pysb5dIbTO3NLt9H+JdnFpqjbqpWCWLuPAIGjBVy8MYBgxJzNQXKOMPwn6UDzsTzHB7xzBtwP/A==",
+      "version": "7.27.1-33674365269.commit-d8b9341",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.27.1-33674365269.commit-d8b9341.tgz",
+      "integrity": "sha512-1mBN29s8ewcNhyl98e72JI4nLREfK4Z6haYpyGVIuXqkFD1aiDpPqiFKn4fw17US68ya2/UsJx6U+2IbUAEy7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/ecs": "7.27.1-33674365269.commit-d8b9341",
         "@dcl/ecs-math": "2.1.0",
-        "@dcl/js-runtime": "7.27.1-33669021544.commit-a6216ed",
-        "@dcl/react-ecs": "7.27.1-33669021544.commit-a6216ed",
-        "@dcl/sdk-commands": "7.27.1-33669021544.commit-a6216ed"
+        "@dcl/js-runtime": "7.27.1-33674365269.commit-d8b9341",
+        "@dcl/react-ecs": "7.27.1-33674365269.commit-d8b9341",
+        "@dcl/sdk-commands": "7.27.1-33674365269.commit-d8b9341"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.27.1-33669021544.commit-a6216ed",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.27.1-33669021544.commit-a6216ed.tgz",
-      "integrity": "sha512-ULFSuQrSgj3O8cJK58gwSMrS3Riwu3xOsIFoQSvIr/tIHe5+O16F/U9i/oAn+ig1WmWFlK8gb7tYrkq3M0pcpA==",
+      "version": "7.27.1-33674365269.commit-d8b9341",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.27.1-33674365269.commit-d8b9341.tgz",
+      "integrity": "sha512-sGQt8ujutyU7PwDM9GRYGVZ4T5FJxp1SlTYKXwKJ6X/dheojed2Zvmyl2B+GANaZkYJt/flOKnPsNOA1kibS8Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/ecs": "7.27.1-33674365269.commit-d8b9341",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
+        "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/react-web/bridge-scene/package-lock.json
+++ b/react-web/bridge-scene/package-lock.json
@@ -8,11 +8,11 @@
       "name": "bevy-ui-scene",
       "version": "1.0.0",
       "devDependencies": {
-        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
-        "@dcl/js-runtime": "7.27.1-33247605236.commit-732120a",
-        "@dcl/react-ecs": "7.27.1-33247605236.commit-732120a",
-        "@dcl/sdk": "7.27.1-33247605236.commit-732120a",
-        "@dcl/sdk-commands": "7.27.1-33247605236.commit-732120a",
+        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/js-runtime": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/react-ecs": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/sdk": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/sdk-commands": "7.27.1-33669021544.commit-a6216ed",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "eslint": "^8.53.0",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.27.1-33247605236.commit-732120a",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.27.1-33247605236.commit-732120a.tgz",
-      "integrity": "sha512-cUrLWiZhZbvHGcD+hYzKZM+lp1WDq4WiikuO1jYf3+oeCqQhHvXMr8i9oG8wwFjV2VkgniJATCqg/tgdZt83hA==",
+      "version": "7.27.1-33669021544.commit-a6216ed",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.27.1-33669021544.commit-a6216ed.tgz",
+      "integrity": "sha512-BE1YEG/3WFzvbN4Fj+xPDS7h/dxgJ11Nw7YrM1z8nNGWJYBhZdueJrCA5l/AsbXvpGeahWpJR27gbmCwh60Edg==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -257,9 +257,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.18.1.tgz",
-      "integrity": "sha512-BJwLqAg2AGzSWLuAbWkxVBlwx9AA0FJNLdUDhaPTsTFjp9uvbKYT8RQ247LjDp1E+TgV/dh9AInsUpk1LZpwrg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.19.0.tgz",
+      "integrity": "sha512-Ym1HL1UcLLNOTgJr0f70KSYOk+lmp1loACEEHsF/7s5LwsCneHchu0tnaezMC2TqZKjsSbmblEiluJ92Wg6l8g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.27.1-33247605236.commit-732120a",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.27.1-33247605236.commit-732120a.tgz",
-      "integrity": "sha512-lrHqhNBdAkKJXLs2o3/gnysVpkuaCyCp5dRNZTnqjhpVbitjhEOEx0R/lkiXGFWrrZTmJ3ItQTNlMPgWtKl5rQ==",
+      "version": "7.27.1-33669021544.commit-a6216ed",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.27.1-33669021544.commit-a6216ed.tgz",
+      "integrity": "sha512-A4oKBITJ9/l2ddDT1vJSSA8hlQydIpuCj7lzxK3K94JDIepdYXTTH+PXugMVEms8dnF1o8ooYMTgsk1Gqk0VJA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -390,9 +390,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33247403125.commit-6e4ee4a",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33247403125.commit-6e4ee4a.tgz",
-      "integrity": "sha512-FmR3J9QaK0VJUJRiDHwGoX9k1Fj24Isnx0k3/Ob102Bp8qdHr3BMkIiRK4z/6pR9QHUgrBobCNfXY3Qy/QbYnQ==",
+      "version": "1.0.0-33668585153.commit-4a844e9",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33668585153.commit-4a844e9.tgz",
+      "integrity": "sha512-I5cSEq7GA3QANs7xG8CWhUheSw1kC/3JA3OYHK82KNxF6YdpOdLFI82t9yraVwWb3+FaE3yYtlPW2Nf8abDIHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -421,13 +421,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.27.1-33247605236.commit-732120a",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.27.1-33247605236.commit-732120a.tgz",
-      "integrity": "sha512-B+4+WbuccDsFNhfNIEiFHqSRDFcmLdKogkzjNhHv4Bu3bTFKwVMiUqNmShN26VPWVHkez1VHVn4K6KhmqQJWsA==",
+      "version": "7.27.1-33669021544.commit-a6216ed",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.27.1-33669021544.commit-a6216ed.tgz",
+      "integrity": "sha512-6FNC0534CPj6GEgLqNAQQxX+hpHBAk4fsUKbrPepbahKu2GAqca9lH3JalxDqktPVnfWtRQ412nK4jcpqLkHag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
+        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -456,35 +456,35 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.27.1-33247605236.commit-732120a",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.27.1-33247605236.commit-732120a.tgz",
-      "integrity": "sha512-VbYK6Cet+De6aIMobm34xjDYaho9LNLJBr6ApHYniBr9E8jQYgc9I7Ly79qJrxf3XC/sh7Au6LtSWPcSIGcGSA==",
+      "version": "7.27.1-33669021544.commit-a6216ed",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.27.1-33669021544.commit-a6216ed.tgz",
+      "integrity": "sha512-gYn9mZC37f/pysb5dIbTO3NLt9H+JdnFpqjbqpWCWLuPAIGjBVy8MYBgxJzNQXKOMPwn6UDzsTzHB7xzBtwP/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
+        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
         "@dcl/ecs-math": "2.1.0",
-        "@dcl/js-runtime": "7.27.1-33247605236.commit-732120a",
-        "@dcl/react-ecs": "7.27.1-33247605236.commit-732120a",
-        "@dcl/sdk-commands": "7.27.1-33247605236.commit-732120a"
+        "@dcl/js-runtime": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/react-ecs": "7.27.1-33669021544.commit-a6216ed",
+        "@dcl/sdk-commands": "7.27.1-33669021544.commit-a6216ed"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.27.1-33247605236.commit-732120a",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.27.1-33247605236.commit-732120a.tgz",
-      "integrity": "sha512-gsxGB4HbFE+/+pGPyV/GKTcgk1PtVb8yXKr4fL4k2nk3vIdBQkjNIOYm+YXe17ZiurXH7y/ZOHKHPp3Wwb2aqg==",
+      "version": "7.27.1-33669021544.commit-a6216ed",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.27.1-33669021544.commit-a6216ed.tgz",
+      "integrity": "sha512-ULFSuQrSgj3O8cJK58gwSMrS3Riwu3xOsIFoQSvIr/tIHe5+O16F/U9i/oAn+ig1WmWFlK8gb7tYrkq3M0pcpA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
+        "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
+        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -1414,9 +1414,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3920,9 +3920,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/react-web/bridge-scene/package.json
+++ b/react-web/bridge-scene/package.json
@@ -16,11 +16,11 @@
     "upgrade-sdk": "npm install @dcl/sdk@experimental-bevy @dcl/js-runtime@experimental-bevy @dcl/react-ecs@experimental-bevy @dcl/sdk-commands@experimental-bevy @dcl/ecs@experimental-bevy --save-exact"
   },
   "devDependencies": {
-    "@dcl/ecs": "7.27.1-33247605236.commit-732120a",
-    "@dcl/js-runtime": "7.27.1-33247605236.commit-732120a",
-    "@dcl/react-ecs": "7.27.1-33247605236.commit-732120a",
-    "@dcl/sdk": "7.27.1-33247605236.commit-732120a",
-    "@dcl/sdk-commands": "7.27.1-33247605236.commit-732120a",
+    "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
+    "@dcl/js-runtime": "7.27.1-33669021544.commit-a6216ed",
+    "@dcl/react-ecs": "7.27.1-33669021544.commit-a6216ed",
+    "@dcl/sdk": "7.27.1-33669021544.commit-a6216ed",
+    "@dcl/sdk-commands": "7.27.1-33669021544.commit-a6216ed",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",

--- a/react-web/bridge-scene/package.json
+++ b/react-web/bridge-scene/package.json
@@ -16,11 +16,11 @@
     "upgrade-sdk": "npm install @dcl/sdk@experimental-bevy @dcl/js-runtime@experimental-bevy @dcl/react-ecs@experimental-bevy @dcl/sdk-commands@experimental-bevy @dcl/ecs@experimental-bevy --save-exact"
   },
   "devDependencies": {
-    "@dcl/ecs": "7.27.1-33669021544.commit-a6216ed",
-    "@dcl/js-runtime": "7.27.1-33669021544.commit-a6216ed",
-    "@dcl/react-ecs": "7.27.1-33669021544.commit-a6216ed",
-    "@dcl/sdk": "7.27.1-33669021544.commit-a6216ed",
-    "@dcl/sdk-commands": "7.27.1-33669021544.commit-a6216ed",
+    "@dcl/ecs": "7.27.1-33674365269.commit-d8b9341",
+    "@dcl/js-runtime": "7.27.1-33674365269.commit-d8b9341",
+    "@dcl/react-ecs": "7.27.1-33674365269.commit-d8b9341",
+    "@dcl/sdk": "7.27.1-33674365269.commit-d8b9341",
+    "@dcl/sdk-commands": "7.27.1-33674365269.commit-d8b9341",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",

--- a/react-web/bridge-scene/src/domains/world.ts
+++ b/react-web/bridge-scene/src/domains/world.ts
@@ -6,7 +6,7 @@
 import { Transform, engine } from '@dcl/sdk/ecs'
 import { Quaternion } from '@dcl/sdk/math'
 import { getPlayer } from '@dcl/sdk/players'
-import { teleportTo, changeRealm } from '~system/RestrictedActions'
+import { teleportTo } from '~system/RestrictedActions'
 import { getRealm } from '~system/Runtime'
 import { BevyApi } from '../bevy-api'
 import type { Ctx } from '../bridge'
@@ -55,10 +55,11 @@ export function registerWorld(ctx: Ctx): void {
     })
   })
 
-  // Travel to a world/realm (e.g. boedo.dcl.eth). The engine auto-grants ChangeRealm for our
+  // Travel to a world/realm (e.g. boedo.dcl.eth), landing on its default spawn: a teleport with a
+  // realm and no parcel (changeRealm is deprecated). The engine auto-grants ChangeRealm for our
   // super-user scene, so the React HUD owns the confirmation prompt.
   ctx.on('changeRealm', (msg) => {
-    changeRealm({ realm: msg.realm }).catch((e: unknown) => {
+    teleportTo({ realm: msg.realm }).catch((e: unknown) => {
       console.error('[world] changeRealm failed', e)
     })
   })

--- a/react-web/bridge-scene/src/domains/world.ts
+++ b/react-web/bridge-scene/src/domains/world.ts
@@ -50,7 +50,7 @@ export function registerWorld(ctx: Ctx): void {
   })
 
   ctx.on('teleport', (msg) => {
-    teleportTo({ worldCoordinates: { x: msg.x, y: msg.y } }).catch((e: unknown) => {
+    teleportTo({ worldCoordinates: { x: msg.x, y: msg.y }, realm: msg.realm }).catch((e: unknown) => {
       console.error('[world] teleport failed', e)
     })
   })

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -317,7 +317,7 @@ function Hud(): React.JSX.Element {
             places={session.places}
             profile={session.profile}
             onNavigate={goToMenuPage}
-            onTeleport={(x, y) => session.map.teleport(x, y)}
+            onTeleport={(x, y) => session.map.teleportToPlace(x, y)}
             onVisitWorld={(realm) => session.map.changeRealm(realm)}
           />
           <GalleryPage

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -479,6 +479,10 @@ export interface TeleportRequest {
   kind: 'teleport'
   x: number
   y: number
+  /** Realm the parcel belongs to (a world name or realm url). The engine changes realm first —
+   *  a full reconnect, as for changeRealm, even to the realm the player is in. Omitted: a parcel of
+   *  the realm the player is in. */
+  realm?: string
 }
 
 /** Change to a world/realm (page → scene → changeRealm). `realm` is a world name

--- a/react-web/src/features/map/MapPage.tsx
+++ b/react-web/src/features/map/MapPage.tsx
@@ -334,7 +334,7 @@ export function MapPage({
   }
   const jumpTo = (pl: Place): void => {
     const [x, y] = pl.base_position.split(',').map(Number)
-    map.teleport(x, y)
+    map.teleportToPlace(x, y)
     map.toggle()
   }
 

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -109,6 +109,10 @@ export interface MapState {
   open: boolean
   toggle: () => void
   teleport: (x: number, y: number) => void
+  /** Teleport to a Genesis City place: from inside a World the parcel carries the Genesis realm,
+   *  so the engine changes realm first. In Genesis already it is a plain teleport — a realm-carrying
+   *  teleport is a full realm reconnect, like changeRealm, even to the realm the player is in. */
+  teleportToPlace: (x: number, y: number) => void
   /** Travel to a world/realm by name (e.g. `boedo.dcl.eth`). */
   changeRealm: (realm: string) => void
 }
@@ -959,6 +963,13 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
   const teleport = useCallback((x: number, y: number) => {
     driverRef.current?.send({ kind: 'teleport', x, y })
   }, [])
+  const teleportToPlace = useCallback(
+    (x: number, y: number) => {
+      if (isWorld) driverRef.current?.send({ kind: 'teleport', realm: DEFAULT_REALM, x, y })
+      else driverRef.current?.send({ kind: 'teleport', x, y })
+    },
+    [isWorld]
+  )
   const changeRealm = useCallback((realm: string) => {
     driverRef.current?.send({ kind: 'changeRealm', realm })
   }, [])
@@ -1696,7 +1707,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       saveOutfit, deleteOutfit, equipOutfit
     },
     communities: { list: communities, open: communitiesOpen, toggle: toggleCommunities, create: createCommunity, join: joinCommunity, leave: leaveCommunity, detail: communityDetail, loadDetail: loadCommunityDetail },
-    map: { x: mapParcel.x, y: mapParcel.y, open: mapOpen, toggle: toggleMap, teleport, changeRealm },
+    map: { x: mapParcel.x, y: mapParcel.y, open: mapOpen, toggle: toggleMap, teleport, changeRealm, teleportToPlace },
     minimap: { pose: poseRef, isWorld, sceneTitle, setConfig: setMinimapConfig },
     places: { open: placesOpen, toggle: togglePlaces },
     gallery: {

--- a/react-web/src/test/harness.tsx
+++ b/react-web/src/test/harness.tsx
@@ -166,7 +166,7 @@ export function fakeSession(): EngineSession {
     emotes: { list: [], open: false, toggle: vi.fn(), play: vi.fn(), equip: vi.fn() },
     backpack: { list: [], total: 0, loading: false, query: vi.fn(), equipped: [], open: false, toggle: vi.fn(), equip: vi.fn(), preview: vi.fn(), outfits: [], outfitSlots: 5, saveOutfit: vi.fn(), deleteOutfit: vi.fn(), equipOutfit: vi.fn() },
     communities: { list: [], open: false, toggle: vi.fn(), create: vi.fn(), join: vi.fn(), leave: vi.fn(), detail: null, loadDetail: vi.fn() },
-    map: { x: 0, y: 0, open: false, toggle: vi.fn(), teleport: vi.fn(), changeRealm: vi.fn() },
+    map: { x: 0, y: 0, open: false, toggle: vi.fn(), teleport: vi.fn(), changeRealm: vi.fn(), teleportToPlace: vi.fn() },
     minimap: { pose: { current: { x: 0, z: 0, yaw: 0, camYaw: 0 } }, isWorld: false, sceneTitle: '', setConfig: vi.fn() },
     places: { open: false, toggle: vi.fn() },
     gallery: { list: [], current: 0, max: 0, loaded: false, open: false, toggle: vi.fn(), metas: {}, loadPhoto: vi.fn(), remove: vi.fn() },

--- a/react-web/src/test/map.clicks.test.tsx
+++ b/react-web/src/test/map.clicks.test.tsx
@@ -6,7 +6,7 @@ import type { MapState } from '../features/session/useEngineSession'
 import { fakeSession } from './harness'
 
 function renderMap(): MapState {
-  const map: MapState = { ...fakeSession().map, open: true, teleport: vi.fn(), toggle: vi.fn() }
+  const map: MapState = { ...fakeSession().map, open: true, teleportToPlace: vi.fn(), toggle: vi.fn() }
   render(<MapPage map={map} profile={{ data: null, open: false, toggle: vi.fn() }} onNavigate={vi.fn()} />)
   return map
 }
@@ -48,7 +48,7 @@ describe('map page', () => {
     fireEvent.mouseUp(view, { clientX: 5, clientY: 5 })
 
     await userEvent.click(await screen.findByRole('button', { name: 'JUMP IN' }))
-    expect(vi.mocked(map.teleport)).toHaveBeenCalledWith(10, -5)
+    expect(vi.mocked(map.teleportToPlace)).toHaveBeenCalledWith(10, -5)
     expect(vi.mocked(map.toggle)).toHaveBeenCalledTimes(1)
   })
 })

--- a/react-web/src/test/world.test.tsx
+++ b/react-web/src/test/world.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { act } from '@testing-library/react'
 import { renderSession, enterAsGuest } from './harness'
+import { DEFAULT_REALM } from '../features/engine/EngineHost'
 
 // DOMAIN: world — map state (parcel), teleport, microphone toggle/state.
 describe('world domain', () => {
@@ -23,6 +24,19 @@ describe('world domain', () => {
     await enterAsGuest(h)
     act(() => h.session().map.teleport(5, -3))
     expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', x: 5, y: -3 })
+  })
+
+  // A place picked from a listing is a Genesis City parcel. From inside a World the realm travels
+  // with it (a bare teleport would land on that world's own 5,-3); in Genesis it stays a plain
+  // teleport, since a realm-carrying teleport reconnects the realm like changeRealm does.
+  it('teleporting to a place carries the Genesis realm only from inside a World', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    act(() => h.session().map.teleportToPlace(5, -3))
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', x: 5, y: -3 })
+    act(() => h.driver.emit({ kind: 'realmInfo', realm: 'boedo.dcl.eth', isWorld: true }))
+    act(() => h.session().map.teleportToPlace(5, -3))
+    expect(h.driver.last('teleport')).toEqual({ kind: 'teleport', realm: DEFAULT_REALM, x: 5, y: -3 })
   })
 
   it('sceneInfo drives the minimap title, and re-pushes as the player crosses scenes', async () => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -30,7 +30,7 @@ pub fn change_location(
         if let Some(realm) = command.realm {
             commands.send_event(RpcCall::TeleportPlayer {
                 scene: None,
-                to: IVec2::new(command.x, command.y),
+                to: Some(IVec2::new(command.x, command.y)),
                 realm: Some(realm.clone()),
                 response: RpcResultSender::default(),
             });

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::*;
 use bevy_console::ConsoleCommand;
-use common::structs::{AppConfig, PreviewMode, PrimaryUser, SceneLoadDistance};
+use common::{
+    rpc::{RpcCall, RpcResultSender},
+    structs::{AppConfig, PreviewMode, PrimaryUser, SceneLoadDistance},
+};
 use scene_runner::{
     initialize_scene::{parcels_in_range, ScenePointers},
     OutOfWorld,
@@ -14,6 +17,8 @@ pub struct ChangeLocationCommand {
     x: i32,
     #[arg(allow_hyphen_values(true))]
     y: i32,
+    /// realm the parcel is in (a world name or realm url): change realm, then land on the parcel
+    realm: Option<String>,
 }
 
 pub fn change_location(
@@ -22,6 +27,19 @@ pub fn change_location(
     mut player: Query<(Entity, &mut Transform), With<PrimaryUser>>,
 ) {
     if let Some(Ok(command)) = input.take() {
+        if let Some(realm) = command.realm {
+            commands.send_event(RpcCall::TeleportPlayer {
+                scene: None,
+                to: IVec2::new(command.x, command.y),
+                realm: Some(realm.clone()),
+                response: RpcResultSender::default(),
+            });
+            input.reply_ok(format!(
+                "new location: {:?} in {realm}",
+                (command.x, command.y)
+            ));
+            return;
+        }
         if let Ok((ent, mut transform)) = player.single_mut() {
             transform.translation.x = command.x as f32 * 16.0 + 8.0;
             transform.translation.z = -command.y as f32 * 16.0 - 8.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use console::{ConsolePlugin, DoAddConsoleCommand};
 use image_processing::ImageProcessingPlugin;
 use imposters::DclImposterPlugin;
 use input_manager::InputManagerPlugin;
-use ipfs::{map_realm_name, IpfsIoPlugin};
+use ipfs::{map_realm_name, IpfsIoPlugin, RealmInitialLocation};
 use livestream_manager::plugin::LivestreamManagerPlugin;
 use nft::{asset_source::NftReaderPlugin, NftShapePlugin};
 use particle_system::plugin::ParticleSystemPlugin;
@@ -150,7 +150,12 @@ impl DecentralandAppConfig {
 /// resource so the AppConfig resource (rewritten wholesale to disk on settings changes)
 /// never carries a one-off --location as home.
 #[derive(Resource)]
-pub struct BootLocation(pub IVec2);
+pub struct BootLocation {
+    pub parcel: IVec2,
+    /// Given on the command line / url rather than taken from the home pin. The realm is then
+    /// asked to land on this parcel instead of its own default spawn (a World's base scene).
+    pub explicit: bool,
+}
 
 pub struct DecentralandArguments {
     pub server: Option<String>,
@@ -259,7 +264,10 @@ impl DecentralandApp {
 
         let boot_server = map_realm_name(&decentraland_app_config.boot_server());
         // computed here too: scene_params is partially moved out of the arguments below
-        let boot_location = BootLocation(decentraland_app_config.boot_location());
+        let boot_location = BootLocation {
+            parcel: decentraland_app_config.boot_location(),
+            explicit: decentraland_app_config.arguments.location.is_some(),
+        };
         // Show out-of-bounds geometry in preview, on a loopback realm (local dev) and in
         // the editor, never on a public realm. Computed before boot_server moves.
         let editor_mode = decentraland_app_config.arguments.editor;
@@ -547,9 +555,9 @@ fn setup(
     let player_id = commands
         .spawn((
             Transform::from_translation(Vec3::new(
-                8.0 + 16.0 * boot_location.0.x as f32,
+                8.0 + 16.0 * boot_location.parcel.x as f32,
                 8.0,
-                -8.0 + -16.0 * boot_location.0.y as f32,
+                -8.0 + -16.0 * boot_location.parcel.y as f32,
             )),
             Visibility::default(),
             config.player_settings.clone(),
@@ -561,6 +569,9 @@ fn setup(
             Propagate(RenderLayers::default()),
         ))
         .id();
+    if boot_location.explicit {
+        commands.insert_resource(RealmInitialLocation::Parcel(boot_location.parcel));
+    }
 
     // add a camera
     let camera_id = commands

--- a/src/web.rs
+++ b/src/web.rs
@@ -323,7 +323,7 @@ pub fn update_winit_fps(config: Res<AppConfig>, mut winit: ResMut<WinitSettings>
 
 #[derive(PartialEq, Default, Clone)]
 struct UrlParams {
-    parcel: Option<IVec2>,
+    parcel: IVec2,
     server: String,
     ui_scene: Option<String>,
     portables: Option<String>,
@@ -339,15 +339,7 @@ fn update_url_params(
     editor: Res<EditorMode>,
     mut prev: Local<UrlParams>,
 ) {
-    // realms with fixed scene urns (worlds) spawn at their base scene and ignore an explicit
-    // position (see load_active_entities' base-position handling) - don't write one into the url
-    let position_honoured = current_realm
-        .config
-        .scenes_urn
-        .as_ref()
-        .is_none_or(Vec::is_empty);
-    let parcel = position_honoured
-        .then(|| vec3_to_parcel(player.single().map(|p| p.translation()).unwrap_or_default()));
+    let parcel = vec3_to_parcel(player.single().map(|p| p.translation()).unwrap_or_default());
     let Some(server) = current_realm.about_url.strip_suffix("/about") else {
         return;
     };
@@ -387,9 +379,7 @@ fn update_url_params(
     if params != *prev {
         *prev = params.clone();
         set_url_params(
-            params
-                .parcel
-                .map(|parcel| format!("{},{}", parcel.x, parcel.y)),
+            Some(format!("{},{}", params.parcel.x, params.parcel.y)),
             params.server,
             params.ui_scene,
             params.portables,


### PR DESCRIPTION
## What

A `teleportTo` request can name the realm its parcel belongs to, and the parcel itself is now optional (protocol `TeleportToRequest.realm` / `world_coordinates`, decentraland/protocol#477). The engine treats a realm-carrying request as a realm change (a full reconnect, as for `changeRealm`) and lands on the parcel once the new realm is live, or on the realm's default spawn when no parcel is given. That covers everything `changeRealm` did, so the protocol deprecates it and the bridge scene's realm change now goes through `teleportTo`. The React HUD uses it for the Places page and the map's JUMP IN, so a Genesis City place picked from inside a World now leaves the World.

The same realm-target plumbing makes an explicit boot location land in a World (`--location` / `?position=` with `?realm=<world>`, issue #1108), and the web URL sync no longer drops `?position` inside a World.

## Why

Reported by Gon: from a World, "Jump in" on a Genesis place teleports but never leaves the World, so the coordinates land on the World's own parcel grid. The HUD only had `changeRealm` and `teleport` as independent requests, and firing both is wrong: `changeRealm` resolves on acceptance, and until the new realm's about lands the *old* realm's scene at that parcel (a World's 0,0) catches the out-of-world player.

This replaces #1038, which worked around it in the bridge scene by polling `getRealm` until the target realm appeared, and covers the in-session navigation half of #957 (the phantom `getRealmProvider` there is separate). Fixes #1108.

## How

- `RpcCall::TeleportPlayer` carries `realm: Option<String>`; the `~system/RestrictedActions` shim passes `body.realm` through (native + wasm ops).
- A teleport that names a realm is a realm change: it goes through the `ChangeRealm` permission gate instead of `Teleport`, sets `RealmInitialLocation::Parcel(to)` (or `Base` without a parcel) and sends `ChangeRealmEvent`. Like `changeRealm`, that is a full reconnect even to the realm the player is already in — no engine-side shortcut. A request with neither parcel nor realm is refused.
- `load_active_entities` handles the new `Parcel` variant: when the realm goes live it places the player out-of-world on that parcel, and the existing sweep holds them until the parcel resolves against the new realm (#1042 already rejects stale pointers).
- `RealmInitialLocation` gains `Parcel(IVec2)` next to `None` / `Base`. An explicit boot location (`BootLocation.explicit`) sets it at startup, so a World entered with a position lands there instead of on its base scene. Fixes #1108; `update_url_params` drops its "worlds ignore a position" gate accordingly.
- `/teleport x y [realm]` console command gains the optional realm, routed through the same `TeleportPlayer` event.
- HUD: `TeleportRequest.realm?`, `map.teleportToPlace(x, y)` for the Places page and map JUMP IN: attaches the default realm only while the session reports a World, so a Genesis-to-Genesis jump stays a plain teleport. Chat `/goto x,y`, chat location links, and the gallery stay realm-relative. `/goto genesis` is unchanged.
- Failures reach the scene. `op_teleport_to` used to fold the engine's reply into a bool the shim discarded, so an empty request and a denied permission both resolved as success; it now returns the engine's error ("teleport needs a parcel or a realm", "User declined"), which rejects the scene's promise (`TeleportToResponse` has no payload, so that is the only signal the SDK type allows; unity throws for the empty request too). `changeRealm` and `openExternalUrl` returned a bare bool where the SDK expects `SuccessResponse { success }`, and `openNftDialog` / `triggerSceneEmote` / `setCommunicationsAdapter` / `copyToClipboard` returned the wrong shape: all fixed in the shim.
- The legacy ChangeRealm permission prompt showed only the scene's optional `message` (since #110), so the usual no-message call named no realm. It now shows the realm, with the message after it.
- Vendored `restricted_actions.proto` updated for the one message; bridge-scene re-pinned to the SDK build that carries the typing.

## Verified

Web build, Playwright against the real engine, guest login:
- boot into `boedo.dcl.eth`, Places → Genesis Plaza: one `teleport` carrying the realm crosses the bridge, `realmInfo` flips to `main`, player lands on -3,-2.
- from Genesis, Places → Commodore 64 Museum (-126,107): plain teleport (no realm attached), lands on -126,107.
- from Genesis, a plain `changeRealm` to `robtfm.dcl.eth` lands on its default 76,-10; back in Genesis, a teleport naming `robtfm.dcl.eth` at 96,5 flips `realmInfo` to the world and lands on 96,5, URL syncing to `?position=96,5&realm=robtfm.dcl.eth`.
- `?realm=boedo.dcl.eth&position=110,2` boots onto 110,2 and the URL keeps the position; without a position the world's own spawn applies (URL shows it).

- pre-change SDK (main, 7.27.0) scene [robtfm/teleport-compat-scene](https://github.com/robtfm/teleport-compat-scene) on unity and bevy web: the old `{ worldCoordinates }` teleport, `changeRealm`, an empty `{ worldCoordinates: undefined }` (rejects) and a `realm` passed past the old type (lands in the world) all behave as expected; denials reject / report `success: false` (confirmed on bevy web).

Native `cargo check`, clippy `-D warnings`, headless feature set, wasm build, react-web tsc + vitest (381), bridge-scene type-check all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

