### PR TITLE
web: define entry-url params once in rust, launch the engine with one named object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
  "serde",
  "serde_json",
  "social",
+ "system_api_types",
  "system_bridge",
  "system_ui",
  "texture_camera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,6 +301,7 @@ getrandom = { version = "0.3" }
 assets = { workspace = true }
 analytics = { workspace = true }
 common = { workspace = true }
+system_api_types = { workspace = true }
 avatar = { workspace = true }
 comms = { workspace = true }
 input_manager = { workspace = true }

--- a/crates/system_api_types/src/lib.rs
+++ b/crates/system_api_types/src/lib.rs
@@ -4,6 +4,8 @@
 //! `ts-rs` (scripts/gen-ts-bindings.sh) to generate the TypeScript the react-web
 //! page and bridge scene consume. `system_bridge` re-exports everything here.
 
+pub mod web_params;
+
 use dcl_component::proto_components::{
     common::{Color3, Vector2, Vector3},
     sdk::components::{pb_pointer_events, PbAvatarBase, PbAvatarEquippedData},

--- a/crates/system_api_types/src/web_params.rs
+++ b/crates/system_api_types/src/web_params.rs
@@ -1,0 +1,162 @@
+//! The entry-url parameters the web build accepts — defined ONCE, here. Exported to the react
+//! page alongside the ts-rs types (scripts/gen-ts-bindings.sh writes `webParamTable.ts` into
+//! react-web/src/engine/generated), so the host page reads the same table the engine is built
+//! from: which params exist, what each does and how it reaches the engine. Whether a LINK may
+//! set one is the front-end's policy, not the engine's (react-web lib/launchGate.ts — a
+//! different host, e.g. the editor, trusts different things). `src/web_options.rs` (the
+//! `engine_run` options object, which the engine also echoes back into the page url) is
+//! checked against this table in a unit test.
+//!
+//! Native has no table: each `--flag` is parsed by hand in src/main.rs. The `doc` strings name
+//! the native counterpart so this doubles as the cross-platform index.
+
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug, ts_rs::TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub enum ParamKind {
+    /// `?name=value`
+    String,
+    /// presence is the value: `?name` / `?name=true`
+    Flag,
+}
+
+/// How the value gets from the entry url to the engine.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug, ts_rs::TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub enum Delivery {
+    /// Read from the entry url by the host page into `window.__bevyBootConfig`, which boot.js
+    /// forwards verbatim as `engine_run` options.
+    Launch,
+    /// Chosen by the host's destination picker (a `?realm=`/`?position=` link only seeds it) and
+    /// passed to `__bevyLaunch(realm, position)`; an `engine_run` option like `Launch`.
+    Destination,
+    /// Set by an embedding host page from its own knowledge (the creator-hub editor sets
+    /// `editor`) — an `engine_run` option the react page must NOT read from the entry url.
+    Host,
+    /// Computed by the engine loader (engine.js) at launch — an `engine_run` option that is
+    /// never read from the url.
+    Page,
+    /// The host page consumes it itself (composing its own backend urls) and publishes it as
+    /// `window.__baseDomain()` before the wasm loads; the engine reads that at `engine_init`,
+    /// ahead of `engine_run`.
+    BaseDomain,
+}
+
+#[derive(Serialize, Clone, PartialEq, Eq, Debug, ts_rs::TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct WebParam {
+    /// The query-string key; for everything but `BaseDomain` also the `engine_run` options key.
+    pub name: &'static str,
+    pub kind: ParamKind,
+    pub delivery: Delivery,
+    pub doc: &'static str,
+}
+
+/// The portable scene set that runs when `--portables` / `?portables=` is absent.
+pub const DEFAULT_PORTABLES: &str = "basiccontroller.dcl.eth";
+
+pub fn web_params() -> Vec<WebParam> {
+    use Delivery::*;
+    use ParamKind::*;
+    vec![
+        WebParam {
+            name: "platform",
+            kind: String,
+            delivery: Page,
+            doc: "\"macos\" | \"windows\" | \"linux\" from the user agent — picks the text-input navigation key binds.",
+        },
+        WebParam {
+            name: "realm",
+            kind: String,
+            delivery: Destination,
+            doc: "Realm to boot into (`--server`); absent = the persisted home realm.",
+        },
+        WebParam {
+            name: "position",
+            kind: String,
+            delivery: Destination,
+            doc: "Spawn parcel as `x,y` (`--location`); absent = the home parcel, or the realm's own spawn point when a realm is given.",
+        },
+        WebParam {
+            name: "systemScene",
+            kind: String,
+            delivery: Launch,
+            doc: "Super-user ui scene source (`--ui`), or `none` for no ui scene. The host substitutes its bundled bridge scene when absent. The engine trusts it completely: permissions.rs waves through every permission check for it and it gets the whole system api.",
+        },
+        WebParam {
+            name: "portables",
+            kind: String,
+            delivery: Launch,
+            doc: "`;`-separated portable/startup scene sources (`--portables`); absent = `basiccontroller.dcl.eth` (DEFAULT_PORTABLES), which the url sync also omits.",
+        },
+        WebParam {
+            name: "preview",
+            kind: Flag,
+            delivery: Launch,
+            doc: "Scene preview mode (`--preview`).",
+        },
+        WebParam {
+            name: "editor",
+            kind: Flag,
+            delivery: Host,
+            doc: "Embedded in a scene editor (`--editor`): scenes freeze after main() until the editor unfreezes them. The editor's own front-end sets it; not a link parameter.",
+        },
+        WebParam {
+            name: "pulseServer",
+            kind: String,
+            delivery: Launch,
+            doc: "Pulse server as `host:port` (`--pulse-server`); absent = the deployment's default.",
+        },
+        WebParam {
+            name: "imposterSource",
+            kind: String,
+            delivery: Launch,
+            doc: "Base url of the imposter store (`--imposter-source`); absent = the default store.",
+        },
+        WebParam {
+            name: "sceneParams",
+            kind: String,
+            delivery: Page,
+            doc: "The page's query string with the launch values folded in, exposed to scenes (`--params`).",
+        },
+        WebParam {
+            name: "baseDomain",
+            kind: String,
+            delivery: BaseDomain,
+            doc: "The deployment domain every backend host is composed from (`--base-domain`) — sign-in, content, comms, everything; absent = derived from the hosting origin, else decentraland.org.",
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Writes the table's VALUES next to the ts-rs types (`TS_RS_EXPORT_DIR`, set by
+    /// scripts/gen-ts-bindings.sh — a no-op under a plain `cargo test`).
+    #[test]
+    fn export_web_param_table() {
+        let Ok(dir) = std::env::var("TS_RS_EXPORT_DIR") else {
+            return;
+        };
+        let json = serde_json::to_string_pretty(&web_params()).unwrap();
+        let ts = format!(
+            "// GENERATED by scripts/gen-ts-bindings.sh from crates/system_api_types/src/web_params.rs — do not edit.\n\
+             import type {{ WebParam }} from './WebParam'\n\n\
+             export const WEB_PARAMS: WebParam[] = {json}\n"
+        );
+        std::fs::write(std::path::Path::new(&dir).join("webParamTable.ts"), ts).unwrap();
+    }
+
+    #[test]
+    fn names_are_unique() {
+        let mut names: Vec<_> = web_params().into_iter().map(|p| p.name).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), web_params().len());
+    }
+}

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -4,7 +4,10 @@
 //
 // Contract with the host page (react-web/src/engine/engineRpc.ts):
 //   set BEFORE injecting:  window.PUBLIC_URL   — base for pkg/ fetches (versioned CDN in prod)
-//                          window.__bevyBootConfig = { systemScene, portables, preview, editor, pulseServer, imposterSource }
+//                          window.__bevyBootConfig — the engine_run options (src/web_options.rs,
+//                            keyed by the web param table: systemScene, portables, preview,
+//                            pulseServer, imposterSource …) minus realm/position, forwarded
+//                            verbatim by __bevyLaunch
 //   provided by this module:
 //     __bevyLoadProgress / __bevyLoadStep  — weighted boot progress for the login bar
 //     __bevyReadyToLaunch / __bevyLaunch(realm?, position?) — deferred engine_run
