### PR TITLE
headless: report remote players' emotes to server scenes

### DIFF
--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -31,7 +31,8 @@ use comms::{
 use console::DoAddConsoleCommand;
 use dcl::interface::CrdtType;
 use dcl_component::{
-    proto_components::sdk::components::PbAvatarEmoteCommand, SceneComponentId, SceneEntityId,
+    proto_components::sdk::components::{EmoteState, PbAvatarEmoteCommand},
+    SceneComponentId, SceneEntityId,
 };
 use ipfs::IpfsAssetServer;
 use scene_runner::{
@@ -451,6 +452,8 @@ fn animate(
                         emote_urn: broadcast_urn.to_string(),
                         r#loop: resolved_loop,
                         timestamp,
+                        mask: None,
+                        state: Some(EmoteState::EsStarted as i32),
                     },
                 );
             }

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -29,13 +29,15 @@ use dcl::{
 use dcl_component::{
     proto_components::{
         kernel::comms::rfc4::{self, packet::Message},
-        sdk::components::{EmoteState, PbAvatarEmoteCommand, PbPlayerIdentityData},
+        sdk::components::{
+            common::AvatarMask, EmoteState, PbAvatarEmoteCommand, PbPlayerIdentityData,
+        },
     },
     transform_and_parent::{DclQuat, DclTransformAndParent, DclTranslation},
     DclReader, DclWriter, GlobalCrdtData, Localizer, SceneComponentId, SceneEntityId, SceneOrigin,
 };
 
-use ipfs::{ActiveEntitiesRequest, ActiveEntityTask, IpfsAssetServer};
+use ipfs::{ActiveEntitiesRequest, ActiveEntityTask, EntityDefinition, IpfsAssetServer};
 
 use crate::{profile::ProfileMetaCache, Transport};
 
@@ -1394,8 +1396,10 @@ pub enum ForeignEmoteEventKind {
 /// - `mask` passes through from the wire.
 ///
 /// The urn is a peer-controlled string headed for every subscribed scene's crdt, so it is bounded
-/// before it gets there; each player's queue, the pointer cache and the lookups in flight are
-/// bounded too.
+/// before it gets there; each player's queue, the pointer cache, the lookup wait queue and the
+/// requests in flight are bounded too. A full player queue force-resolves its blocked head as a
+/// one-shot rather than parting a start from its stop; a full wait queue reports a start as a
+/// one-shot at once, uncached.
 ///
 /// Deliberately not part of [`GlobalCrdtPlugin`]: the client must not report twice.
 pub struct ForeignEmoteRelayPlugin;
@@ -1419,16 +1423,24 @@ impl Plugin for ForeignEmoteRelayPlugin {
 
 /// Longest emote identifier accepted from a peer.
 const MAX_EMOTE_URN_BYTES: usize = 256;
-/// Lifecycle reports one player may have waiting on a metadata lookup. Beyond this the oldest are
-/// dropped: the newest are the ones a scene still cares about.
+/// Lifecycle reports one player may have waiting on a metadata lookup. Only a start awaiting its
+/// `loop` can hold a queue, so at this size that head is reported as a one-shot instead and the
+/// queue drains; nothing is dropped, so a start is never parted from its stop. Past twice this —
+/// a single-frame burst from one peer, which Pulse rate-limits — the oldest go.
 const MAX_PENDING_PER_PLAYER: usize = 16;
 /// Resolved `loop` flags kept, by pointer. Emote collections are large, but a room's players use a
 /// small working set.
 const MAX_CACHED_POINTERS: usize = 1024;
 /// How long a failed lookup answers `false` before the pointer is looked up again.
 const LOOKUP_RETRY_SECS: f64 = 60.0;
-/// Metadata batches in flight at once; further unknown pointers wait for a slot.
+/// Metadata requests in flight at once; further unknown pointers wait for a slot.
 const MAX_LOOKUP_BATCHES: usize = 4;
+/// Pointers per metadata request.
+const MAX_LOOKUP_POINTERS_PER_REQUEST: usize = 32;
+/// Pointers waiting for a request slot. Pointers derive from peer-controlled urns, so a burst of
+/// unique ones must not grow memory or request size without bound: past this a start is reported
+/// as a one-shot at once, uncached, rather than queued.
+const MAX_WANTED_POINTERS: usize = 256;
 
 const SCENE_EMOTE_PREFIX: &str = "urn:decentraland:off-chain:scene-emote:";
 const BASE_EMOTE_PREFIX: &str = "urn:decentraland:off-chain:base-emotes:";
@@ -1486,6 +1498,30 @@ fn foreign_emote_urn_is_acceptable(urn: &str) -> bool {
         && !urn.chars().any(|c| c.is_whitespace() || c.is_control())
 }
 
+/// The key a collectible pointer is requested and cached under: each `:` segment lowercased except
+/// `b64-` ones, whose base64 payload is case-sensitive (as `CollectibleUrn` does). Applied to the
+/// pointer derived from a peer's urn AND to the pointers a catalyst answers with, so the two meet.
+fn canonical_pointer(pointer: &str) -> String {
+    pointer
+        .split(':')
+        .map(|segment| {
+            if segment.starts_with("b64-") {
+                segment.to_owned()
+            } else {
+                segment.to_ascii_lowercase()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// A relayed mask is written to a scene only if it names a value of the generated `AvatarMask`;
+/// anything else would reach scene code as an unrecognised enum. (The generated enum offers no
+/// `TryFrom<i32>`, so the variants are listed.)
+fn valid_avatar_mask(mask: i32) -> bool {
+    [AvatarMask::AmUpperBody as i32].contains(&mask)
+}
+
 /// Classify an emote identifier: a scene emote carries its loop flag, an embedded id is tabled, a
 /// bare legacy name is a base emote, and a collectible urn is shortened to the pointer its deployed
 /// entity is registered under (token id dropped, lowercased apart from `b64-` segments, as
@@ -1518,18 +1554,9 @@ fn classify_emote(urn: &str) -> Option<LoopSource> {
     if parts.len() < pointer_parts {
         return None;
     }
-    let pointer = parts[..pointer_parts]
-        .iter()
-        .map(|segment| {
-            if segment.starts_with("b64-") {
-                (*segment).to_owned()
-            } else {
-                segment.to_ascii_lowercase()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(":");
-    Some(LoopSource::Pointer(pointer))
+    Some(LoopSource::Pointer(canonical_pointer(
+        &parts[..pointer_parts].join(":"),
+    )))
 }
 
 /// The `loop` flag in a deployed emote entity's metadata.
@@ -1578,8 +1605,8 @@ pub struct ForeignEmoteRelay {
     cache_order: VecDeque<String>,
     /// pointers with a lookup in flight, or waiting for a batch slot
     requested: HashSet<String>,
-    /// pointers waiting for a batch slot
-    wanted: Vec<String>,
+    /// pointers waiting for a request slot, oldest first
+    wanted: VecDeque<String>,
     batches: Vec<LookupBatch>,
     sequence: u32,
 }
@@ -1634,7 +1661,7 @@ fn queue_foreign_emote_reports(
                 let source = classify_emote(urn).unwrap_or(LoopSource::Known(false));
                 PendingReport::Start {
                     urn: urn.clone(),
-                    mask: *mask,
+                    mask: mask.filter(|mask| valid_avatar_mask(*mask)),
                     source,
                 }
             }
@@ -1643,8 +1670,22 @@ fn queue_foreign_emote_reports(
             },
         };
         let queue = relay.pending.entry(event.player).or_default();
+        if queue.len() >= MAX_PENDING_PER_PLAYER {
+            // full. Only a start awaiting its loop can hold a queue: report it as a one-shot so
+            // the queue drains, rather than drop anything and part a start from its stop
+            if let Some(PendingReport::Start { source, .. }) = queue.front_mut() {
+                if matches!(source, LoopSource::Pointer(_)) {
+                    debug!(
+                        "emote queue full for {:#x}; reporting its blocked start as a one-shot",
+                        player.address
+                    );
+                    *source = LoopSource::Known(false);
+                }
+            }
+        }
         queue.push_back(report);
-        while queue.len() > MAX_PENDING_PER_PLAYER {
+        // last resort against a single-frame burst from one peer
+        while queue.len() > 2 * MAX_PENDING_PER_PLAYER {
             queue.pop_front();
         }
     }
@@ -1694,13 +1735,20 @@ fn flush_foreign_emote_reports(
                 PendingReport::Start { urn, mask, source } => {
                     let loops = match source {
                         LoopSource::Known(loops) => Some(*loops),
-                        LoopSource::Pointer(pointer) => {
-                            let cached = cached_loop(cache, pointer, now);
-                            if cached.is_none() && requested.insert(pointer.clone()) {
-                                wanted.push(pointer.clone());
+                        LoopSource::Pointer(pointer) => match cached_loop(cache, pointer, now) {
+                            Some(loops) => Some(loops),
+                            // asked already; the answer is on its way
+                            None if requested.contains(pointer) => None,
+                            None if wanted.len() >= MAX_WANTED_POINTERS => {
+                                debug!("emote lookup queue full; reporting {pointer} as a one-shot");
+                                Some(false)
                             }
-                            cached
-                        }
+                            None => {
+                                requested.insert(pointer.clone());
+                                wanted.push_back(pointer.clone());
+                                None
+                            }
+                        },
                     };
                     match loops {
                         Some(loops) => HeadAction::Write {
@@ -1763,7 +1811,57 @@ fn flush_foreign_emote_reports(
     });
 }
 
-/// Bank the answers of landed metadata lookups and start one for the pointers now wanted.
+/// The next request's pointers: up to `MAX_LOOKUP_POINTERS_PER_REQUEST`, oldest first.
+fn take_lookup_chunk(wanted: &mut VecDeque<String>) -> Vec<String> {
+    let count = wanted.len().min(MAX_LOOKUP_POINTERS_PER_REQUEST);
+    wanted.drain(..count).collect()
+}
+
+/// Bank a landed lookup's answers for the `pointers` it asked about. Returned pointers go through
+/// the same canonicalisation as requested ones so an answer always finds its question; a pointer the
+/// catalyst did not answer is a definitive "no such emote" and is cached as a one-shot too, else an
+/// unknown urn would be looked up again on every trigger. A failed request answers `false` for
+/// `LOOKUP_RETRY_SECS` and is then retried.
+fn bank_lookup(
+    relay: &mut ForeignEmoteRelay,
+    pointers: Vec<String>,
+    result: Result<Vec<EntityDefinition>, anyhow::Error>,
+    now: f64,
+) {
+    match result {
+        Ok(entities) => {
+            let mut answered: HashSet<String> = HashSet::default();
+            for entity in entities {
+                let loops = entity
+                    .metadata
+                    .as_ref()
+                    .and_then(loop_from_emote_metadata)
+                    .unwrap_or(false);
+                for pointer in entity.pointers {
+                    let pointer = canonical_pointer(&pointer);
+                    answered.insert(pointer.clone());
+                    relay.remember(pointer, loops, None);
+                }
+            }
+            for pointer in &pointers {
+                if !answered.contains(pointer) {
+                    relay.remember(pointer.clone(), false, None);
+                }
+            }
+        }
+        Err(e) => {
+            warn!("emote metadata lookup failed: {e}");
+            for pointer in &pointers {
+                relay.remember(pointer.clone(), false, Some(now + LOOKUP_RETRY_SECS));
+            }
+        }
+    }
+    for pointer in &pointers {
+        relay.requested.remove(pointer);
+    }
+}
+
+/// Bank the answers of landed metadata lookups and start requests for the pointers now wanted.
 fn resolve_foreign_emote_metadata(
     mut relay: ResMut<ForeignEmoteRelay>,
     ipfas: IpfsAssetServer,
@@ -1782,43 +1880,11 @@ fn resolve_foreign_emote_metadata(
             None => true,
         });
     for (pointers, result) in landed {
-        match result {
-            Ok(entities) => {
-                let mut answered: HashSet<String> = HashSet::default();
-                for entity in entities {
-                    let loops = entity
-                        .metadata
-                        .as_ref()
-                        .and_then(loop_from_emote_metadata)
-                        .unwrap_or(false);
-                    for pointer in entity.pointers {
-                        let pointer = pointer.to_ascii_lowercase();
-                        answered.insert(pointer.clone());
-                        relay.remember(pointer, loops, None);
-                    }
-                }
-                // a definitive "no such emote" is cached too, else an unknown urn would be looked
-                // up again on every trigger
-                for pointer in &pointers {
-                    if !answered.contains(pointer) {
-                        relay.remember(pointer.clone(), false, None);
-                    }
-                }
-            }
-            Err(e) => {
-                warn!("emote metadata lookup failed: {e}");
-                for pointer in &pointers {
-                    relay.remember(pointer.clone(), false, Some(now + LOOKUP_RETRY_SECS));
-                }
-            }
-        }
-        for pointer in &pointers {
-            relay.requested.remove(pointer);
-        }
+        bank_lookup(&mut relay, pointers, result, now);
     }
 
-    if !relay.wanted.is_empty() && relay.batches.len() < MAX_LOOKUP_BATCHES {
-        let pointers = std::mem::take(&mut relay.wanted);
+    while !relay.wanted.is_empty() && relay.batches.len() < MAX_LOOKUP_BATCHES {
+        let pointers = take_lookup_chunk(&mut relay.wanted);
         let task = ipfas.ipfs().active_entities(
             ActiveEntitiesRequest::Pointers(pointers.clone()),
             Some(&emote_catalyst_url()),
@@ -1911,6 +1977,25 @@ mod foreign_emote_relay_tests {
             .unwrap_or_default()
     }
 
+    fn started_with_mask(app: &mut App, player: Entity, urn: &str, mask: i32) {
+        app.world_mut().send_event(ForeignEmoteEvent {
+            player,
+            kind: ForeignEmoteEventKind::Started {
+                urn: urn.to_owned(),
+                mask: Some(mask),
+            },
+        });
+    }
+
+    fn looping_entity(pointer: &str) -> EntityDefinition {
+        EntityDefinition {
+            id: "bafyentity".to_owned(),
+            pointers: vec![pointer.to_owned()],
+            content: Default::default(),
+            metadata: Some(serde_json::json!({ "emoteDataADR74": { "loop": true } })),
+        }
+    }
+
     fn state_of(command: &PbAvatarEmoteCommand) -> EmoteState {
         match command.state.expect("state is always written") {
             s if s == EmoteState::EsStarted as i32 => EmoteState::EsStarted,
@@ -1983,7 +2068,7 @@ mod foreign_emote_relay_tests {
         {
             let relay = app.world().resource::<ForeignEmoteRelay>();
             assert!(relay.requested.contains(WEARABLE_POINTER));
-            assert_eq!(relay.wanted, vec![WEARABLE_POINTER.to_owned()]);
+            assert_eq!(relay.wanted, VecDeque::from([WEARABLE_POINTER.to_owned()]));
         }
 
         // the cancel lands before the metadata does; it must not overtake the start
@@ -2006,7 +2091,7 @@ mod foreign_emote_relay_tests {
         // the pointer is asked for once
         assert_eq!(
             app.world().resource::<ForeignEmoteRelay>().wanted,
-            vec![WEARABLE_POINTER.to_owned()]
+            VecDeque::from([WEARABLE_POINTER.to_owned()])
         );
     }
 
@@ -2155,5 +2240,194 @@ mod foreign_emote_relay_tests {
         assert!(relay
             .cache
             .contains_key(&format!("pointer-{MAX_CACHED_POINTERS}")));
+    }
+
+    #[test]
+    fn canonicalises_b64_segments_on_both_paths() {
+        // a preview-server item id: base64 is case-sensitive, so `b64-` segments keep their case
+        // while the rest of the urn is lowercased — on the request AND the answer
+        const URN: &str = "urn:decentraland:matic:collections-v2:b64-QWJjRGVm:0:7";
+        const POINTER: &str = "urn:decentraland:matic:collections-v2:b64-QWJjRGVm:0";
+        assert_eq!(
+            classify_emote(URN),
+            Some(LoopSource::Pointer(POINTER.to_owned()))
+        );
+
+        let mut app = app();
+        let (context, _receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(40, 0);
+        let player = spawn_player(&mut app, context, scene_id);
+        started(&mut app, player, URN);
+        app.update();
+        assert!(reported(&app, context, scene_id).is_empty());
+
+        // the catalyst echoes the pointer in its own casing
+        let answered = "URN:DECENTRALAND:MATIC:COLLECTIONS-V2:b64-QWJjRGVm:0";
+        {
+            let mut relay = app.world_mut().resource_mut::<ForeignEmoteRelay>();
+            bank_lookup(
+                &mut relay,
+                vec![POINTER.to_owned()],
+                Ok(vec![looping_entity(answered)]),
+                0.0,
+            );
+            assert_eq!(relay.cache.len(), 1, "one key for request and answer");
+            assert!(relay.cache.contains_key(POINTER));
+            assert!(!relay.requested.contains(POINTER));
+        }
+        app.update();
+
+        let commands = reported(&app, context, scene_id);
+        assert_eq!(commands.len(), 1);
+        assert!(commands[0].r#loop, "the looping answer reached the report");
+        assert_eq!(commands[0].emote_urn, URN);
+    }
+
+    #[test]
+    fn unanswered_and_failed_lookups_are_banked_distinctly() {
+        let mut relay = ForeignEmoteRelay::default();
+        relay.requested.insert("a".to_owned());
+        relay.requested.insert("b".to_owned());
+        // `a` answered, `b` not: `b` is a definitive miss, cached for good
+        bank_lookup(
+            &mut relay,
+            vec!["a".to_owned(), "b".to_owned()],
+            Ok(vec![looping_entity("a")]),
+            0.0,
+        );
+        assert_eq!(cached_loop(&relay.cache, "a", 1e9), Some(true));
+        assert_eq!(cached_loop(&relay.cache, "b", 1e9), Some(false));
+        assert!(relay.requested.is_empty());
+
+        // a failed request is a stand-in answer that expires
+        relay.requested.insert("c".to_owned());
+        bank_lookup(
+            &mut relay,
+            vec!["c".to_owned()],
+            Err(anyhow::anyhow!("offline")),
+            5.0,
+        );
+        assert_eq!(cached_loop(&relay.cache, "c", 5.0), Some(false));
+        assert_eq!(
+            cached_loop(&relay.cache, "c", 5.0 + LOOKUP_RETRY_SECS),
+            None
+        );
+        assert!(relay.requested.is_empty());
+    }
+
+    #[test]
+    fn caps_the_lookup_queue_and_chunks_requests() {
+        let mut app = app();
+        let (context, _receiver) = spawn_context(&mut app);
+        // more players than the wait queue holds, each triggering a distinct unresolved emote
+        let players: Vec<(Entity, SceneEntityId)> = (0..MAX_WANTED_POINTERS + 44)
+            .map(|i| {
+                let scene_id = SceneEntityId::new(1000 + i as u16, 0);
+                (spawn_player(&mut app, context, scene_id), scene_id)
+            })
+            .collect();
+        for (i, (player, _)) in players.iter().enumerate() {
+            started(
+                &mut app,
+                *player,
+                &format!("urn:decentraland:matic:collections-v2:0xabc:{i}:1"),
+            );
+        }
+        app.update();
+
+        {
+            let relay = app.world().resource::<ForeignEmoteRelay>();
+            assert_eq!(relay.wanted.len(), MAX_WANTED_POINTERS);
+            assert_eq!(relay.requested.len(), MAX_WANTED_POINTERS);
+        }
+        // the overflow was reported at once as one-shots, not queued or dropped
+        let overflow: Vec<PbAvatarEmoteCommand> = players
+            .iter()
+            .flat_map(|(_, scene_id)| reported(&app, context, *scene_id))
+            .collect();
+        assert_eq!(overflow.len(), 44);
+        assert!(overflow.iter().all(|command| !command.r#loop));
+        {
+            let relay = app.world().resource::<ForeignEmoteRelay>();
+            assert_eq!(relay.cache.len(), 0, "overflow answers are not cached");
+        }
+
+        // requests go out in fixed-size chunks, oldest first
+        let mut wanted =
+            std::mem::take(&mut app.world_mut().resource_mut::<ForeignEmoteRelay>().wanted);
+        // players flush in map order, so which pointer is oldest is not the spawn order; what
+        // matters is that a chunk takes from the front
+        let oldest = wanted.front().cloned().unwrap();
+        let first = take_lookup_chunk(&mut wanted);
+        assert_eq!(first.len(), MAX_LOOKUP_POINTERS_PER_REQUEST);
+        assert_eq!(first[0], oldest);
+        assert_eq!(
+            wanted.len(),
+            MAX_WANTED_POINTERS - MAX_LOOKUP_POINTERS_PER_REQUEST
+        );
+        let mut chunks = 1;
+        while !wanted.is_empty() {
+            assert!(take_lookup_chunk(&mut wanted).len() <= MAX_LOOKUP_POINTERS_PER_REQUEST);
+            chunks += 1;
+        }
+        assert_eq!(
+            chunks,
+            MAX_WANTED_POINTERS / MAX_LOOKUP_POINTERS_PER_REQUEST
+        );
+    }
+
+    #[test]
+    fn full_queue_force_resolves_its_blocked_head() {
+        let mut app = app();
+        let (context, _receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(41, 0);
+        let player = spawn_player(&mut app, context, scene_id);
+
+        // a start awaiting metadata, then a backlog behind it
+        started(&mut app, player, WEARABLE);
+        for _ in 0..MAX_PENDING_PER_PLAYER {
+            stopped(&mut app, player, false);
+        }
+        app.update();
+
+        let commands = reported(&app, context, scene_id);
+        assert_eq!(
+            commands.len(),
+            2,
+            "the start went out (as a one-shot) and its stop followed"
+        );
+        assert_eq!(state_of(&commands[0]), EmoteState::EsStarted);
+        assert!(!commands[0].r#loop);
+        assert_eq!(state_of(&commands[1]), EmoteState::EsInterrupted);
+        assert_eq!(commands[1].emote_urn, WEARABLE);
+        let relay = app.world().resource::<ForeignEmoteRelay>();
+        assert!(relay.pending.is_empty(), "the backlog drained");
+        assert!(
+            !relay.cache.contains_key(WEARABLE_POINTER),
+            "a forced answer is not cached"
+        );
+    }
+
+    #[test]
+    fn writes_only_masks_the_enum_defines() {
+        let mut app = app();
+        let (context, _receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(42, 0);
+        let player = spawn_player(&mut app, context, scene_id);
+
+        started_with_mask(
+            &mut app,
+            player,
+            SCENE_LOOPING,
+            AvatarMask::AmUpperBody as i32,
+        );
+        app.update();
+        started_with_mask(&mut app, player, SCENE_LOOPING, 7);
+        app.update();
+
+        let commands = reported(&app, context, scene_id);
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].mask, Some(AvatarMask::AmUpperBody as i32));
+        assert_eq!(commands[1].mask, None);
     }
 }

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -1,4 +1,4 @@
-use std::{f32::consts::TAU, sync::Arc};
+use std::{collections::VecDeque, f32::consts::TAU, sync::Arc};
 
 use bevy::{
     app::Propagate,
@@ -13,7 +13,7 @@ use common::{
         AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, HeadSync, MoveKind, PointAtSync,
         SceneDrivenAnimationRequest,
     },
-    util::ModifyComponentExt,
+    util::{ModifyComponentExt, TaskExt},
 };
 use ethers_core::types::Address;
 use serde::{Deserialize, Serialize};
@@ -29,11 +29,13 @@ use dcl::{
 use dcl_component::{
     proto_components::{
         kernel::comms::rfc4::{self, packet::Message},
-        sdk::components::PbPlayerIdentityData,
+        sdk::components::{EmoteState, PbAvatarEmoteCommand, PbPlayerIdentityData},
     },
     transform_and_parent::{DclQuat, DclTransformAndParent, DclTranslation},
     DclReader, DclWriter, GlobalCrdtData, Localizer, SceneComponentId, SceneEntityId, SceneOrigin,
 };
+
+use ipfs::{ActiveEntitiesRequest, ActiveEntityTask, IpfsAssetServer};
 
 use crate::{profile::ProfileMetaCache, Transport};
 
@@ -119,6 +121,7 @@ impl Plugin for GlobalCrdtPlugin {
         app.add_event::<PlayerSceneAnimEvent>();
         app.add_event::<ProfileEvent>();
         app.add_event::<ChatEvent>();
+        app.add_event::<ForeignEmoteEvent>();
     }
 }
 
@@ -152,6 +155,11 @@ pub enum PlayerMessage {
         /// The server tick the emote started on; ordering only.
         incremental_id: u32,
         stopping: bool,
+        /// On a stop: the server's one-shot timer expired (a natural finish) rather than the
+        /// player cancelling a looping emote. Always false on a start.
+        completed: bool,
+        /// On a start: the `AvatarMask` value the server relayed, if the emote is partial-body.
+        mask: Option<i32>,
     },
     AudioStreamAvailable {
         transport: Entity,
@@ -181,11 +189,15 @@ impl std::fmt::Debug for PlayerMessage {
                 urn,
                 incremental_id,
                 stopping,
+                completed,
+                mask,
             } => f
                 .debug_struct("Emote")
                 .field("urn", urn)
                 .field("incremental_id", incremental_id)
                 .field("stopping", stopping)
+                .field("completed", completed)
+                .field("mask", mask)
                 .finish(),
             Self::AudioStreamAvailable { transport } => f
                 .debug_tuple("AudioStreamAvailable")
@@ -913,6 +925,8 @@ pub fn process_transport_updates(
                             urn,
                             incremental_id,
                             stopping,
+                            completed,
+                            mask,
                         } => {
                             debug!("emote: {urn} (stopping: {stopping})");
                             if stopping {
@@ -920,11 +934,19 @@ pub fn process_transport_updates(
                                 // completion). Foreign emotes no longer self-cancel on motion (see
                                 // `animate`), so the wire stop is what ends a looping one.
                                 commands.entity(entity).remove::<EmoteCommand>();
+                                commands.send_event(ForeignEmoteEvent {
+                                    player: entity,
+                                    kind: ForeignEmoteEventKind::Stopped { completed },
+                                });
                             } else {
                                 commands.entity(entity).try_insert(EmoteCommand {
                                     timestamp: incremental_id as i64,
-                                    urn,
+                                    urn: urn.clone(),
                                     r#loop: false,
+                                });
+                                commands.send_event(ForeignEmoteEvent {
+                                    player: entity,
+                                    kind: ForeignEmoteEventKind::Started { urn, mask },
                                 });
                             }
                         }
@@ -1317,5 +1339,821 @@ fn receive_new_voice_message_senders(
         if let SystemApi::GetVoiceStream(stream) = event {
             voice_message_streams.push(stream.clone());
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Foreign emote relay (render-free)
+// ---------------------------------------------------------------------------
+
+/// A remote player's emote lifecycle as decoded from the wire. Emitted by
+/// [`process_transport_updates`] next to the `EmoteCommand` it maintains on the player entity, so
+/// a consumer sees every transition in order — including a start and stop landing in one frame,
+/// which the component alone would collapse — and gets what the component cannot carry: why an
+/// emote stopped, and its body mask.
+#[derive(Event, Debug, Clone, PartialEq)]
+pub struct ForeignEmoteEvent {
+    pub player: Entity,
+    pub kind: ForeignEmoteEventKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ForeignEmoteEventKind {
+    Started {
+        urn: String,
+        /// `AvatarMask` value from the server, if the emote is partial-body.
+        mask: Option<i32>,
+    },
+    Stopped {
+        /// The server's one-shot timer expired (a natural finish) rather than the player cancelling.
+        completed: bool,
+    },
+}
+
+/// Reports remote players' emotes to scenes as `AvatarEmoteCommand` entries — a grow-only set on
+/// the player's entity — without any avatar rendering. Headless / authoritative-server only.
+///
+/// On the client this is `avatar::animate`'s job, and it reports only starts, once the clip has
+/// loaded. A server loads no avatar assets, so nothing there ever wrote the component and a server
+/// scene could never react to what players do. This relays the wire events instead, and reports the
+/// whole lifecycle the component can express:
+///
+/// - a start is `ES_STARTED` with the emote's real `loop`: a scene emote carries it in the urn's
+///   trailing `-{loop}` token, the reference client's embedded animations come from a fixed table,
+///   and everything else — base and wearable emotes — is looked up in the emote's deployed
+///   metadata (`emoteDataADR74.loop`) on the catalyst, cached by pointer. A start whose metadata
+///   is still in flight waits, and so does everything queued behind it for that player, so a scene
+///   always sees a player's events in wire order. A lookup that fails answers `false` for a while
+///   and is then retried; an identifier no catalyst could resolve reports `false` at once.
+/// - a stop is `ES_FINISHED` when the server's one-shot timer expired and `ES_INTERRUPTED` when
+///   the player cancelled a looping emote, echoing the started emote's urn and loop so a scene can
+///   match it without bookkeeping. A stop with no start on record is dropped.
+/// - `timestamp` is a host-side monotonic counter. The SDK's grow-only set sorts a row by it and
+///   trims from the front, so a non-monotonic key — the peer's clock, or the Pulse start tick of a
+///   replayed emote — could see an entry dropped outright.
+/// - `mask` passes through from the wire.
+///
+/// The urn is a peer-controlled string headed for every subscribed scene's crdt, so it is bounded
+/// before it gets there; each player's queue, the pointer cache and the lookups in flight are
+/// bounded too.
+///
+/// Deliberately not part of [`GlobalCrdtPlugin`]: the client must not report twice.
+pub struct ForeignEmoteRelayPlugin;
+
+impl Plugin for ForeignEmoteRelayPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ForeignEmoteRelay>();
+        // flush before resolve so a pointer first needed this frame is requested this frame
+        app.add_systems(
+            Update,
+            (
+                queue_foreign_emote_reports,
+                flush_foreign_emote_reports,
+                resolve_foreign_emote_metadata,
+            )
+                .chain()
+                .after(process_transport_updates),
+        );
+    }
+}
+
+/// Longest emote identifier accepted from a peer.
+const MAX_EMOTE_URN_BYTES: usize = 256;
+/// Lifecycle reports one player may have waiting on a metadata lookup. Beyond this the oldest are
+/// dropped: the newest are the ones a scene still cares about.
+const MAX_PENDING_PER_PLAYER: usize = 16;
+/// Resolved `loop` flags kept, by pointer. Emote collections are large, but a room's players use a
+/// small working set.
+const MAX_CACHED_POINTERS: usize = 1024;
+/// How long a failed lookup answers `false` before the pointer is looked up again.
+const LOOKUP_RETRY_SECS: f64 = 60.0;
+/// Metadata batches in flight at once; further unknown pointers wait for a slot.
+const MAX_LOOKUP_BATCHES: usize = 4;
+
+const SCENE_EMOTE_PREFIX: &str = "urn:decentraland:off-chain:scene-emote:";
+const BASE_EMOTE_PREFIX: &str = "urn:decentraland:off-chain:base-emotes:";
+
+/// The reference client's embedded animation set (`EmbeddedEmotes.asset`), triggered by bare id
+/// and never deployed to a catalyst, so a lookup could not resolve them. Only the sitting
+/// animations loop.
+const EMBEDDED_LOOPING_EMOTES: [&str; 4] = [
+    "sittingchair1",
+    "sittingchair2",
+    "sittingground1",
+    "sittingground2",
+];
+const EMBEDDED_ONESHOT_EMOTES: [&str; 17] = [
+    "crafting",
+    "handsintheair",
+    "victory",
+    "waving",
+    "buttondown",
+    "buttonfront",
+    "gethit",
+    "knockout",
+    "lever",
+    "openchest",
+    "opendoor",
+    "punch",
+    "push",
+    "swingweapononehand",
+    "swingweapontwohands",
+    "throw",
+    "fistpump_short",
+];
+
+/// Where emote entities are deployed. Wearables and emotes live on the catalyst network, not on a
+/// world or preview realm's content server, so the lookup goes there regardless of realm.
+fn emote_catalyst_url() -> String {
+    common::base_domain::https("peer", "/content")
+}
+
+/// How an emote's `loop` is known, decided from the identifier alone.
+#[derive(Debug, Clone, PartialEq)]
+enum LoopSource {
+    /// Known without a lookup.
+    Known(bool),
+    /// Needs the deployed metadata registered under this catalyst pointer.
+    Pointer(String),
+}
+
+/// Reject what no real emote identifier looks like: empty, oversized, or carrying whitespace /
+/// control characters (urns, legacy names and embedded ids are all single tokens). Not a charset
+/// allowlist: a false reject would silently drop a legitimate emote.
+fn foreign_emote_urn_is_acceptable(urn: &str) -> bool {
+    !urn.is_empty()
+        && urn.len() <= MAX_EMOTE_URN_BYTES
+        && !urn.chars().any(|c| c.is_whitespace() || c.is_control())
+}
+
+/// Classify an emote identifier: a scene emote carries its loop flag, an embedded id is tabled, a
+/// bare legacy name is a base emote, and a collectible urn is shortened to the pointer its deployed
+/// entity is registered under (token id dropped, lowercased apart from `b64-` segments, as
+/// `CollectibleUrn` does). `None`: nothing a catalyst could resolve.
+fn classify_emote(urn: &str) -> Option<LoopSource> {
+    if let Some(scene_emote) = urn.strip_prefix(SCENE_EMOTE_PREFIX) {
+        let loops = scene_emote
+            .rsplit_once('-')
+            .is_some_and(|(_, flag)| flag.eq_ignore_ascii_case("true"));
+        return Some(LoopSource::Known(loops));
+    }
+    let lowered = urn.to_ascii_lowercase();
+    if EMBEDDED_LOOPING_EMOTES.contains(&lowered.as_str()) {
+        return Some(LoopSource::Known(true));
+    }
+    if EMBEDDED_ONESHOT_EMOTES.contains(&lowered.as_str()) {
+        return Some(LoopSource::Known(false));
+    }
+    if !urn.contains(':') {
+        // legacy bare base-emote name ("wave"), still emitted by older clients and scene calls
+        return Some(LoopSource::Pointer(format!("{BASE_EMOTE_PREFIX}{lowered}")));
+    }
+    let parts: Vec<&str> = urn.split(':').collect();
+    let pointer_parts = match parts.get(3).copied() {
+        Some("base-avatars" | "base-emotes") => 5,
+        Some("collections-v1" | "collections-v2") => 6,
+        Some("collections-thirdparty") => 7,
+        _ => return None,
+    };
+    if parts.len() < pointer_parts {
+        return None;
+    }
+    let pointer = parts[..pointer_parts]
+        .iter()
+        .map(|segment| {
+            if segment.starts_with("b64-") {
+                (*segment).to_owned()
+            } else {
+                segment.to_ascii_lowercase()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(":");
+    Some(LoopSource::Pointer(pointer))
+}
+
+/// The `loop` flag in a deployed emote entity's metadata.
+fn loop_from_emote_metadata(metadata: &serde_json::Value) -> Option<bool> {
+    metadata
+        .get("emoteDataADR74")
+        .or_else(|| metadata.get("data"))
+        .and_then(|data| data.get("loop"))
+        .and_then(serde_json::Value::as_bool)
+}
+
+/// A lifecycle report waiting to be written, in wire order per player.
+#[derive(Debug)]
+enum PendingReport {
+    Start {
+        urn: String,
+        mask: Option<i32>,
+        source: LoopSource,
+    },
+    Stop {
+        completed: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CachedLoop {
+    loops: bool,
+    /// `Some(when)`: a failed lookup's stand-in answer, superseded once `when` has passed.
+    retry_after: Option<f64>,
+}
+
+struct LookupBatch {
+    pointers: Vec<String>,
+    task: ActiveEntityTask,
+}
+
+/// State of the [`ForeignEmoteRelayPlugin`]: per-player report queues, the pointer → `loop` cache
+/// and the metadata lookups in flight.
+#[derive(Resource, Default)]
+pub struct ForeignEmoteRelay {
+    pending: HashMap<Entity, VecDeque<PendingReport>>,
+    /// urn and loop of the last start reported per player, so a stop can echo them
+    started: HashMap<Entity, (String, bool)>,
+    cache: HashMap<String, CachedLoop>,
+    /// insertion order of `cache`, for eviction
+    cache_order: VecDeque<String>,
+    /// pointers with a lookup in flight, or waiting for a batch slot
+    requested: HashSet<String>,
+    /// pointers waiting for a batch slot
+    wanted: Vec<String>,
+    batches: Vec<LookupBatch>,
+    sequence: u32,
+}
+
+impl ForeignEmoteRelay {
+    fn remember(&mut self, pointer: String, loops: bool, retry_after: Option<f64>) {
+        if self
+            .cache
+            .insert(pointer.clone(), CachedLoop { loops, retry_after })
+            .is_none()
+        {
+            self.cache_order.push_back(pointer);
+            while self.cache_order.len() > MAX_CACHED_POINTERS {
+                if let Some(oldest) = self.cache_order.pop_front() {
+                    self.cache.remove(&oldest);
+                }
+            }
+        }
+    }
+}
+
+/// The cached `loop` for a pointer, unless it is a failed lookup's stand-in whose retry is due.
+fn cached_loop(cache: &HashMap<String, CachedLoop>, pointer: &str, now: f64) -> Option<bool> {
+    cache
+        .get(pointer)
+        .filter(|cached| cached.retry_after.is_none_or(|when| now < when))
+        .map(|cached| cached.loops)
+}
+
+/// Queue each wire event behind the player's earlier ones.
+fn queue_foreign_emote_reports(
+    mut events: EventReader<ForeignEmoteEvent>,
+    players: Query<&ForeignPlayer>,
+    mut relay: ResMut<ForeignEmoteRelay>,
+) {
+    for event in events.read() {
+        // gone before we got here: nothing to report it against
+        let Ok(player) = players.get(event.player) else {
+            continue;
+        };
+        let report = match &event.kind {
+            ForeignEmoteEventKind::Started { urn, mask } => {
+                if !foreign_emote_urn_is_acceptable(urn) {
+                    debug!(
+                        "dropping emote with unacceptable urn from {:#x}",
+                        player.address
+                    );
+                    continue;
+                }
+                // an identifier no catalyst could resolve still names a playback: report it as a
+                // one-shot rather than losing the event
+                let source = classify_emote(urn).unwrap_or(LoopSource::Known(false));
+                PendingReport::Start {
+                    urn: urn.clone(),
+                    mask: *mask,
+                    source,
+                }
+            }
+            ForeignEmoteEventKind::Stopped { completed } => PendingReport::Stop {
+                completed: *completed,
+            },
+        };
+        let queue = relay.pending.entry(event.player).or_default();
+        queue.push_back(report);
+        while queue.len() > MAX_PENDING_PER_PLAYER {
+            queue.pop_front();
+        }
+    }
+}
+
+/// What to do with the head of a player's queue.
+enum HeadAction {
+    Write {
+        urn: String,
+        loops: bool,
+        mask: Option<i32>,
+        state: EmoteState,
+    },
+    Skip,
+    Wait,
+}
+
+/// Drain each player's queue for as long as its head can be written.
+fn flush_foreign_emote_reports(
+    players: Query<&ForeignPlayer>,
+    mut contexts: Query<&mut GlobalCrdtState>,
+    mut relay: ResMut<ForeignEmoteRelay>,
+    time: Res<Time>,
+) {
+    let now = time.elapsed_secs_f64();
+    let ForeignEmoteRelay {
+        pending,
+        started,
+        cache,
+        requested,
+        wanted,
+        sequence,
+        ..
+    } = &mut *relay;
+
+    pending.retain(|player, queue| {
+        let Ok(foreign) = players.get(*player) else {
+            started.remove(player);
+            return false;
+        };
+        let Ok(mut state) = contexts.get_mut(foreign.context) else {
+            return false;
+        };
+
+        while let Some(head) = queue.front() {
+            let action = match head {
+                PendingReport::Start { urn, mask, source } => {
+                    let loops = match source {
+                        LoopSource::Known(loops) => Some(*loops),
+                        LoopSource::Pointer(pointer) => {
+                            let cached = cached_loop(cache, pointer, now);
+                            if cached.is_none() && requested.insert(pointer.clone()) {
+                                wanted.push(pointer.clone());
+                            }
+                            cached
+                        }
+                    };
+                    match loops {
+                        Some(loops) => HeadAction::Write {
+                            urn: urn.clone(),
+                            loops,
+                            mask: *mask,
+                            state: EmoteState::EsStarted,
+                        },
+                        None => HeadAction::Wait,
+                    }
+                }
+                PendingReport::Stop { completed } => match started.remove(player) {
+                    Some((urn, loops)) => HeadAction::Write {
+                        urn,
+                        loops,
+                        mask: None,
+                        state: if *completed {
+                            EmoteState::EsFinished
+                        } else {
+                            EmoteState::EsInterrupted
+                        },
+                    },
+                    // a stop with no start on record
+                    None => HeadAction::Skip,
+                },
+            };
+
+            match action {
+                HeadAction::Wait => break,
+                HeadAction::Skip => {
+                    queue.pop_front();
+                }
+                HeadAction::Write {
+                    urn,
+                    loops,
+                    mask,
+                    state: emote_state,
+                } => {
+                    if emote_state == EmoteState::EsStarted {
+                        started.insert(*player, (urn.clone(), loops));
+                    }
+                    *sequence = sequence.wrapping_add(1);
+                    state.update_crdt(
+                        SceneComponentId::AVATAR_EMOTE_COMMAND,
+                        CrdtType::GO_ANY,
+                        foreign.scene_id,
+                        &PbAvatarEmoteCommand {
+                            emote_urn: urn,
+                            r#loop: loops,
+                            timestamp: *sequence,
+                            mask,
+                            state: Some(emote_state as i32),
+                        },
+                    );
+                    queue.pop_front();
+                }
+            }
+        }
+        !queue.is_empty()
+    });
+}
+
+/// Bank the answers of landed metadata lookups and start one for the pointers now wanted.
+fn resolve_foreign_emote_metadata(
+    mut relay: ResMut<ForeignEmoteRelay>,
+    ipfas: IpfsAssetServer,
+    time: Res<Time>,
+) {
+    let now = time.elapsed_secs_f64();
+
+    let mut landed = Vec::new();
+    relay
+        .batches
+        .retain_mut(|batch| match batch.task.complete() {
+            Some(result) => {
+                landed.push((std::mem::take(&mut batch.pointers), result));
+                false
+            }
+            None => true,
+        });
+    for (pointers, result) in landed {
+        match result {
+            Ok(entities) => {
+                let mut answered: HashSet<String> = HashSet::default();
+                for entity in entities {
+                    let loops = entity
+                        .metadata
+                        .as_ref()
+                        .and_then(loop_from_emote_metadata)
+                        .unwrap_or(false);
+                    for pointer in entity.pointers {
+                        let pointer = pointer.to_ascii_lowercase();
+                        answered.insert(pointer.clone());
+                        relay.remember(pointer, loops, None);
+                    }
+                }
+                // a definitive "no such emote" is cached too, else an unknown urn would be looked
+                // up again on every trigger
+                for pointer in &pointers {
+                    if !answered.contains(pointer) {
+                        relay.remember(pointer.clone(), false, None);
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("emote metadata lookup failed: {e}");
+                for pointer in &pointers {
+                    relay.remember(pointer.clone(), false, Some(now + LOOKUP_RETRY_SECS));
+                }
+            }
+        }
+        for pointer in &pointers {
+            relay.requested.remove(pointer);
+        }
+    }
+
+    if !relay.wanted.is_empty() && relay.batches.len() < MAX_LOOKUP_BATCHES {
+        let pointers = std::mem::take(&mut relay.wanted);
+        let task = ipfas.ipfs().active_entities(
+            ActiveEntitiesRequest::Pointers(pointers.clone()),
+            Some(&emote_catalyst_url()),
+        );
+        relay.batches.push(LookupBatch { pointers, task });
+    }
+}
+
+#[cfg(test)]
+mod foreign_emote_relay_tests {
+    use super::*;
+    use dcl::interface::CrdtMessageType;
+    use prost::Message as _;
+
+    const SCENE_LOOPING: &str = "urn:decentraland:off-chain:scene-emote:bafyhash-true";
+    const WEARABLE: &str = "urn:decentraland:matic:collections-v2:0xAbC:0:12345";
+    const WEARABLE_POINTER: &str = "urn:decentraland:matic:collections-v2:0xabc:0";
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.init_resource::<Time>();
+        app.init_resource::<ForeignEmoteRelay>();
+        app.add_event::<ForeignEmoteEvent>();
+        // the lookup system needs a realm; these tests bank answers into the cache directly
+        app.add_systems(
+            Update,
+            (queue_foreign_emote_reports, flush_foreign_emote_reports).chain(),
+        );
+        app
+    }
+
+    fn spawn_context(app: &mut App) -> (Entity, broadcast::Receiver<GlobalCrdtStateUpdate>) {
+        let state = GlobalCrdtState::new(None);
+        let (_, receiver) = state.subscribe(Vec3::ZERO);
+        (app.world_mut().spawn(state).id(), receiver)
+    }
+
+    fn spawn_player(app: &mut App, context: Entity, scene_id: SceneEntityId) -> Entity {
+        let (audio_sender, _audio_receiver) = mpsc::channel::<ForeignAudioData>(1);
+        app.world_mut()
+            .spawn(ForeignPlayer {
+                address: Address::from_low_u64_be(0x1234),
+                context,
+                transports: HashSet::default(),
+                scene_id,
+                profile_version: 0,
+                audio_sender,
+            })
+            .id()
+    }
+
+    fn started(app: &mut App, player: Entity, urn: &str) {
+        app.world_mut().send_event(ForeignEmoteEvent {
+            player,
+            kind: ForeignEmoteEventKind::Started {
+                urn: urn.to_owned(),
+                mask: None,
+            },
+        });
+    }
+
+    fn stopped(app: &mut App, player: Entity, completed: bool) {
+        app.world_mut().send_event(ForeignEmoteEvent {
+            player,
+            kind: ForeignEmoteEventKind::Stopped { completed },
+        });
+    }
+
+    fn resolve(app: &mut App, pointer: &str, loops: bool) {
+        app.world_mut()
+            .resource_mut::<ForeignEmoteRelay>()
+            .remember(pointer.to_owned(), loops, None);
+    }
+
+    /// Every `AvatarEmoteCommand` appended for `scene_id` in the context's store, oldest first.
+    fn reported(app: &App, context: Entity, scene_id: SceneEntityId) -> Vec<PbAvatarEmoteCommand> {
+        app.world()
+            .get::<GlobalCrdtState>(context)
+            .unwrap()
+            .store
+            .go
+            .get(&SceneComponentId::AVATAR_EMOTE_COMMAND)
+            .and_then(|state| state.0.get(&scene_id))
+            .map(|entries| {
+                entries
+                    .iter()
+                    .map(|entry| PbAvatarEmoteCommand::decode(entry.data.as_slice()).unwrap())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn state_of(command: &PbAvatarEmoteCommand) -> EmoteState {
+        match command.state.expect("state is always written") {
+            s if s == EmoteState::EsStarted as i32 => EmoteState::EsStarted,
+            s if s == EmoteState::EsFinished as i32 => EmoteState::EsFinished,
+            s if s == EmoteState::EsInterrupted as i32 => EmoteState::EsInterrupted,
+            other => panic!("unknown emote state {other}"),
+        }
+    }
+
+    /// The entities named by the APPEND_VALUE messages broadcast to subscribed scenes so far.
+    fn broadcast_appends(
+        receiver: &mut broadcast::Receiver<GlobalCrdtStateUpdate>,
+    ) -> Vec<SceneEntityId> {
+        let mut entities = Vec::new();
+        while let Ok(update) = receiver.try_recv() {
+            let GlobalCrdtStateUpdate::Crdt(bytes, localizer) = update else {
+                continue;
+            };
+            assert!(matches!(localizer, Localizer::None));
+            let mut reader = DclReader::new(&bytes);
+            let _length = reader.read_u32().unwrap();
+            assert_eq!(
+                reader.read_u32().unwrap(),
+                CrdtMessageType::AppendValue as u32
+            );
+            let entity: SceneEntityId = reader.read().unwrap();
+            let component: SceneComponentId = reader.read().unwrap();
+            assert_eq!(component, SceneComponentId::AVATAR_EMOTE_COMMAND);
+            entities.push(entity);
+        }
+        entities
+    }
+
+    #[test]
+    fn reports_start_then_finish_with_monotonic_timestamps() {
+        let mut app = app();
+        let (context, mut receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(32, 0);
+        let player = spawn_player(&mut app, context, scene_id);
+
+        started(&mut app, player, SCENE_LOOPING);
+        app.update();
+        // nothing new: no re-report
+        app.update();
+        stopped(&mut app, player, true);
+        app.update();
+
+        let commands = reported(&app, context, scene_id);
+        assert_eq!(commands.len(), 2);
+        assert_eq!(state_of(&commands[0]), EmoteState::EsStarted);
+        assert_eq!(state_of(&commands[1]), EmoteState::EsFinished);
+        for command in &commands {
+            assert_eq!(command.emote_urn, SCENE_LOOPING);
+            assert!(command.r#loop);
+        }
+        assert!(commands[0].timestamp < commands[1].timestamp);
+        assert_eq!(broadcast_appends(&mut receiver), vec![scene_id, scene_id]);
+    }
+
+    #[test]
+    fn waits_for_metadata_and_keeps_wire_order() {
+        let mut app = app();
+        let (context, _receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(33, 0);
+        let player = spawn_player(&mut app, context, scene_id);
+
+        started(&mut app, player, WEARABLE);
+        app.update();
+        assert!(reported(&app, context, scene_id).is_empty());
+        {
+            let relay = app.world().resource::<ForeignEmoteRelay>();
+            assert!(relay.requested.contains(WEARABLE_POINTER));
+            assert_eq!(relay.wanted, vec![WEARABLE_POINTER.to_owned()]);
+        }
+
+        // the cancel lands before the metadata does; it must not overtake the start
+        stopped(&mut app, player, false);
+        app.update();
+        assert!(reported(&app, context, scene_id).is_empty());
+
+        resolve(&mut app, WEARABLE_POINTER, true);
+        app.update();
+
+        let commands = reported(&app, context, scene_id);
+        assert_eq!(commands.len(), 2);
+        assert_eq!(state_of(&commands[0]), EmoteState::EsStarted);
+        assert_eq!(state_of(&commands[1]), EmoteState::EsInterrupted);
+        for command in &commands {
+            // the full instance urn is reported, not the pointer it resolved through
+            assert_eq!(command.emote_urn, WEARABLE);
+            assert!(command.r#loop);
+        }
+        // the pointer is asked for once
+        assert_eq!(
+            app.world().resource::<ForeignEmoteRelay>().wanted,
+            vec![WEARABLE_POINTER.to_owned()]
+        );
+    }
+
+    #[test]
+    fn unresolvable_identifier_is_reported_as_a_one_shot() {
+        let mut app = app();
+        let (context, _receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(34, 0);
+        let player = spawn_player(&mut app, context, scene_id);
+
+        started(
+            &mut app,
+            player,
+            "urn:decentraland:off-chain:no-such-collection:x",
+        );
+        app.update();
+
+        let commands = reported(&app, context, scene_id);
+        assert_eq!(commands.len(), 1);
+        assert!(!commands[0].r#loop);
+        assert_eq!(state_of(&commands[0]), EmoteState::EsStarted);
+    }
+
+    #[test]
+    fn drops_unacceptable_urns_and_orphan_stops() {
+        let mut app = app();
+        let (context, mut receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(35, 0);
+        let player = spawn_player(&mut app, context, scene_id);
+
+        for urn in [
+            String::new(),
+            "x".repeat(MAX_EMOTE_URN_BYTES + 1),
+            "urn:decentraland:off-chain:base-emotes:wave dance".to_owned(),
+            "urn:decentraland:off-chain:base-emotes:wave\u{1b}[31m".to_owned(),
+        ] {
+            started(&mut app, player, &urn);
+            app.update();
+        }
+        // no start on record
+        stopped(&mut app, player, true);
+        app.update();
+
+        assert!(reported(&app, context, scene_id).is_empty());
+        assert!(broadcast_appends(&mut receiver).is_empty());
+    }
+
+    #[test]
+    fn writes_only_to_the_players_own_context() {
+        let mut app = app();
+        let (shared, mut shared_receiver) = spawn_context(&mut app);
+        let (room, mut room_receiver) = spawn_context(&mut app);
+        let scene_id = SceneEntityId::new(36, 0);
+        let player = spawn_player(&mut app, room, scene_id);
+
+        started(&mut app, player, SCENE_LOOPING);
+        app.update();
+
+        assert!(reported(&app, shared, scene_id).is_empty());
+        assert_eq!(reported(&app, room, scene_id).len(), 1);
+        assert!(broadcast_appends(&mut shared_receiver).is_empty());
+        assert_eq!(broadcast_appends(&mut room_receiver), vec![scene_id]);
+    }
+
+    #[test]
+    fn classifies_emote_identifiers() {
+        assert_eq!(
+            classify_emote("urn:decentraland:off-chain:scene-emote:bafyhash-true"),
+            Some(LoopSource::Known(true))
+        );
+        assert_eq!(
+            classify_emote("urn:decentraland:off-chain:scene-emote:bafyhash-false"),
+            Some(LoopSource::Known(false))
+        );
+        assert_eq!(
+            classify_emote("sittingChair1"),
+            Some(LoopSource::Known(true))
+        );
+        assert_eq!(classify_emote("Waving"), Some(LoopSource::Known(false)));
+        assert_eq!(
+            classify_emote("Wave"),
+            Some(LoopSource::Pointer(
+                "urn:decentraland:off-chain:base-emotes:wave".to_owned()
+            ))
+        );
+        assert_eq!(
+            classify_emote("urn:decentraland:off-chain:base-emotes:Dance"),
+            Some(LoopSource::Pointer(
+                "urn:decentraland:off-chain:base-emotes:dance".to_owned()
+            ))
+        );
+        assert_eq!(
+            classify_emote(WEARABLE),
+            Some(LoopSource::Pointer(WEARABLE_POINTER.to_owned()))
+        );
+        assert_eq!(
+            classify_emote("urn:decentraland:matic:collections-thirdparty:tp:coll:item:1:2:3"),
+            Some(LoopSource::Pointer(
+                "urn:decentraland:matic:collections-thirdparty:tp:coll:item".to_owned()
+            ))
+        );
+        assert_eq!(
+            classify_emote("urn:decentraland:matic:collections-v2:0xabc"),
+            None
+        );
+        assert_eq!(
+            classify_emote("urn:decentraland:off-chain:no-such-collection:x"),
+            None
+        );
+    }
+
+    #[test]
+    fn reads_loop_from_deployed_metadata() {
+        let adr74 = serde_json::json!({ "emoteDataADR74": { "loop": true } });
+        let legacy = serde_json::json!({ "data": { "loop": false } });
+        let neither = serde_json::json!({ "name": "wave" });
+        assert_eq!(loop_from_emote_metadata(&adr74), Some(true));
+        assert_eq!(loop_from_emote_metadata(&legacy), Some(false));
+        assert_eq!(loop_from_emote_metadata(&neither), None);
+    }
+
+    #[test]
+    fn failed_lookup_answers_false_until_its_retry_is_due() {
+        let mut relay = ForeignEmoteRelay::default();
+        relay.remember(WEARABLE_POINTER.to_owned(), false, Some(10.0));
+        assert_eq!(
+            cached_loop(&relay.cache, WEARABLE_POINTER, 0.0),
+            Some(false)
+        );
+        assert_eq!(cached_loop(&relay.cache, WEARABLE_POINTER, 10.0), None);
+        relay.remember(WEARABLE_POINTER.to_owned(), true, None);
+        assert_eq!(
+            cached_loop(&relay.cache, WEARABLE_POINTER, 10.0),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn evicts_the_oldest_cached_pointers() {
+        let mut relay = ForeignEmoteRelay::default();
+        for i in 0..=MAX_CACHED_POINTERS {
+            relay.remember(format!("pointer-{i}"), true, None);
+        }
+        assert_eq!(relay.cache.len(), MAX_CACHED_POINTERS);
+        assert!(!relay.cache.contains_key("pointer-0"));
+        assert!(relay
+            .cache
+            .contains_key(&format!("pointer-{MAX_CACHED_POINTERS}")));
     }
 }

--- a/crates/comms/src/pulse/mod.rs
+++ b/crates/comms/src/pulse/mod.rs
@@ -168,9 +168,12 @@ pub enum PulseEvent {
         address: Address,
         urn: String,
         tick: u32,
+        /// `AvatarMask` value the server relayed with the start, if the emote is partial-body.
+        mask: Option<i32>,
     },
-    /// Subject's emote stopped (one-shot completed or looping cancelled).
-    EmoteStop { address: Address },
+    /// Subject's emote stopped. `completed`: the server's one-shot timer expired (a natural
+    /// finish) rather than the player cancelling a looping emote.
+    EmoteStop { address: Address, completed: bool },
     /// A sequence gap was detected — transmit this reliably so the server replays full state.
     Resync(pulse::ResyncRequest),
 }
@@ -386,6 +389,7 @@ impl PulseDecoder {
                         address: subject.wallet,
                         urn: e.emote_id,
                         tick: e.server_tick,
+                        mask: e.mask,
                     });
                 }
                 events
@@ -402,6 +406,7 @@ impl PulseDecoder {
                 if let Some(subject) = self.subjects.get(&e.subject_id) {
                     events.push(PulseEvent::EmoteStop {
                         address: subject.wallet,
+                        completed: e.reason == pulse::EmoteStopReason::Completed as i32,
                     });
                 }
                 events

--- a/crates/comms/src/pulse/plugin.rs
+++ b/crates/comms/src/pulse/plugin.rs
@@ -951,22 +951,31 @@ fn drain_inbound(
                 // Emote start/stop are delivered natively (`PlayerMessage::Emote`) rather than as an
                 // rfc4 `PlayerEmote`: byte-transport emotes are dropped as duplicates, so the Pulse
                 // copy has to be distinguishable from them by variant, exactly as movement is.
-                PulseEvent::EmoteStart { address, urn, tick } => session.forward(
+                PulseEvent::EmoteStart {
+                    address,
+                    urn,
+                    tick,
+                    mask,
+                } => session.forward(
                     sinks,
                     address,
                     PlayerMessage::Emote {
                         urn,
                         incremental_id: tick,
                         stopping: false,
+                        completed: false,
+                        mask,
                     },
                 ),
-                PulseEvent::EmoteStop { address } => session.forward(
+                PulseEvent::EmoteStop { address, completed } => session.forward(
                     sinks,
                     address,
                     PlayerMessage::Emote {
                         urn: String::new(),
                         incremental_id: 0,
                         stopping: true,
+                        completed,
+                        mask: None,
                     },
                 ),
                 // A peer entered our interest set. Report the arrival, then their initial profile

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_emote_command.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_emote_command.proto
@@ -2,12 +2,31 @@ syntax = "proto3";
 package decentraland.sdk.components;
 
 import "decentraland/sdk/components/common/id.proto";
+import "decentraland/sdk/components/common/avatar_mask.proto";
 option (common.ecs_component_id) = 1088;
 
-// AvatarEmoteCommand is a grow only value set, used to signal the renderer about
-// avatar emotes playback.
+// EmoteState describes the lifecycle state of an emote playback.
+enum EmoteState {
+  // ES_STARTED indicates the emote started playing.
+  // This is the zero value and is used for backward compatibility — entries
+  // written by older explorers (field absent) read as "started".
+  ES_STARTED = 0;
+  // ES_FINISHED indicates a non-looping emote completed naturally.
+  ES_FINISHED = 1;
+  // ES_INTERRUPTED indicates playback was cancelled (movement, teleport,
+  // another emote superseding it, explicit stop, or scene change).
+  ES_INTERRUPTED = 2;
+}
+
+// AvatarEmoteCommand is a grow only value set, written by the explorer to report
+// avatar emote playback to the scene. It is appended to every player entity in the
+// scene (the local player and remote avatars alike).
 message PBAvatarEmoteCommand {
   string emote_urn = 1;
   bool loop = 2;
-  uint32 timestamp = 3;          // monotonic counter
+  uint32 timestamp = 3; // monotonic counter
+  optional decentraland.sdk.components.common.AvatarMask mask = 4;
+  // state describes the lifecycle event for this emote entry.
+  // When absent (older explorers), defaults to ES_STARTED.
+  optional EmoteState state = 5;
 }

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/common/avatar_mask.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/common/avatar_mask.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package decentraland.sdk.components.common;
+
+// Mask for which bones an animation applies to.
+enum AvatarMask {
+  AM_UPPER_BODY = 0;
+}

--- a/crates/dcl_component/src/proto_components.rs
+++ b/crates/dcl_component/src/proto_components.rs
@@ -157,6 +157,7 @@ impl DclProtoComponent for sdk::components::PbParticleSystem {}
 impl PositionFree for sdk::components::PbPlayerIdentityData {}
 impl PositionFree for sdk::components::PbAvatarBase {}
 impl PositionFree for sdk::components::PbAvatarEquippedData {}
+impl PositionFree for sdk::components::PbAvatarEmoteCommand {}
 
 // GlobalCrdtData impl for PbAvatarMovementInfo (walk_target is a world-space position that needs localization)
 impl GlobalCrdtData for sdk::components::PbAvatarMovementInfo {

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -363,6 +363,10 @@ fn main() {
         // without these, engine-side position logic — scene membership, avatar colliders,
         // trigger areas — sees every remote player at the origin
         .add_plugins(avatar::foreign_dynamics::PlayerMovementPlugin)
+        // remote players' emotes -> `AvatarEmoteCommand` in their scene's crdt. The client
+        // reports these from `avatar::animate` (render-bound, omitted here); without this a
+        // server scene never sees what players do
+        .add_plugins(comms::global_crdt::ForeignEmoteRelayPlugin)
         .add_plugins(DuiPlugin)
         .add_plugins(SystemBridgePlugin { bare: true });
 


### PR DESCRIPTION
## Why

Scenes read `AvatarEmoteCommand` on player entities to react to what players do (dance floors, emote-triggered doors, gesture mini-games). On the client that component is written by `avatar::animate` once the emote clip has loaded. The headless server omits the render-bound avatar plugin, so nothing ever wrote it there: a server scene could never observe a remote player's emote.

## What

A render-free `ForeignEmoteRelayPlugin` in `comms`, registered only by the headless binary, reports the full lifecycle the component can express:

- **Start** → `ES_STARTED` with the emote's real `loop`. Scene emotes carry it in the URN, the reference client's embedded animations come from a fixed table, and base/wearable emotes are looked up in their deployed metadata (`emoteDataADR74.loop`) on the catalyst, cached by pointer. A legacy bare name like `wave` resolves as a base emote. A start waiting on metadata holds everything queued behind it *for that player*, so a cancel can never overtake its start; other players are not blocked.
- **Stop** → `ES_FINISHED` when the server's one-shot timer expired, `ES_INTERRUPTED` when the player cancelled. Echoes the started emote's URN and loop so a scene can match it without bookkeeping. A stop with no start on record is dropped.
- **Mask** passes through from the wire. **Timestamps** are a host-side monotonic counter, which the SDK's grow-only set needs to sort and trim correctly.

Supporting changes:

- `crates/dcl_component`: the vendored `avatar_emote_command.proto` is brought up to the SDK's current version (adds `EmoteState` and the `AvatarMask` import); `PbAvatarEmoteCommand` is marked position-free so the global CRDT path accepts it.
- `crates/comms/src/pulse`: the decoder keeps the stop reason and mask it previously dropped; `PlayerMessage::Emote` carries both.
- `crates/comms/src/global_crdt.rs`: the transport handler emits a `ForeignEmoteEvent` per transition alongside the `EmoteCommand` it already maintained. The relay is three chained systems: queue events, flush what is resolvable, then bank landed lookups and request new pointers through the ipfs client against `peer.<domain>/content`. A failed lookup answers `false` for 60 s and is then retried; an unknown collection type reports a one-shot immediately rather than losing the event.
- `crates/avatar/src/animate.rs`: the client's own start report sets `state: ES_STARTED` explicitly. Client behaviour is otherwise unchanged; the plugin is deliberately not part of `GlobalCrdtPlugin` so the client never reports twice.

Bounds: 256-byte URN cap with whitespace/control-character rejection, 16 pending reports per player, 1024 cached pointers, 4 lookup batches in flight.

## Verification

- 9 new unit tests in `comms` (`foreign_emote_relay_tests`): start/finish ordering and monotonic timestamps, deferral on metadata with wire order preserved across a cancel, one-shot fallback for unresolvable identifiers, URN rejection and orphan stops, per-context routing, identifier classification, metadata parsing, failed-lookup retry window, cache eviction.
- `cargo test -p dcl_component` passes with the proto change.
- `cargo check --bin headless --no-default-features --features headless,livekit` passes.
- `cargo clippy -p comms -p dcl_component -p avatar --tests -- -D warnings` clean; `cargo fmt` applied.

Not yet exercised against a live Pulse server with real emoting peers; opening as a draft for that.

## Left open

- The client still reports only starts. Reporting finishes/interrupts there too needs changes inside the avatar animation system.
- Lookups target the catalyst rather than the realm's content server, which is where emotes are deployed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
