### PR TITLE
headless: flatten LaunchOptions into the headless CLI

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -749,7 +749,7 @@ impl Default for GraphicsSettings {
     fn default() -> Self {
         Self {
             vsync: false,
-            log_fps: true,
+            log_fps: !cfg!(target_arch = "wasm32"),
             msaa: AaSetting::FxaaLow,
             fps_target: 60,
             shadow_distance: 20.0,
@@ -766,7 +766,11 @@ impl Default for GraphicsSettings {
             ambient_brightness: 50,
             cel_shading: true,
             avatar_outline: true,
-            gpu_bytes_per_frame: 0,
+            gpu_bytes_per_frame: if cfg!(target_arch = "wasm32") {
+                10_000_000
+            } else {
+                0
+            },
         }
     }
 }

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -9,8 +9,8 @@
 //! - [`ClientOptions`]: the rendering clients only (native and web); headless never sees them,
 //!   so they are unknown flags there
 //!
-//! What each one DOES is `src/launch.rs` in the root crate, split the same way. Field names are
-//! the web names, and the native flags are the same names in kebab-case. Everything is
+//! What each one DOES is `src/launch.rs` in the root crate (`apply` / `apply_client`). Field
+//! names are the web names, and the native flags are the same names in kebab-case. Everything is
 //! optional: absent = the engine's default. Native-only flags live on `DecentralandArguments`
 //! (src/lib.rs).
 

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -1,18 +1,23 @@
-//! The launch parameters both platforms accept — defined ONCE, here. Natively each field is a
-//! `--flag` (clap; the doc comment is its `--help` text), on web the same field is a key of the
-//! `engine_run` options object (serde, camelCase) and an entry-url query param. The web param
-//! table (`web_params`) is derived from this struct's clap metadata plus a per-field delivery
-//! annotation, and the host page is generated from that table — so a parameter is declared
-//! here and nowhere else.
+//! The launch parameters, defined ONCE, here. Natively each field is a `--flag` (clap; the doc
+//! comment is its `--help` text), on web the same field is a key of the `engine_run` options
+//! object (serde, camelCase) and an entry-url query param. The web param table (`web_params`)
+//! is derived from these structs' clap metadata plus a per-field delivery annotation, and the
+//! host page is generated from that table — so a parameter is declared here and nowhere else.
 //!
-//! Field names are the web names, and the native flags are the same names in kebab-case.
-//! Everything is optional: absent = the engine's default. Native-only flags live on `DecentralandArguments` (src/lib.rs), which
-//! flattens this struct in.
+//! Two structs, by which binaries take them:
+//! - [`LaunchOptions`]: every binary — native, web and headless flatten it in
+//! - [`ClientOptions`]: the rendering clients only (native and web); headless never sees them,
+//!   so they are unknown flags there
+//!
+//! What each one DOES is `src/launch.rs` in the root crate, split the same way. Field names are
+//! the web names, and the native flags are the same names in kebab-case. Everything is
+//! optional: absent = the engine's default. Native-only flags live on `DecentralandArguments`
+//! (src/lib.rs).
 
 use serde::{Deserialize, Serialize};
 
 #[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
-#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+#[serde(rename_all = "camelCase", default)]
 pub struct LaunchOptions {
     /// Realm to boot into; absent = the persisted home realm or default realm
     #[arg(long, value_name = "url", display_order = 1)]
@@ -33,10 +38,6 @@ pub struct LaunchOptions {
     #[arg(long, value_name = "domain", display_order = 4)]
     pub base_domain: Option<String>,
 
-    /// Embedded in a scene editor (creator hub). Set by editor front-ends.
-    #[arg(long, display_order = 5)]
-    pub editor: bool,
-
     /// Override the content server only
     #[arg(long, value_name = "url", display_order = 7)]
     pub content_server: Option<String>,
@@ -44,6 +45,19 @@ pub struct LaunchOptions {
     /// Pulse server as `host:port`; absent = the deployment's default
     #[arg(long, value_name = "host:port", display_order = 8)]
     pub pulse_server: Option<String>,
+
+    /// Log the frame rate to the console
+    #[arg(long, value_name = "true|false", display_order = 13)]
+    pub log_fps: Option<bool>,
+}
+
+/// The options only a rendering client (native, web) has a use for.
+#[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ClientOptions {
+    /// Embedded in a scene editor (creator hub). Set by editor front-ends.
+    #[arg(long, display_order = 5)]
+    pub editor: bool,
 
     /// Base url of the imposter store; absent = the default store. The realm-keyed path under
     /// it is the same as the default store's
@@ -61,34 +75,57 @@ pub struct LaunchOptions {
     #[arg(long, value_name = "a;b", display_order = 12)]
     pub portables: Option<String>,
 
-    /// Log the frame rate to the console
-    #[arg(long, value_name = "true|false", display_order = 13)]
-    pub log_fps: Option<bool>,
-
     /// Cap per-frame gpu uploads
     #[arg(long, value_name = "bytes", display_order = 17)]
     pub gpu_bytes_per_frame: Option<usize>,
 }
 
-impl LaunchOptions {
+/// The web page's `engine_run` options: both structs as ONE flat object, which is also what the
+/// engine echoes back for the url sync.
+#[derive(Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
+pub struct EngineRunOptions {
+    #[serde(flatten)]
+    pub launch: LaunchOptions,
+    #[serde(flatten)]
+    pub client: ClientOptions,
+}
+
+impl EngineRunOptions {
     /// From the web page's options object serialised as JSON. `JSON.stringify` drops
     /// `undefined`-valued keys, which is what makes them "absent"; an unknown key fails the
-    /// launch so a misspelt one can never silently fall through to a default.
+    /// launch so a misspelt one can never silently fall through to a default. (Checked by hand
+    /// against the web param table: serde's `flatten` and `deny_unknown_fields` are exclusive.)
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
-        serde_json::from_str(json)
+        use serde::de::Error;
+        let value: serde_json::Value = serde_json::from_str(json)?;
+        let Some(object) = value.as_object() else {
+            return Err(Error::custom("expected an object"));
+        };
+        let known: Vec<String> = crate::web_params::web_params()
+            .into_iter()
+            .filter(|p| p.delivery != crate::web_params::Delivery::BaseDomain)
+            .map(|p| p.name)
+            .collect();
+        if let Some(key) = object.keys().find(|key| !known.contains(key)) {
+            return Err(Error::custom(format!(
+                "unknown field `{key}`, expected one of {}",
+                known.join(", ")
+            )));
+        }
+        serde_json::from_value(value)
     }
 
     /// An empty string is "absent" too — the web page may pass `''` for an unset field.
     pub fn without_empty_strings(mut self) -> Self {
         for value in [
-            &mut self.realm,
-            &mut self.position,
-            &mut self.system_scene,
-            &mut self.content_server,
-            &mut self.portables,
-            &mut self.pulse_server,
-            &mut self.imposter_source,
-            &mut self.base_domain,
+            &mut self.launch.realm,
+            &mut self.launch.position,
+            &mut self.launch.content_server,
+            &mut self.launch.pulse_server,
+            &mut self.launch.base_domain,
+            &mut self.client.system_scene,
+            &mut self.client.portables,
+            &mut self.client.imposter_source,
         ] {
             if value.as_deref() == Some("") {
                 *value = None;
@@ -107,6 +144,8 @@ mod tests {
     struct Cli {
         #[command(flatten)]
         launch: LaunchOptions,
+        #[command(flatten)]
+        client: ClientOptions,
     }
 
     #[test]
@@ -129,12 +168,12 @@ mod tests {
         ]);
         assert_eq!(cli.launch.realm.as_deref(), Some("https://r"));
         assert_eq!(cli.launch.position.as_deref(), Some("1,-2"));
-        assert_eq!(cli.launch.system_scene.as_deref(), Some("none"));
+        assert_eq!(cli.client.system_scene.as_deref(), Some("none"));
         assert_eq!(cli.launch.base_domain.as_deref(), Some("decentraland.zone"));
         assert!(cli.launch.preview);
-        assert!(!cli.launch.editor);
+        assert!(!cli.client.editor);
         assert_eq!(cli.launch.log_fps, Some(false));
-        assert_eq!(cli.launch.gpu_bytes_per_frame, Some(500_000));
+        assert_eq!(cli.client.gpu_bytes_per_frame, Some(500_000));
         // the pre-table spellings are gone, not aliased
         assert!(Cli::try_parse_from(["x", "--server", "r"]).is_err());
         assert!(Cli::try_parse_from(["x", "--ui", "none"]).is_err());
@@ -142,19 +181,31 @@ mod tests {
 
     #[test]
     fn unknown_json_keys_are_rejected() {
-        assert!(LaunchOptions::from_json(r#"{"pulseServr": "localhost:7777"}"#).is_err());
+        let err = EngineRunOptions::from_json(r#"{"pulseServr": "localhost:7777"}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field `pulseServr`"),
+            "{err}"
+        );
         // the base domain never travels as an engine_run key
-        assert!(LaunchOptions::from_json(r#"{"baseDomain": "decentraland.zone"}"#).is_err());
-        let options = LaunchOptions::from_json(
+        assert!(EngineRunOptions::from_json(r#"{"baseDomain": "decentraland.zone"}"#).is_err());
+        let options = EngineRunOptions::from_json(
             r#"{"pulseServer": "localhost:7777", "preview": true, "logFps": true, "gpuBytesPerFrame": 500000}"#,
         )
         .unwrap();
-        assert_eq!(options.pulse_server.as_deref(), Some("localhost:7777"));
-        assert!(options.preview);
-        assert!(!options.editor);
-        assert_eq!(options.log_fps, Some(true));
-        assert_eq!(options.gpu_bytes_per_frame, Some(500_000));
+        assert_eq!(
+            options.launch.pulse_server.as_deref(),
+            Some("localhost:7777")
+        );
+        assert!(options.launch.preview);
+        assert!(!options.client.editor);
+        assert_eq!(options.launch.log_fps, Some(true));
+        assert_eq!(options.client.gpu_bytes_per_frame, Some(500_000));
         // typed keys take their type, not a string
-        assert!(LaunchOptions::from_json(r#"{"gpuBytesPerFrame": "500000"}"#).is_err());
+        assert!(EngineRunOptions::from_json(r#"{"gpuBytesPerFrame": "500000"}"#).is_err());
+        // and the echo is one flat object again
+        let json = serde_json::to_value(&options).unwrap();
+        assert_eq!(json["pulseServer"], "localhost:7777");
+        assert_eq!(json["gpuBytesPerFrame"], 500_000);
+        assert!(json.get("baseDomain").is_none());
     }
 }

--- a/crates/system_api_types/src/web_params.rs
+++ b/crates/system_api_types/src/web_params.rs
@@ -1,6 +1,6 @@
 //! The entry-url parameters the web build accepts, as the react page sees them. Derived from
-//! [`LaunchOptions`] (the one declaration of every launch parameter, native and web): each of
-//! its clap args becomes a row — camelCase name, kind from whether the flag takes a value, doc
+//! [`LaunchOptions`] + [`ClientOptions`] (the one declaration of every launch parameter, native
+//! and web): each of their clap args becomes a row — camelCase name, kind from whether the flag takes a value, doc
 //! from the `--help` text — joined with the web-only fact this module owns, how the value gets
 //! from the entry url to the engine ([`Delivery`]). Exported to the react page alongside the
 //! ts-rs types (scripts/gen-ts-bindings.sh writes `webParamTable.ts` into
@@ -13,7 +13,7 @@ use std::any::TypeId;
 use clap::Args;
 use serde::Serialize;
 
-use crate::launch_options::LaunchOptions;
+use crate::launch_options::{ClientOptions, LaunchOptions};
 
 #[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
@@ -79,7 +79,7 @@ fn delivery(field: &str) -> Delivery {
         "editor" => Host,
         "base_domain" => BaseDomain,
         other => {
-            panic!("LaunchOptions::{other} has no web delivery — add it to web_params::delivery")
+            panic!("launch option `{other}` has no web delivery — add it to web_params::delivery")
         }
     }
 }
@@ -101,8 +101,11 @@ fn camel_case(snake: &str) -> String {
 }
 
 pub fn web_params() -> Vec<WebParam> {
-    LaunchOptions::augment_args(clap::Command::new("launch"))
+    let launch = LaunchOptions::augment_args(clap::Command::new("launch"));
+    let client = ClientOptions::augment_args(clap::Command::new("client"));
+    launch
         .get_arguments()
+        .chain(client.get_arguments())
         .map(|arg| {
             let field = arg.get_id().as_str();
             WebParam {
@@ -130,6 +133,7 @@ pub fn web_params() -> Vec<WebParam> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::launch_options::EngineRunOptions;
     use std::collections::BTreeSet;
 
     /// Writes the table's VALUES next to the ts-rs types (`TS_RS_EXPORT_DIR`, set by
@@ -149,8 +153,8 @@ mod tests {
     }
 
     /// Every field has a delivery (the panic in `delivery`), every row has a doc, and the
-    /// `engine_run` keys — the struct as serialised — are exactly the table minus the
-    /// host-consumed base domain.
+    /// `engine_run` keys — the structs as serialised, one flat object — are exactly the table
+    /// minus the host-consumed base domain.
     #[test]
     fn table_matches_the_struct() {
         let params = web_params();
@@ -164,7 +168,7 @@ mod tests {
             .filter(|p| p.delivery != Delivery::BaseDomain)
             .map(|p| p.name.clone())
             .collect();
-        let json = serde_json::to_value(LaunchOptions::default()).unwrap();
+        let json = serde_json::to_value(EngineRunOptions::default()).unwrap();
         let fields: BTreeSet<_> = json.as_object().unwrap().keys().cloned().collect();
         assert_eq!(fields, engine_run);
         assert!(names.contains("baseDomain"));

--- a/crates/visuals/src/lib.rs
+++ b/crates/visuals/src/lib.rs
@@ -8,10 +8,7 @@ use bevy::{
     core_pipeline::dof::{DepthOfField, DepthOfFieldMode},
     pbr::{wireframe::WireframePlugin, CascadeShadowConfigBuilder, DirectionalLightShadowMap},
     prelude::*,
-    render::{
-        render_asset::RenderAssetBytesPerFrame,
-        view::{Layer, RenderLayers},
-    },
+    render::view::{Layer, RenderLayers},
 };
 
 use bevy::render::RenderApp;
@@ -70,14 +67,6 @@ impl Plugin for VisualsPlugin {
         })
         .insert_resource(AtmosphereModel::new(NishitaCloud::default()))
         .add_plugins(AtmospherePlugin);
-
-        let config = app.world().resource::<AppConfig>();
-
-        if config.graphics.gpu_bytes_per_frame > 0 {
-            app.insert_resource(RenderAssetBytesPerFrame::new_with_priorities(
-                config.graphics.gpu_bytes_per_frame,
-            ));
-        }
 
         // app.add_plugins(EnvmapDownsamplePlugin);
 

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -6,12 +6,14 @@
 //! uses. `--server-mode` makes `isServer()` return true to scene JS, so a scene's
 //! authoritative-server branch runs. Intended to replace hammurabi-headless.
 
-use std::{sync::OnceLock, time::Duration};
+use std::{str::FromStr, sync::OnceLock, time::Duration};
 
 use bevy::tasks::IoTaskPool;
 use bevy::{
     app::ScheduleRunnerPlugin,
-    diagnostic::{DiagnosticsPlugin, FrameCountPlugin},
+    diagnostic::{
+        DiagnosticsPlugin, FrameCountPlugin, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin,
+    },
     gizmos::GizmoPlugin,
     gltf::GltfPlugin,
     input::InputPlugin,
@@ -23,6 +25,7 @@ use bevy::{
     time::TimePlugin,
 };
 use bevy_dui::DuiPlugin;
+use clap::Parser;
 use common::{
     inputs::InputMap,
     profile::SerializedProfile,
@@ -30,9 +33,10 @@ use common::{
     sets::SetupSets,
     structs::{
         AppConfig, AppError, AvatarDynamicState, CursorLocks, EngineMovementControl,
-        GraphicsSettings, HeadSync, NoRenderApp, PermissionType, PermissionUsed, PermissionValue,
-        PointAtSync, PreviewMode, PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, PrimaryUser,
-        SceneGlobalLight, SceneLoadDistance, SystemAudio, TimeOfDay, ToolTips,
+        GraphicsSettings, HeadSync, IVec2Arg, NoRenderApp, PermissionType, PermissionUsed,
+        PermissionValue, PointAtSync, PreviewMode, PrimaryCamera, PrimaryCameraRes,
+        PrimaryPlayerRes, PrimaryUser, SceneGlobalLight, SceneLoadDistance, SystemAudio, TimeOfDay,
+        ToolTips,
     },
     util::{TaskCompat, TaskExt, UtilsPlugin},
 };
@@ -55,6 +59,7 @@ use scene_runner::{
     renderer_context::RendererSceneContext,
     SceneRunnerPlugin,
 };
+use system_api_types::launch_options::LaunchOptions;
 use system_bridge::SystemBridgePlugin;
 use tween::TweenPlugin;
 use user_input::avatar_movement::{
@@ -67,98 +72,158 @@ use wallet::{
 
 static SESSION_LOG: OnceLock<String> = OnceLock::new();
 
+// The shared launch params (realm, position, preview, base domain, pulse server, content
+// server, and whatever gets added later — accepted here automatically) plus the server-role
+// flags. The shared fields headless has no consumer for are hidden from `--help` and refused
+// in `parse_args`.
+#[derive(clap::Parser)]
+#[command(
+    name = "headless",
+    about = "Headless scene runner: an authoritative scene server, or a render-free test client",
+    mut_arg("realm", |a| a.help("Realm to boot into; absent = http://localhost:8000")),
+    mut_arg("position", |a| {
+        a.visible_alias("location")
+            .help("Parcel to load as `x,y`; absent = 0,0")
+    }),
+    mut_arg("editor", |a| a.hide(true)),
+    mut_arg("system_scene", |a| a.hide(true)),
+    mut_arg("portables", |a| a.hide(true)),
+    mut_arg("imposter_source", |a| a.hide(true)),
+    mut_arg("gpu_bytes_per_frame", |a| a.hide(true))
+)]
 struct Args {
-    realm: String,
-    location: IVec2,
-    preview: bool,
+    #[command(flatten)]
+    launch: LaunchOptions,
+
+    /// Serve the scene: `isServer()` is true to scene code and realm-wide comms are never
+    /// joined. Standalone (without --orchestrated) is a local-dev flow and requires --preview
+    #[arg(long, display_order = 50)]
     server_mode: bool,
+
+    /// Multi-scene worker driven over stdin by an orchestrator; implies --server-mode
+    #[arg(long, display_order = 51)]
     orchestrated: bool,
+
+    /// Exit cleanly after this many seconds
+    #[arg(long, value_name = "secs", display_order = 52)]
     timeout: Option<f32>,
-    scene_threads: usize,
+
+    /// Scene javascript threads; absent = 16 orchestrated, 4 otherwise
+    #[arg(
+        long,
+        value_name = "n",
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..),
+        display_order = 53
+    )]
+    scene_threads: Option<usize>,
+
+    /// Scene tick rate
+    #[arg(
+        long,
+        value_name = "hz",
+        default_value_t = 30,
+        value_parser = clap::value_parser!(u32).range(1..),
+        display_order = 54
+    )]
     tick_hz: u32,
-    /// base64 world-storage delegation (hammurabi envelope); single-scene runs only —
-    /// orchestrated scenes receive theirs via the control channel
+
+    /// base64 world-storage delegation (hammurabi envelope), or the PROCESS_STORAGE_DELEGATION
+    /// env var; single-scene runs only — orchestrated scenes receive theirs via the control
+    /// channel
+    #[arg(long, value_name = "base64", display_order = 55)]
     storage_delegation: Option<String>,
-    /// deterministic guest wallet (test harness): address derivable offline from the seed
+
+    /// Deterministic guest wallet (test harness): the address is derivable offline from the seed
+    #[arg(long, value_name = "seed", display_order = 56)]
     wallet_seed: Option<u64>,
-    /// Pulse realm to announce verbatim; `--server-mode` only. Orchestrated servers host several
-    /// realms at once and take one per scene on `add-scene` instead.
+
+    /// Pulse realm to announce verbatim; `--server-mode` only, and optional there: absent, the
+    /// engine derives the same key from a locally hosted scene's entity id once it loads, this
+    /// just announces it sooner. Orchestrated servers host several realms at once and take one
+    /// per scene on `add-scene` instead
+    #[arg(long, value_name = "key", display_order = 57)]
     pulse_realm: Option<String>,
-    /// Pulse server as `host:port`; the orchestrator passes its deployment's (zone or prod)
-    pulse_server: Option<String>,
+
+    // resolved after parsing: realm defaults to a local preview server, position to 0,0
+    #[arg(skip)]
+    realm: String,
+    #[arg(skip)]
+    location: IVec2,
+}
+
+fn usage_error(message: impl std::fmt::Display) -> ! {
+    eprintln!("{message}");
+    std::process::exit(2);
 }
 
 fn parse_args() -> Args {
-    let mut args = pico_args::Arguments::from_env();
-    // latch first: everything below that composes a backend host reads it
-    if let Err(e) = args
-        .opt_value_from_str::<_, String>("--base-domain")
-        .map_err(|e| e.to_string())
-        .and_then(|domain| domain.map_or(Ok(()), |d| common::base_domain::set(&d)))
-    {
-        eprintln!("{e}");
-        std::process::exit(2);
+    let mut args = match Args::try_parse() {
+        Ok(args) => args,
+        Err(e) => {
+            let _ = e.print();
+            std::process::exit(if e.use_stderr() { 2 } else { 0 });
+        }
+    };
+    // shared params headless has no consumer for: refuse rather than silently do nothing
+    for (passed, flag) in [
+        (args.launch.editor, "--editor"),
+        (args.launch.system_scene.is_some(), "--system-scene"),
+        (args.launch.portables.is_some(), "--portables"),
+        (args.launch.imposter_source.is_some(), "--imposter-source"),
+        (
+            args.launch.gpu_bytes_per_frame.is_some(),
+            "--gpu-bytes-per-frame",
+        ),
+    ] {
+        if passed {
+            usage_error(format!("{flag} has no effect headless"));
+        }
     }
-    let realm: String = args
-        .value_from_str("--realm")
-        .unwrap_or_else(|_| "http://localhost:8000".to_owned());
-    let location = args
-        .value_from_str::<_, common::structs::IVec2Arg>("--location")
-        .ok()
-        .map(|va| va.0)
-        .unwrap_or(IVec2::ZERO);
-    let preview = args.contains("--preview");
-    let orchestrated = args.contains("--orchestrated");
+    // latch first: everything below that composes a backend host reads it
+    if let Some(domain) = &args.launch.base_domain {
+        if let Err(e) = common::base_domain::set(domain) {
+            usage_error(e);
+        }
+    }
+    args.realm = args
+        .launch
+        .realm
+        .clone()
+        .unwrap_or_else(|| "http://localhost:8000".to_owned());
+    args.location = match &args.launch.position {
+        Some(position) => {
+            IVec2Arg::from_str(position)
+                .unwrap_or_else(|e| usage_error(format!("--location {position}: {e}")))
+                .0
+        }
+        None => IVec2::ZERO,
+    };
     // orchestrated mode is always a server
-    let server_mode = args.contains("--server-mode") || orchestrated;
+    args.server_mode |= args.orchestrated;
     // standalone server mode is a local-dev flow (single scene on the shared context,
     // self-minted scene room); production servers are always orchestrated
-    if server_mode && !orchestrated && !preview {
-        eprintln!(
-            "--server-mode without --orchestrated is a local-dev mode and requires --preview"
+    if args.server_mode && !args.orchestrated && !args.launch.preview {
+        usage_error(
+            "--server-mode without --orchestrated is a local-dev mode and requires --preview",
         );
-        std::process::exit(2);
     }
     // latch the process-global server-role flags before the app is built
-    if server_mode {
+    if args.server_mode {
         common::structs::set_server_mode();
     }
-    if orchestrated {
+    if args.orchestrated {
         common::structs::set_multi_tenant();
     }
-    let timeout: Option<f32> = args.value_from_str("--timeout").ok();
-    let scene_threads: usize = args
-        .value_from_str("--scene-threads")
-        .unwrap_or(if orchestrated { 16 } else { 4 });
-    let tick_hz: u32 = args.value_from_str("--tick-hz").unwrap_or(30);
     // mirror hammurabi's worker env contract (PROCESS_STORAGE_DELEGATION)
-    let storage_delegation: Option<String> = args
-        .value_from_str("--storage-delegation")
-        .ok()
-        .or_else(|| std::env::var("PROCESS_STORAGE_DELEGATION").ok());
-    let wallet_seed: Option<u64> = args.value_from_str("--wallet-seed").ok();
-    let pulse_realm: Option<String> = args.value_from_str("--pulse-realm").ok();
-    let pulse_server: Option<String> = args.value_from_str("--pulse-server").ok();
-    if pulse_realm.is_some() && orchestrated {
-        eprintln!(
-            "--pulse-realm is a --server-mode flag; orchestrated scenes carry their own realm"
+    if args.storage_delegation.is_none() {
+        args.storage_delegation = std::env::var("PROCESS_STORAGE_DELEGATION").ok();
+    }
+    if args.pulse_realm.is_some() && args.orchestrated {
+        usage_error(
+            "--pulse-realm is a --server-mode flag; orchestrated scenes carry their own realm",
         );
-        std::process::exit(2);
     }
-    Args {
-        realm,
-        location,
-        preview,
-        server_mode,
-        orchestrated,
-        timeout,
-        scene_threads,
-        tick_hz,
-        storage_delegation,
-        wallet_seed,
-        pulse_realm,
-        pulse_server,
-    }
+    args
 }
 
 /// harness support: a seeded wallet gives a deterministic address, so livekit tokens
@@ -279,18 +344,19 @@ fn main() {
         .set(session_log.to_string_lossy().into_owned())
         .unwrap();
 
+    // args first, so --help and a bad flag answer without spawning the scene runtime
+    let args = parse_args();
+    TIMEOUT.set(args.timeout).ok();
+
     // v8 runtime must init on the main thread before the App is built (matches the tests).
     // Headless is always a server: a lost JS sidecar must restart the whole engine (the
     // desktop client and the scene_runner tests leave this false).
     dcl_deno_ipc::EXIT_ON_SIDECAR_LOSS.store(true, std::sync::atomic::Ordering::SeqCst);
     init_runtime().unwrap();
 
-    let args = parse_args();
-    TIMEOUT.set(args.timeout).ok();
-
     println!(
         "[headless] realm={} location={} preview={} server_mode={} tick_hz={}",
-        args.realm, args.location, args.preview, args.server_mode, args.tick_hz
+        args.realm, args.location, args.launch.preview, args.server_mode, args.tick_hz
     );
 
     let config = AppConfig {
@@ -298,11 +364,13 @@ fn main() {
         home_location: Some(args.location),
         graphics: GraphicsSettings {
             vsync: false,
-            log_fps: false,
+            log_fps: args.launch.log_fps.unwrap_or(false),
             fps_target: args.tick_hz as usize,
             ..Default::default()
         },
-        scene_threads: args.scene_threads,
+        scene_threads: args
+            .scene_threads
+            .unwrap_or(if args.orchestrated { 16 } else { 4 }),
         // load everything around the fake player generously; unload never.
         scene_load_distance: 100.0,
         scene_unload_extra_distance: 0.0,
@@ -341,10 +409,10 @@ fn main() {
         .add_plugins(TransformPlugin)
         .add_plugins(DiagnosticsPlugin)
         .add_plugins(IpfsIoPlugin {
-            preview: args.preview,
+            preview: args.launch.preview,
             assets_root: None,
             starting_realm: Some(map_realm_name(&args.realm)),
-            content_server_override: None,
+            content_server_override: args.launch.content_server.clone(),
             num_slots: config.max_concurrent_remotes,
         })
         .add_plugins(AssetPlugin::default())
@@ -393,6 +461,14 @@ fn main() {
 
     // embedded assets: the scene-loading material (grid.png / loading.wgsl)
     app.add_plugins(assets::EmbedAssetsPlugin);
+
+    // --log-fps: the tick rate, against --tick-hz
+    if config.graphics.log_fps {
+        app.add_plugins((
+            FrameTimeDiagnosticsPlugin::default(),
+            LogDiagnosticsPlugin::default(),
+        ));
+    }
 
     // world-storage delegations (per scene; CLI/env value is the single-scene fallback)
     let mut delegations = StorageDelegations::default();
@@ -451,8 +527,8 @@ fn main() {
             load_imposter: 0.0,
         })
         .insert_resource(PreviewMode {
-            server: args.preview.then(|| map_realm_name(&args.realm)),
-            is_preview: args.preview,
+            server: args.launch.preview.then(|| map_realm_name(&args.realm)),
+            is_preview: args.launch.preview,
             preview_parcel: None,
         })
         // servers must never join realm-wide comms (archipelago / world room) — they would
@@ -470,7 +546,7 @@ fn main() {
     if let Some(realm) = args.pulse_realm.clone() {
         app.insert_resource(comms::pulse::plugin::PulseRealmOverride(realm));
     }
-    if let Some(endpoint) = args.pulse_server.clone() {
+    if let Some(endpoint) = args.launch.pulse_server.clone() {
         app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(endpoint));
     }
 

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -11,9 +11,7 @@ use std::{str::FromStr, sync::OnceLock, time::Duration};
 use bevy::tasks::IoTaskPool;
 use bevy::{
     app::ScheduleRunnerPlugin,
-    diagnostic::{
-        DiagnosticsPlugin, FrameCountPlugin, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin,
-    },
+    diagnostic::{DiagnosticsPlugin, FrameCountPlugin},
     gizmos::GizmoPlugin,
     gltf::GltfPlugin,
     input::InputPlugin,
@@ -25,7 +23,7 @@ use bevy::{
     time::TimePlugin,
 };
 use bevy_dui::DuiPlugin;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches};
 use common::{
     inputs::InputMap,
     profile::SerializedProfile,
@@ -84,12 +82,7 @@ static SESSION_LOG: OnceLock<String> = OnceLock::new();
     mut_arg("position", |a| {
         a.visible_alias("location")
             .help("Parcel to load as `x,y`; absent = 0,0")
-    }),
-    mut_arg("editor", |a| a.hide(true)),
-    mut_arg("system_scene", |a| a.hide(true)),
-    mut_arg("portables", |a| a.hide(true)),
-    mut_arg("imposter_source", |a| a.hide(true)),
-    mut_arg("gpu_bytes_per_frame", |a| a.hide(true))
+    })
 )]
 struct Args {
     #[command(flatten)]
@@ -156,34 +149,37 @@ fn usage_error(message: impl std::fmt::Display) -> ! {
     std::process::exit(2);
 }
 
+/// Shared launch options (`LaunchOptions` fields) whose effect (src/launch.rs) has no consumer
+/// in the headless plugin set: hidden from --help and refused rather than silently inert.
+const INERT: [&str; 5] = [
+    "editor",
+    "system_scene",
+    "portables",
+    "imposter_source",
+    "gpu_bytes_per_frame",
+];
+
 fn parse_args() -> Args {
-    let mut args = match Args::try_parse() {
-        Ok(args) => args,
+    let mut command = Args::command();
+    for id in INERT {
+        command = command.mut_arg(id, |a| a.hide(true));
+    }
+    let matches = match command.try_get_matches() {
+        Ok(matches) => matches,
         Err(e) => {
             let _ = e.print();
             std::process::exit(if e.use_stderr() { 2 } else { 0 });
         }
     };
-    // shared params headless has no consumer for: refuse rather than silently do nothing
-    for (passed, flag) in [
-        (args.launch.editor, "--editor"),
-        (args.launch.system_scene.is_some(), "--system-scene"),
-        (args.launch.portables.is_some(), "--portables"),
-        (args.launch.imposter_source.is_some(), "--imposter-source"),
-        (
-            args.launch.gpu_bytes_per_frame.is_some(),
-            "--gpu-bytes-per-frame",
-        ),
-    ] {
-        if passed {
-            usage_error(format!("{flag} has no effect headless"));
+    for id in INERT {
+        if matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine) {
+            usage_error(format!("--{} has no effect headless", id.replace('_', "-")));
         }
     }
+    let mut args = Args::from_arg_matches(&matches).unwrap_or_else(|e| usage_error(e));
     // latch first: everything below that composes a backend host reads it
-    if let Some(domain) = &args.launch.base_domain {
-        if let Err(e) = common::base_domain::set(domain) {
-            usage_error(e);
-        }
+    if let Err(e) = webgpu_build::launch::latch(&args.launch) {
+        usage_error(e);
     }
     args.realm = args
         .launch
@@ -359,12 +355,11 @@ fn main() {
         args.realm, args.location, args.launch.preview, args.server_mode, args.tick_hz
     );
 
-    let config = AppConfig {
+    let mut config = AppConfig {
         home_realm: Some(args.realm.clone()),
         home_location: Some(args.location),
         graphics: GraphicsSettings {
             vsync: false,
-            log_fps: args.launch.log_fps.unwrap_or(false),
             fps_target: args.tick_hz as usize,
             ..Default::default()
         },
@@ -392,6 +387,7 @@ fn main() {
         .into(),
         ..Default::default()
     };
+    webgpu_build::launch::configure(&mut config, &args.launch);
 
     let mut app = App::new();
 
@@ -462,13 +458,14 @@ fn main() {
     // embedded assets: the scene-loading material (grid.png / loading.wgsl)
     app.add_plugins(assets::EmbedAssetsPlugin);
 
-    // --log-fps: the tick rate, against --tick-hz
-    if config.graphics.log_fps {
-        app.add_plugins((
-            FrameTimeDiagnosticsPlugin::default(),
-            LogDiagnosticsPlugin::default(),
-        ));
-    }
+    // the shared launch options' resources and plugins (--log-fps logs the tick rate, against
+    // --tick-hz)
+    webgpu_build::launch::apply(
+        &mut app,
+        &args.launch,
+        &config,
+        &map_realm_name(&args.realm),
+    );
 
     // world-storage delegations (per scene; CLI/env value is the single-scene fallback)
     let mut delegations = StorageDelegations::default();
@@ -526,11 +523,6 @@ fn main() {
             unload: 0.0,
             load_imposter: 0.0,
         })
-        .insert_resource(PreviewMode {
-            server: args.launch.preview.then(|| map_realm_name(&args.realm)),
-            is_preview: args.launch.preview,
-            preview_parcel: None,
-        })
         // servers must never join realm-wide comms (archipelago / world room) — they would
         // show up as a ghost participant. A non-server headless follows its realm about's
         // fixed_adapter like any client (offline about ⇒ no comms), so it can act as a
@@ -545,9 +537,6 @@ fn main() {
     // waiting for a scene to load and deriving the same string from its entity id
     if let Some(realm) = args.pulse_realm.clone() {
         app.insert_resource(comms::pulse::plugin::PulseRealmOverride(realm));
-    }
-    if let Some(endpoint) = args.launch.pulse_server.clone() {
-        app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(endpoint));
     }
 
     app.configure_sets(Startup, SetupSets::Init.before(SetupSets::Main));

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -157,7 +157,7 @@ fn parse_args() -> Args {
         }
     };
     // latch first: everything below that composes a backend host reads it
-    if let Err(e) = webgpu_build::launch::shared::latch(&args.launch) {
+    if let Err(e) = webgpu_build::launch::latch(&args.launch) {
         usage_error(e);
     }
     args.realm = args
@@ -334,11 +334,12 @@ fn main() {
         args.realm, args.location, args.launch.preview, args.server_mode, args.tick_hz
     );
 
-    let mut config = AppConfig {
+    let config = AppConfig {
         home_realm: Some(args.realm.clone()),
         home_location: Some(args.location),
         graphics: GraphicsSettings {
             vsync: false,
+            log_fps: false,
             fps_target: args.tick_hz as usize,
             ..Default::default()
         },
@@ -366,7 +367,6 @@ fn main() {
         .into(),
         ..Default::default()
     };
-    webgpu_build::launch::shared::configure(&mut config, &args.launch);
 
     let mut app = App::new();
 
@@ -439,7 +439,7 @@ fn main() {
 
     // the shared launch options' resources and plugins (--log-fps logs the tick rate, against
     // --tick-hz)
-    webgpu_build::launch::shared::apply(
+    webgpu_build::launch::apply(
         &mut app,
         &args.launch,
         &config,

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -23,7 +23,7 @@ use bevy::{
     time::TimePlugin,
 };
 use bevy_dui::DuiPlugin;
-use clap::{CommandFactory, FromArgMatches};
+use clap::Parser;
 use common::{
     inputs::InputMap,
     profile::SerializedProfile,
@@ -72,8 +72,7 @@ static SESSION_LOG: OnceLock<String> = OnceLock::new();
 
 // The shared launch params (realm, position, preview, base domain, pulse server, content
 // server, and whatever gets added later — accepted here automatically) plus the server-role
-// flags. The shared fields headless has no consumer for are hidden from `--help` and refused
-// in `parse_args`.
+// flags. The rendering clients' options (`ClientOptions`) are not flags here at all.
 #[derive(clap::Parser)]
 #[command(
     name = "headless",
@@ -82,7 +81,7 @@ static SESSION_LOG: OnceLock<String> = OnceLock::new();
     mut_arg("position", |a| {
         a.visible_alias("location")
             .help("Parcel to load as `x,y`; absent = 0,0")
-    })
+    }),
 )]
 struct Args {
     #[command(flatten)]
@@ -149,36 +148,16 @@ fn usage_error(message: impl std::fmt::Display) -> ! {
     std::process::exit(2);
 }
 
-/// Shared launch options (`LaunchOptions` fields) whose effect (src/launch.rs) has no consumer
-/// in the headless plugin set: hidden from --help and refused rather than silently inert.
-const INERT: [&str; 5] = [
-    "editor",
-    "system_scene",
-    "portables",
-    "imposter_source",
-    "gpu_bytes_per_frame",
-];
-
 fn parse_args() -> Args {
-    let mut command = Args::command();
-    for id in INERT {
-        command = command.mut_arg(id, |a| a.hide(true));
-    }
-    let matches = match command.try_get_matches() {
-        Ok(matches) => matches,
+    let mut args = match Args::try_parse() {
+        Ok(args) => args,
         Err(e) => {
             let _ = e.print();
             std::process::exit(if e.use_stderr() { 2 } else { 0 });
         }
     };
-    for id in INERT {
-        if matches.value_source(id) == Some(clap::parser::ValueSource::CommandLine) {
-            usage_error(format!("--{} has no effect headless", id.replace('_', "-")));
-        }
-    }
-    let mut args = Args::from_arg_matches(&matches).unwrap_or_else(|e| usage_error(e));
     // latch first: everything below that composes a backend host reads it
-    if let Err(e) = webgpu_build::launch::latch(&args.launch) {
+    if let Err(e) = webgpu_build::launch::shared::latch(&args.launch) {
         usage_error(e);
     }
     args.realm = args
@@ -387,7 +366,7 @@ fn main() {
         .into(),
         ..Default::default()
     };
-    webgpu_build::launch::configure(&mut config, &args.launch);
+    webgpu_build::launch::shared::configure(&mut config, &args.launch);
 
     let mut app = App::new();
 
@@ -460,7 +439,7 @@ fn main() {
 
     // the shared launch options' resources and plugins (--log-fps logs the tick rate, against
     // --tick-hz)
-    webgpu_build::launch::apply(
+    webgpu_build::launch::shared::apply(
         &mut app,
         &args.launch,
         &config,

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,0 +1,86 @@
+//! What each shared launch option DOES — once, for every binary. `LaunchOptions`
+//! (crates/system_api_types) declares the options; this is where they take effect, so a
+//! binary that flattens the struct (native, headless) or deserialises it (web) gets each
+//! option's behaviour by calling the three phases below rather than re-implementing them:
+//!
+//! 1. [`latch`] before anything else — process-wide globals that url composition reads
+//! 2. [`configure`] on the app config — option overrides of persisted settings
+//! 3. [`apply`] at app assembly — resources and plugins
+//!
+//! [`apply`] destructures the struct without `..`, so a new field fails to compile until it is
+//! given a meaning in one of the phases (or, for the destination and scene set, explicitly left
+//! to the binary).
+
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::*,
+};
+use common::structs::{AppConfig, EditorMode, PreviewMode};
+use system_api_types::launch_options::LaunchOptions;
+
+/// Process-wide globals: the base domain every backend host composes from (so this runs before
+/// `AppConfig::default()`, which composes the default realm) and the imposter store.
+pub fn latch(launch: &LaunchOptions) -> Result<(), String> {
+    if let Some(domain) = &launch.base_domain {
+        common::base_domain::set(domain)?;
+    }
+    if let Some(source) = &launch.imposter_source {
+        imposters::imposter_spec::set_source(source);
+    }
+    Ok(())
+}
+
+/// Option overrides of persisted settings.
+pub fn configure(config: &mut AppConfig, launch: &LaunchOptions) {
+    if let Some(log_fps) = launch.log_fps {
+        config.graphics.log_fps = log_fps;
+    }
+    if let Some(bytes) = launch.gpu_bytes_per_frame {
+        config.graphics.gpu_bytes_per_frame = bytes;
+    }
+}
+
+/// Resources and plugins. `boot_server` is the realm the binary decided to boot into (mapped
+/// through `map_realm_name`), `config` the app config after [`configure`].
+pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_server: &str) {
+    let LaunchOptions {
+        // the destination and the scene set are the binary's: boot server / location, the
+        // startup scenes, the IpfsIoPlugin's realm and content server
+        realm: _,
+        position: _,
+        system_scene: _,
+        portables: _,
+        content_server: _,
+        // latch
+        base_domain: _,
+        imposter_source: _,
+        // configure
+        log_fps: _,
+        gpu_bytes_per_frame: _,
+        preview,
+        editor,
+        pulse_server,
+    } = launch;
+
+    app.insert_resource(PreviewMode {
+        server: preview.then(|| boot_server.to_owned()),
+        is_preview: *preview,
+        preview_parcel: None,
+    })
+    .insert_resource(EditorMode(*editor));
+
+    if let Some(endpoint) = pulse_server {
+        app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(
+            endpoint.clone(),
+        ));
+    }
+
+    // frame timing feeds the fps log and the preview-mode sysinfo panel; the HUD adds it too
+    if (config.graphics.log_fps || *preview) && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>()
+    {
+        app.add_plugins(FrameTimeDiagnosticsPlugin::default());
+    }
+    if config.graphics.log_fps {
+        app.add_plugins(LogDiagnosticsPlugin::default());
+    }
+}

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,86 +1,137 @@
-//! What each shared launch option DOES — once, for every binary. `LaunchOptions`
-//! (crates/system_api_types) declares the options; this is where they take effect, so a
-//! binary that flattens the struct (native, headless) or deserialises it (web) gets each
-//! option's behaviour by calling the three phases below rather than re-implementing them:
+//! What each launch option DOES — once, for every binary. `LaunchOptions` / `ClientOptions`
+//! (crates/system_api_types) declare the options; this is where they take effect, so a binary
+//! that flattens a struct (native, headless) or deserialises it (web) gets each option's
+//! behaviour by calling the three phases below rather than re-implementing them:
 //!
-//! 1. [`latch`] before anything else — process-wide globals that url composition reads
-//! 2. [`configure`] on the app config — option overrides of persisted settings
-//! 3. [`apply`] at app assembly — resources and plugins
+//! 1. `latch` before anything else — process-wide globals that url composition reads
+//! 2. `configure` on the app config — option overrides of persisted settings
+//! 3. `apply` at app assembly — resources and plugins
 //!
-//! [`apply`] destructures the struct without `..`, so a new field fails to compile until it is
-//! given a meaning in one of the phases (or, for the destination and scene set, explicitly left
-//! to the binary).
+//! [`shared`] is `LaunchOptions` (every binary), [`client`] is `ClientOptions` (the rendering
+//! clients: native and web call the top-level functions, which do both; headless calls
+//! [`shared`] alone). Each `apply` destructures its struct without `..`, so a new field fails
+//! to compile until it is given a meaning in one of the phases (or, for the destination and
+//! scene set, explicitly left to the binary).
 
-use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
-    prelude::*,
-};
-use common::structs::{AppConfig, EditorMode, PreviewMode};
-use system_api_types::launch_options::LaunchOptions;
+use bevy::prelude::*;
+use common::structs::AppConfig;
+use system_api_types::launch_options::{ClientOptions, LaunchOptions};
 
-/// Process-wide globals: the base domain every backend host composes from (so this runs before
-/// `AppConfig::default()`, which composes the default realm) and the imposter store.
-pub fn latch(launch: &LaunchOptions) -> Result<(), String> {
-    if let Some(domain) = &launch.base_domain {
-        common::base_domain::set(domain)?;
-    }
-    if let Some(source) = &launch.imposter_source {
-        imposters::imposter_spec::set_source(source);
-    }
+pub fn latch(launch: &LaunchOptions, client: &ClientOptions) -> Result<(), String> {
+    shared::latch(launch)?;
+    client::latch(client);
     Ok(())
 }
 
-/// Option overrides of persisted settings.
-pub fn configure(config: &mut AppConfig, launch: &LaunchOptions) {
-    if let Some(log_fps) = launch.log_fps {
-        config.graphics.log_fps = log_fps;
+pub fn configure(config: &mut AppConfig, launch: &LaunchOptions, client: &ClientOptions) {
+    shared::configure(config, launch);
+    client::configure(config, client);
+}
+
+pub fn apply(
+    app: &mut App,
+    launch: &LaunchOptions,
+    client: &ClientOptions,
+    config: &AppConfig,
+    boot_server: &str,
+) {
+    shared::apply(app, launch, config, boot_server);
+    client::apply(app, client);
+}
+
+pub mod shared {
+    use bevy::{
+        diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+        prelude::*,
+    };
+    use common::structs::{AppConfig, PreviewMode};
+    use system_api_types::launch_options::LaunchOptions;
+
+    /// The base domain every backend host composes from — so this runs before
+    /// `AppConfig::default()`, which composes the default realm.
+    pub fn latch(launch: &LaunchOptions) -> Result<(), String> {
+        if let Some(domain) = &launch.base_domain {
+            common::base_domain::set(domain)?;
+        }
+        Ok(())
     }
-    if let Some(bytes) = launch.gpu_bytes_per_frame {
-        config.graphics.gpu_bytes_per_frame = bytes;
+
+    pub fn configure(config: &mut AppConfig, launch: &LaunchOptions) {
+        if let Some(log_fps) = launch.log_fps {
+            config.graphics.log_fps = log_fps;
+        }
+    }
+
+    /// `boot_server` is the realm the binary decided to boot into (mapped through
+    /// `map_realm_name`), `config` the app config after [`configure`].
+    pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_server: &str) {
+        let LaunchOptions {
+            // the destination is the binary's: boot server / location, the IpfsIoPlugin's realm
+            // and content server
+            realm: _,
+            position: _,
+            content_server: _,
+            // latch
+            base_domain: _,
+            // configure
+            log_fps: _,
+            preview,
+            pulse_server,
+        } = launch;
+
+        app.insert_resource(PreviewMode {
+            server: preview.then(|| boot_server.to_owned()),
+            is_preview: *preview,
+            preview_parcel: None,
+        });
+
+        if let Some(endpoint) = pulse_server {
+            app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(
+                endpoint.clone(),
+            ));
+        }
+
+        // frame timing feeds the fps log and the preview-mode sysinfo panel; the HUD adds it too
+        if (config.graphics.log_fps || *preview)
+            && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>()
+        {
+            app.add_plugins(FrameTimeDiagnosticsPlugin::default());
+        }
+        if config.graphics.log_fps {
+            app.add_plugins(LogDiagnosticsPlugin::default());
+        }
     }
 }
 
-/// Resources and plugins. `boot_server` is the realm the binary decided to boot into (mapped
-/// through `map_realm_name`), `config` the app config after [`configure`].
-pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_server: &str) {
-    let LaunchOptions {
-        // the destination and the scene set are the binary's: boot server / location, the
-        // startup scenes, the IpfsIoPlugin's realm and content server
-        realm: _,
-        position: _,
-        system_scene: _,
-        portables: _,
-        content_server: _,
-        // latch
-        base_domain: _,
-        imposter_source: _,
-        // configure
-        log_fps: _,
-        gpu_bytes_per_frame: _,
-        preview,
-        editor,
-        pulse_server,
-    } = launch;
+pub mod client {
+    use bevy::prelude::*;
+    use common::structs::{AppConfig, EditorMode};
+    use system_api_types::launch_options::ClientOptions;
 
-    app.insert_resource(PreviewMode {
-        server: preview.then(|| boot_server.to_owned()),
-        is_preview: *preview,
-        preview_parcel: None,
-    })
-    .insert_resource(EditorMode(*editor));
-
-    if let Some(endpoint) = pulse_server {
-        app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(
-            endpoint.clone(),
-        ));
+    pub fn latch(client: &ClientOptions) {
+        if let Some(source) = &client.imposter_source {
+            imposters::imposter_spec::set_source(source);
+        }
     }
 
-    // frame timing feeds the fps log and the preview-mode sysinfo panel; the HUD adds it too
-    if (config.graphics.log_fps || *preview) && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>()
-    {
-        app.add_plugins(FrameTimeDiagnosticsPlugin::default());
+    pub fn configure(config: &mut AppConfig, client: &ClientOptions) {
+        if let Some(bytes) = client.gpu_bytes_per_frame {
+            config.graphics.gpu_bytes_per_frame = bytes;
+        }
     }
-    if config.graphics.log_fps {
-        app.add_plugins(LogDiagnosticsPlugin::default());
+
+    pub fn apply(app: &mut App, client: &ClientOptions) {
+        let ClientOptions {
+            // the scene set is the binary's: the ui scene and the startup scenes
+            system_scene: _,
+            portables: _,
+            // latch
+            imposter_source: _,
+            // configure
+            gpu_bytes_per_frame: _,
+            editor,
+        } = client;
+
+        app.insert_resource(EditorMode(*editor));
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,137 +1,92 @@
 //! What each launch option DOES — once, for every binary. `LaunchOptions` / `ClientOptions`
 //! (crates/system_api_types) declare the options; this is where they take effect, so a binary
 //! that flattens a struct (native, headless) or deserialises it (web) gets each option's
-//! behaviour by calling the three phases below rather than re-implementing them:
+//! behaviour by calling the two phases below rather than re-implementing them:
 //!
-//! 1. `latch` before anything else — process-wide globals that url composition reads
-//! 2. `configure` on the app config — option overrides of persisted settings
-//! 3. `apply` at app assembly — resources and plugins
+//! 1. [`latch`] before anything else — process-wide globals that url composition reads
+//! 2. [`apply`] (every binary) and [`apply_client`] (the rendering clients: native and web) at
+//!    app assembly — resources and plugins
 //!
-//! [`shared`] is `LaunchOptions` (every binary), [`client`] is `ClientOptions` (the rendering
-//! clients: native and web call the top-level functions, which do both; headless calls
-//! [`shared`] alone). Each `apply` destructures its struct without `..`, so a new field fails
-//! to compile until it is given a meaning in one of the phases (or, for the destination and
-//! scene set, explicitly left to the binary).
+//! An option never writes into the app config, which is persisted: where one overrides a
+//! config setting, `apply` reads the option first and the config second. Each `apply`
+//! destructures its struct without `..`, so a new field fails to compile until it is given a
+//! meaning here (or, for the destination and scene set, explicitly left to the binary).
 
-use bevy::prelude::*;
-use common::structs::AppConfig;
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::*,
+    render::render_asset::RenderAssetBytesPerFrame,
+};
+use common::structs::{AppConfig, EditorMode, PreviewMode};
 use system_api_types::launch_options::{ClientOptions, LaunchOptions};
 
-pub fn latch(launch: &LaunchOptions, client: &ClientOptions) -> Result<(), String> {
-    shared::latch(launch)?;
-    client::latch(client);
+/// The base domain every backend host composes from — so this runs before
+/// `AppConfig::default()`, which composes the default realm.
+pub fn latch(launch: &LaunchOptions) -> Result<(), String> {
+    if let Some(domain) = &launch.base_domain {
+        common::base_domain::set(domain)?;
+    }
     Ok(())
 }
 
-pub fn configure(config: &mut AppConfig, launch: &LaunchOptions, client: &ClientOptions) {
-    shared::configure(config, launch);
-    client::configure(config, client);
-}
+/// `boot_server` is the realm the binary decided to boot into (mapped through
+/// `map_realm_name`), `config` the app config the options override.
+pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_server: &str) {
+    let LaunchOptions {
+        // the destination is the binary's: boot server / location, the IpfsIoPlugin's realm
+        // and content server
+        realm: _,
+        position: _,
+        content_server: _,
+        // latch
+        base_domain: _,
+        preview,
+        pulse_server,
+        log_fps,
+    } = launch;
 
-pub fn apply(
-    app: &mut App,
-    launch: &LaunchOptions,
-    client: &ClientOptions,
-    config: &AppConfig,
-    boot_server: &str,
-) {
-    shared::apply(app, launch, config, boot_server);
-    client::apply(app, client);
-}
+    app.insert_resource(PreviewMode {
+        server: preview.then(|| boot_server.to_owned()),
+        is_preview: *preview,
+        preview_parcel: None,
+    });
 
-pub mod shared {
-    use bevy::{
-        diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
-        prelude::*,
-    };
-    use common::structs::{AppConfig, PreviewMode};
-    use system_api_types::launch_options::LaunchOptions;
-
-    /// The base domain every backend host composes from — so this runs before
-    /// `AppConfig::default()`, which composes the default realm.
-    pub fn latch(launch: &LaunchOptions) -> Result<(), String> {
-        if let Some(domain) = &launch.base_domain {
-            common::base_domain::set(domain)?;
-        }
-        Ok(())
+    if let Some(endpoint) = pulse_server {
+        app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(
+            endpoint.clone(),
+        ));
     }
 
-    pub fn configure(config: &mut AppConfig, launch: &LaunchOptions) {
-        if let Some(log_fps) = launch.log_fps {
-            config.graphics.log_fps = log_fps;
-        }
+    let log_fps = log_fps.unwrap_or(config.graphics.log_fps);
+    // frame timing feeds the fps log and the preview-mode sysinfo panel; the HUD adds it too
+    if (log_fps || *preview) && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>() {
+        app.add_plugins(FrameTimeDiagnosticsPlugin::default());
     }
-
-    /// `boot_server` is the realm the binary decided to boot into (mapped through
-    /// `map_realm_name`), `config` the app config after [`configure`].
-    pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_server: &str) {
-        let LaunchOptions {
-            // the destination is the binary's: boot server / location, the IpfsIoPlugin's realm
-            // and content server
-            realm: _,
-            position: _,
-            content_server: _,
-            // latch
-            base_domain: _,
-            // configure
-            log_fps: _,
-            preview,
-            pulse_server,
-        } = launch;
-
-        app.insert_resource(PreviewMode {
-            server: preview.then(|| boot_server.to_owned()),
-            is_preview: *preview,
-            preview_parcel: None,
-        });
-
-        if let Some(endpoint) = pulse_server {
-            app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(
-                endpoint.clone(),
-            ));
-        }
-
-        // frame timing feeds the fps log and the preview-mode sysinfo panel; the HUD adds it too
-        if (config.graphics.log_fps || *preview)
-            && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>()
-        {
-            app.add_plugins(FrameTimeDiagnosticsPlugin::default());
-        }
-        if config.graphics.log_fps {
-            app.add_plugins(LogDiagnosticsPlugin::default());
-        }
+    if log_fps {
+        app.add_plugins(LogDiagnosticsPlugin::default());
     }
 }
 
-pub mod client {
-    use bevy::prelude::*;
-    use common::structs::{AppConfig, EditorMode};
-    use system_api_types::launch_options::ClientOptions;
+pub fn apply_client(app: &mut App, client: &ClientOptions, config: &AppConfig) {
+    let ClientOptions {
+        // the scene set is the binary's: the ui scene and the startup scenes
+        system_scene: _,
+        portables: _,
+        editor,
+        imposter_source,
+        gpu_bytes_per_frame,
+    } = client;
 
-    pub fn latch(client: &ClientOptions) {
-        if let Some(source) = &client.imposter_source {
-            imposters::imposter_spec::set_source(source);
-        }
+    app.insert_resource(EditorMode(*editor));
+
+    if let Some(source) = imposter_source {
+        imposters::imposter_spec::set_source(source);
     }
 
-    pub fn configure(config: &mut AppConfig, client: &ClientOptions) {
-        if let Some(bytes) = client.gpu_bytes_per_frame {
-            config.graphics.gpu_bytes_per_frame = bytes;
-        }
-    }
-
-    pub fn apply(app: &mut App, client: &ClientOptions) {
-        let ClientOptions {
-            // the scene set is the binary's: the ui scene and the startup scenes
-            system_scene: _,
-            portables: _,
-            // latch
-            imposter_source: _,
-            // configure
-            gpu_bytes_per_frame: _,
-            editor,
-        } = client;
-
-        app.insert_resource(EditorMode(*editor));
+    let gpu_bytes_per_frame = gpu_bytes_per_frame.unwrap_or(config.graphics.gpu_bytes_per_frame);
+    if gpu_bytes_per_frame > 0 {
+        app.insert_resource(RenderAssetBytesPerFrame::new_with_priorities(
+            gpu_bytes_per_frame,
+        ));
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -57,17 +57,22 @@ pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_ser
         ));
     }
 
-    let log_fps = log_fps.unwrap_or(config.graphics.log_fps);
-    // frame timing feeds the fps log and the preview-mode sysinfo panel; the HUD adds it too
-    if (log_fps || *preview) && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>() {
-        app.add_plugins(FrameTimeDiagnosticsPlugin::default());
-    }
-    if log_fps {
+    if log_fps.unwrap_or(config.graphics.log_fps) {
+        // the HUD adds the frame timing too
+        if !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>() {
+            app.add_plugins(FrameTimeDiagnosticsPlugin::default());
+        }
         app.add_plugins(LogDiagnosticsPlugin::default());
     }
 }
 
-pub fn apply_client(app: &mut App, client: &ClientOptions, config: &AppConfig) {
+/// `launch` for the shared options' client-only effects.
+pub fn apply_client(
+    app: &mut App,
+    launch: &LaunchOptions,
+    client: &ClientOptions,
+    config: &AppConfig,
+) {
     let ClientOptions {
         // the scene set is the binary's: the ui scene and the startup scenes
         system_scene: _,
@@ -78,6 +83,11 @@ pub fn apply_client(app: &mut App, client: &ClientOptions, config: &AppConfig) {
     } = client;
 
     app.insert_resource(EditorMode(*editor));
+
+    // the preview stats and sysinfo panels (system_ui) read the frame rate
+    if launch.preview && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>() {
+        app.add_plugins(FrameTimeDiagnosticsPlugin::default());
+    }
 
     if let Some(source) = imposter_source {
         imposters::imposter_spec::set_source(source);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,6 +524,7 @@ impl DecentralandApp {
         );
         launch::apply_client(
             &mut app,
+            &decentraland_app_config.arguments.launch,
             &decentraland_app_config.arguments.client,
             &decentraland_app_config.app_config,
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,10 @@ use scene_runner::{
     OutOfWorld, SceneRunnerPlugin,
 };
 use social::SocialPlugin;
-use system_api_types::{launch_options::LaunchOptions, web_params::DEFAULT_PORTABLES};
+use system_api_types::{
+    launch_options::{ClientOptions, LaunchOptions},
+    web_params::DEFAULT_PORTABLES,
+};
 use system_bridge::{settings::NewCameraEvent, NativeUi, SystemBridgePlugin};
 #[cfg(not(target_arch = "wasm32"))]
 use system_ui::crash_report::CrashReportPlugin;
@@ -157,14 +160,16 @@ impl DecentralandAppConfig {
 pub struct BootLocation(pub IVec2);
 
 /// The native command line. The launch parameters shared with the web build are
-/// [`LaunchOptions`] (declared once, in system_api_types — its doc comments are the `--help`
-/// text and the web param table); everything here is native-only. Values that are derived
+/// [`LaunchOptions`] + [`ClientOptions`] (declared once, in system_api_types — their doc
+/// comments are the `--help` text and the web param table); everything here is native-only. Values that are derived
 /// rather than given (test mode, the ui scene, the spawn parcel) are methods.
 #[derive(clap::Parser, Default)]
 #[command(name = "decentra-bevy", about = "Decentraland Bevy Explorer")]
 pub struct DecentralandArguments {
     #[command(flatten)]
     pub launch: LaunchOptions,
+    #[command(flatten)]
+    pub client: ClientOptions,
     /// Echo scene logs to the console
     #[arg(long = "scene_log_to_console", display_order = 6)]
     pub scene_log_to_console: bool,
@@ -272,7 +277,7 @@ impl DecentralandArguments {
 
     /// The super-user ui scene: `--system-scene` / `?systemScene=`, less the `none` opt-out.
     pub fn ui_scene(&self) -> Option<&str> {
-        self.launch
+        self.client
             .system_scene
             .as_deref()
             .filter(|scene| *scene != "none")
@@ -289,7 +294,7 @@ impl DecentralandArguments {
 
     /// `--portables` / `?portables=`, else the default set.
     pub fn startup_scenes(&self) -> Vec<StartupScene> {
-        self.launch
+        self.client
             .portables
             .as_deref()
             .unwrap_or(DEFAULT_PORTABLES)
@@ -368,7 +373,7 @@ impl DecentralandApp {
         let boot_location = BootLocation(decentraland_app_config.boot_location());
         // Show out-of-bounds geometry in preview, on a loopback realm (local dev) and in
         // the editor, never on a public realm.
-        let show_out_of_bounds = decentraland_app_config.arguments.launch.editor
+        let show_out_of_bounds = decentraland_app_config.arguments.client.editor
             || decentraland_app_config.arguments.launch.preview
             || is_loopback_realm(&boot_server);
 
@@ -514,6 +519,7 @@ impl DecentralandApp {
         launch::apply(
             &mut app,
             &decentraland_app_config.arguments.launch,
+            &decentraland_app_config.arguments.client,
             &decentraland_app_config.app_config,
             &boot_server,
         );
@@ -668,7 +674,7 @@ fn update_app_config_from_arguments(
         .graphics
         .fps_target
         .replace_if_some(arguments.fps_target);
-    launch::configure(base_app_config, &arguments.launch);
+    launch::configure(base_app_config, &arguments.launch, &arguments.client);
 
     base_app_config
         .scene_threads

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ use bevy::{
 };
 use bevy::{
     app::{PluginGroupBuilder, Propagate},
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     log::LogPlugin,
     prelude::*,
     render::view::RenderLayers,
@@ -40,9 +39,9 @@ use common::{
     inputs::InputMap,
     sets::SetupSets,
     structs::{
-        AppConfig, AvatarDynamicState, EditorMode, HeadSync, IVec2Arg, PointAtSync, PreviewMode,
-        PrimaryCamera, PrimaryCameraRes, PrimaryPlayerRes, SceneImposterBake, SceneLoadDistance,
-        ShowOutOfBounds, StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
+        AppConfig, AvatarDynamicState, HeadSync, IVec2Arg, PointAtSync, PrimaryCamera,
+        PrimaryCameraRes, PrimaryPlayerRes, SceneImposterBake, SceneLoadDistance, ShowOutOfBounds,
+        StartupScene, StartupScenes, Version, GROUND_RENDERLAYER,
     },
     util::UtilsPlugin,
 };
@@ -97,6 +96,8 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DISTRIBUTION: &str = "desktop";
 #[cfg(target_arch = "wasm32")]
 pub const DISTRIBUTION: &str = "web";
+
+pub mod launch;
 
 pub struct DecentralandApp(App);
 
@@ -366,9 +367,8 @@ impl DecentralandApp {
         let boot_server = map_realm_name(&decentraland_app_config.boot_server());
         let boot_location = BootLocation(decentraland_app_config.boot_location());
         // Show out-of-bounds geometry in preview, on a loopback realm (local dev) and in
-        // the editor, never on a public realm. Computed before boot_server moves.
-        let editor_mode = decentraland_app_config.arguments.launch.editor;
-        let show_out_of_bounds = editor_mode
+        // the editor, never on a public realm.
+        let show_out_of_bounds = decentraland_app_config.arguments.launch.editor
             || decentraland_app_config.arguments.launch.preview
             || is_loopback_realm(&boot_server);
 
@@ -402,16 +402,6 @@ impl DecentralandApp {
                     .into_iter()
                     .collect(),
             })
-            .insert_resource(PreviewMode {
-                server: decentraland_app_config
-                    .arguments
-                    .launch
-                    .preview
-                    .then_some(boot_server),
-                is_preview: decentraland_app_config.arguments.launch.preview,
-                preview_parcel: None,
-            })
-            .insert_resource(EditorMode(editor_mode))
             .insert_resource(ShowOutOfBounds(show_out_of_bounds))
             .insert_resource(SceneLoadDistance {
                 load: if decentraland_app_config.arguments.launch.preview {
@@ -520,21 +510,15 @@ impl DecentralandApp {
             });
         }
 
-        if let Some(endpoint) = decentraland_app_config
-            .arguments
-            .launch
-            .pulse_server
-            .clone()
-        {
-            app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(endpoint));
-        }
-        if let Some(source) = &decentraland_app_config.arguments.launch.imposter_source {
-            imposters::imposter_spec::set_source(source);
-        }
+        // the shared launch options' resources and plugins (src/launch.rs)
+        launch::apply(
+            &mut app,
+            &decentraland_app_config.arguments.launch,
+            &decentraland_app_config.app_config,
+            &boot_server,
+        );
 
-        // Create copies of structs that still need to be accessed
-        // and add AppConfig as a resource
-        let graphics_config = decentraland_app_config.app_config.graphics.clone();
+        // add AppConfig as a resource
         app.insert_resource(decentraland_app_config.app_config.audio.clone());
         app.insert_resource(boot_location);
         app.insert_resource(decentraland_app_config.app_config);
@@ -594,14 +578,6 @@ impl DecentralandApp {
 
         // Analytics plugins
         app.add_plugins(MetricsPlugin);
-        if (graphics_config.log_fps || decentraland_app_config.arguments.launch.preview)
-            && !app.is_plugin_added::<FrameTimeDiagnosticsPlugin>()
-        {
-            app.add_plugins(FrameTimeDiagnosticsPlugin::default());
-        }
-        if graphics_config.log_fps {
-            app.add_plugins(LogDiagnosticsPlugin::default());
-        }
 
         if decentraland_app_config.arguments.test_scenes.is_some() {
             app.add_plugins(AutomaticTestingPlugin);
@@ -690,16 +666,9 @@ fn update_app_config_from_arguments(
         .replace_if_some(arguments.vsync);
     base_app_config
         .graphics
-        .log_fps
-        .replace_if_some(arguments.launch.log_fps);
-    base_app_config
-        .graphics
         .fps_target
         .replace_if_some(arguments.fps_target);
-    base_app_config
-        .graphics
-        .gpu_bytes_per_frame
-        .replace_if_some(arguments.launch.gpu_bytes_per_frame);
+    launch::configure(base_app_config, &arguments.launch);
 
     base_app_config
         .scene_threads

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,9 +519,13 @@ impl DecentralandApp {
         launch::apply(
             &mut app,
             &decentraland_app_config.arguments.launch,
-            &decentraland_app_config.arguments.client,
             &decentraland_app_config.app_config,
             &boot_server,
+        );
+        launch::apply_client(
+            &mut app,
+            &decentraland_app_config.arguments.client,
+            &decentraland_app_config.app_config,
         );
 
         // add AppConfig as a resource
@@ -674,7 +678,6 @@ fn update_app_config_from_arguments(
         .graphics
         .fps_target
         .replace_if_some(arguments.fps_target);
-    launch::configure(base_app_config, &arguments.launch, &arguments.client);
 
     base_app_config
         .scene_threads

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,12 +112,10 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
         }
     };
 
-    if let Some(domain) = &args.launch.base_domain {
-        common::base_domain::set(domain).map_err(|e| {
-            error!("{e}");
-            UserError(true)
-        })?;
-    }
+    webgpu_build::launch::latch(&args.launch).map_err(|e| {
+        error!("{e}");
+        UserError(true)
+    })?;
     if let Some(position) = &args.launch.position {
         IVec2Arg::from_str(position).map_err(|e| {
             error!("--position {position}: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
         }
     };
 
-    webgpu_build::launch::latch(&args.launch, &args.client).map_err(|e| {
+    webgpu_build::launch::latch(&args.launch).map_err(|e| {
         error!("{e}");
         UserError(true)
     })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
         }
     };
 
-    webgpu_build::launch::latch(&args.launch).map_err(|e| {
+    webgpu_build::launch::latch(&args.launch, &args.client).map_err(|e| {
         error!("{e}");
         UserError(true)
     })?;
@@ -125,9 +125,9 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
 
     // An explicit --system-scene (a scene source, or "none" for the engine's builtin ui) opts out of the
     // react HUD entirely — the given ui scene drives instead (see lib.rs).
-    args.hud = args.launch.system_scene.is_none();
-    if args.launch.system_scene.is_none() {
-        args.launch.system_scene = default_ui_scene();
+    args.hud = args.client.system_scene.is_none();
+    if args.client.system_scene.is_none() {
+        args.client.system_scene = default_ui_scene();
     }
     Ok(args)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -184,6 +184,11 @@ pub fn engine_run(options: EngineRunOptionsJs) -> Result<(), JsValue> {
     let options = parse_options(&options)?;
     let _ = LAUNCH_OPTIONS.set(options.clone());
     apply_base_domain();
+    // the shared launch options' globals (src/launch.rs; the base domain itself came from the
+    // page above, so this can't fail on it)
+    if let Err(e) = crate::launch::latch(&options) {
+        warn!("{e}");
+    }
     init_runtime();
 
     let default_filter = "symphonia=warn";

--- a/src/web.rs
+++ b/src/web.rs
@@ -141,9 +141,6 @@ pub fn engine_home_scene() -> String {
         .to_string()
 }
 
-/// Bytes of gpu uploads per frame on web — was a constant the page passed in; the engine owns it.
-const WEB_GPU_BYTES_PER_FRAME: usize = 10_000_000;
-
 // Type the `engine_run` parameter in the generated .d.ts — keep in step with
 // `system_api_types::launch_options::EngineRunOptions` (the web param table's source).
 #[wasm_bindgen(typescript_custom_section)]
@@ -186,7 +183,7 @@ pub fn engine_run(options: EngineRunOptionsJs) -> Result<(), JsValue> {
     apply_base_domain();
     // the shared launch options' globals (src/launch.rs; the base domain itself came from the
     // page above, so this can't fail on it)
-    if let Err(e) = crate::launch::latch(&options.launch, &options.client) {
+    if let Err(e) = crate::launch::latch(&options.launch) {
         warn!("{e}");
     }
     init_runtime();
@@ -418,25 +415,11 @@ fn update_url_params(
 }
 
 fn decentraland_serialized_app_config() -> AppConfig {
-    INIT_DATA.get().cloned().unwrap_or_else(|| AppConfig {
-        graphics: common::structs::GraphicsSettings {
-            shadow_distance: 20.0,
-            shadow_settings: common::structs::ShadowSetting::Low,
-            ..Default::default()
-        },
-        ..Default::default()
-    })
+    INIT_DATA.get().cloned().unwrap_or_default()
 }
 
 fn decentraland_app_arguments(options: &EngineRunOptions) -> DecentralandArguments {
-    let EngineRunOptions {
-        mut launch,
-        mut client,
-    } = options.clone();
-    client
-        .gpu_bytes_per_frame
-        .get_or_insert(WEB_GPU_BYTES_PER_FRAME);
-    launch.log_fps.get_or_insert(false);
+    let EngineRunOptions { launch, client } = options.clone();
     DecentralandArguments {
         launch,
         client,

--- a/src/web.rs
+++ b/src/web.rs
@@ -20,7 +20,7 @@ use system_bridge::{SystemApi, SystemBridge};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::js_sys;
 
-use system_api_types::launch_options::LaunchOptions;
+use system_api_types::launch_options::{ClientOptions, EngineRunOptions, LaunchOptions};
 
 use crate::{DecentralandApp, DecentralandAppConfig, DecentralandArguments};
 
@@ -30,7 +30,7 @@ static CONSOLE_BRIDGE_SENDER: OnceCell<tokio::sync::mpsc::UnboundedSender<System
     OnceCell::new();
 /// The options the page launched with; the url sync echoes them back with the live values
 /// (realm, position, …) swapped in.
-static LAUNCH_OPTIONS: OnceCell<LaunchOptions> = OnceCell::new();
+static LAUNCH_OPTIONS: OnceCell<EngineRunOptions> = OnceCell::new();
 
 #[wasm_bindgen]
 extern "C" {
@@ -145,7 +145,7 @@ pub fn engine_home_scene() -> String {
 const WEB_GPU_BYTES_PER_FRAME: usize = 10_000_000;
 
 // Type the `engine_run` parameter in the generated .d.ts — keep in step with
-// `system_api_types::launch_options::LaunchOptions` (the web param table's source).
+// `system_api_types::launch_options::EngineRunOptions` (the web param table's source).
 #[wasm_bindgen(typescript_custom_section)]
 const ENGINE_RUN_OPTIONS_TS: &str = r#"
 export interface EngineRunOptions {
@@ -171,10 +171,10 @@ extern "C" {
 
 /// Round-trip the page's object through JSON rather than `serde_wasm_bindgen::from_value`: that
 /// only visits the struct's own fields, so `deny_unknown_fields` would never see a misspelt key.
-fn parse_options(options: &JsValue) -> Result<LaunchOptions, JsValue> {
+fn parse_options(options: &JsValue) -> Result<EngineRunOptions, JsValue> {
     let json = String::from(js_sys::JSON::stringify(options)?);
-    LaunchOptions::from_json(&json)
-        .map(LaunchOptions::without_empty_strings)
+    EngineRunOptions::from_json(&json)
+        .map(EngineRunOptions::without_empty_strings)
         .map_err(|e| JsValue::from_str(&format!("engine_run: invalid options: {e}")))
 }
 
@@ -186,7 +186,7 @@ pub fn engine_run(options: EngineRunOptionsJs) -> Result<(), JsValue> {
     apply_base_domain();
     // the shared launch options' globals (src/launch.rs; the base domain itself came from the
     // page above, so this can't fail on it)
-    if let Err(e) = crate::launch::latch(&options) {
+    if let Err(e) = crate::launch::latch(&options.launch, &options.client) {
         warn!("{e}");
     }
     init_runtime();
@@ -354,7 +354,7 @@ fn update_url_params(
     startup_scenes: Option<Res<StartupScenes>>,
     preview: Res<PreviewMode>,
     editor: Res<EditorMode>,
-    mut prev: Local<Option<LaunchOptions>>,
+    mut prev: Local<Option<EngineRunOptions>>,
 ) {
     // realms with fixed scene urns (worlds) spawn at their base scene and ignore an explicit
     // position (see load_active_entities' base-position handling) - don't write one into the url
@@ -393,15 +393,21 @@ fn update_url_params(
         (None, None)
     };
 
-    let options = LaunchOptions {
-        realm: Some(server.to_owned()),
-        position,
-        system_scene,
-        // the default set is omitted so the canonical url stays clean (the page doesn't know it)
-        portables: portables.filter(|p| p != system_api_types::web_params::DEFAULT_PORTABLES),
-        preview: preview.is_preview,
-        editor: editor.0,
-        ..LAUNCH_OPTIONS.get().cloned().unwrap_or_default()
+    let launched = LAUNCH_OPTIONS.get().cloned().unwrap_or_default();
+    let options = EngineRunOptions {
+        launch: LaunchOptions {
+            realm: Some(server.to_owned()),
+            position,
+            preview: preview.is_preview,
+            ..launched.launch
+        },
+        client: ClientOptions {
+            system_scene,
+            // the default set is omitted so the canonical url stays clean (the page doesn't know it)
+            portables: portables.filter(|p| p != system_api_types::web_params::DEFAULT_PORTABLES),
+            editor: editor.0,
+            ..launched.client
+        },
     };
 
     if prev.as_ref() != Some(&options) {
@@ -422,14 +428,18 @@ fn decentraland_serialized_app_config() -> AppConfig {
     })
 }
 
-fn decentraland_app_arguments(options: &LaunchOptions) -> DecentralandArguments {
-    let mut launch = options.clone();
-    launch
+fn decentraland_app_arguments(options: &EngineRunOptions) -> DecentralandArguments {
+    let EngineRunOptions {
+        mut launch,
+        mut client,
+    } = options.clone();
+    client
         .gpu_bytes_per_frame
         .get_or_insert(WEB_GPU_BYTES_PER_FRAME);
     launch.log_fps.get_or_insert(false);
     DecentralandArguments {
         launch,
+        client,
         // wasm has no engine-managed HUD: the react page hosting the engine is the HUD
         hud: false,
         ..Default::default()


### PR DESCRIPTION
Follow-on to #1218, which declared the launch parameters once in `system_api_types`. This PR makes every binary take them from that declaration, and gives each option one place where it takes effect.

## The options, by who takes them

`LaunchOptions` (realm, position, preview, base-domain, content-server, pulse-server, log-fps) is flattened into all three binaries: native `DecentralandArguments`, web `engine_run`, and headless. `ClientOptions` (editor, imposter-source, system-scene, portables, gpu-bytes-per-frame) is a second struct that only the rendering clients (native, web) flatten in; headless never sees those fields, so they are plain unknown flags there (exit 2), with no hide list, refuse list or `cfg` to maintain. On web the two are one flat `engine_run` object (`EngineRunOptions`, serde `flatten`), which is also what the engine echoes back for the url sync. Serde's `flatten` and `deny_unknown_fields` are exclusive, so `engine_run` checks the keys against the web param table by hand and rejects the launch on a misspelt one.

## Where an option takes effect: `src/launch.rs`

Three functions in the root crate, called by every binary instead of each re-implementing the behaviour:

- `latch(&LaunchOptions)` before anything else: the process-wide globals url composition reads (the base domain), so it runs before config.json is parsed.
- `apply(app, &LaunchOptions, config, boot_server)` at app assembly: the `PreviewMode` resource, the pulse override, the fps log diagnostics.
- `apply_client(app, &LaunchOptions, &ClientOptions, config)`: `EditorMode`, the imposter source, the gpu upload cap (moved here from the visuals plugin), and the frame timing the preview panels read (system_ui is client-only, so preview on headless adds no diagnostics).

Each `apply` destructures its struct without `..`, so adding a field to either struct fails to compile until it is given a meaning there, or explicitly left to the binary (the destination and the scene set). That answers the review point that headless would silently drop future options: a shared option gets its effect in headless via `apply`, a client option never becomes a headless flag.

Options never write into the (persisted) `AppConfig` any more: `--log-fps` and `--gpu-bytes-per-frame` read the option first and the config second at apply time. Web's platform defaults (no fps log, 10 MB gpu cap) live in `GraphicsSettings::default` under `cfg!(wasm32)` instead of in web.rs; the first-run shadow override in web.rs was identical to the global default since #947 and is gone.

## Headless

The headless binary parsed its own flags with pico-args, duplicating realm, position, preview, base-domain and pulse-server and ignoring anything it did not know. It now derives a clap parser from `LaunchOptions` plus its own server-role flags.

- `--location` stays as a visible alias of the shared `--position`; `--scene-threads` and `--tick-hz` keep their names, so the launcher (`deploy/headless/launcher`), docs and workflows are unchanged.
- `--content-server` and `--log-fps` are now honoured: the content server override, and the diagnostics plugins logging the tick rate against `--tick-hz`.
- Unknown flags, malformed values, and zero for `--tick-hz`/`--scene-threads` are errors instead of silently falling back to defaults; `-h`/`--help` prints usage. Args are parsed before the scene runtime spawns, as on native.
- The realm/position help is overridden on headless to state its own defaults (`http://localhost:8000` and `0,0`); `--pulse-realm` says it is optional in server mode.

`--help` now:

```
Headless scene runner: an authoritative scene server, or a render-free test client

Usage: headless [OPTIONS]

Options:
      --realm <url>                  Realm to boot into; absent = http://localhost:8000
      --position <x,y>               Parcel to load as `x,y`; absent = 0,0 [alias: --location]
      --preview                      Scene preview mode: hot-reloading, no failed-asset backoff, plain-http fetches allowed, realm fixed
      --base-domain <domain>         The deployment domain every backend host is composed from — sign-in, content, comms, everything; absent = decentraland.org. on web: derived from the hosting origin
      --content-server <url>         Override the content server only
      --pulse-server <host:port>     Pulse server as `host:port`; absent = the deployment's default
      --log-fps <true|false>         Log the frame rate to the console [possible values: true, false]
      --server-mode                  Serve the scene: `isServer()` is true to scene code and realm-wide comms are never joined. Standalone (without --orchestrated) is a local-dev flow and requires --preview
      --orchestrated                 Multi-scene worker driven over stdin by an orchestrator; implies --server-mode
      --timeout <secs>               Exit cleanly after this many seconds
      --scene-threads <n>            Scene javascript threads; absent = 16 orchestrated, 4 otherwise
      --tick-hz <hz>                 Scene tick rate [default: 30]
      --storage-delegation <base64>  base64 world-storage delegation (hammurabi envelope), or the PROCESS_STORAGE_DELEGATION env var; single-scene runs only — orchestrated scenes receive theirs via the control channel
      --wallet-seed <seed>           Deterministic guest wallet (test harness): the address is derivable offline from the seed
      --pulse-realm <key>            Pulse realm to announce verbatim; `--server-mode` only, and optional there: absent, the engine derives the same key from a locally hosted scene's entity id once it loads, this just announces it sooner. Orchestrated servers host several realms at once and take one per scene on `add-scene` instead
  -h, --help                         Print help
```

Behaviour change: a harness passing a flag the binary previously ignored now exits 2. The launcher only forwards known flags and validates position itself; ci.yml and publish-headless.yml pass only known flags.

Supersedes #1030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
