### PR TITLE
ci: workflow_dispatch with an optional publish-tag to publish the web package from any ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,16 @@ on:
     branches:
       - main
   pull_request:
+  # Manual run of the full workflow on any ref. Setting `publish-tag` also publishes
+  # the web package (as 0.1.0-<runId>.commit-<sha>, under that npm dist-tag) and
+  # uploads it to the CDN, ready for a manual rollout. NOTE: any CDN upload triggers
+  # the automatic zone rollout (set-rollout.yml) — undo by rolling that version to 0%.
+  workflow_dispatch:
+    inputs:
+      publish-tag:
+        description: 'npm dist-tag to publish the web package under (empty = build only). Not next/latest.'
+        required: false
+        default: ''
 
 # PRs share a per-ref group so a superseded push cancels the in-flight run. Main
 # pushes get a unique group each (run_id): sharing one made every main run queue
@@ -461,7 +471,7 @@ jobs:
           npm run bundle
         working-directory: react-web/bridge-scene
       - name: Publish
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish-tag != '')
         uses: decentraland/oddish-action@0074f2d535c43b5c83f136525304a6277166d77f # @master
         with:
           cwd: './deploy/web'
@@ -470,3 +480,7 @@ jobs:
           access: public
           gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
           gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
+          # oddish only publishes from main (-> next) or from a branch it is told about;
+          # both inputs are empty on push/release, leaving that behaviour unchanged.
+          custom-tag: ${{ inputs.publish-tag }}
+          branch-to-custom-tag: ${{ inputs.publish-tag != '' && github.ref_name || '' }}


### PR DESCRIPTION
Adds a manual trigger to the CI workflow so the web package can be built, and optionally published, from any ref without editing the workflow on a branch.

**Why**

Deploying #1134 to org as a hotfix (org was on `0cfd373`, and could not take the full zone state) needed the web package published from a branch. Today that means three branch-only edits to `ci.yml`: a `workflow_dispatch` trigger, widening the Publish step's condition, and telling oddish about the branch via `custom-tag` / `branch-to-custom-tag`, because oddish only publishes from main or a branch it has been told about. This makes that a first-class, zero-edit path.

**What changes**

- `workflow_dispatch` trigger with one optional input, `publish-tag`.
- The Publish step also runs on a dispatch when `publish-tag` is set, passing it to oddish as `custom-tag` with `branch-to-custom-tag` = the dispatched branch.

**Behaviour by trigger**

- Push to main, pull request, release: unchanged. The inputs context is empty on these events, so oddish sees blank `custom-tag` values and behaves exactly as before.
- Dispatch, `publish-tag` empty: full CI on the ref, web package built, nothing published.
- Dispatch on a branch with e.g. `publish-tag: hotfix`: publishes `0.1.0-<runId>.commit-<sha>` under the `hotfix` dist-tag and uploads to the CDN, ready for a manual org rollout via "Set rollout by path - Manual". `next`/`latest` are refused by oddish for non-main branches.
- Dispatch on main with any `publish-tag`: oddish checks the branch first, so this is a normal main publish to `next` with a fresh version. Useful to republish main head on demand.

**Caveat, noted in the workflow comment**

Every CDN upload fires the automatic zone rollout (`set-rollout.yml`), whatever branch it came from, so a branch publish moves zone too. Rollouts are a per-version record list walked highest-version-first by percentage, so this is undone by rolling that version to 0% on zone; the same 0%/100% toggle is how an org hotfix is reverted and later re-released without rebuilding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)