### PR TITLE
Send unsanitised transforms back to scenes

### DIFF
--- a/crates/dcl_component/src/transform_and_parent.rs
+++ b/crates/dcl_component/src/transform_and_parent.rs
@@ -162,6 +162,25 @@ impl From<DclTransformAndParentJson> for DclTransformAndParent {
     }
 }
 
+/// Make a scene-supplied scale safe for a bevy [`Transform`]. Only for the
+/// renderer-side value: anything written back to the scene must use the
+/// original scale, as scenes read exact values (e.g. `scale.z == 0`) back.
+pub fn sanitize_scale(mut scale: Vec3) -> Vec3 {
+    if !scale.is_finite() {
+        scale = Vec3::ONE;
+    }
+    if scale.x == 0.0 {
+        scale.x = f32::EPSILON;
+    };
+    if scale.y == 0.0 {
+        scale.y = f32::EPSILON;
+    };
+    if scale.z == 0.0 {
+        scale.z = f32::EPSILON;
+    };
+    scale
+}
+
 impl DclTransformAndParent {
     pub fn to_bevy_transform(&self) -> Transform {
         let rotation = self.rotation.to_bevy_quat().normalize();
@@ -171,19 +190,7 @@ impl DclTransformAndParent {
             bevy::prelude::Quat::IDENTITY
         };
 
-        let mut scale = self.scale;
-        if !scale.is_finite() {
-            scale = Vec3::ONE;
-        }
-        if scale.x == 0.0 {
-            scale.x = f32::EPSILON;
-        };
-        if scale.y == 0.0 {
-            scale.y = f32::EPSILON;
-        };
-        if scale.z == 0.0 {
-            scale.z = f32::EPSILON;
-        };
+        let scale = sanitize_scale(self.scale);
 
         let translation = self.translation.to_bevy_translation();
         let translation = if translation.is_finite() {

--- a/crates/scene_runner/src/update_world/transform_and_parent.rs
+++ b/crates/scene_runner/src/update_world/transform_and_parent.rs
@@ -328,7 +328,7 @@ pub fn parent_position_sync<T: ParentPositionSyncStage>(
         &ParentPositionSync<T>,
         &ChildOf,
         Option<&VisibilityComponent>,
-        Option<(&SceneEntity, &Transform)>,
+        Option<&SceneEntity>,
     )>,
     globals: Query<&GlobalTransform>,
     gt_helper: TransformHelperPub,
@@ -356,10 +356,9 @@ pub fn parent_position_sync<T: ParentPositionSyncStage>(
         // translation delta is deliberately NOT rotated into the target's
         // frame - that's what unity writes, and scenes in the wild correct
         // for exactly that. scale and the declared parent are passed through
-        // unchanged.
-        if let (Some(target), Some((scene_entity, current_transform))) =
-            (sync.translation_target, maybe_scene_entity)
-        {
+        // unchanged, taken from the scene's own last write rather than the
+        // (sanitised) bevy transform so the scene reads back exactly what it set.
+        if let (Some(target), Some(scene_entity)) = (sync.translation_target, maybe_scene_entity) {
             if let (Ok(target_gt), Ok(mut context)) = (
                 gt_helper.compute_global_transform(target, None),
                 contexts.get_mut(scene_entity.root),
@@ -368,7 +367,7 @@ pub fn parent_position_sync<T: ParentPositionSyncStage>(
                 let (_, target_rotation, target_translation) =
                     target_gt.to_scale_rotation_translation();
 
-                let parent_id = context
+                let (parent_id, scale) = context
                     .crdt_store
                     .get(
                         SceneComponentId::TRANSFORM,
@@ -378,14 +377,14 @@ pub fn parent_position_sync<T: ParentPositionSyncStage>(
                     .and_then(|data| {
                         DclTransformAndParent::from_reader(&mut DclReader::new(data)).ok()
                     })
-                    .map(|t| t.parent)
-                    .unwrap_or(SceneEntityId::ROOT);
+                    .map(|t| (t.parent, t.scale))
+                    .unwrap_or((SceneEntityId::ROOT, Vec3::ONE));
 
                 let dcl_transform = DclTransformAndParent::from_bevy_transform_and_parent(
                     &Transform {
                         translation: anchor_translation - target_translation,
                         rotation: target_rotation.inverse() * anchor_rotation,
-                        scale: current_transform.scale,
+                        scale,
                     },
                     parent_id,
                 );

--- a/crates/tween/src/lib.rs
+++ b/crates/tween/src/lib.rs
@@ -14,8 +14,8 @@ use dcl_component::{
             TextureMovementType, TweenStateStatus,
         },
     },
-    transform_and_parent::DclTransformAndParent,
-    SceneComponentId,
+    transform_and_parent::{sanitize_scale, DclTransformAndParent},
+    SceneComponentId, SceneEntityId,
 };
 use scene_runner::{
     renderer_context::RendererSceneContext,
@@ -272,15 +272,6 @@ impl Tween {
 
     fn apply_scale(start: Vec3, end: Vec3, ease_value: f32, transform: &mut Transform) {
         transform.scale = start + ((end - start) * ease_value);
-        if transform.scale.x == 0.0 {
-            transform.scale.x = f32::EPSILON;
-        };
-        if transform.scale.y == 0.0 {
-            transform.scale.y = f32::EPSILON;
-        };
-        if transform.scale.z == 0.0 {
-            transform.scale.z = f32::EPSILON;
-        };
     }
 }
 
@@ -431,17 +422,23 @@ fn update_tween(
                 },
             );
 
-            let Ok(parent) = parents.get(parent.parent()) else {
-                warn!("no parent for tweened ent");
-                return;
-            };
+            let parent_id = parents
+                .get(parent.parent())
+                .map(|p| p.id)
+                .unwrap_or_else(|_| {
+                    warn!("no parent for tweened ent {scene_ent:?}");
+                    SceneEntityId::ROOT
+                });
 
+            // the scene gets the raw interpolated value; only the bevy transform is sanitised
             scene.update_crdt(
                 SceneComponentId::TRANSFORM,
                 CrdtType::LWW_ENT,
                 scene_ent.container_id,
-                &DclTransformAndParent::from_bevy_transform_and_parent(&transform, parent.id),
+                &DclTransformAndParent::from_bevy_transform_and_parent(&transform, parent_id),
             );
+
+            transform.scale = sanitize_scale(transform.scale);
             if tween.is_texture_move() {
                 tween_updated_texture_writer.write(TweenUpdatedTexture(ent));
             }


### PR DESCRIPTION
Engine-to-scene Transform writes carried the renderer-side sanitised value (zero scale clamped to `f32::EPSILON`), so a scene that round-trips a tweened scale never sees exactly 0. Unity never clamps.

The redeployed Genesis Plaza greeter (2026-09-02) fades its react-ecs dialog by reading `Transform.get(helper).scale.z` back from a scale tween to `(1,1,0)` and unmounts the card only when `scale.z <= 0`. On bevy the value settled at epsilon, so the card stayed mounted and its fixed-alpha parts (name pill, "Skip [F]" border and text) remained on screen after dismissing.

Changes:
- move the scale clamp out of `to_bevy_transform` into a shared `sanitize_scale`, applied only to the bevy `Transform`
- tween: write the raw interpolated transform to the CRDT, then sanitise the bevy component. An orphan tween now warns and falls back to `ROOT` instead of `return`ing out of the whole system and skipping the remaining tweens that frame
- AvatarAttach write-back (`parent_position_sync`): take scale from the scene's own last CRDT entry, decoded alongside the parent id it already reads, rather than the sanitised bevy transform

The other engine-to-scene Transform writes (player/camera, foreign avatars, GltfNode) never carried a sanitised value and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
