### PR TITLE
launch: accept a negative parcel in --position

### DIFF
--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -19,7 +19,12 @@ pub struct LaunchOptions {
     pub realm: Option<String>,
 
     /// Spawn parcel as `x,y`; absent = the home parcel, or the realm's spawn point
-    #[arg(long, value_name = "x,y", display_order = 2)]
+    #[arg(
+        long,
+        value_name = "x,y",
+        allow_hyphen_values = true,
+        display_order = 2
+    )]
     pub position: Option<String>,
 
     /// Scene preview mode: hot-reloading, no failed-asset backoff, plain-http fetches allowed,
@@ -138,6 +143,13 @@ mod tests {
         // the pre-table spellings are gone, not aliased
         assert!(Cli::try_parse_from(["x", "--server", "r"]).is_err());
         assert!(Cli::try_parse_from(["x", "--ui", "none"]).is_err());
+    }
+
+    #[test]
+    fn position_takes_a_negative_x() {
+        // most of Genesis City is negative, and the value arrives as its own argv entry
+        let cli = Cli::try_parse_from(["x", "--position", "-125,-96"]).unwrap();
+        assert_eq!(cli.launch.position.as_deref(), Some("-125,-96"));
     }
 
     #[test]


### PR DESCRIPTION
`--position -125,-96` fails with `error: unexpected argument '-1' found` — clap reads a value starting with `-` as a flag unless the arg opts out. Most of Genesis City has a negative x. `--position=-125,-96` happens to work, which is what hides it.

Native-only today. Once #1219 lands, headless inherits the fix with no edit there: it flattens the same `LaunchOptions` and only `mut_arg`s the help text and the `--location` alias. The npm launcher forwards `--position` as a separate `['--location', value]` pair, so `bevy-headless-server --position=-125,-96` hits exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)