@@ -20,7 +23,7 @@
 //       it before composing any backend URL (parity with native --base-domain)
 //     __bevyHomeScene() — the persisted home scene { realm, parcel: "x,y" } (or the derived
 //       defaults), for the host's "Skip to Home"; set alongside __bevyReadyToLaunch
-import { initEngine, start, engine_home_scene, gpu_cache_hash, initGpuCache } from './engine.js'
+import { initEngine, start, applyOptionsToUrlParams, engine_home_scene, gpu_cache_hash, initGpuCache } from './engine.js'
 
 // ---- boot progress (replaces ui.js's DOM loading steps) -----------------------------------------
 // Weight of each step in the overall bar (sums to 100). Step ids are read by the React login bar
@@ -261,40 +264,42 @@ const forwardWheelToEngine = (e) => {
 window.addEventListener('wheel', forwardWheelToEngine)
 
 // ---- URL sync (CALLED BY THE WASM — src/web.rs set_url_params) -----------------------------------
-// Keeps the browser URL in step with the player's realm/position so a reload/share lands back at
-// the same place. Defaults are omitted so the canonical entry URL stays clean.
+// Keeps the browser URL in step with the engine so a reload/share lands back in the same state.
+// The wasm sends its CURRENT launch options — the engine_run options object with the live realm,
+// position, ui scene, portables and mode swapped in — so every param given at launch is echoed
+// back, not just the ones this file knows about. Defaults are omitted so the canonical entry URL
+// stays clean; unknown (HUD-only) params are preserved.
 // The base domain is the HUD's call (see the __baseDomain contract above): the ?baseDomain=
-// entry param, else the hosting origin's apex, else org. set_url_params below preserves unknown
-// params, so the param form survives URL syncs.
+// entry param, else the hosting origin's apex, else org. It never comes through here.
 const BASE_DOMAIN = window.__baseDomain()
 const DEFAULT_SERVER = `https://realm-provider-ea.${BASE_DOMAIN}/main`
-const DEFAULT_PORTABLES = 'basiccontroller.dcl.eth'
 // The engine connects to the EXPANDED world url (ipfs map_realm_name turns `name.dcl.eth` into
 // worlds-content-server…/world/name.dcl.eth) and echoes that back here. Reverse it so the address
 // bar keeps the short name the user typed; a reload re-expands it the same way.
 const WORLDS_PREFIX = `https://worlds-content-server.${BASE_DOMAIN}/world/`
 // captured from the ENTRY url (later syncs rewrite location.search)
 const explicitSystemScene = new URLSearchParams(window.location.search).has('systemScene')
-window.set_url_params = (position, server, system_scene, portables, preview, editor) => {
+// The values that mean "default" and are dropped from the url — the two defaults only this page
+// knows (the engine already omits its own, e.g. the default portables). systemScene: null from the
+// engine = NO ui scene (systemScene=none); an explicit ?systemScene= boot override stays across
+// reloads, only the host's default scene is omitted.
+const urlValue = (name, value) => {
+  switch (name) {
+    case 'realm':
+      if (typeof value === 'string' && value.startsWith(WORLDS_PREFIX)) value = value.slice(WORLDS_PREFIX.length)
+      return value === DEFAULT_SERVER ? null : value
+    case 'systemScene':
+      value = value ?? 'none'
+      return explicitSystemScene || value !== (config.systemScene ?? 'none') ? value : null
+    default:
+      return value
+  }
+}
+window.set_url_params = (optionsJson) => {
   try {
-    if (server.startsWith(WORLDS_PREFIX)) server = server.slice(WORLDS_PREFIX.length)
     const urlParams = new URLSearchParams(window.location.search)
-    // absent when the realm won't honour a position (worlds spawn at their base scene)
-    if (position != null) urlParams.set('position', position)
-    else urlParams.delete('position')
-    if (server !== DEFAULT_SERVER) urlParams.set('realm', server)
-    else urlParams.delete('realm')
-    // An explicit ?systemScene= boot override stays in the URL across reloads (null from the
-    // engine = NO ui scene running, i.e. systemScene=none); only the default scene is omitted
-    // to keep the canonical entry URL clean.
-    if (explicitSystemScene || system_scene !== (config.systemScene ?? '')) urlParams.set('systemScene', system_scene ?? 'none')
-    else urlParams.delete('systemScene')
-    if (portables !== DEFAULT_PORTABLES) urlParams.set('portables', portables)
-    else urlParams.delete('portables')
-    if (preview) urlParams.set('preview', true)
-    else urlParams.delete('preview')
-    if (editor) urlParams.set('editor', true)
-    else urlParams.delete('editor')
+    const options = Object.fromEntries(Object.entries(JSON.parse(optionsJson)).map(([name, raw]) => [name, urlValue(name, raw)]))
+    applyOptionsToUrlParams(urlParams, options)
     history.replaceState(null, '', window.location.pathname + '?' + urlParams.toString())
   } catch (e) {
     console.log(`set url params failed: ${e}`)
@@ -323,7 +328,7 @@ initEngine()
     window.setLoadingStepCompleted('gpu')
     // Deferred launch: the host calls this once the user picks a destination — avoiding a wasted
     // default-realm load. One engine per page (see start()'s __bevyStarted guard).
-    window.__bevyLaunch = (realm, position) => start({ realm, position, systemScene: config.systemScene, portables: config.portables, preview: config.preview, editor: config.editor, pulseServer: config.pulseServer, imposterSource: config.imposterSource })
+    window.__bevyLaunch = (realm, position) => start({ ...config, realm, position })
     // The persisted home scene ({ realm, parcel: "x,y" }), valid once engine_init has loaded the
     // config — the host's places picker targets it from "Skip to Home" before launching.
     window.__bevyHomeScene = () => { try { return JSON.parse(engine_home_scene()) } catch { return null } }

--- a/deploy/web/engine/engine.js
+++ b/deploy/web/engine/engine.js
@@ -489,10 +489,26 @@ export async function initEngine() {
 }
 
 /**
- * Starts the game engine. Values come from the caller (boot.js's __bevyLaunch, fed by the React
- * host) — the old boot page's form inputs are gone.
+ * Writes launch options (an engine_run options object, or the engine's echo of it) into url params:
+ * absent (null), an unset flag (false) or empty = removed, so the url only carries what is set.
+ * Shared with boot.js's url sync.
+ * @param {URLSearchParams} urlParams
+ * @param {Record<string, string | boolean | null | undefined>} options
  */
-export function start({ realm, position, systemScene, portables, preview, editor, pulseServer, imposterSource } = {}) {
+export function applyOptionsToUrlParams(urlParams, options) {
+  for (const [name, value] of Object.entries(options)) {
+    if (value == null || value === false || value === '') urlParams.delete(name);
+    else urlParams.set(name, value === true ? 'true' : String(value));
+  }
+}
+
+/**
+ * Starts the game engine. `options` is the engine_run options object — one named key per
+ * launch parameter (EngineRunOptions in src/web.rs: realm, position, systemScene, portables,
+ * preview, editor, pulseServer, imposterSource). It comes from boot.js's __bevyLaunch, fed by
+ * the React host. Absent keys take the engine's defaults; an unknown key makes engine_run throw.
+ */
+export function start(options = {}) {
   // Launch at most once per page: a second engine_run re-runs init_runtime, whose OnceCell is
   // already set, and panics ("can't init wasm queue"). One engine per page — ignore re-entry.
   if (window.__bevyStarted) {
@@ -501,50 +517,13 @@ export function start({ realm, position, systemScene, portables, preview, editor
   }
   window.__bevyStarted = true;
 
-  const realmValue = realm ?? '';
-  const positionValue = position ?? '';
-  const systemSceneValue = systemScene ?? '';
-  const portablesValue = portables ?? 'basiccontroller.dcl.eth';
-  const previewValue = preview === true;
-  const editorValue = editor === true;
-  // Pulse server as host:port (the WebTransport port on web); empty = the engine's default.
-  const pulseServerValue = pulseServer ?? '';
-  // Base url of the imposter store; empty = the engine's default.
-  const imposterSourceValue = imposterSource ?? '';
-
-  // Build params from URL, overriding with form field values
+  // Mirror the launch options into the page's query string — the scenes see it as their params
+  // (SceneParams), so a launch-time choice (the picked realm/position) shows up there too.
   const urlParams = new URLSearchParams(window.location.search);
-  urlParams.set("realm", realmValue);
-  if (positionValue) {
-    urlParams.set("position", positionValue);
-  }
-  urlParams.set("systemScene", systemSceneValue);
-  urlParams.set("portables", portablesValue);
   urlParams.delete("initialRealm");
-  if (previewValue) {
-    urlParams.set("preview", "true");
-  } else {
-    urlParams.delete("preview");
-  }
-  if (editorValue) {
-    urlParams.set("editor", "true");
-  } else {
-    urlParams.delete("editor");
-  }
-  if (pulseServerValue) {
-    urlParams.set("pulseServer", pulseServerValue);
-  } else {
-    urlParams.delete("pulseServer");
-  }
-  if (imposterSourceValue) {
-    urlParams.set("imposterSource", imposterSourceValue);
-  } else {
-    urlParams.delete("imposterSource");
-  }
-  const params = urlParams.toString();
-  console.log(
-    `[Main JS] "Launch" button clicked. Initial Realm: "${realmValue}", Position (coords): "${positionValue}", System Scene: "${systemSceneValue}", Portables: "${portablesValue}"`
-  );
+  applyOptionsToUrlParams(urlParams, options);
+  const sceneParams = urlParams.toString();
+  console.log(`[Main JS] launching with ${JSON.stringify(options)}`);
   hideHeader();
 
   const platform = (() => {
@@ -602,7 +581,9 @@ export function start({ realm, position, systemScene, portables, preview, editor
     delete window._buildEngineApi;
   };
 
-  engine_run(platform, realmValue, positionValue, systemSceneValue, portablesValue, true, previewValue, editorValue, 1e7, params, pulseServerValue, imposterSourceValue);
+  // Everything the host handed us goes through as-is (the engine rejects unknown keys); only
+  // the page-derived values are added here.
+  engine_run({ ...options, platform, sceneParams });
   window.engine_console_command = engine_console_command;
   window.loadSceneUtils = () => {
     return new Promise((resolve, reject) => {

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -39,8 +39,7 @@ import { isMobile, isChromiumBased, hasBypassCookie } from './lib/isMobile'
 import { hasUsableGpu } from './lib/gpu'
 import { MobileGate, GateChecking } from './features/gate/MobileGate'
 import { UntrustedLaunchGate } from './features/gate/UntrustedLaunchGate'
-import { isTrustedSystemScene } from './lib/systemScene'
-import { BASE_DOMAIN, isTrustedBaseDomain } from './lib/baseDomain'
+import { untrustedLaunchParams } from './lib/launchGate'
 import { ErrorBoundary } from './features/error/ErrorBoundary'
 import { CrashModal } from './features/error/CrashModal'
 import { openRealmError } from './features/error/RealmErrorModal'
@@ -79,16 +78,11 @@ function gateReason(): 'mobile' | 'browser' | 'gpu' | null {
 }
 const GATE_REASON = gateReason()
 
-// `?systemScene=` picks the super-user scene, which permissions.rs waves through every permission
-// check and hands the whole SystemApi. A link carrying an unrecognised one is a session takeover
-// with no sandbox escape involved, so it gets an interstitial before anything boots — captured at
-// module scope, from the ENTRY url, so a later history.replaceState can't retire the warning.
-const SYSTEM_SCENE_OVERRIDE = bootMode().systemScene
-const UNTRUSTED_SYSTEM_SCENE =
-  SYSTEM_SCENE_OVERRIDE != null && !isTrustedSystemScene(SYSTEM_SCENE_OVERRIDE) ? SYSTEM_SCENE_OVERRIDE : null
-// `?baseDomain=` likewise: it points every backend at another deployment. Native is exempt —
-// there the shell injects it from the user's own --base-domain flag, not from a link.
-const UNTRUSTED_BASE_DOMAIN = MODE !== 'native' && !isTrustedBaseDomain(BASE_DOMAIN) ? BASE_DOMAIN : null
+// Gated entry-url params (lib/launchGate.ts: `?systemScene=` is a session takeover delivered as
+// a link, `?baseDomain=` points every backend at another deployment) carrying a value this
+// front-end doesn't recognise get an interstitial before anything boots — captured at module
+// scope, from the ENTRY url, so a later history.replaceState can't retire the warning.
+const UNTRUSTED_PARAMS = untrustedLaunchParams({ native: MODE === 'native' })
 
 export function App(): React.JSX.Element {
   const showFps = useFpsToggle()
@@ -100,14 +94,8 @@ export function App(): React.JSX.Element {
   // Ahead of every other gate: returning here is what keeps EngineHost unmounted, and EngineHost is
   // what injects boot.js and starts the scene.
   const [trustUntrusted, setTrustUntrusted] = useState(false)
-  if ((UNTRUSTED_SYSTEM_SCENE != null || UNTRUSTED_BASE_DOMAIN != null) && !trustUntrusted) {
-    return (
-      <UntrustedLaunchGate
-        systemScene={UNTRUSTED_SYSTEM_SCENE ?? undefined}
-        baseDomain={UNTRUSTED_BASE_DOMAIN ?? undefined}
-        onProceed={() => setTrustUntrusted(true)}
-      />
-    )
+  if (UNTRUSTED_PARAMS.length > 0 && !trustUntrusted) {
+    return <UntrustedLaunchGate params={UNTRUSTED_PARAMS} onProceed={() => setTrustUntrusted(true)} />
   }
   if (GATE_REASON) return <MobileGate reason={GATE_REASON} />
   if (gpu === 'checking') return <GateChecking />

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -10,7 +10,7 @@ import { bridgeChannelName } from '../../engine/protocol'
 import { serviceUrl } from '../../lib/baseDomain'
 import { bootMode } from '../../lib/bootMode'
 import { PAGE_DIR } from '../../lib/publicUrl'
-// Moved to lib/systemScene.ts, which also decides whether a link is allowed to override it.
+// Moved to lib/systemScene.ts; whether a link may override it is lib/launchGate.ts's call.
 import { SYSTEM_SCENE } from '../../lib/systemScene'
 import { launchOptionsFromUrl, type LaunchOptions } from '../../lib/webParams'
 

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -12,6 +12,7 @@ import { bootMode } from '../../lib/bootMode'
 import { PAGE_DIR } from '../../lib/publicUrl'
 // Moved to lib/systemScene.ts, which also decides whether a link is allowed to override it.
 import { SYSTEM_SCENE } from '../../lib/systemScene'
+import { launchOptionsFromUrl, type LaunchOptions } from '../../lib/webParams'
 
 // The main (Genesis City) realm, on the ?baseDomain= entry param when present (parity with the
 // engine's own derived default). Exported: parcel launches pass it EXPLICITLY so a ?realm
@@ -42,15 +43,11 @@ function injectEngine(): void {
   const params = new URLSearchParams(location.search)
   // pkg/ fetch base: the versioned CDN in prod builds (BASE_URL), the served engine dir otherwise.
   window.PUBLIC_URL = new URL('engine', new URL(import.meta.env.BASE_URL, PAGE_DIR)).href
+  // Every launch param the engine's web param table lists, read from the entry url; only the
+  // ui scene has a HUD-side default (our bundled bridge scene, unless a link overrode it).
   window.__bevyBootConfig = {
-    systemScene: bootMode().systemScene ?? SYSTEM_SCENE,
-    portables: params.get('portables') ?? undefined,
-    preview: params.has('preview'),
-    // host:port of the Pulse server the engine joins (WebTransport port); a zone deploy points
-    // it at the zone server. Absent = the engine's built-in production default.
-    pulseServer: params.get('pulseServer') ?? undefined,
-    // base url of the imposter store (native --imposter-source). Absent = the engine's default.
-    imposterSource: params.get('imposterSource') ?? undefined
+    ...launchOptionsFromUrl(params),
+    systemScene: bootMode().systemScene ?? SYSTEM_SCENE
   }
 
   for (const src of CDN_LIBS) {
@@ -68,13 +65,9 @@ function injectEngine(): void {
 declare global {
   interface Window {
     PUBLIC_URL?: string
-    __bevyBootConfig?: {
-      systemScene?: string
-      portables?: string
-      preview?: boolean
-      pulseServer?: string
-      imposterSource?: string
-    }
+    // Forwarded verbatim to the engine's launch options (src/web_options.rs, keyed by the web
+    // param table) — an unknown key fails the launch.
+    __bevyBootConfig?: LaunchOptions
   }
 }
 

--- a/react-web/src/features/gate/UntrustedLaunchGate.tsx
+++ b/react-web/src/features/gate/UntrustedLaunchGate.tsx
@@ -1,6 +1,7 @@
-// Interstitial for a link that carries an infrastructure-pointing parameter: its own super-user
-// scene (`?systemScene=` — see lib/systemScene.ts for why that is worth stopping on) and/or its
-// own backend deployment (`?baseDomain=` — see lib/baseDomain.ts).
+// Interstitial for a link that carries an infrastructure-pointing parameter (lib/launchGate.ts
+// decides which, and supplies the per-param copy): its own super-user scene (`?systemScene=` — see
+// lib/systemScene.ts for why that is worth stopping on) and/or its own backend deployment
+// (`?baseDomain=` — see lib/baseDomain.ts).
 //
 // Not dismissible: ModalShell is scrimless (its host owns the overlay, Escape and focus — see
 // design/Modal.tsx), so this gate draws its own inert full-screen layer and `closeButton={false}`
@@ -13,6 +14,7 @@
 
 import { useState } from 'react'
 import { Button, DclLogo, ModalShell } from '../../design'
+import type { UntrustedParam } from '../../lib/launchGate'
 import styles from './UntrustedLaunchGate.module.css'
 
 // A tab the user opened themselves can't be closed by script, so send them somewhere safe instead.
@@ -24,12 +26,10 @@ function exitApplication(): void {
 const TITLE = 'This Launch Link Is Not Trusted'
 
 export function UntrustedLaunchGate({
-  systemScene,
-  baseDomain,
+  params,
   onProceed
 }: {
-  systemScene?: string
-  baseDomain?: string
+  params: UntrustedParam[]
   onProceed: () => void
 }): React.JSX.Element {
   const [advanced, setAdvanced] = useState(false)
@@ -74,33 +74,19 @@ export function UntrustedLaunchGate({
       >
         <p className={styles.lead}>Someone may be trying to change how your Explorer behaves.</p>
         <p className={styles.lead}>
-          This link carries {systemScene != null && baseDomain != null ? 'parameters' : 'a parameter'} the
-          Explorer does not accept from links:
+          This link carries {params.length > 1 ? 'parameters' : 'a parameter'} the Explorer does not accept
+          from links:
         </p>
 
         <dl className={styles.params}>
-          {systemScene != null && (
-            <>
+          {params.map((p) => (
+            <div key={p.name}>
               <dt>
-                systemScene = <span className={styles.paramValue}>{systemScene}</span>
+                {p.name} = <span className={styles.paramValue}>{p.value}</span>
               </dt>
-              <dd className={styles.paramDesc}>
-                Replaces the Explorer&apos;s interface with a scene loaded from this address. It can move
-                your avatar, change your profile, and answer permission prompts on your behalf.
-              </dd>
-            </>
-          )}
-          {baseDomain != null && (
-            <>
-              <dt>
-                baseDomain = <span className={styles.paramValue}>{baseDomain}</span>
-              </dt>
-              <dd className={styles.paramDesc}>
-                Points every backend service — sign-in, content, comms — at servers under this domain.
-                Whoever runs them would see your session and control what you play.
-              </dd>
-            </>
-          )}
+              <dd className={styles.paramDesc}>{p.warning}</dd>
+            </div>
+          ))}
         </dl>
 
         <p className={styles.lead}>Unless you built this link yourself, the safe choice is to exit.</p>

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -10,9 +10,13 @@
 // wasm (src/web.rs apply_base_domain → crates/common/src/base_domain.rs), both of which run
 // only after the HUD has mounted EngineHost.
 
+// Decentraland's own deployments — the hosting origins we derive from, and the only domains a
+// LINK may point the session at without the UntrustedLaunchGate (lib/launchGate.ts).
+const TRUSTED_BASE_DOMAINS = ['decentraland.org', 'decentraland.zone']
+
 /** The apex deployment domain a hosting origin implies, or null for unrecognised hosts. */
 export function hostBaseDomain(hostname: string): string | null {
-  for (const apex of ['decentraland.org', 'decentraland.zone']) {
+  for (const apex of TRUSTED_BASE_DOMAINS) {
     if (hostname === apex || hostname.endsWith(`.${apex}`)) return apex
   }
   return null
@@ -45,10 +49,10 @@ export function serviceUrl(sub: string): string {
   return `https://${sub}.${BASE_DOMAIN}`
 }
 
-// Decentraland's own deployments. Any other domain arriving by LINK points the whole session's
-// backends — sign-in, content, comms — at someone else's servers, so App.tsx stops on it with the
-// UntrustedLaunchGate before anything boots. The native shell injects the param from the user's
-// own --base-domain flag (App runs in native mode there), which needs no gate.
+// Any other domain arriving by LINK points the whole session's backends — sign-in, content,
+// comms — at someone else's servers, so App.tsx stops on it with the UntrustedLaunchGate before
+// anything boots (lib/launchGate.ts, which also exempts native: there the shell injects the
+// user's own --base-domain flag).
 export function isTrustedBaseDomain(domain: string): boolean {
-  return domain === 'decentraland.org' || domain === 'decentraland.zone'
+  return TRUSTED_BASE_DOMAINS.includes(domain)
 }

--- a/react-web/src/lib/bootMode.ts
+++ b/react-web/src/lib/bootMode.ts
@@ -9,11 +9,9 @@
 //   ?systemScene=  debug: substitute the super-user ui scene (a url/dir, or "none" for the
 //                  engine's builtin ui). The scene owns login/UI in-engine (pre-react
 //                  behavior), so this implies a hidden HUD and no React login at all.
-//   ?pulseServer=  host:port of the Pulse server the engine joins, handed to the engine via
-//                  __bevyBootConfig like ?portables= (a zone deploy points it at the zone
-//                  server). Not a boot-mode decision — listed so every entry-URL param is here.
-//   ?imposterSource= base url of the imposter store the engine fetches tiles from (native
-//                  --imposter-source), handed over the same way. Not a boot-mode decision.
+// The engine-bound params (?portables=, ?pulseServer=, ?imposterSource=, …) are not boot-mode
+// decisions: they come from the engine's web param table (lib/webParams.ts) and are handed over
+// as-is by EngineHost.
 export interface BootMode {
   /** explicit ?systemScene= override; null = the default bridge scene drives */
   systemScene: string | null

--- a/react-web/src/lib/launchGate.ts
+++ b/react-web/src/lib/launchGate.ts
@@ -1,0 +1,57 @@
+// Which entry-url params stop the boot on the UntrustedLaunchGate — THIS front-end's policy.
+// The engine's web param table (lib/webParams.ts) says what a param does; whether a link may set
+// it is decided here, because trust is a property of the host: the editor app trusts its editor
+// scene, this app trusts its bundled bridge scene and Decentraland's own deployments.
+
+import { BASE_DOMAIN, isTrustedBaseDomain } from './baseDomain'
+import { bootMode } from './bootMode'
+import { isTrustedSystemScene } from './systemScene'
+import { webParam } from './webParams'
+
+export interface UntrustedParam {
+  name: string
+  value: string
+  /** what the param would let the link do — the gate's copy */
+  warning: string
+}
+
+interface Gate {
+  warning: string
+  /** The effective value the engine will see, or null when the param is not in play. Read from
+   *  the ENTRY url on first use — a later history.replaceState can't retire a warning. */
+  read: (native: boolean) => string | null
+  isTrusted: (value: string) => boolean
+}
+
+// Keyed by the table's param name (checked at module load).
+const GATES: Record<string, Gate> = {
+  // Substitutes the super-user scene — see lib/systemScene.ts for why that is a session takeover.
+  systemScene: {
+    warning:
+      "Replaces the Explorer's interface with a scene loaded from this address. It can move your avatar, change your profile, and answer permission prompts on your behalf.",
+    read: () => bootMode().systemScene,
+    isTrusted: isTrustedSystemScene
+  },
+  // The HUD consumes this one itself (its own backend urls), so the value is the resolved
+  // BASE_DOMAIN — normalised by the engine's rule, or derived from the origin when the param is
+  // absent/invalid (both derive to a trusted deployment). Native is exempt: there the shell
+  // injects it from the user's own --base-domain flag, not from a link.
+  baseDomain: {
+    warning:
+      'Points every backend service — sign-in, content, comms — at servers under this domain. Whoever runs them would see your session and control what you play.',
+    read: (native) => (native ? null : BASE_DOMAIN),
+    isTrusted: isTrustedBaseDomain
+  }
+}
+for (const name of Object.keys(GATES)) webParam(name)
+
+/** The gated params whose entry-url value this front-end doesn't recognise. Empty = boot. */
+export function untrustedLaunchParams({ native }: { native: boolean }): UntrustedParam[] {
+  const out: UntrustedParam[] = []
+  for (const [name, gate] of Object.entries(GATES)) {
+    const value = gate.read(native)
+    if (value == null || value === '' || gate.isTrusted(value)) continue
+    out.push({ name, value, warning: gate.warning })
+  }
+  return out
+}

--- a/react-web/src/lib/systemScene.ts
+++ b/react-web/src/lib/systemScene.ts
@@ -3,7 +3,9 @@
 // `?systemScene=` substitutes the scene that owns the UI, and that scene is trusted: permissions.rs
 // short-circuits every permission check for it and it gets the whole SystemApi. So a crafted link
 // on our own origin is a complete takeover of the session — no sandbox escape needed, just a click.
-// Anything not on the list below gets the interstitial in features/gate/UntrustedLaunchGate.
+// Anything not recognised below gets the interstitial (lib/launchGate.ts →
+// features/gate/UntrustedLaunchGate). What to trust is THIS front-end's call — the editor app,
+// for one, trusts its editor scene.
 
 import { PAGE_DIR } from './publicUrl'
 import { serviceUrl } from './baseDomain'

--- a/react-web/src/lib/webParams.ts
+++ b/react-web/src/lib/webParams.ts
@@ -1,0 +1,26 @@
+// The engine's entry-url parameter table, generated from crates/system_api_types/src/web_params.rs
+// (scripts/gen-ts-bindings.sh → engine/generated/webParamTable.ts). Which params exist, how each
+// reaches the engine and which ones a link may not set silently are all decided THERE; this
+// module only derives the HUD's handling from it. Leaf module: imports nothing but the table.
+
+import { WEB_PARAMS, type WebParam } from '../engine/generated'
+
+/** A table row by name. Throws so a renamed/removed row fails at module load, not at launch. */
+export function webParam(name: string): WebParam {
+  const p = WEB_PARAMS.find((p) => p.name === name)
+  if (p == null) throw new Error(`webParam: '${name}' is not in the engine's web param table`)
+  return p
+}
+
+/** The `launch`-delivered params — what the host hands boot.js as window.__bevyBootConfig. */
+export type LaunchOptions = Record<string, string | boolean | undefined>
+
+/** Every `launch` param as it appears in the entry url; absent = undefined (the engine's default). */
+export function launchOptionsFromUrl(q: URLSearchParams): LaunchOptions {
+  const out: LaunchOptions = {}
+  for (const p of WEB_PARAMS) {
+    if (p.delivery !== 'launch') continue
+    out[p.name] = p.kind === 'flag' ? q.has(p.name) : (q.get(p.name) ?? undefined)
+  }
+  return out
+}

--- a/react-web/src/test/systemScene.test.tsx
+++ b/react-web/src/test/systemScene.test.tsx
@@ -75,9 +75,16 @@ describe('isTrustedBaseDomain', () => {
   })
 })
 
+const EVIL_SCENE = {
+  name: 'systemScene',
+  value: 'https://example.com/evil',
+  warning: 'Replaces the interface with a scene loaded from this address.'
+}
+const EVIL_DOMAIN = { name: 'baseDomain', value: 'interconnected.online', warning: 'Points every backend at this domain.' }
+
 describe('UntrustedLaunchGate', () => {
   it('names the offending value and leads with the safe action', () => {
-    render(<UntrustedLaunchGate systemScene="https://example.com/evil" onProceed={vi.fn()} />)
+    render(<UntrustedLaunchGate params={[EVIL_SCENE]} onProceed={vi.fn()} />)
     expect(screen.getByText(/not trusted/i)).toBeInTheDocument()
     expect(screen.getByText('https://example.com/evil')).toBeInTheDocument()
     // Proceeding is not reachable in one click — it sits behind Advanced.
@@ -85,16 +92,14 @@ describe('UntrustedLaunchGate', () => {
   })
 
   it('names an untrusted base domain the same way', () => {
-    render(<UntrustedLaunchGate baseDomain="interconnected.online" onProceed={vi.fn()} />)
+    render(<UntrustedLaunchGate params={[EVIL_DOMAIN]} onProceed={vi.fn()} />)
     expect(screen.getByText(/not trusted/i)).toBeInTheDocument()
     expect(screen.getByText('interconnected.online')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /continue anyway/i })).not.toBeInTheDocument()
   })
 
   it('names both parameters when a link carries both', () => {
-    render(
-      <UntrustedLaunchGate systemScene="https://example.com/evil" baseDomain="interconnected.online" onProceed={vi.fn()} />
-    )
+    render(<UntrustedLaunchGate params={[EVIL_SCENE, EVIL_DOMAIN]} onProceed={vi.fn()} />)
     expect(screen.getByText('https://example.com/evil')).toBeInTheDocument()
     expect(screen.getByText('interconnected.online')).toBeInTheDocument()
   })
@@ -102,7 +107,7 @@ describe('UntrustedLaunchGate', () => {
   it('only proceeds after Advanced, and only on the explicit confirm', async () => {
     const onProceed = vi.fn()
     const user = userEvent.setup()
-    render(<UntrustedLaunchGate systemScene="https://example.com/evil" onProceed={onProceed} />)
+    render(<UntrustedLaunchGate params={[EVIL_SCENE]} onProceed={onProceed} />)
 
     await user.click(screen.getByRole('button', { name: /advanced/i }))
     expect(onProceed).not.toHaveBeenCalled()

--- a/react-web/src/test/webParams.test.ts
+++ b/react-web/src/test/webParams.test.ts
@@ -1,0 +1,46 @@
+// DOMAIN: the engine's web param table as the HUD consumes it (lib/webParams.ts) — the boot config
+// is filled from it — and this front-end's launch gate over those params (lib/launchGate.ts).
+
+import { describe, expect, it } from 'vitest'
+import { WEB_PARAMS } from '../engine/generated'
+import { launchOptionsFromUrl, webParam } from '../lib/webParams'
+import { untrustedLaunchParams } from '../lib/launchGate'
+
+describe('launchOptionsFromUrl', () => {
+  it('reads every launch param, flags by presence, strings verbatim, absent = undefined', () => {
+    const q = new URLSearchParams('?pulseServer=localhost:7777&preview&portables=a;b&editor')
+    const opts = launchOptionsFromUrl(q)
+    // editor is the creator-hub front-end's to set (delivery `host`), never a link's
+    expect('editor' in opts).toBe(false)
+    expect(opts.pulseServer).toBe('localhost:7777')
+    expect(opts.preview).toBe(true)
+    expect(opts.portables).toBe('a;b')
+    expect(opts.imposterSource).toBeUndefined()
+    // only launch-delivered params: the picker's realm/position and the host-side baseDomain stay out
+    for (const name of Object.keys(opts)) expect(webParam(name).delivery).toBe('launch')
+    expect(Object.keys(opts).sort()).toEqual(
+      WEB_PARAMS.filter((p) => p.delivery === 'launch')
+        .map((p) => p.name)
+        .sort()
+    )
+  })
+})
+
+describe('untrustedLaunchParams', () => {
+  it('is empty on a plain entry url', () => {
+    expect(untrustedLaunchParams({ native: false })).toEqual([])
+  })
+
+  it('reports an unrecognised system scene with the gate copy', () => {
+    window.history.replaceState(null, '', '/?systemScene=https://example.com/evil')
+    try {
+      const [p, ...rest] = untrustedLaunchParams({ native: false })
+      expect(rest).toEqual([])
+      expect(p.name).toBe('systemScene')
+      expect(p.value).toBe('https://example.com/evil')
+      expect(p.warning).toMatch(/Replaces the Explorer/)
+    } finally {
+      window.history.replaceState(null, '', '/')
+    }
+  })
+})

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,8 @@ cargo build --release --bin headless --no-default-features --features headless,l
 
 `cargo run --release --bin decentra-bevy -- [options]`
 
+On web the equivalents are query params on the entry url, defined once in `crates/system_api_types/src/web_params.rs` (the react page is generated from that table; which of them a link may set without a warning is the page's own policy, `react-web/src/lib/launchGate.ts`).
+
 **World**
 - `--server <url>` — content server / realm. Defaults to `https://realm-provider-ea.decentraland.org/main`.
 - `--content-server <url>` — override the content server only.

--- a/scripts/gen-ts-bindings.sh
+++ b/scripts/gen-ts-bindings.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 # Generate the TypeScript bindings for the ~system/BevyExplorerApi boundary from the Rust
 # structs in crates/system_api_types, into react-web/src/engine/generated (+ a barrel index.ts).
+# Also writes the web param TABLE (crates/system_api_types/src/web_params.rs → webParamTable.ts):
+# the `export_` filter catches both ts-rs's export_bindings_* tests and export_web_param_table.
 # Called by `just ts-bindings` and by CI (ci.yml deploy-web, package.yml) before the
 # react-web / bridge-scene builds, which import the generated (gitignored) types.
 set -eu
@@ -13,7 +15,7 @@ esac
 out="$root/react-web/src/engine/generated"
 rm -rf "$out"
 mkdir -p "$out"
-TS_RS_EXPORT_DIR="$out" cargo test --manifest-path "$root/Cargo.toml" -p system_api_types export_bindings
+TS_RS_EXPORT_DIR="$out" cargo test --manifest-path "$root/Cargo.toml" -p system_api_types export_
 cd "$out"
 : >index.ts
 for f in $(ls ./*.ts 2>/dev/null | grep -v '^\./index\.ts$' | LC_ALL=C sort); do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod ext;
 #[cfg(target_arch = "wasm32")]
 mod web;
+pub mod web_options;
 // POC: react-web HUD via CEF offscreen rendering into an in-engine texture (`react-hud-cef`).
 #[cfg(all(not(target_arch = "wasm32"), feature = "react-hud-cef"))]
 mod react_hud_cef;
@@ -363,7 +364,7 @@ impl DecentralandApp {
             .startup_scenes
             .unwrap_or_else(|| {
                 vec![StartupScene {
-                    source: String::from("basiccontroller.dcl.eth"),
+                    source: String::from(system_api_types::web_params::DEFAULT_PORTABLES),
                     super_user: false,
                     preview: decentraland_app_config.arguments.startup_scenes_preview,
                     hot_reload: None,

--- a/src/web.rs
+++ b/src/web.rs
@@ -25,12 +25,18 @@ use system_bridge::{SystemApi, SystemBridge};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::js_sys;
 
-use crate::{DecentralandApp, DecentralandAppConfig, DecentralandArguments};
+use crate::{
+    web_options::{self, non_empty, EngineRunOptions},
+    DecentralandApp, DecentralandAppConfig, DecentralandArguments,
+};
 
 static WASM_ASSET_LOADER_HANDLE: OnceCell<WasmLoaderHandle> = OnceCell::new();
 static INIT_DATA: OnceCell<AppConfig> = OnceCell::new();
 static CONSOLE_BRIDGE_SENDER: OnceCell<tokio::sync::mpsc::UnboundedSender<SystemApi>> =
     OnceCell::new();
+/// The options the page launched with; the url sync echoes them back with the live values
+/// (realm, position, …) swapped in.
+static LAUNCH_OPTIONS: OnceCell<EngineRunOptions> = OnceCell::new();
 
 #[wasm_bindgen]
 extern "C" {
@@ -40,15 +46,10 @@ extern "C" {
 
 #[wasm_bindgen(js_namespace = window)]
 extern "C" {
+    /// The engine's current launch options as JSON — the `engine_run` options object minus the
+    /// page-derived keys — for boot.js to mirror into the page url.
     #[wasm_bindgen(js_name = set_url_params)]
-    fn set_url_params(
-        position: Option<String>,
-        realm: String,
-        system_scene: Option<String>,
-        portables: Option<String>,
-        is_preview: bool,
-        is_editor: bool,
-    );
+    fn set_url_params(options_json: &str);
 
     #[wasm_bindgen(js_name = "allowADummyPipeline")]
     fn allow_a_dummy_pipeline();
@@ -146,22 +147,46 @@ pub fn engine_home_scene() -> String {
         .to_string()
 }
 
-#[expect(clippy::too_many_arguments)]
+/// Bytes of gpu uploads per frame on web — was a constant the page passed in; the engine owns it.
+const WEB_GPU_BYTES_PER_FRAME: usize = 10_000_000;
+
+// Type the `engine_run` parameter in the generated .d.ts — keep in step with
+// `web_options::EngineRunOptions` (tested against the web param table).
+#[wasm_bindgen(typescript_custom_section)]
+const ENGINE_RUN_OPTIONS_TS: &str = r#"
+export interface EngineRunOptions {
+    platform?: string;
+    realm?: string;
+    position?: string;
+    systemScene?: string;
+    portables?: string;
+    preview?: boolean;
+    editor?: boolean;
+    sceneParams?: string;
+    pulseServer?: string;
+    imposterSource?: string;
+}
+"#;
+
 #[wasm_bindgen]
-pub fn engine_run(
-    platform: &str,
-    server: &str,
-    location: &str,
-    system_scene: &str,
-    portables: &str,
-    with_thread_loader: bool,
-    is_preview: bool,
-    is_editor: bool,
-    gpu_bytes_per_frame: usize,
-    params: &str,
-    pulse_server: &str,
-    imposter_source: &str,
-) {
+extern "C" {
+    #[wasm_bindgen(typescript_type = "EngineRunOptions")]
+    pub type EngineRunOptionsJs;
+}
+
+/// Round-trip the page's object through JSON rather than `serde_wasm_bindgen::from_value`: that
+/// only visits the struct's own fields, so `deny_unknown_fields` would never see a misspelt key.
+fn parse_options(options: &JsValue) -> Result<EngineRunOptions, JsValue> {
+    let json = String::from(js_sys::JSON::stringify(options)?);
+    web_options::parse(&json)
+        .map_err(|e| JsValue::from_str(&format!("engine_run: invalid options: {e}")))
+}
+
+/// Launch the engine. Throws (rejects the launch) on an invalid options object.
+#[wasm_bindgen]
+pub fn engine_run(options: EngineRunOptionsJs) -> Result<(), JsValue> {
+    let options = parse_options(&options)?;
+    let _ = LAUNCH_OPTIONS.set(options.clone());
     apply_base_domain();
     init_runtime();
 
@@ -176,24 +201,16 @@ pub fn engine_run(
         custom_layer: |_| None,
     });
 
-    let decentraland_app_config = decentraland_app_config(
-        server,
-        location,
-        system_scene,
-        portables,
-        gpu_bytes_per_frame,
-        is_preview,
-        is_editor,
-        params,
-        pulse_server,
-        imposter_source,
-        with_thread_loader.then(|| WASM_ASSET_LOADER_HANDLE.get().unwrap().clone()),
+    let decentraland_app_config = DecentralandAppConfig::new(
+        decentraland_serialized_app_config(),
+        decentraland_app_arguments(&options),
+        Some(WASM_ASSET_LOADER_HANDLE.get().unwrap().clone()),
     );
 
     let mut app = decentraland_app.build(decentraland_app_config);
 
     // on wasm we need to explicitly specify key binds for the platform
-    let text_bindings = if platform.contains("mac") {
+    let text_bindings = if options.platform.contains("mac") {
         bevy_simple_text_input::TextInputNavigationBindings::macos_default()
     } else {
         bevy_simple_text_input::TextInputNavigationBindings::non_macos_default()
@@ -218,6 +235,7 @@ pub fn engine_run(
     let _ = CONSOLE_BRIDGE_SENDER.set(bridge_sender);
 
     app.run();
+    Ok(())
 }
 
 /// Send a console command to the engine from JavaScript.
@@ -323,23 +341,16 @@ pub fn update_winit_fps(config: Res<AppConfig>, mut winit: ResMut<WinitSettings>
     }
 }
 
-#[derive(PartialEq, Default, Clone)]
-struct UrlParams {
-    parcel: Option<IVec2>,
-    server: String,
-    ui_scene: Option<String>,
-    portables: Option<String>,
-    preview: bool,
-    editor: bool,
-}
-
+/// Keeps the page url in step with the engine: the launch options with the live realm,
+/// position, ui scene, portables and mode swapped in, sent whole so every param given at
+/// launch (pulse server, imposter source, …) is retained alongside them.
 fn update_url_params(
     player: Query<&GlobalTransform, With<PrimaryUser>>,
     current_realm: Res<CurrentRealm>,
     startup_scenes: Option<Res<StartupScenes>>,
     preview: Res<PreviewMode>,
     editor: Res<EditorMode>,
-    mut prev: Local<UrlParams>,
+    mut prev: Local<Option<EngineRunOptions>>,
 ) {
     // realms with fixed scene urns (worlds) spawn at their base scene and ignore an explicit
     // position (see load_active_entities' base-position handling) - don't write one into the url
@@ -348,12 +359,14 @@ fn update_url_params(
         .scenes_urn
         .as_ref()
         .is_none_or(Vec::is_empty);
-    let parcel = position_honoured
-        .then(|| vec3_to_parcel(player.single().map(|p| p.translation()).unwrap_or_default()));
+    let position = position_honoured.then(|| {
+        let parcel = vec3_to_parcel(player.single().map(|p| p.translation()).unwrap_or_default());
+        format!("{},{}", parcel.x, parcel.y)
+    });
     let Some(server) = current_realm.about_url.strip_suffix("/about") else {
         return;
     };
-    let (ui_scene, portables) = if let Some(s) = startup_scenes {
+    let (system_scene, portables) = if let Some(s) = startup_scenes {
         // the ui scene is the super-user scene inserted at index 0 — when one was given at all
         // (?systemScene=none boots with only regular startup scenes/portables)
         let ui_scene = s
@@ -375,61 +388,31 @@ fn update_url_params(
     } else {
         (None, None)
     };
-    let preview = preview.is_preview;
 
-    let params = UrlParams {
-        parcel,
-        server: server.to_owned(),
-        ui_scene,
-        portables,
-        preview,
+    let options = EngineRunOptions {
+        realm: Some(server.to_owned()),
+        position,
+        system_scene,
+        // the default set is omitted so the canonical url stays clean (the page doesn't know it)
+        portables: portables.filter(|p| p != system_api_types::web_params::DEFAULT_PORTABLES),
+        preview: preview.is_preview,
         editor: editor.0,
+        ..LAUNCH_OPTIONS.get().cloned().unwrap_or_default()
     };
 
-    if params != *prev {
-        *prev = params.clone();
-        set_url_params(
-            params
-                .parcel
-                .map(|parcel| format!("{},{}", parcel.x, parcel.y)),
-            params.server,
-            params.ui_scene,
-            params.portables,
-            params.preview,
-            params.editor,
-        );
+    if prev.as_ref() != Some(&options) {
+        let mut json = serde_json::to_value(&options).unwrap_or_default();
+        if let Some(map) = json.as_object_mut() {
+            // the page-derived keys are the loader's to compute, never url state
+            for param in system_api_types::web_params::web_params() {
+                if param.delivery == system_api_types::web_params::Delivery::Page {
+                    map.remove(param.name);
+                }
+            }
+        }
+        set_url_params(&json.to_string());
+        *prev = Some(options);
     }
-}
-
-#[expect(clippy::too_many_arguments)]
-fn decentraland_app_config(
-    server: &str,
-    location: &str,
-    ui_scene: &str,
-    portables: &str,
-    gpu_bytes_per_frame: usize,
-    is_preview: bool,
-    is_editor: bool,
-    params: &str,
-    pulse_server: &str,
-    imposter_source: &str,
-    wasm_loader_handle: Option<WasmLoaderHandle>,
-) -> DecentralandAppConfig {
-    let app_config = decentraland_serialized_app_config();
-    let arguments = decentraland_app_arguments(
-        server,
-        location,
-        ui_scene,
-        portables,
-        gpu_bytes_per_frame,
-        is_preview,
-        is_editor,
-        params,
-        pulse_server,
-        imposter_source,
-    );
-
-    DecentralandAppConfig::new(app_config, arguments, wasm_loader_handle)
 }
 
 fn decentraland_serialized_app_config() -> AppConfig {
@@ -443,26 +426,16 @@ fn decentraland_serialized_app_config() -> AppConfig {
     })
 }
 
-#[expect(clippy::too_many_arguments)]
-fn decentraland_app_arguments(
-    server: &str,
-    location: &str,
-    ui_scene: &str,
-    portables: &str,
-    gpu_bytes_per_frame: usize,
-    is_preview: bool,
-    is_editor: bool,
-    params: &str,
-    pulse_server: &str,
-    imposter_source: &str,
-) -> DecentralandArguments {
+fn decentraland_app_arguments(options: &EngineRunOptions) -> DecentralandArguments {
     DecentralandArguments {
-        server: Some(server.to_owned()),
+        server: non_empty(&options.realm),
         content_server_override: None,
-        location: IVec2Arg::from_str(location)
-            .map(|location_arg| location_arg.0)
-            .ok(),
-        startup_scenes: Some(
+        location: options
+            .position
+            .as_deref()
+            .and_then(|location| IVec2Arg::from_str(location).ok())
+            .map(|location_arg| location_arg.0),
+        startup_scenes: non_empty(&options.portables).map(|portables| {
             portables
                 .split(";")
                 .map(|portable| StartupScene {
@@ -472,28 +445,25 @@ fn decentraland_app_arguments(
                     hot_reload: None,
                     hash: None,
                 })
-                .collect::<Vec<_>>(),
-        )
-        .filter(|startup_scenes| !startup_scenes.is_empty()),
-        ui_scene: (!ui_scene.is_empty())
-            .then(|| ui_scene.to_owned())
-            .filter(|scene| scene != "none"),
+                .collect::<Vec<_>>()
+        }),
+        ui_scene: non_empty(&options.system_scene).filter(|scene| scene != "none"),
         // wasm has no engine-managed HUD: the react page hosting the engine is the HUD
         hud: false,
-        scene_params: Some(params.to_owned()),
-        pulse_server: (!pulse_server.is_empty()).then(|| pulse_server.to_owned()),
+        scene_params: options.scene_params.clone(),
+        pulse_server: non_empty(&options.pulse_server),
         scene_threads: None,
         scene_load_distance: None,
         scene_unload_extra_distance: None,
         scene_imposter_bake: None,
         scene_imposter_distances: None,
         scene_imposter_multisample: None,
-        imposter_source: (!imposter_source.is_empty()).then(|| imposter_source.to_owned()),
+        imposter_source: non_empty(&options.imposter_source),
         vsync: None,
         fps_target: None,
-        gpu_bytes_per_frame: Some(gpu_bytes_per_frame),
-        is_preview,
-        editor: is_editor,
+        gpu_bytes_per_frame: Some(WEB_GPU_BYTES_PER_FRAME),
+        is_preview: options.preview,
+        editor: options.editor,
         sysinfo_visible: false,
         scene_log_to_console: false,
         startup_scenes_preview: false,

--- a/src/web_options.rs
+++ b/src/web_options.rs
@@ -1,0 +1,69 @@
+//! The options object `engine_run` takes from the page (src/web.rs) — one named key per launch
+//! parameter, the web counterpart of the native command line. The engine echoes the same shape
+//! back to the page as it runs (`set_url_params`) so every param given stays in the url.
+//! Compiled on every target so the test below can hold it to the web param table
+//! (`system_api_types::web_params`), which is what the host page is generated from.
+
+use serde::{Deserialize, Serialize};
+
+/// Every key is optional; absent = the engine's default. Unknown keys fail the launch (see
+/// [`parse`]) so a misspelt key can never silently fall through to a default. Adding a
+/// parameter = a row in the table + a field here.
+#[derive(Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct EngineRunOptions {
+    pub platform: String,
+    pub realm: Option<String>,
+    pub position: Option<String>,
+    pub system_scene: Option<String>,
+    pub portables: Option<String>,
+    pub preview: bool,
+    pub editor: bool,
+    pub scene_params: Option<String>,
+    pub pulse_server: Option<String>,
+    pub imposter_source: Option<String>,
+}
+
+/// From the page's object serialised as JSON. `JSON.stringify` drops `undefined`-valued keys,
+/// which is what makes them "absent".
+pub fn parse(json: &str) -> Result<EngineRunOptions, serde_json::Error> {
+    serde_json::from_str(json)
+}
+
+/// An empty string is "absent" too — the page may pass `''` for an unset field.
+pub fn non_empty(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use system_api_types::web_params::{web_params, Delivery};
+
+    /// The struct's keys are exactly the table's engine_run params (everything but the
+    /// host-consumed base domain), so the two can't drift.
+    #[test]
+    fn options_match_the_web_param_table() {
+        let json = serde_json::to_value(EngineRunOptions::default()).unwrap();
+        let fields: BTreeSet<_> = json.as_object().unwrap().keys().cloned().collect();
+        let table: BTreeSet<_> = web_params()
+            .into_iter()
+            .filter(|p| p.delivery != Delivery::BaseDomain)
+            .map(|p| p.name.to_owned())
+            .collect();
+        assert_eq!(fields, table);
+    }
+
+    #[test]
+    fn unknown_keys_are_rejected() {
+        assert!(parse(r#"{"pulseServr": "localhost:7777"}"#).is_err());
+        let options = parse(r#"{"pulseServer": "localhost:7777", "preview": true}"#).unwrap();
+        assert_eq!(options.pulse_server.as_deref(), Some("localhost:7777"));
+        assert!(options.preview);
+        assert!(!options.editor);
+    }
+}


### PR DESCRIPTION
The wasm `engine_run` took 12 positional arguments, hand-threaded through `EngineHost.tsx` → `boot.js` → `engine.js` with nothing checking the order, and every new param (`pulseServer`, `imposterSource`) grew the chain in four places. This makes the params a single Rust definition and the JS boundary a named object.

### One table

`system_api_types::web_params` defines every web param: name, kind (`string` | `flag`), delivery and doc. `gen-ts-bindings.sh` now also exports the table's *values* (`webParamTable.ts`) next to the ts-rs types, so the react page is generated from it; the `cargo test` filter widened from `export_bindings` to `export_` to catch that test. `DEFAULT_PORTABLES` lives there too, replacing three copies of `basiccontroller.dcl.eth`.

Delivery says how a value reaches the engine:
- `launch` — read from the entry url by EngineHost into `__bevyBootConfig`, forwarded verbatim (`portables`, `preview`, `pulseServer`, `imposterSource`, `systemScene`)
- `destination` — chosen by the host's picker (`realm`, `position`)
- `host` — set by an embedding front-end from its own knowledge, never read from a link (`editor`, which is the editor app's)
- `page` — computed by engine.js at launch (`platform`, `sceneParams`)
- `baseDomain` — consumed by the host itself and published as `__baseDomain()` before the wasm loads; the engine reads it at `engine_init`, ahead of `engine_run`. Stays host-side because the gate renders and the HUD composes its own service urls before any engine exists.

### One object into the engine

`engine_run(options)` takes a plain object. `src/web_options.rs` is the serde struct (`deny_unknown_fields`), compiled on every target so a unit test can hold its keys to the table. Parsing goes through a JSON round-trip rather than `serde_wasm_bindgen::from_value`, which only visits declared fields and would silently accept a misspelt key; a bad key now fails the launch with `unknown field ...`. The generated `.d.ts` types the parameter as `EngineRunOptions`. `gpu_bytes_per_frame` (1e7) and `with_thread_loader` (always true) become engine-side constants.

### The url sync keys off the same struct

`set_url_params` now receives the engine's *current* launch options — the live realm, position, ui scene, portables and mode swapped in, page-derived keys stripped via the table — and `boot.js` writes them generically, so every param given at launch is retained in the url (previously only the six it knew about). The default portables set is omitted on the Rust side; `boot.js` keeps the two defaults only the page knows (realm incl. the worlds-prefix reversal, and its own systemScene). One shared `applyOptionsToUrlParams` serves both this and `engine.js`'s scene-params mirror.

### Trust is the front-end's

The table says what a param *does*; whether a link may set it is this front-end's policy — a different host (the editor app) trusts different things. `react-web/src/lib/launchGate.ts` holds the gated params (warning copy, value reader, trust check) keyed by table name and checked against it at module load; `UntrustedLaunchGate` renders whatever it returns. The trusted domains and worlds stay in `baseDomain.ts` / `systemScene.ts` as before.

### Behaviour notes
- `?editor=` is not read from the url by the react page (it never was; the table now says why).
- The scene-params string no longer carries `portables=basiccontroller.dcl.eth` when the default set runs, since nothing supplies the default on the JS side any more.
- `realm: ''` from a host now means "home realm" rather than a literal empty server; no caller passed it.

### Verified
`cargo fmt`, `cargo clippy --all -- -D warnings`, headless check, wasm build, root + `system_api_types` unit tests, react-web typecheck + vitest (383), and a headed Playwright run against the worktree engine: the gate lists both gated params with the page's copy, `?systemScene=none` is ungated, `__bevyBootConfig` holds exactly the launch params (no `editor`), `engine_run({ pulseServr })` throws without marking the engine started, and after a real boot to Genesis the engine echoed `preview` and `imposterSource` back into the url while the default realm/portables/systemScene and an empty `pulseServer` were dropped.

### Follow-ups
- Native: put clap derive on `DecentralandArguments` and hold the web table to it by test (one struct as the native source, `--help` for free, readme rows generatable); headless parser decision alongside. Separate PR.
- The per-service endpoint map (#TBD) adds a row here plus a struct field; its web param needs the HUD reader too, since the HUD composes its own service urls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
