### PR TITLE
Service endpoint overrides: one url flag per backend service, on every binary and the HUD

### DIFF
--- a/crates/collectibles/src/base_wearables.rs
+++ b/crates/collectibles/src/base_wearables.rs
@@ -308,10 +308,10 @@ pub fn default_bodyshape_instance() -> WearableInstance {
 }
 
 pub fn content_url() -> String {
-    common::base_domain::https("peer", "/content/contents/")
+    common::base_domain::url(common::base_domain::Service::Catalyst, "/content/contents/")
 }
 pub fn base_url() -> String {
-    common::base_domain::https("peer", "/content")
+    common::base_domain::url(common::base_domain::Service::Catalyst, "/content")
 }
 
 pub fn default_wearables(body_shape: &WearableUrn) -> impl Iterator<Item = WearableInstance> {

--- a/crates/collectibles/src/wearables.rs
+++ b/crates/collectibles/src/wearables.rs
@@ -97,7 +97,10 @@ fn load_collections(
             let t: Task<Result<Collections, anyhow::Error>> =
                 IoTaskPool::get().spawn_compat(async move {
                     let response = client
-                        .get(common::base_domain::https("peer", "/lambdas/collections"))
+                        .get(common::base_domain::url(
+                            common::base_domain::Service::Catalyst,
+                            "/lambdas/collections",
+                        ))
                         .timeout(std::time::Duration::from_secs(10))
                         .send()
                         .await

--- a/crates/common/src/base_domain.rs
+++ b/crates/common/src/base_domain.rs
@@ -1,5 +1,5 @@
-//! The base domain every backend host is composed from; set once via --base-domain
-//! (native) or the ?baseDomain= entry param (web, via boot.js + src/web.rs). On top of it the
+//! The base domain every backend host is composed from; set once from the shared launch options
+//! (`--base-domain` / `?baseDomain=`, by src/launch.rs `latch` on every binary). On top of it the
 //! per-[`Service`] resolver: an explicit override (`--<service> <url>` / `?<service>=`, latched
 //! once with [`set_services`]) wins, else the service composes from the domain by convention.
 //! Service urls should go through [`service`] / [`url`]; the raw [`https`] / [`wss`] / [`host`]
@@ -87,12 +87,13 @@ pub fn set_services<'a>(
         }
         map.insert(service, parsed.as_str().trim_end_matches('/').to_owned());
     }
-    // nothing given latches nothing: a binary with no overrides (or the wasm's `launch::latch`,
-    // whose overrides came through the page instead) must not clobber an earlier latch
+    // nothing given latches nothing: `latch` runs unconditionally, and no overrides means the
+    // lock stays empty (every `service_override` None) rather than holding an empty map
     if map.is_empty() {
         return Ok(());
     }
-    // re-latching the same set is fine (the wasm applies it at both entry points, like `set`)
+    // re-latching the same set is fine, like `set` (the lock is process-wide: a crate's tests
+    // share it)
     if SERVICES.set(map.clone()).is_err() && SERVICES.get() != Some(&map) {
         return Err("service overrides already latched with different values".to_owned());
     }

--- a/crates/common/src/base_domain.rs
+++ b/crates/common/src/base_domain.rs
@@ -1,11 +1,18 @@
 //! The base domain every backend host is composed from; set once via --base-domain
-//! (native) or the ?baseDomain= entry param (web, via boot.js + src/web.rs).
+//! (native) or the ?baseDomain= entry param (web, via boot.js + src/web.rs). On top of it the
+//! per-[`Service`] resolver: an explicit override (`--<service> <url>` / `?<service>=`, latched
+//! once with [`set_services`]) wins, else the service composes from the domain by convention.
+//! Service urls should go through [`service`] / [`url`]; the raw [`https`] / [`wss`] / [`host`]
+//! composition stays for the odd host that is not a service (pulse's `host:port`).
 
-use std::sync::OnceLock;
+use std::{collections::HashMap, sync::OnceLock};
+
+pub use system_api_types::services::Service;
 
 pub const DEFAULT: &str = "decentraland.org";
 
 static BASE_DOMAIN: OnceLock<String> = OnceLock::new();
+static SERVICES: OnceLock<HashMap<Service, String>> = OnceLock::new();
 
 pub fn set(domain: &str) -> Result<(), String> {
     let d = domain.trim().to_ascii_lowercase();
@@ -47,6 +54,74 @@ pub fn host(sub: &str) -> String {
     format!("{sub}.{}", get())
 }
 
+/// Latch the per-service overrides, once, before anything composes a service url. Each value
+/// is a full base url: its scheme must fit the service (http(s) or ws(s)), and a trailing slash
+/// is dropped so paths can always be appended.
+pub fn set_services<'a>(
+    overrides: impl IntoIterator<Item = (Service, &'a str)>,
+) -> Result<(), String> {
+    let mut map = HashMap::new();
+    for (service, url) in overrides {
+        let flag = service.flag();
+        let parsed =
+            url::Url::parse(url.trim()).map_err(|e| format!("{flag} {url}: not a url ({e})"))?;
+        let scheme_ok = if service.is_websocket() {
+            matches!(parsed.scheme(), "ws" | "wss")
+        } else {
+            matches!(parsed.scheme(), "http" | "https")
+        };
+        if !scheme_ok || parsed.host_str().is_none() {
+            return Err(format!(
+                "{flag} {url}: must be a full {} base url",
+                if service.is_websocket() {
+                    "ws(s)"
+                } else {
+                    "http(s)"
+                }
+            ));
+        }
+        if parsed.query().is_some() || parsed.fragment().is_some() {
+            return Err(format!(
+                "{flag} {url}: a base url takes no query or fragment"
+            ));
+        }
+        map.insert(service, parsed.as_str().trim_end_matches('/').to_owned());
+    }
+    // nothing given latches nothing: a binary with no overrides (or the wasm's `launch::latch`,
+    // whose overrides came through the page instead) must not clobber an earlier latch
+    if map.is_empty() {
+        return Ok(());
+    }
+    // re-latching the same set is fine (the wasm applies it at both entry points, like `set`)
+    if SERVICES.set(map.clone()).is_err() && SERVICES.get() != Some(&map) {
+        return Err("service overrides already latched with different values".to_owned());
+    }
+    Ok(())
+}
+
+/// The explicit override for a service, if one was given.
+pub fn service_override(service: Service) -> Option<&'static str> {
+    SERVICES.get()?.get(&service).map(String::as_str)
+}
+
+/// The service's base url: its override, else its composition from the base domain.
+pub fn service(service: Service) -> String {
+    if let Some(url) = service_override(service) {
+        return url.to_owned();
+    }
+    let (scheme, sub, path) = service.composition();
+    if sub.is_empty() {
+        format!("{scheme}://{}{path}", get())
+    } else {
+        format!("{scheme}://{}{path}", host(sub))
+    }
+}
+
+/// A url under a service: its base url with `path` (leading `/`) appended.
+pub fn url(service: Service, path: &str) -> String {
+    format!("{}{path}", self::service(service))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,6 +139,35 @@ mod tests {
             "wss://rpc-social-service-ea.decentraland.org"
         );
         assert_eq!(host("pulse-server"), "pulse-server.decentraland.org");
+        assert_eq!(
+            url(Service::RealmProvider, "/main"),
+            "https://realm-provider-ea.decentraland.org/main"
+        );
+        assert_eq!(
+            url(Service::AuthPage, "/requests"),
+            "https://decentraland.org/auth/requests"
+        );
+        assert_eq!(
+            url(Service::SocialRpc, ""),
+            "wss://rpc-social-service-ea.decentraland.org"
+        );
+    }
+
+    // NOTE: never latches (the OnceLock is process-wide); only the rejections are testable here.
+    #[test]
+    fn rejects_bad_service_overrides() {
+        for (service, bad) in [
+            (Service::Catalyst, "localhost:3000"),
+            (Service::Catalyst, "wss://peer.example"),
+            (Service::SocialRpc, "https://social.example"),
+            (Service::Places, "https://places.example/?x=1"),
+            (Service::Places, ""),
+        ] {
+            assert!(
+                set_services([(service, bad)]).is_err(),
+                "`{bad}` should be refused for {service:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -472,7 +472,7 @@ pub struct PreviousLogin {
 }
 
 pub fn default_home_realm() -> String {
-    crate::base_domain::https("realm-provider-ea", "/main")
+    crate::base_domain::url(crate::base_domain::Service::RealmProvider, "/main")
 }
 // app configuration
 #[derive(Serialize, Deserialize, Resource, Clone)]

--- a/crates/comms/src/lib.rs
+++ b/crates/comms/src/lib.rs
@@ -58,19 +58,21 @@ use self::{
 #[cfg(feature = "livekit")]
 use self::livekit::{plugin::LivekitPlugin, StartLivekit};
 
+use common::base_domain::Service;
+
 fn gatekeeper_url() -> String {
-    common::base_domain::https("comms-gatekeeper", "/get-scene-adapter")
+    common::base_domain::url(Service::CommsGatekeeper, "/get-scene-adapter")
 }
 fn preview_gatekeeper_url() -> String {
-    common::base_domain::https("comms-gatekeeper-local", "/get-scene-adapter")
+    common::base_domain::url(Service::PreviewGatekeeper, "/get-scene-adapter")
 }
 // Authoritative-server endpoints: yield a token with the LiveKit identity
 // `authoritative-server`, which clients target for authoritative-scene traffic.
 fn server_gatekeeper_url() -> String {
-    common::base_domain::https("comms-gatekeeper", "/get-server-scene-adapter")
+    common::base_domain::url(Service::CommsGatekeeper, "/get-server-scene-adapter")
 }
 fn preview_server_gatekeeper_url() -> String {
-    common::base_domain::https("comms-gatekeeper-local", "/get-server-scene-adapter")
+    common::base_domain::url(Service::PreviewGatekeeper, "/get-server-scene-adapter")
 }
 
 pub mod chat_marker_things {

--- a/crates/comms/src/profile/mod.rs
+++ b/crates/comms/src/profile/mod.rs
@@ -928,16 +928,20 @@ const REGISTRY_ZONE: &str = "https://asset-bundle-registry.decentraland.zone/pro
 /// The .zone and .org registries hold separate profile namespaces, so the registry must
 /// match the profile owner's environment, judged by their announced lambdas endpoint:
 /// a host under the custom base domain uses that domain's registry, else a host under
-/// the zone tld uses the zone registry.
+/// the zone tld uses the zone registry. An explicit registry override serves everyone.
 fn registry_url(endpoint: Option<&str>) -> String {
     let host = endpoint
         .and_then(|e| reqwest::Url::parse(e).ok())
         .and_then(|url| url.host_str().map(str::to_owned));
+    let registry = common::base_domain::Service::AssetBundleRegistry;
+    if common::base_domain::service_override(registry).is_some() {
+        return common::base_domain::url(registry, "/profiles");
+    }
     if let Some(host) = host {
         let base = common::base_domain::get();
         if common::base_domain::is_custom() && (host == base || host.ends_with(&format!(".{base}")))
         {
-            return common::base_domain::https("asset-bundle-registry", "/profiles");
+            return common::base_domain::url(registry, "/profiles");
         }
         if host.rsplit('.').next() == Some("zone") {
             return REGISTRY_ZONE.to_owned();

--- a/crates/dcl/src/js/ethereum_controller.rs
+++ b/crates/dcl/src/js/ethereum_controller.rs
@@ -10,7 +10,10 @@ use crate::{interface::crdt_context::CrdtContext, RpcCalls};
 use super::State;
 
 fn provider_url() -> String {
-    common::base_domain::wss("rpc", "/mainnet?project=kernel-local")
+    common::base_domain::url(
+        common::base_domain::Service::EthereumRpc,
+        "/mainnet?project=kernel-local",
+    )
 }
 
 pub async fn op_send_async(

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -684,7 +684,10 @@ pub fn change_realm(
 
 pub fn map_realm_name(request: &str) -> String {
     if request.ends_with(".dcl.eth") && !request.starts_with("https://") {
-        common::base_domain::https("worlds-content-server", &format!("/world/{request}"))
+        common::base_domain::url(
+            common::base_domain::Service::WorldsServer,
+            &format!("/world/{request}"),
+        )
     } else {
         request.to_owned()
     }

--- a/crates/nft/src/asset_source.rs
+++ b/crates/nft/src/asset_source.rs
@@ -82,8 +82,8 @@ impl AssetReader for NftReader {
                 ))));
             }
 
-            let remote = common::base_domain::https(
-                "opensea",
+            let remote = common::base_domain::url(
+                common::base_domain::Service::Opensea,
                 &format!("/api/v2/chain/{chain}/contract/{address}/nfts/{token}"),
             );
 

--- a/crates/restricted_actions/src/lib.rs
+++ b/crates/restricted_actions/src/lib.rs
@@ -695,7 +695,10 @@ pub async fn lookup_ens(
     } else {
         lookup_portable(
             parent_scene,
-            common::base_domain::https("worlds-content-server", &format!("/world/{ens}")),
+            common::base_domain::url(
+                common::base_domain::Service::WorldsServer,
+                &format!("/world/{ens}"),
+            ),
             super_user,
             ipfs,
         )

--- a/crates/social/src/client.rs
+++ b/crates/social/src/client.rs
@@ -467,7 +467,7 @@ fn dbgerr<E: std::fmt::Debug>(e: E) -> anyhow::Error {
 }
 
 fn social_url() -> String {
-    common::base_domain::wss("rpc-social-service-ea", "")
+    common::base_domain::service(common::base_domain::Service::SocialRpc)
 }
 
 const PAGE_SIZE: i32 = 100;

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -39,9 +39,8 @@ pub struct LaunchOptions {
     #[arg(long, display_order = 3)]
     pub preview: bool,
 
-    /// The deployment domain every backend host is composed from — sign-in, content, comms,
-    /// everything; absent = decentraland.org. On web the page always passes the domain it
-    /// resolved for itself: the `?baseDomain=` param, else derived from the hosting origin.
+    /// The base domain for all services (comms, profiles, etc); absent = the hosting origin (on
+    /// web), or decentraland.org
     #[arg(long, value_name = "domain", display_order = 4)]
     pub base_domain: Option<String>,
 

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -16,6 +16,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::services::ServiceOverrides;
+
 #[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
 #[serde(rename_all = "camelCase", default)]
 pub struct LaunchOptions {
@@ -38,8 +40,8 @@ pub struct LaunchOptions {
     pub preview: bool,
 
     /// The deployment domain every backend host is composed from — sign-in, content, comms,
-    /// everything; absent = decentraland.org. on web: derived from the hosting origin.
-    #[serde(skip)]
+    /// everything; absent = decentraland.org. On web the page always passes the domain it
+    /// resolved for itself: the `?baseDomain=` param, else derived from the hosting origin.
     #[arg(long, value_name = "domain", display_order = 4)]
     pub base_domain: Option<String>,
 
@@ -54,6 +56,12 @@ pub struct LaunchOptions {
     /// Log the frame rate to the console
     #[arg(long, value_name = "true|false", display_order = 13)]
     pub log_fps: Option<bool>,
+
+    /// Per-service url overrides (`services.rs`): flags natively, keys of the `engine_run`
+    /// object on web (the page resolves the same overrides for its own fetches first).
+    #[serde(flatten)]
+    #[command(flatten)]
+    pub services: ServiceOverrides,
 }
 
 /// The options only a rendering client (native, web) has a use for.
@@ -108,7 +116,6 @@ impl EngineRunOptions {
         };
         let known: Vec<String> = crate::web_params::web_params()
             .into_iter()
-            .filter(|p| p.delivery != crate::web_params::Delivery::BaseDomain)
             .map(|p| p.name)
             .collect();
         if let Some(key) = object.keys().find(|key| !known.contains(key)) {
@@ -198,12 +205,19 @@ mod tests {
             err.to_string().contains("unknown field `pulseServr`"),
             "{err}"
         );
-        // the base domain never travels as an engine_run key
-        assert!(EngineRunOptions::from_json(r#"{"baseDomain": "decentraland.zone"}"#).is_err());
+        // the page-resolved base domain and service overrides are keys like any other
         let options = EngineRunOptions::from_json(
-            r#"{"pulseServer": "localhost:7777", "preview": true, "logFps": true, "gpuBytesPerFrame": 500000}"#,
+            r#"{"pulseServer": "localhost:7777", "preview": true, "logFps": true, "gpuBytesPerFrame": 500000, "baseDomain": "decentraland.zone", "catalyst": "http://localhost:3000"}"#,
         )
         .unwrap();
+        assert_eq!(
+            options.launch.base_domain.as_deref(),
+            Some("decentraland.zone")
+        );
+        assert_eq!(
+            options.launch.services.catalyst.as_deref(),
+            Some("http://localhost:3000")
+        );
         assert_eq!(
             options.launch.pulse_server.as_deref(),
             Some("localhost:7777")
@@ -218,6 +232,11 @@ mod tests {
         let json = serde_json::to_value(&options).unwrap();
         assert_eq!(json["pulseServer"], "localhost:7777");
         assert_eq!(json["gpuBytesPerFrame"], 500_000);
-        assert!(json.get("baseDomain").is_none());
+        assert_eq!(json["baseDomain"], "decentraland.zone");
+        assert_eq!(json["catalyst"], "http://localhost:3000");
+        assert!(
+            json.get("places").is_some(),
+            "every service key is echoed (as null when unset)"
+        );
     }
 }

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -227,6 +227,8 @@ mod tests {
         assert_eq!(options.client.gpu_bytes_per_frame, Some(500_000));
         // typed keys take their type, not a string
         assert!(EngineRunOptions::from_json(r#"{"gpuBytesPerFrame": "500000"}"#).is_err());
+        // a native-only service is an unknown key on web
+        assert!(EngineRunOptions::from_json(r#"{"authPage": "http://localhost:1"}"#).is_err());
         // and the echo is one flat object again
         let json = serde_json::to_value(&options).unwrap();
         assert_eq!(json["pulseServer"], "localhost:7777");

--- a/crates/system_api_types/src/lib.rs
+++ b/crates/system_api_types/src/lib.rs
@@ -5,6 +5,7 @@
 //! page and bridge scene consume. `system_bridge` re-exports everything here.
 
 pub mod launch_options;
+pub mod services;
 pub mod web_params;
 
 use dcl_component::proto_components::{

--- a/crates/system_api_types/src/services.rs
+++ b/crates/system_api_types/src/services.rs
@@ -94,6 +94,13 @@ impl Service {
         Service::iter()
     }
 
+    /// Whether the web build can point the service elsewhere. The web page signs in at its own
+    /// origin's `/auth` and hands the engine the identity, so the browser sign-in services are
+    /// not the wasm's to redirect: they have no web param and no row in the HUD's table.
+    pub const fn has_web_param(self) -> bool {
+        !matches!(self, Service::AuthApi | Service::AuthPage)
+    }
+
     pub fn flag(self) -> String {
         format!("--{}", self.field().replace('_', "-"))
     }
@@ -146,11 +153,11 @@ pub struct ServiceOverrides {
     #[arg(long, value_name = "url", display_order = 66, help_heading = HELP_HEADING)]
     pub preview_gatekeeper: Option<String>,
 
-    /// Auth api; absent = `https://auth-api.<base>`
+    /// Auth api the sign-in flow polls (native only); absent = `https://auth-api.<base>`
     #[arg(long, value_name = "url", display_order = 67, help_heading = HELP_HEADING)]
     pub auth_api: Option<String>,
 
-    /// Sign-in page the browser opens; absent = `https://<base>/auth`
+    /// Sign-in page the browser opens (native only); absent = `https://<base>/auth`
     #[arg(long, value_name = "url", display_order = 68, help_heading = HELP_HEADING)]
     pub auth_page: Option<String>,
 
@@ -216,6 +223,7 @@ impl ServiceOverrides {
 
 /// A row of the service table exported to the react HUD: which web param overrides the service
 /// and how its default composes, so the HUD resolves the urls it needs exactly as the engine does.
+/// Only the services with a web param ([`Service::has_web_param`]).
 #[derive(Serialize, Clone, PartialEq, Eq, Debug, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
@@ -230,6 +238,7 @@ pub struct ServiceDef {
 
 pub fn service_table() -> Vec<ServiceDef> {
     Service::all()
+        .filter(|service| service.has_web_param())
         .map(|service| {
             let (scheme, sub, path) = service.composition();
             ServiceDef {
@@ -284,5 +293,13 @@ mod tests {
         );
         assert_eq!(Service::WorldsServer.flag(), "--worlds-server");
         assert_eq!(Service::WorldsServer.param(), "worldsServer");
+    }
+
+    /// The sign-in services are native flags only: no row in the HUD's table.
+    #[test]
+    fn auth_services_have_no_web_side() {
+        let table: BTreeSet<_> = service_table().into_iter().map(|d| d.name).collect();
+        assert!(!table.contains("authApi") && !table.contains("authPage"));
+        assert!(table.contains("catalyst"));
     }
 }

--- a/crates/system_api_types/src/services.rs
+++ b/crates/system_api_types/src/services.rs
@@ -1,0 +1,287 @@
+//! The backend services the engine and the react HUD talk to, and the launch parameter that
+//! points each one somewhere else. By deployment convention every service lives at
+//! `{scheme}://{sub}.{base domain}{path}`; an override is a FULL base url that replaces that
+//! composition for one service (a local instance, a mixed deployment) while the rest keep
+//! following the domain. Resolution — override, else composition — is
+//! `common::base_domain::service`; on web the HUD resolves the same way from the same table
+//! (react-web lib/baseDomain.ts, from the generated `serviceTable.ts`) because it composes its
+//! own urls before the engine exists.
+
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, EnumIter)]
+pub enum Service {
+    /// The realm provider: its `/main` is the realm to boot into when none is given or persisted
+    RealmProvider,
+    /// The catalyst peer: `/content` and `/lambdas`
+    Catalyst,
+    /// Worlds content server: `/world/<name>` realms
+    WorldsServer,
+    /// Places api: place and world metadata
+    Places,
+    /// Comms gatekeeper: LiveKit adapters for scenes
+    CommsGatekeeper,
+    /// The local-preview comms gatekeeper
+    PreviewGatekeeper,
+    /// Auth api the browser sign-in flow polls
+    AuthApi,
+    /// The sign-in web page the browser is sent to
+    AuthPage,
+    /// Asset-bundle registry: profile lookups
+    AssetBundleRegistry,
+    /// World storage (storage delegation signing)
+    Storage,
+    /// Ethereum json-rpc websocket
+    EthereumRpc,
+    /// Social service websocket (friends)
+    SocialRpc,
+    /// OpenSea api (NftShape metadata)
+    Opensea,
+    /// Reels (camera reel photos) — HUD only
+    Reels,
+    /// Map tile api — HUD only
+    MapApi,
+}
+
+impl Service {
+    /// The deployment-convention default as `(scheme, sub, path)`; an empty sub is the apex.
+    pub const fn composition(self) -> (&'static str, &'static str, &'static str) {
+        match self {
+            Service::RealmProvider => ("https", "realm-provider-ea", ""),
+            Service::Catalyst => ("https", "peer", ""),
+            Service::WorldsServer => ("https", "worlds-content-server", ""),
+            Service::Places => ("https", "places", ""),
+            Service::CommsGatekeeper => ("https", "comms-gatekeeper", ""),
+            Service::PreviewGatekeeper => ("https", "comms-gatekeeper-local", ""),
+            Service::AuthApi => ("https", "auth-api", ""),
+            Service::AuthPage => ("https", "", "/auth"),
+            Service::AssetBundleRegistry => ("https", "asset-bundle-registry", ""),
+            Service::Storage => ("https", "storage", ""),
+            Service::EthereumRpc => ("wss", "rpc", ""),
+            Service::SocialRpc => ("wss", "rpc-social-service-ea", ""),
+            Service::Opensea => ("https", "opensea", ""),
+            Service::Reels => ("https", "reels", ""),
+            Service::MapApi => ("https", "api", ""),
+        }
+    }
+
+    /// The [`ServiceOverrides`] field (= the native flag in kebab-case, the web param in
+    /// camelCase) that overrides it.
+    pub const fn field(self) -> &'static str {
+        match self {
+            Service::RealmProvider => "realm_provider",
+            Service::Catalyst => "catalyst",
+            Service::WorldsServer => "worlds_server",
+            Service::Places => "places",
+            Service::CommsGatekeeper => "comms_gatekeeper",
+            Service::PreviewGatekeeper => "preview_gatekeeper",
+            Service::AuthApi => "auth_api",
+            Service::AuthPage => "auth_page",
+            Service::AssetBundleRegistry => "asset_bundle_registry",
+            Service::Storage => "storage",
+            Service::EthereumRpc => "ethereum_rpc",
+            Service::SocialRpc => "social_rpc",
+            Service::Opensea => "opensea",
+            Service::Reels => "reels",
+            Service::MapApi => "map_api",
+        }
+    }
+
+    /// Every service, in declaration order.
+    pub fn all() -> impl Iterator<Item = Service> {
+        use strum::IntoEnumIterator;
+        Service::iter()
+    }
+
+    pub fn flag(self) -> String {
+        format!("--{}", self.field().replace('_', "-"))
+    }
+
+    pub fn param(self) -> String {
+        crate::web_params::camel_case(self.field())
+    }
+
+    /// Whether the service is one of the secure-websocket ones (the override must be `ws(s)://`
+    /// rather than `http(s)://`).
+    pub fn is_websocket(self) -> bool {
+        self.composition().0 == "wss"
+    }
+}
+
+/// One full base url per service, each replacing that service's base-domain composition. A
+/// value is taken verbatim with paths appended, so it carries its own scheme and port and no
+/// trailing slash (`http://localhost:3000`).
+// per-arg rather than the struct's `next_help_heading`: clap_derive doesn't restore the parent's
+// heading after a flatten, so a struct-level one would capture every flag a binary declares after
+// this struct
+const HELP_HEADING: &str =
+    "Service endpoints (full base urls; absent = composed from the base domain)";
+
+#[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ServiceOverrides {
+    /// Realm provider (the realm list, and `/main` is the default realm); absent =
+    /// `https://realm-provider-ea.<base>`
+    #[arg(long, value_name = "url", display_order = 61, help_heading = HELP_HEADING)]
+    pub realm_provider: Option<String>,
+
+    /// Catalyst peer (`/content`, `/lambdas`); absent = `https://peer.<base>`
+    #[arg(long, value_name = "url", display_order = 62, help_heading = HELP_HEADING)]
+    pub catalyst: Option<String>,
+
+    /// Worlds content server; absent = `https://worlds-content-server.<base>`
+    #[arg(long, value_name = "url", display_order = 63, help_heading = HELP_HEADING)]
+    pub worlds_server: Option<String>,
+
+    /// Places api; absent = `https://places.<base>`
+    #[arg(long, value_name = "url", display_order = 64, help_heading = HELP_HEADING)]
+    pub places: Option<String>,
+
+    /// Comms gatekeeper; absent = `https://comms-gatekeeper.<base>`
+    #[arg(long, value_name = "url", display_order = 65, help_heading = HELP_HEADING)]
+    pub comms_gatekeeper: Option<String>,
+
+    /// Local-preview comms gatekeeper; absent = `https://comms-gatekeeper-local.<base>`
+    #[arg(long, value_name = "url", display_order = 66, help_heading = HELP_HEADING)]
+    pub preview_gatekeeper: Option<String>,
+
+    /// Auth api; absent = `https://auth-api.<base>`
+    #[arg(long, value_name = "url", display_order = 67, help_heading = HELP_HEADING)]
+    pub auth_api: Option<String>,
+
+    /// Sign-in page the browser opens; absent = `https://<base>/auth`
+    #[arg(long, value_name = "url", display_order = 68, help_heading = HELP_HEADING)]
+    pub auth_page: Option<String>,
+
+    /// Asset-bundle registry; absent = `https://asset-bundle-registry.<base>` (custom domains
+    /// only: org and zone profiles use the registry of the profile's own environment)
+    #[arg(long, value_name = "url", display_order = 69, help_heading = HELP_HEADING)]
+    pub asset_bundle_registry: Option<String>,
+
+    /// World storage; absent = `https://storage.<base>`
+    #[arg(long, value_name = "url", display_order = 70, help_heading = HELP_HEADING)]
+    pub storage: Option<String>,
+
+    /// Ethereum json-rpc websocket; absent = `wss://rpc.<base>`
+    #[arg(long, value_name = "url", display_order = 71, help_heading = HELP_HEADING)]
+    pub ethereum_rpc: Option<String>,
+
+    /// Social service websocket; absent = `wss://rpc-social-service-ea.<base>`
+    #[arg(long, value_name = "url", display_order = 72, help_heading = HELP_HEADING)]
+    pub social_rpc: Option<String>,
+
+    /// OpenSea api; absent = `https://opensea.<base>`
+    #[arg(long, value_name = "url", display_order = 73, help_heading = HELP_HEADING)]
+    pub opensea: Option<String>,
+
+    /// Reels (camera reel) api, used by the HUD; absent = `https://reels.<base>`
+    #[arg(long, value_name = "url", display_order = 74, help_heading = HELP_HEADING)]
+    pub reels: Option<String>,
+
+    /// Map tile api, used by the HUD; absent = `https://api.<base>`
+    #[arg(long, value_name = "url", display_order = 75, help_heading = HELP_HEADING)]
+    pub map_api: Option<String>,
+}
+
+impl ServiceOverrides {
+    pub fn get(&self, service: Service) -> Option<&str> {
+        match service {
+            Service::RealmProvider => &self.realm_provider,
+            Service::Catalyst => &self.catalyst,
+            Service::WorldsServer => &self.worlds_server,
+            Service::Places => &self.places,
+            Service::CommsGatekeeper => &self.comms_gatekeeper,
+            Service::PreviewGatekeeper => &self.preview_gatekeeper,
+            Service::AuthApi => &self.auth_api,
+            Service::AuthPage => &self.auth_page,
+            Service::AssetBundleRegistry => &self.asset_bundle_registry,
+            Service::Storage => &self.storage,
+            Service::EthereumRpc => &self.ethereum_rpc,
+            Service::SocialRpc => &self.social_rpc,
+            Service::Opensea => &self.opensea,
+            Service::Reels => &self.reels,
+            Service::MapApi => &self.map_api,
+        }
+        .as_deref()
+        .filter(|url| !url.is_empty())
+    }
+
+    /// The overrides that were given.
+    pub fn iter(&self) -> impl Iterator<Item = (Service, &str)> {
+        Service::all().filter_map(|service| self.get(service).map(|url| (service, url)))
+    }
+}
+
+/// A row of the service table exported to the react HUD: which web param overrides the service
+/// and how its default composes, so the HUD resolves the urls it needs exactly as the engine does.
+#[derive(Serialize, Clone, PartialEq, Eq, Debug, ts_rs::TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct ServiceDef {
+    /// The web param (and `ServiceOverrides` field in camelCase)
+    pub name: String,
+    pub scheme: String,
+    /// Empty = the apex domain
+    pub sub: String,
+    pub path: String,
+}
+
+pub fn service_table() -> Vec<ServiceDef> {
+    Service::all()
+        .map(|service| {
+            let (scheme, sub, path) = service.composition();
+            ServiceDef {
+                name: service.param(),
+                scheme: scheme.to_owned(),
+                sub: sub.to_owned(),
+                path: path.to_owned(),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Args as _;
+    use std::collections::BTreeSet;
+
+    /// Writes the service table next to the ts-rs types (`TS_RS_EXPORT_DIR`, set by
+    /// scripts/gen-ts-bindings.sh — a no-op under a plain `cargo test`).
+    #[test]
+    fn export_service_table() {
+        let Ok(dir) = std::env::var("TS_RS_EXPORT_DIR") else {
+            return;
+        };
+        let json = serde_json::to_string_pretty(&service_table()).unwrap();
+        let ts = format!(
+            "// GENERATED by scripts/gen-ts-bindings.sh from crates/system_api_types/src/services.rs — do not edit.\n\
+             import type {{ ServiceDef }} from './ServiceDef'\n\n\
+             export const SERVICES: ServiceDef[] = {json}\n"
+        );
+        std::fs::write(std::path::Path::new(&dir).join("serviceTable.ts"), ts).unwrap();
+    }
+
+    /// Every variant's field is a real flag of the struct, and every flag is some variant's.
+    #[test]
+    fn fields_match_the_variants() {
+        let flags: BTreeSet<_> = ServiceOverrides::augment_args(clap::Command::new("x"))
+            .get_arguments()
+            .map(|a| a.get_id().as_str().to_owned())
+            .collect();
+        let fields: BTreeSet<_> = Service::all().map(|s| s.field().to_owned()).collect();
+        assert_eq!(flags, fields);
+        let overrides = ServiceOverrides {
+            catalyst: Some("http://localhost:3000".into()),
+            reels: Some(String::new()),
+            ..Default::default()
+        };
+        assert_eq!(
+            overrides.iter().collect::<Vec<_>>(),
+            vec![(Service::Catalyst, "http://localhost:3000")]
+        );
+        assert_eq!(Service::WorldsServer.flag(), "--worlds-server");
+        assert_eq!(Service::WorldsServer.param(), "worldsServer");
+    }
+}

--- a/crates/system_api_types/src/services.rs
+++ b/crates/system_api_types/src/services.rs
@@ -159,7 +159,8 @@ pub struct ServiceOverrides {
     #[arg(long, value_name = "url", display_order = 69, help_heading = HELP_HEADING)]
     pub asset_bundle_registry: Option<String>,
 
-    /// World storage; absent = `https://storage.<base>`
+    /// World storage; absent = `https://storage.<base>`. https only: an http instance is never
+    /// signed for (the delegation claim must not go out in cleartext)
     #[arg(long, value_name = "url", display_order = 70, help_heading = HELP_HEADING)]
     pub storage: Option<String>,
 

--- a/crates/system_api_types/src/web_params.rs
+++ b/crates/system_api_types/src/web_params.rs
@@ -110,9 +110,12 @@ pub(crate) fn camel_case(snake: &str) -> String {
 pub fn web_params() -> Vec<WebParam> {
     let launch = LaunchOptions::augment_args(clap::Command::new("launch"));
     let client = ClientOptions::augment_args(clap::Command::new("client"));
+    let native_only =
+        |field: &str| Service::all().any(|s| s.field() == field && !s.has_web_param());
     launch
         .get_arguments()
         .chain(client.get_arguments())
+        .filter(|arg| !native_only(arg.get_id().as_str()))
         .map(|arg| {
             let field = arg.get_id().as_str();
             WebParam {
@@ -160,7 +163,8 @@ mod tests {
     }
 
     /// Every field has a delivery (the panic in `delivery`), every row has a doc, and the
-    /// `engine_run` keys — the structs as serialised, one flat object — are exactly the table.
+    /// `engine_run` keys — the structs as serialised, one flat object — are exactly the table
+    /// (less the native-only services, which are no web param).
     #[test]
     fn table_matches_the_struct() {
         let params = web_params();
@@ -170,13 +174,25 @@ mod tests {
         let names: BTreeSet<_> = params.iter().map(|p| p.name.clone()).collect();
         assert_eq!(names.len(), params.len(), "duplicate names");
         let json = serde_json::to_value(EngineRunOptions::default()).unwrap();
-        let fields: BTreeSet<_> = json.as_object().unwrap().keys().cloned().collect();
+        let native_only: BTreeSet<_> = Service::all()
+            .filter(|s| !s.has_web_param())
+            .map(Service::param)
+            .collect();
+        let fields: BTreeSet<_> = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .filter(|k| !native_only.contains(*k))
+            .cloned()
+            .collect();
         assert_eq!(fields, names);
         let delivery = |name: &str| params.iter().find(|p| p.name == name).unwrap().delivery;
         assert_eq!(delivery("baseDomain"), Delivery::Resolved);
         let catalyst = params.iter().find(|p| p.name == "catalyst").unwrap();
         assert_eq!(catalyst.delivery, Delivery::Resolved);
         assert_eq!(catalyst.kind, ParamKind::String);
+        // the native-only sign-in services are no web param at all
+        assert!(!names.contains("authApi") && !names.contains("authPage"));
         assert_eq!(
             params.iter().find(|p| p.name == "preview").unwrap().kind,
             ParamKind::Flag

--- a/crates/system_api_types/src/web_params.rs
+++ b/crates/system_api_types/src/web_params.rs
@@ -13,7 +13,10 @@ use std::any::TypeId;
 use clap::Args;
 use serde::Serialize;
 
-use crate::launch_options::{ClientOptions, LaunchOptions};
+use crate::{
+    launch_options::{ClientOptions, LaunchOptions},
+    services::Service,
+};
 
 #[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
@@ -43,17 +46,18 @@ pub enum Delivery {
     /// Set by an embedding host page from its own knowledge (the creator-hub editor sets
     /// `editor`) — an `engine_run` option the react page must NOT read from the entry url.
     Host,
-    /// The host page consumes it itself (composing its own backend urls) and publishes it as
-    /// `window.__baseDomain()` before the wasm loads; the engine reads that at `engine_init`,
-    /// ahead of `engine_run`.
-    BaseDomain,
+    /// Read from the entry url by the host page, which resolves it for its own use before the
+    /// engine exists (the base domain: normalised, else derived from the hosting origin; a
+    /// service url: validated) and passes the resolved value as an `engine_run` option like
+    /// `Launch`. The engine never reads these from the page by any other route.
+    Resolved,
 }
 
 #[derive(Serialize, Clone, PartialEq, Eq, Debug, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct WebParam {
-    /// The query-string key; for everything but `BaseDomain` also the `engine_run` options key.
+    /// The query-string key, and the `engine_run` options key.
     pub name: String,
     pub kind: ParamKind,
     pub delivery: Delivery,
@@ -66,6 +70,9 @@ pub const DEFAULT_PORTABLES: &str = "basiccontroller.dcl.eth";
 /// The web-only half of a parameter's declaration, keyed by the [`LaunchOptions`] field.
 fn delivery(field: &str) -> Delivery {
     use Delivery::*;
+    if Service::all().any(|s| s.field() == field) {
+        return Resolved;
+    }
     match field {
         "realm" | "position" => Destination,
         "system_scene"
@@ -77,14 +84,14 @@ fn delivery(field: &str) -> Delivery {
         | "log_fps"
         | "gpu_bytes_per_frame" => Launch,
         "editor" => Host,
-        "base_domain" => BaseDomain,
+        "base_domain" => Resolved,
         other => {
             panic!("launch option `{other}` has no web delivery — add it to web_params::delivery")
         }
     }
 }
 
-fn camel_case(snake: &str) -> String {
+pub(crate) fn camel_case(snake: &str) -> String {
     let mut out = String::with_capacity(snake.len());
     let mut upper = false;
     for c in snake.chars() {
@@ -153,8 +160,7 @@ mod tests {
     }
 
     /// Every field has a delivery (the panic in `delivery`), every row has a doc, and the
-    /// `engine_run` keys — the structs as serialised, one flat object — are exactly the table
-    /// minus the host-consumed base domain.
+    /// `engine_run` keys — the structs as serialised, one flat object — are exactly the table.
     #[test]
     fn table_matches_the_struct() {
         let params = web_params();
@@ -163,15 +169,14 @@ mod tests {
         }
         let names: BTreeSet<_> = params.iter().map(|p| p.name.clone()).collect();
         assert_eq!(names.len(), params.len(), "duplicate names");
-        let engine_run: BTreeSet<_> = params
-            .iter()
-            .filter(|p| p.delivery != Delivery::BaseDomain)
-            .map(|p| p.name.clone())
-            .collect();
         let json = serde_json::to_value(EngineRunOptions::default()).unwrap();
         let fields: BTreeSet<_> = json.as_object().unwrap().keys().cloned().collect();
-        assert_eq!(fields, engine_run);
-        assert!(names.contains("baseDomain"));
+        assert_eq!(fields, names);
+        let delivery = |name: &str| params.iter().find(|p| p.name == name).unwrap().delivery;
+        assert_eq!(delivery("baseDomain"), Delivery::Resolved);
+        let catalyst = params.iter().find(|p| p.name == "catalyst").unwrap();
+        assert_eq!(catalyst.delivery, Delivery::Resolved);
+        assert_eq!(catalyst.kind, ParamKind::String);
         assert_eq!(
             params.iter().find(|p| p.name == "preview").unwrap().kind,
             ParamKind::Flag

--- a/crates/system_ui/src/change_realm.rs
+++ b/crates/system_ui/src/change_realm.rs
@@ -76,7 +76,8 @@ fn change_realm_dialog(
     // let target_url = format!("{endpoint}/explore/realms");
 
     // hard coded since the other doesn't list main
-    let target_url = common::base_domain::https("realm-provider-ea", "/realms");
+    let target_url =
+        common::base_domain::url(common::base_domain::Service::RealmProvider, "/realms");
 
     let client = ipfas.ipfs().client();
     let task: Task<Result<Vec<ServerDesc>, anyhow::Error>> =

--- a/crates/system_ui/src/discover.rs
+++ b/crates/system_ui/src/discover.rs
@@ -8,6 +8,7 @@ use bevy::{
 };
 use bevy_dui::{DuiCommandsExt, DuiEntities, DuiEntityCommandsExt, DuiProps, DuiRegistry};
 use common::{
+    base_domain::Service,
     rpc::RpcCall,
     structs::{IVec2Arg, SettingsTab, ZOrder},
     util::{ModifyComponentExt, TaskCompat, TaskExt},
@@ -203,9 +204,9 @@ impl DiscoverSettings {
 
     fn request(&mut self) {
         let mut url = if self.worlds {
-            common::base_domain::https("places", "/api/worlds/?limit=50")
+            common::base_domain::url(Service::Places, "/api/worlds/?limit=50")
         } else {
-            common::base_domain::https("places", "/api/places/?limit=50")
+            common::base_domain::url(Service::Places, "/api/places/?limit=50")
         };
 
         url = format!("{url}&offset={}", self.data.len());
@@ -432,8 +433,8 @@ impl DiscoverPage {
         Self {
             title: format!("({}, {})", coords.x, coords.y),
             base_position: format!("{},{}", coords.x, coords.y),
-            image: common::base_domain::https(
-                "peer",
+            image: common::base_domain::url(
+                Service::Catalyst,
                 "/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y",
             ),
             ..Default::default()
@@ -625,9 +626,7 @@ pub fn spawn_discover_popup(
     item: &DiscoverPage,
 ) {
     let url = match &item.world_name {
-        Some(name) => {
-            common::base_domain::https("worlds-content-server", &format!("/world/{name}"))
-        }
+        Some(name) => common::base_domain::url(Service::WorldsServer, &format!("/world/{name}")),
         None => common::structs::default_home_realm(),
     };
 

--- a/crates/system_ui/src/map.rs
+++ b/crates/system_ui/src/map.rs
@@ -192,8 +192,8 @@ fn set_map_content(
                     let parcel = cursor_parcel.floor().as_ivec2() + IVec2::Y;
                     debug!("click parcel {}", parcel);
 
-                    let url = common::base_domain::https(
-                        "places",
+                    let url = common::base_domain::url(
+                        common::base_domain::Service::Places,
                         &format!("/api/places?positions={},{}", parcel.x, parcel.y),
                     );
 

--- a/crates/wallet/src/browser_auth.rs
+++ b/crates/wallet/src/browser_auth.rs
@@ -42,10 +42,10 @@ struct ServerResponseError {
 }
 
 fn auth_front_url() -> String {
-    format!("https://{}/auth/requests", common::base_domain::get())
+    common::base_domain::url(common::base_domain::Service::AuthPage, "/requests")
 }
 fn auth_server_endpoint_url() -> String {
-    common::base_domain::https("auth-api", "/requests")
+    common::base_domain::url(common::base_domain::Service::AuthApi, "/requests")
 }
 const AUTH_SERVER_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const AUTH_SERVER_TIMEOUT: Duration = Duration::from_secs(600);

--- a/crates/wallet/src/delegation.rs
+++ b/crates/wallet/src/delegation.rs
@@ -151,25 +151,25 @@ impl StorageDelegations {
 }
 
 /// True when a signed fetch to `uri` must be signed with a storage delegation: exact-match
-/// world-storage hosts, https only (the claim must never go out in cleartext) — or the resolved
-/// storage service, whose origin an explicit override chooses (a local http instance included).
+/// world-storage hosts, or the resolved storage service (host and port; an explicit override
+/// chooses them). https only either way — the claim must never go out in cleartext, so an http
+/// storage override is simply never signed for.
 pub fn is_storage_request(uri: &http::Uri) -> bool {
-    let known = uri.scheme_str() == Some("https")
-        && uri
-            .host()
-            .is_some_and(|h| STORAGE_HOSTS.contains(&h.to_lowercase().as_str()));
-    known || {
-        let origin = |u: &http::Uri| {
-            (
-                u.scheme_str().map(str::to_lowercase),
-                u.host().map(str::to_lowercase),
-                u.port_u16(),
-            )
-        };
-        common::base_domain::service(common::base_domain::Service::Storage)
-            .parse::<http::Uri>()
-            .is_ok_and(|storage| origin(&storage) == origin(uri))
+    fn https_origin(u: &http::Uri) -> Option<(String, u16)> {
+        if u.scheme_str() != Some("https") {
+            return None;
+        }
+        Some((u.host()?.to_lowercase(), u.port_u16().unwrap_or(443)))
     }
+    let Some((host, port)) = https_origin(uri) else {
+        return false;
+    };
+    STORAGE_HOSTS.contains(&host.as_str())
+        || common::base_domain::service(common::base_domain::Service::Storage)
+            .parse::<http::Uri>()
+            .ok()
+            .and_then(|storage| https_origin(&storage))
+            == Some((host, port))
 }
 
 #[cfg(test)]
@@ -243,6 +243,30 @@ mod test {
             &"https://storage.decentraland.org.evil.com/values"
                 .parse()
                 .unwrap()
+        ));
+    }
+
+    // NOTE: latches the process-wide storage override — the only test in this crate that may.
+    #[test]
+    fn storage_override_matching() {
+        common::base_domain::set_services([(
+            common::base_domain::Service::Storage,
+            "https://storage.example:8443/",
+        )])
+        .unwrap();
+        assert!(is_storage_request(
+            &"https://storage.example:8443/values/x".parse().unwrap()
+        ));
+        // the known hosts stay signed for alongside an override
+        assert!(is_storage_request(
+            &"https://storage.decentraland.org/values/x".parse().unwrap()
+        ));
+        // port is part of the origin (default 443 when implicit), and https is not negotiable
+        assert!(!is_storage_request(
+            &"https://storage.example/values/x".parse().unwrap()
+        ));
+        assert!(!is_storage_request(
+            &"http://storage.example:8443/values/x".parse().unwrap()
         ));
     }
 }

--- a/crates/wallet/src/delegation.rs
+++ b/crates/wallet/src/delegation.rs
@@ -150,15 +150,26 @@ impl StorageDelegations {
     }
 }
 
-/// True when a signed fetch to `uri` must be signed with a storage delegation:
-/// exact-match world-storage hosts, https only (the claim must never go out in cleartext).
+/// True when a signed fetch to `uri` must be signed with a storage delegation: exact-match
+/// world-storage hosts, https only (the claim must never go out in cleartext) — or the resolved
+/// storage service, whose origin an explicit override chooses (a local http instance included).
 pub fn is_storage_request(uri: &http::Uri) -> bool {
-    uri.scheme_str() == Some("https")
-        && uri.host().is_some_and(|h| {
-            let h = h.to_lowercase();
-            STORAGE_HOSTS.contains(&h.as_str())
-                || (common::base_domain::is_custom() && h == common::base_domain::host("storage"))
-        })
+    let known = uri.scheme_str() == Some("https")
+        && uri
+            .host()
+            .is_some_and(|h| STORAGE_HOSTS.contains(&h.to_lowercase().as_str()));
+    known || {
+        let origin = |u: &http::Uri| {
+            (
+                u.scheme_str().map(str::to_lowercase),
+                u.host().map(str::to_lowercase),
+                u.port_u16(),
+            )
+        };
+        common::base_domain::service(common::base_domain::Service::Storage)
+            .parse::<http::Uri>()
+            .is_ok_and(|storage| origin(&storage) == origin(uri))
+    }
 }
 
 #[cfg(test)]

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -4,10 +4,10 @@
 //
 // Contract with the host page (react-web/src/engine/engineRpc.ts):
 //   set BEFORE injecting:  window.PUBLIC_URL   — base for pkg/ fetches (versioned CDN in prod)
-//                          window.__bevyBootConfig — the engine_run options (src/web_options.rs,
-//                            keyed by the web param table: systemScene, portables, preview,
-//                            pulseServer, imposterSource …) minus realm/position, forwarded
-//                            verbatim by __bevyLaunch
+//                          window.__bevyBootConfig — the engine_run options (keyed by the web
+//                            param table: systemScene, portables, preview, pulseServer, the
+//                            host-resolved baseDomain and service overrides …) minus
+//                            realm/position, forwarded verbatim by __bevyLaunch
 //   provided by this module:
 //     __bevyLoadProgress / __bevyLoadStep  — weighted boot progress for the login bar
 //     __bevyReadyToLaunch / __bevyLaunch(realm?, position?) — deferred engine_run
@@ -18,11 +18,13 @@
 //     __onEngineCrash(message, source) — OPTIONAL host callback; the watchdog calls it instead of
 //       rendering any overlay (React owns the error UI)
 //     window.engine / engine_console_command — the console RPC (built by engine.js post-launch)
-//     __baseDomain() — HOST-PROVIDED (react-web/src/lib/baseDomain.ts, defined before this module
-//       is injected): the deployment domain every backend host is composed from; the wasm reads
-//       it before composing any backend URL (parity with native --base-domain)
-//     __bevyHomeScene() — the persisted home scene { realm, parcel: "x,y" } (or the derived
-//       defaults), for the host's "Skip to Home"; set alongside __bevyReadyToLaunch
+//     __defaultRealm() / __serviceUrl(name) / __defaultBaseDomain() — HOST-PROVIDED
+//       (react-web/src/lib/baseDomain.ts, defined before this module is injected), for the url
+//       sync only: the host's default realm, a service's resolved base url (its ?<name>= override,
+//       else composed from the base domain), and the domain a url without ?baseDomain= means
+//       here. The engine itself takes the domain and the overrides as engine_run options.
+//     __bevyHomeScene() — the persisted home scene { realm, parcel: "x,y" } (realm null = none
+//       pinned), for the host's "Skip to Home"; set alongside __bevyReadyToLaunch
 import { initEngine, start, applyOptionsToUrlParams, engine_home_scene, gpu_cache_hash, initGpuCache } from './engine.js'
 
 // ---- boot progress (replaces ui.js's DOM loading steps) -----------------------------------------
@@ -269,25 +271,26 @@ window.addEventListener('wheel', forwardWheelToEngine)
 // position, ui scene, portables and mode swapped in — so every param given at launch is echoed
 // back, not just the ones this file knows about. Defaults are omitted so the canonical entry URL
 // stays clean; unknown (HUD-only) params are preserved.
-// The base domain is the HUD's call (see the __baseDomain contract above): the ?baseDomain=
-// entry param, else the hosting origin's apex, else org. It never comes through here.
-const BASE_DOMAIN = window.__baseDomain()
-const DEFAULT_SERVER = `https://realm-provider-ea.${BASE_DOMAIN}/main`
+// The default realm and service urls are the HUD's call (see the contract above): a ?<service>=
+// entry param, else composed from the base domain.
 // The engine connects to the EXPANDED world url (ipfs map_realm_name turns `name.dcl.eth` into
 // worlds-content-server…/world/name.dcl.eth) and echoes that back here. Reverse it so the address
 // bar keeps the short name the user typed; a reload re-expands it the same way.
-const WORLDS_PREFIX = `https://worlds-content-server.${BASE_DOMAIN}/world/`
+const WORLDS_PREFIX = `${window.__serviceUrl('worldsServer')}/world/`
 // captured from the ENTRY url (later syncs rewrite location.search)
 const explicitSystemScene = new URLSearchParams(window.location.search).has('systemScene')
-// The values that mean "default" and are dropped from the url — the two defaults only this page
+// The values that mean "default" and are dropped from the url — the defaults only this page
 // knows (the engine already omits its own, e.g. the default portables). systemScene: null from the
 // engine = NO ui scene (systemScene=none); an explicit ?systemScene= boot override stays across
-// reloads, only the host's default scene is omitted.
+// reloads, only the host's default scene is omitted. baseDomain: the host always passes the
+// resolved domain, so it is a url param only when it differs from what this origin derives.
 const urlValue = (name, value) => {
   switch (name) {
     case 'realm':
       if (typeof value === 'string' && value.startsWith(WORLDS_PREFIX)) value = value.slice(WORLDS_PREFIX.length)
-      return value === DEFAULT_SERVER ? null : value
+      return value === window.__defaultRealm() ? null : value
+    case 'baseDomain':
+      return value === window.__defaultBaseDomain() ? null : value
     case 'systemScene':
       value = value ?? 'none'
       return explicitSystemScene || value !== (config.systemScene ?? 'none') ? value : null
@@ -329,8 +332,9 @@ initEngine()
     // Deferred launch: the host calls this once the user picks a destination — avoiding a wasted
     // default-realm load. One engine per page (see start()'s __bevyStarted guard).
     window.__bevyLaunch = (realm, position) => start({ ...config, realm, position })
-    // The persisted home scene ({ realm, parcel: "x,y" }), valid once engine_init has loaded the
-    // config — the host's places picker targets it from "Skip to Home" before launching.
+    // The persisted home scene ({ realm (null = none pinned), parcel: "x,y" }), valid once
+    // engine_init has loaded the config — the host's places picker targets it from "Skip to
+    // Home" before launching.
     window.__bevyHomeScene = () => { try { return JSON.parse(engine_home_scene()) } catch { return null } }
     window.__bevyReadyToLaunch = true
   })

--- a/react-web/src/engine/EngineDriver.ts
+++ b/react-web/src/engine/EngineDriver.ts
@@ -130,7 +130,7 @@ export class EngineDriver implements LoginDriver {
     this.rpc.launch(realm, position)
   }
 
-  homeScene(): { realm: string; parcel: string } | null {
+  homeScene(): { realm: string | null; parcel: string } | null {
     return this.rpc.homeScene()
   }
 

--- a/react-web/src/engine/driver.ts
+++ b/react-web/src/engine/driver.ts
@@ -62,5 +62,5 @@ export interface LoginDriver {
   /** The engine's persisted home scene — the Skip target. Available pre-launch; null until the
    *  engine module is up. Optional — the mock has no engine (and native skips keep the engine's
    *  own start realm, which already IS home). */
-  homeScene?(): { realm: string; parcel: string } | null
+  homeScene?(): { realm: string | null; parcel: string } | null
 }

--- a/react-web/src/engine/engineRpc.ts
+++ b/react-web/src/engine/engineRpc.ts
@@ -9,7 +9,7 @@ type EngineWindow = Window & {
   engine_console_command?: (line: string) => Promise<string>
   __bevyReadyToLaunch?: boolean
   __bevyLaunch?: (realm?: string, position?: string) => void
-  __bevyHomeScene?: () => { realm: string; parcel: string } | null
+  __bevyHomeScene?: () => { realm: string | null; parcel: string } | null
   __bevyLoadProgress?: number
   __bevyLoadStep?: string | null
   __bevyPanic?: { message: string }
@@ -61,10 +61,11 @@ export class EngineRpc {
     this.win?.__bevyLaunch?.(realm, position)
   }
 
-  /** The engine's persisted home scene (realm + "x,y" parcel, or the engine's derived defaults).
-   *  Available alongside readyToLaunch — i.e. BEFORE launch, which is what lets the places
-   *  picker's Skip target home. Null until the engine module is up. */
-  homeScene(): { realm: string; parcel: string } | null {
+  /** The engine's persisted home scene: the pinned realm (null = none pinned; the caller uses
+   *  its own default realm) + "x,y" parcel. Available alongside readyToLaunch — i.e. BEFORE
+   *  launch, which is what lets the places picker's Skip target home. Null until the engine
+   *  module is up. */
+  homeScene(): { realm: string | null; parcel: string } | null {
     return this.win?.__bevyHomeScene?.() ?? null
   }
 

--- a/react-web/src/features/engine/EngineHost.tsx
+++ b/react-web/src/features/engine/EngineHost.tsx
@@ -7,18 +7,12 @@
 import { useEffect } from 'react'
 import type { EngineRpc } from '../../engine/engineRpc'
 import { bridgeChannelName } from '../../engine/protocol'
-import { serviceUrl } from '../../lib/baseDomain'
+import { BASE_DOMAIN, SERVICE_OVERRIDES } from '../../lib/baseDomain'
 import { bootMode } from '../../lib/bootMode'
 import { PAGE_DIR } from '../../lib/publicUrl'
 // Moved to lib/systemScene.ts; whether a link may override it is lib/launchGate.ts's call.
 import { SYSTEM_SCENE } from '../../lib/systemScene'
 import { launchOptionsFromUrl, type LaunchOptions } from '../../lib/webParams'
-
-// The main (Genesis City) realm, on the ?baseDomain= entry param when present (parity with the
-// engine's own derived default). Exported: parcel launches pass it EXPLICITLY so a ?realm
-// override — possibly an invalid world — never leaks into a Places pick (always a Genesis
-// coordinate).
-export const DEFAULT_REALM = `${serviceUrl('realm-provider-ea')}/main`
 
 // Engine media libs the wasm expects as globals (LivekitClient, Hls) — loaded from CDNs like the
 // old boot page did.
@@ -43,10 +37,13 @@ function injectEngine(): void {
   const params = new URLSearchParams(location.search)
   // pkg/ fetch base: the versioned CDN in prod builds (BASE_URL), the served engine dir otherwise.
   window.PUBLIC_URL = new URL('engine', new URL(import.meta.env.BASE_URL, PAGE_DIR)).href
-  // Every launch param the engine's web param table lists, read from the entry url; only the
+  // Every launch param the engine's web param table lists, read from the entry url; the
+  // `resolved` ones are what this HUD resolved for itself (lib/baseDomain.ts), and only the
   // ui scene has a HUD-side default (our bundled bridge scene, unless a link overrode it).
   window.__bevyBootConfig = {
     ...launchOptionsFromUrl(params),
+    ...SERVICE_OVERRIDES,
+    baseDomain: BASE_DOMAIN,
     systemScene: bootMode().systemScene ?? SYSTEM_SCENE
   }
 

--- a/react-web/src/features/login/LoadingAndLogin.tsx
+++ b/react-web/src/features/login/LoadingAndLogin.tsx
@@ -72,7 +72,7 @@ function useProfile(address?: string): { name?: string; body?: string } {
       return
     }
     let cancelled = false
-    fetch(`${serviceUrl('peer')}/lambdas/profiles/${address}`)
+    fetch(`${serviceUrl('catalyst')}/lambdas/profiles/${address}`)
       .then((r) => r.json() as Promise<ProfileResponse>)
       .then((j) => {
         const a = j.avatars?.[0]

--- a/react-web/src/features/map/atlas.ts
+++ b/react-web/src/features/map/atlas.ts
@@ -91,7 +91,7 @@ export function parcelTileFor(worldX: number, worldZ: number): ParcelTile {
   const centerParcelY = chunkY * PARCEL_TILE_CHUNK + PARCEL_TILE_CHUNK / 2
   const px = PARCEL_TILE_PARCELS * PARCEL_TILE_PX_PER_PARCEL
   return {
-    url: `${serviceUrl('api')}/v1/map.png?center=${centerParcelX},${centerParcelY}&width=${px}&height=${px}&size=${PARCEL_TILE_PX_PER_PARCEL}`,
+    url: `${serviceUrl('mapApi')}/v1/map.png?center=${centerParcelX},${centerParcelY}&width=${px}&height=${px}&size=${PARCEL_TILE_PX_PER_PARCEL}`,
     centerX: centerParcelX * PARCEL_METERS,
     centerZ: centerParcelY * PARCEL_METERS,
     meters: PARCEL_TILE_PARCELS * PARCEL_METERS

--- a/react-web/src/features/places/placesApi.ts
+++ b/react-web/src/features/places/placesApi.ts
@@ -105,7 +105,7 @@ export function fetchWorlds(args: FetchPlacesArgs = {}): Promise<PlacesResponse>
 // only covers Genesis City, and /worlds user counts lag behind live presence. We fetch the
 // live counts and resolve card metadata for those names in one batch.
 
-const WORLDS_LIVE_URL = `${serviceUrl('worlds-content-server')}/live-data`
+const WORLDS_LIVE_URL = `${serviceUrl('worldsServer')}/live-data`
 
 type LiveWorldEntry = { worldName: string; users: number }
 

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -6,7 +6,7 @@ import { serviceUrl } from '../../lib/baseDomain'
 import { clearStoredLogins, getStoredLogin, redirectToAuth, rootAddress, type StoredLogin } from '../auth/sso'
 import type { LoginDriver } from '../../engine/driver'
 import type { FatalError } from '../error/fatalError'
-import { DEFAULT_REALM } from '../engine/EngineHost'
+import { DEFAULT_REALM } from '../../lib/baseDomain'
 import { closeTopPopup, hasOpenPopup, subscribePopups } from '../../design'
 import { bootMode } from '../../lib/bootMode'
 import { isCancelKey, isEditableTarget, setBindingsSnapshot, useBindingsSnapshot } from '../../lib/bindingLabels'
@@ -1052,8 +1052,8 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       // strand a Genesis pick "Reconnecting to the realm" forever.
       try {
         if (dest == null) {
-          // Skip goes HOME — the engine's persisted home scene (the derived default realm at
-          // 0,0 unless the user pinned one), not a hardcoded Genesis Plaza.
+          // Skip goes HOME — the engine's persisted home scene (0,0 on the default realm unless
+          // the user pinned one; the engine gives no realm before launch, so the default is ours).
           const home = driver.homeScene?.()
           driver.launch?.(home?.realm ?? DEFAULT_REALM, home?.parcel ?? '0,0')
         } else if (dest.kind === 'world') driver.launch?.(dest.realm, dest.position)
@@ -1132,7 +1132,7 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       validatingRealm.current = true
       const base =
         dest.realm.endsWith('.dcl.eth') && !dest.realm.startsWith('https://')
-          ? `${serviceUrl('worlds-content-server')}/world/${dest.realm}`
+          ? `${serviceUrl('worldsServer')}/world/${dest.realm}`
           : dest.realm
       // Launching against an unreachable realm strands the engine in a cryptic login failure, so
       // block up front: 404 → not found, no/failed answer (incl. timeout) → unreachable.

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -67,7 +67,9 @@ function service(name: string): ServiceDef {
  * The ?<service>= value the engine will accept (crates/common/src/base_domain.rs
  * `set_services`): a full http(s) — ws(s) for the websocket services — base url with no query or
  * fragment, trailing slash dropped. Anything else is null so the HUD and the engine fall back to
- * the same composed default rather than splitting.
+ * the same composed default rather than splitting. Recomposed from scheme, host and path rather
+ * than serialised: a bare trailing `?` or `#` is empty to `search`/`hash` but a query/fragment to
+ * the engine's parser, which would refuse it and fail the launch.
  */
 export function normaliseServiceUrl(s: ServiceDef, raw: string | null): string | null {
   if (raw == null) return null
@@ -75,7 +77,7 @@ export function normaliseServiceUrl(s: ServiceDef, raw: string | null): string |
     const u = new URL(raw.trim())
     const ok = s.scheme === 'wss' ? /^wss?:$/ : /^https?:$/
     if (!ok.test(u.protocol) || u.search !== '' || u.hash !== '') return null
-    return u.href.replace(/\/+$/, '')
+    return `${u.protocol}//${u.host}${u.pathname}`.replace(/\/+$/, '')
   } catch {
     return null
   }

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -4,11 +4,20 @@
 //   2. else derived from the hosting origin — the staging deployment at decentraland.zone/bevy-web
 //      keys to zone backends, prod to org
 //   3. else decentraland.org (localhost dev, the native CEF page, everything else)
-// Captured once from the entry URL; the engine's URL syncs preserve unknown params so the
-// param form survives realm/position rewrites. This module is the single source: it publishes
-// the value as window.__baseDomain() for the engine loader (deploy/web/engine/boot.js) and the
-// wasm (src/web.rs apply_base_domain → crates/common/src/base_domain.rs), both of which run
-// only after the HUD has mounted EngineHost.
+// Captured once from the entry URL. This module is the HUD's single source; the ENGINE takes the
+// resolved value as an ordinary engine_run option (EngineHost puts `baseDomain` in the boot
+// config, the same route as every other launch param — the wasm never reads it from the page),
+// and echoes it back into the url like the rest (boot.js drops it when it is the derived default).
+//
+// On top of it, per-service urls (serviceUrl): a ?<service>= entry param — a FULL base url, the
+// web form of the native --<service> flags — else composed from the base domain by the
+// convention in the engine's service table (crates/system_api_types/src/services.rs, generated
+// into engine/generated/serviceTable.ts). The explicit overrides go to the engine the same way
+// (SERVICE_OVERRIDES, spread into the boot config); window.__serviceUrl(name) is for the engine
+// loader (deploy/web/engine/boot.js), which composes the default realm / worlds prefix for its
+// url sync exactly as the HUD does.
+
+import { SERVICES, type ServiceDef } from '../engine/generated'
 
 // Decentraland's own deployments — the hosting origins we derive from, and the only domains a
 // LINK may point the session at without the UntrustedLaunchGate (lib/launchGate.ts).
@@ -32,22 +41,74 @@ export function normaliseBaseDomain(raw: string | null): string | null {
   return /^[a-z0-9-]+(\.[a-z0-9-]+)+$/.test(d) ? d : null
 }
 
+/** The domain a url without ?baseDomain= means here: derived from the hosting origin, else org. */
+export const DEFAULT_BASE_DOMAIN = hostBaseDomain(window.location.hostname) ?? 'decentraland.org'
+
 export const BASE_DOMAIN =
-  normaliseBaseDomain(new URLSearchParams(window.location.search).get('baseDomain')) ??
-  hostBaseDomain(window.location.hostname) ??
-  'decentraland.org'
+  normaliseBaseDomain(new URLSearchParams(window.location.search).get('baseDomain')) ?? DEFAULT_BASE_DOMAIN
 
 declare global {
   interface Window {
-    __baseDomain?: () => string
+    __defaultBaseDomain?: () => string
+    __defaultRealm?: () => string
+    __serviceUrl?: (name: string) => string
   }
 }
-window.__baseDomain = () => BASE_DOMAIN
+window.__defaultBaseDomain = () => DEFAULT_BASE_DOMAIN
 
-/** https origin for a service subdomain, e.g. serviceUrl('places') → "https://places.decentraland.org". */
-export function serviceUrl(sub: string): string {
-  return `https://${sub}.${BASE_DOMAIN}`
+/** A service table row by web param name. Throws so a renamed service fails at module load. */
+function service(name: string): ServiceDef {
+  const s = SERVICES.find((s) => s.name === name)
+  if (s == null) throw new Error(`serviceUrl: '${name}' is not in the engine's service table`)
+  return s
 }
+
+/**
+ * The ?<service>= value the engine will accept (crates/common/src/base_domain.rs
+ * `set_services`): a full http(s) — ws(s) for the websocket services — base url with no query or
+ * fragment, trailing slash dropped. Anything else is null so the HUD and the engine fall back to
+ * the same composed default rather than splitting.
+ */
+export function normaliseServiceUrl(s: ServiceDef, raw: string | null): string | null {
+  if (raw == null) return null
+  try {
+    const u = new URL(raw.trim())
+    const ok = s.scheme === 'wss' ? /^wss?:$/ : /^https?:$/
+    if (!ok.test(u.protocol) || u.search !== '' || u.hash !== '') return null
+    return u.href.replace(/\/+$/, '')
+  } catch {
+    return null
+  }
+}
+
+/** The explicit overrides in the ENTRY url, by service name — also the engine's, via the boot config. */
+export const SERVICE_OVERRIDES: Readonly<Record<string, string>> = {}
+{
+  const q = new URLSearchParams(window.location.search)
+  for (const s of SERVICES) {
+    const url = normaliseServiceUrl(s, q.get(s.name))
+    if (url != null) (SERVICE_OVERRIDES as Record<string, string>)[s.name] = url
+  }
+}
+
+/**
+ * A service's base url by its table name: the entry url's override, else composed from the base
+ * domain, e.g. serviceUrl('places') → "https://places.decentraland.org".
+ */
+export function serviceUrl(name: string): string {
+  const s = service(name)
+  const host = s.sub === '' ? BASE_DOMAIN : `${s.sub}.${BASE_DOMAIN}`
+  return SERVICE_OVERRIDES[name] ?? `${s.scheme}://${host}${s.path}`
+}
+window.__serviceUrl = serviceUrl
+
+/**
+ * The main (Genesis City) realm: the realm provider's `/main`, composed exactly as the engine's
+ * common::structs::default_home_realm. Parcel launches pass it EXPLICITLY so a ?realm override —
+ * possibly an invalid world — never leaks into a Places pick (always a Genesis coordinate).
+ */
+export const DEFAULT_REALM = `${serviceUrl('realmProvider')}/main`
+window.__defaultRealm = () => DEFAULT_REALM
 
 // Any other domain arriving by LINK points the whole session's backends — sign-in, content,
 // comms — at someone else's servers, so App.tsx stops on it with the UntrustedLaunchGate before

--- a/react-web/src/lib/identity.ts
+++ b/react-web/src/lib/identity.ts
@@ -14,7 +14,7 @@ const RARITY = [
 
 // Catalyst thumbnail for an emote URN — derived client-side so the wheel shows previews
 // even if the scene relay didn't send a thumbnail. Strips a trailing `:tokenId` (on-chain NFTs).
-const CATALYST_CONTENTS = `${serviceUrl('peer')}/lambdas/collections/contents`
+const CATALYST_CONTENTS = `${serviceUrl('catalyst')}/lambdas/collections/contents`
 
 // Direct catalyst thumbnail URL — used straight as an <img>/<image> src. The catalyst sends
 // no Cross-Origin-Resource-Policy header, but the page runs COEP `credentialless`, under which

--- a/react-web/src/lib/launchGate.ts
+++ b/react-web/src/lib/launchGate.ts
@@ -3,6 +3,7 @@
 // it is decided here, because trust is a property of the host: the editor app trusts its editor
 // scene, this app trusts its bundled bridge scene and Decentraland's own deployments.
 
+import { SERVICES } from '../engine/generated'
 import { BASE_DOMAIN, hostBaseDomain, isTrustedBaseDomain } from './baseDomain'
 import { bootMode } from './bootMode'
 import { isTrustedSystemScene } from './systemScene'
@@ -57,6 +58,16 @@ function isTrustedContentServer(url: string): boolean {
     return hostBaseDomain(new URL(url).hostname) != null
   } catch {
     return false
+  }
+}
+// Every per-service url override: worse than ?baseDomain= in that it can poison ONE service —
+// sign-in, profiles — while everything else looks normal. Same rule as the content server, and
+// native is exempt the same way as the base domain (the shell injects the user's own flags).
+for (const s of SERVICES) {
+  GATES[s.name] = {
+    warning: `Points the Explorer's "${s.name}" backend service at this server, with everything else looking normal. Whoever runs it would see the requests and choose the answers.`,
+    read: (native) => (native ? null : new URLSearchParams(location.search).get(s.name)),
+    isTrusted: isTrustedContentServer
   }
 }
 for (const name of Object.keys(GATES)) webParam(name)

--- a/react-web/src/lib/launchGate.ts
+++ b/react-web/src/lib/launchGate.ts
@@ -4,7 +4,7 @@
 // scene, this app trusts its bundled bridge scene and Decentraland's own deployments.
 
 import { SERVICES } from '../engine/generated'
-import { BASE_DOMAIN, hostBaseDomain, isTrustedBaseDomain } from './baseDomain'
+import { BASE_DOMAIN, hostBaseDomain, isTrustedBaseDomain, normaliseServiceUrl } from './baseDomain'
 import { bootMode } from './bootMode'
 import { isTrustedSystemScene } from './systemScene'
 import { webParam } from './webParams'
@@ -63,10 +63,11 @@ function isTrustedContentServer(url: string): boolean {
 // Every per-service url override: worse than ?baseDomain= in that it can poison ONE service —
 // sign-in, profiles — while everything else looks normal. Same rule as the content server, and
 // native is exempt the same way as the base domain (the shell injects the user's own flags).
+// Read normalised, like the base domain: a value the HUD discards is never put to the user.
 for (const s of SERVICES) {
   GATES[s.name] = {
     warning: `Points the Explorer's "${s.name}" backend service at this server, with everything else looking normal. Whoever runs it would see the requests and choose the answers.`,
-    read: (native) => (native ? null : new URLSearchParams(location.search).get(s.name)),
+    read: (native) => (native ? null : normaliseServiceUrl(s, new URLSearchParams(location.search).get(s.name))),
     isTrusted: isTrustedContentServer
   }
 }

--- a/react-web/src/lib/systemScene.ts
+++ b/react-web/src/lib/systemScene.ts
@@ -29,7 +29,7 @@ export const SYSTEM_SCENE =
 // the engine's ipfs layer expands `name.dcl.eth` into the latter, and boot.js reverses it for the
 // address bar, so both spellings reach users.
 const TRUSTED_WORLDS = ['tortilla.dcl.eth', 'sceneviewer.dcl.eth']
-const WORLDS_PREFIX = `${serviceUrl('worlds-content-server')}/world/`
+const WORLDS_PREFIX = `${serviceUrl('worldsServer')}/world/`
 
 // A scene served from the developer's own machine. `sdk-commands start` is the whole point of the
 // parameter, and a link can't make someone else's machine serve it.

--- a/react-web/src/lib/webParams.ts
+++ b/react-web/src/lib/webParams.ts
@@ -12,7 +12,8 @@ export function webParam(name: string): WebParam {
   return p
 }
 
-/** The `launch`-delivered params — what the host hands boot.js as window.__bevyBootConfig. */
+/** What the host hands boot.js as window.__bevyBootConfig: the `launch`-delivered params as read
+ *  here, plus the `resolved` ones the HUD adds from lib/baseDomain.ts. */
 export type LaunchOptions = Record<string, string | boolean | number | undefined>
 
 /** A url value in the type the engine expects for the param's kind. A number that doesn't parse

--- a/react-web/src/test/webParams.test.ts
+++ b/react-web/src/test/webParams.test.ts
@@ -54,6 +54,19 @@ describe('untrustedLaunchParams', () => {
     }
   })
 
+  it('gates a per-service url override outside decentraland.org/.zone, native exempt', () => {
+    window.history.replaceState(null, '', '/?places=https://places.decentraland.zone&catalyst=http://localhost:3000')
+    try {
+      const [p, ...rest] = untrustedLaunchParams({ native: false })
+      expect(rest).toEqual([])
+      expect(p.name).toBe('catalyst')
+      expect(p.warning).toMatch(/"catalyst" backend service/)
+      expect(untrustedLaunchParams({ native: true })).toEqual([])
+    } finally {
+      window.history.replaceState(null, '', '/')
+    }
+  })
+
   it('reports an unrecognised system scene with the gate copy', () => {
     window.history.replaceState(null, '', '/?systemScene=https://example.com/evil')
     try {

--- a/react-web/src/test/webParams.test.ts
+++ b/react-web/src/test/webParams.test.ts
@@ -2,9 +2,10 @@
 // is filled from it — and this front-end's launch gate over those params (lib/launchGate.ts).
 
 import { describe, expect, it } from 'vitest'
-import { WEB_PARAMS } from '../engine/generated'
+import { SERVICES, WEB_PARAMS } from '../engine/generated'
 import { launchOptionsFromUrl, webParam } from '../lib/webParams'
 import { untrustedLaunchParams } from '../lib/launchGate'
+import { normaliseServiceUrl } from '../lib/baseDomain'
 
 describe('launchOptionsFromUrl', () => {
   it('reads every launch param, flags by presence, strings verbatim, absent = undefined', () => {
@@ -30,6 +31,32 @@ describe('launchOptionsFromUrl', () => {
         .map((p) => p.name)
         .sort()
     )
+  })
+})
+
+describe('normaliseServiceUrl', () => {
+  const catalyst = SERVICES.find((s) => s.name === 'catalyst')!
+  const socialRpc = SERVICES.find((s) => s.name === 'socialRpc')!
+
+  it('yields a base url the engine accepts: scheme + host + path, no trailing slash', () => {
+    expect(normaliseServiceUrl(catalyst, ' https://peer.example/ ')).toBe('https://peer.example')
+    expect(normaliseServiceUrl(catalyst, 'http://127.0.0.1:8799/content/')).toBe('http://127.0.0.1:8799/content')
+    expect(normaliseServiceUrl(socialRpc, 'ws://localhost:9000')).toBe('ws://localhost:9000')
+  })
+
+  it("drops a bare trailing ? or # — empty to URL.search/hash, a query/fragment to the engine's parser", () => {
+    expect(normaliseServiceUrl(catalyst, 'http://127.0.0.1:8799/?')).toBe('http://127.0.0.1:8799')
+    expect(normaliseServiceUrl(catalyst, 'http://127.0.0.1:8799/#')).toBe('http://127.0.0.1:8799')
+    expect(normaliseServiceUrl(catalyst, 'http://127.0.0.1:8799?#')).toBe('http://127.0.0.1:8799')
+  })
+
+  it('is null for anything else, so both sides fall back to the composed default', () => {
+    expect(normaliseServiceUrl(catalyst, null)).toBeNull()
+    expect(normaliseServiceUrl(catalyst, 'localhost:3000')).toBeNull()
+    expect(normaliseServiceUrl(catalyst, 'wss://peer.example')).toBeNull()
+    expect(normaliseServiceUrl(socialRpc, 'https://social.example')).toBeNull()
+    expect(normaliseServiceUrl(catalyst, 'https://places.example/?x=1')).toBeNull()
+    expect(normaliseServiceUrl(catalyst, 'https://places.example/#top')).toBeNull()
   })
 })
 
@@ -62,6 +89,15 @@ describe('untrustedLaunchParams', () => {
       expect(p.name).toBe('catalyst')
       expect(p.warning).toMatch(/"catalyst" backend service/)
       expect(untrustedLaunchParams({ native: true })).toEqual([])
+    } finally {
+      window.history.replaceState(null, '', '/')
+    }
+  })
+
+  it('does not gate a service override the HUD discards (nothing to approve)', () => {
+    window.history.replaceState(null, '', '/?catalyst=localhost:3000&places=https://x.example/?q=1')
+    try {
+      expect(untrustedLaunchParams({ native: false })).toEqual([])
     } finally {
       window.history.replaceState(null, '', '/')
     }

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,12 @@ just native-release --base-domain interconnected.online --position 0,0
 
 On web the same thing is the `?baseDomain=` query param, e.g. `?baseDomain=interconnected.online`. Without the param, the hosting origin decides: a page served under decentraland.zone keys to zone backends, anything else to org.
 
+One service at a time: each has its own flag taking a full base url that replaces that service's composition while the rest keep following the domain (`--help`, "Service endpoints"). The same names are web query params, e.g. `--catalyst http://localhost:3000` / `?catalyst=http://localhost:3000`:
+
+```bash
+just native-release --places http://localhost:5000 --realm-provider http://localhost:8000
+```
+
 Doing it by hand instead of via `just`:
 
 ```bash

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -1117,8 +1117,8 @@ fn drain_control_commands(
                     let client = ipfs.ipfs().client();
                     let sid = scene_id.clone();
                     let task = IoTaskPool::get().spawn_compat(async move {
-                        let url = common::base_domain::https(
-                            "comms-gatekeeper-local",
+                        let url = common::base_domain::url(
+                            common::base_domain::Service::PreviewGatekeeper,
                             "/get-server-scene-adapter",
                         );
                         let uri = http::Uri::try_from(url.as_str())?;

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -26,7 +26,7 @@ pub fn latch(launch: &LaunchOptions) -> Result<(), String> {
     if let Some(domain) = &launch.base_domain {
         common::base_domain::set(domain)?;
     }
-    Ok(())
+    common::base_domain::set_services(launch.services.iter())
 }
 
 /// `boot_server` is the realm the binary decided to boot into (mapped through
@@ -40,6 +40,7 @@ pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_ser
         content_server: _,
         // latch
         base_domain: _,
+        services: _,
         preview,
         pulse_server,
         log_fps,

--- a/src/react_hud_cef.rs
+++ b/src/react_hud_cef.rs
@@ -180,8 +180,10 @@ fn spawn_hud(
         url.push_str("baseDomain=");
         url.push_str(&urlencoding::encode(common::base_domain::get()));
     }
-    // and so does each explicit service override (the HUD resolves its own service urls)
-    for service in common::base_domain::Service::all() {
+    // and so does each explicit service override the HUD has a param for (it resolves its own
+    // service urls); a native-only service is not in its table, so it would land in the page's
+    // unrecognised-parameter dialog
+    for service in common::base_domain::Service::all().filter(|s| s.has_web_param()) {
         if let Some(override_url) = common::base_domain::service_override(service) {
             url.push_str(if url.contains('?') { "&" } else { "?" });
             url.push_str(&service.param());

--- a/src/react_hud_cef.rs
+++ b/src/react_hud_cef.rs
@@ -180,6 +180,15 @@ fn spawn_hud(
         url.push_str("baseDomain=");
         url.push_str(&urlencoding::encode(common::base_domain::get()));
     }
+    // and so does each explicit service override (the HUD resolves its own service urls)
+    for service in common::base_domain::Service::all() {
+        if let Some(override_url) = common::base_domain::service_override(service) {
+            url.push_str(if url.contains('?') { "&" } else { "?" });
+            url.push_str(&service.param());
+            url.push('=');
+            url.push_str(&urlencoding::encode(override_url));
+        }
+    }
 
     let (w, h) = windows
         .single()

--- a/src/web.rs
+++ b/src/web.rs
@@ -67,24 +67,6 @@ extern "C" {
     /// leave keys alone while the user types into scene UI.
     #[wasm_bindgen(js_name = "__setEngineTextFocus")]
     fn set_engine_text_focus(focused: bool);
-
-    /// The ?baseDomain= entry param, captured by boot.js (web parity with --base-domain).
-    /// `catch` so a host page without boot.js just falls through to the default domain.
-    #[wasm_bindgen(js_name = "__baseDomain", catch)]
-    fn base_domain_param() -> Result<String, JsValue>;
-}
-
-/// Latch the base domain before any backend URL is composed. Called at the top of BOTH wasm
-/// entry points: engine_init's config deserialization already materializes
-/// `AppConfig::default()` fields, so engine_run alone would be too late.
-fn apply_base_domain() {
-    if let Ok(domain) = base_domain_param() {
-        if !domain.is_empty() {
-            if let Err(e) = common::base_domain::set(&domain) {
-                warn!("ignoring baseDomain param: {e}");
-            }
-        }
-    }
 }
 
 /// call from a separate worker to initialize a channel for asset load processing
@@ -99,7 +81,6 @@ pub fn init_asset_load_thread() {
 #[wasm_bindgen]
 pub async fn engine_init() -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
-    apply_base_domain();
 
     let mut file = match web_fs::File::open("config.json").await {
         Ok(f) => f,
@@ -125,45 +106,19 @@ pub async fn engine_init() -> Result<JsValue, JsValue> {
     Ok("Config loaded".into())
 }
 
-/// The persisted home scene — realm + "x,y" parcel — as a JSON string, falling back to the
-/// derived defaults. Valid after [`engine_init`] (it reads the loaded config); exposed so the
-/// HUD's places picker can target home from "Skip" BEFORE the engine is launched.
+/// The persisted home scene — the pinned realm (null = none pinned: the HUD substitutes its own
+/// default realm, since this runs before `engine_run` latches the base domain the engine would
+/// compose one from) + "x,y" parcel — as a JSON string. Valid after [`engine_init`] (it reads the
+/// loaded config); exposed so the HUD's places picker can target home from "Skip" BEFORE the
+/// engine is launched.
 #[wasm_bindgen]
 pub fn engine_home_scene() -> String {
     let (realm, parcel) = INIT_DATA
         .get()
-        .map(|config| (config.home_realm(), config.home_location()))
-        .unwrap_or_else(|| {
-            let config = AppConfig::default();
-            (config.home_realm(), config.home_location())
-        });
+        .map(|config| (config.home_realm.clone(), config.home_location()))
+        .unwrap_or_else(|| (None, AppConfig::default().home_location()));
     serde_json::json!({ "realm": realm, "parcel": format!("{},{}", parcel.x, parcel.y) })
         .to_string()
-}
-
-// Type the `engine_run` parameter in the generated .d.ts — keep in step with
-// `system_api_types::launch_options::EngineRunOptions` (the web param table's source).
-#[wasm_bindgen(typescript_custom_section)]
-const ENGINE_RUN_OPTIONS_TS: &str = r#"
-export interface EngineRunOptions {
-    realm?: string;
-    position?: string;
-    systemScene?: string;
-    portables?: string;
-    preview?: boolean;
-    editor?: boolean;
-    contentServer?: string;
-    pulseServer?: string;
-    imposterSource?: string;
-    logFps?: boolean;
-    gpuBytesPerFrame?: number;
-}
-"#;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(typescript_type = "EngineRunOptions")]
-    pub type EngineRunOptionsJs;
 }
 
 /// Round-trip the page's object through JSON rather than `serde_wasm_bindgen::from_value`: that
@@ -175,17 +130,16 @@ fn parse_options(options: &JsValue) -> Result<EngineRunOptions, JsValue> {
         .map_err(|e| JsValue::from_str(&format!("engine_run: invalid options: {e}")))
 }
 
-/// Launch the engine. Throws (rejects the launch) on an invalid options object.
+/// Launch the engine. `options` is the `engine_run` object keyed by the web param table (one
+/// key per launch option; absent = the engine's default). Throws (rejects the launch) on an
+/// invalid one.
 #[wasm_bindgen]
-pub fn engine_run(options: EngineRunOptionsJs) -> Result<(), JsValue> {
+pub fn engine_run(options: JsValue) -> Result<(), JsValue> {
     let options = parse_options(&options)?;
     let _ = LAUNCH_OPTIONS.set(options.clone());
-    apply_base_domain();
-    // the shared launch options' globals (src/launch.rs; the base domain itself came from the
-    // page above, so this can't fail on it)
-    if let Err(e) = crate::launch::latch(&options.launch) {
-        warn!("{e}");
-    }
+    // the shared launch options' globals (src/launch.rs) — before anything composes a backend url
+    crate::launch::latch(&options.launch)
+        .map_err(|e| JsValue::from_str(&format!("engine_run: {e}")))?;
     init_runtime();
 
     let default_filter = "symphonia=warn";


### PR DESCRIPTION
Follow-on to #1219.

Every backend the client talks to is composed from the base domain by convention (`peer.<domain>`, `places.<domain>`, …). This adds one url override per service, so a single backend can be pointed at a local or staging instance while the rest keep following the domain — the pulse-server / content-server pattern, generalised — on native, headless and web, and in the react HUD which resolves the same urls for its own fetches.

## The service table

`Service` (crates/system_api_types/src/services.rs) names each backend with its composition (scheme, sub, path). `common::base_domain::{service, url}` resolve a service to its explicit override, else the composition; the domain-derived call sites (catalyst, worlds, places, gatekeepers, auth, storage, rpc, social, opensea, reels, map) go through them. Pulse keeps its own `host:port` chain. The default realm is not a service: it is the realm provider's `/main`, composed in `default_home_realm` and in the HUD alike.

`ServiceOverrides` is one `--<service> <url>` flag per service under a "Service endpoints" help heading, flattened into the shared `LaunchOptions`, so all three binaries take them (headless has no reader for some, and that is fine). A value is a full base url — scheme must fit the service (http(s), or ws(s) for the websocket ones), no query or fragment, trailing slash dropped — validated once at `launch::latch`, alongside the base domain. Web param names are the camelCase of the flags.

## How they reach the engine on web

The base domain and the overrides are ordinary `engine_run` keys now (web param delivery `resolved`). The HUD reads the entry params, resolves them for its own use first — `lib/baseDomain.ts` `serviceUrl(name)` from the generated service table, the launch gate vetting any url outside decentraland.org/.zone exactly as it does the base domain — and passes the resolved values in the boot config. web.rs no longer reads `window.__baseDomain()` / service overrides from the page; `engine_run` rejects the launch if a value fails validation. boot.js keeps two host callbacks for its url sync only (the default realm and the origin-derived base domain, so an echoed default stays out of the url). `engine_home_scene` returns no realm when none is pinned — it runs before `engine_run` latches the domain — and the HUD's skip-to-home substitutes its own default.

Native is unchanged in shape: the cli flags are forwarded to the HUD page as `?<service>=` params, like `?baseDomain=`.

**Validation lives on both sides, and the HUD's output is what the engine sees.** The HUD's `normaliseServiceUrl` recomposes each override from scheme, host and path, so nothing it hands to `engine_run` can carry a query or fragment the engine's parser would refuse (a bare trailing `?` is empty to `URL.search` but a query to the url crate). The launch gates read the same normalised value, so a value the HUD discards is never put to the user.

**Two services are deliberately narrower.** Storage delegation signing is https-only on both the fetch and the resolved storage service: an http `--storage` override is accepted but never signed for, so the claim cannot go out in cleartext via a link. The two browser sign-in services (`--auth-api`, `--auth-page`) are native flags only: the web page signs in at its own origin's `/auth`, so they have no web param and no row in the HUD's table.

The hand-written `EngineRunOptions` typescript section in web.rs is gone: nothing consumed it, and the web param table is the derived form of the same information.

## Example

```bash
just native-release --places http://localhost:5000 --realm-provider http://localhost:8000
```

`?places=http://localhost:5000` on web (gated, as an untrusted host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

