### PR TITLE
Pulse server as a service; --help sections

### DIFF
--- a/crates/common/src/base_domain.rs
+++ b/crates/common/src/base_domain.rs
@@ -2,12 +2,12 @@
 //! (`--base-domain` / `?baseDomain=`, by src/launch.rs `latch` on every binary). On top of it the
 //! per-[`Service`] resolver: an explicit override (`--<service> <url>` / `?<service>=`, latched
 //! once with [`set_services`]) wins, else the service composes from the domain by convention.
-//! Service urls should go through [`service`] / [`url`]; the raw [`https`] / [`wss`] / [`host`]
-//! composition stays for the odd host that is not a service (pulse's `host:port`).
+//! Service urls go through [`service`] / [`url`] (an authority service — pulse — through
+//! [`with_default_port`]).
 
 use std::{collections::HashMap, sync::OnceLock};
 
-pub use system_api_types::services::Service;
+pub use system_api_types::services::{Service, ServiceValue};
 
 pub const DEFAULT: &str = "decentraland.org";
 
@@ -42,50 +42,50 @@ pub fn is_custom() -> bool {
     !matches!(get(), DEFAULT | "decentraland.zone")
 }
 
-pub fn https(sub: &str, path: &str) -> String {
-    format!("https://{}{path}", host(sub))
-}
-
-pub fn wss(sub: &str, path: &str) -> String {
-    format!("wss://{}{path}", host(sub))
-}
-
-pub fn host(sub: &str) -> String {
+fn host(sub: &str) -> String {
     format!("{sub}.{}", get())
 }
 
 /// Latch the per-service overrides, once, before anything composes a service url. Each value
-/// is a full base url: its scheme must fit the service (http(s) or ws(s)), and a trailing slash
-/// is dropped so paths can always be appended.
+/// takes the service's shape ([`Service::value`]): a full base url whose scheme fits the service
+/// (http(s) or ws(s)), trailing slash dropped so paths can always be appended — or, for an
+/// authority service, `host` or `host:port`.
 pub fn set_services<'a>(
     overrides: impl IntoIterator<Item = (Service, &'a str)>,
 ) -> Result<(), String> {
     let mut map = HashMap::new();
-    for (service, url) in overrides {
+    for (service, value) in overrides {
         let flag = service.flag();
-        let parsed =
-            url::Url::parse(url.trim()).map_err(|e| format!("{flag} {url}: not a url ({e})"))?;
-        let scheme_ok = if service.is_websocket() {
-            matches!(parsed.scheme(), "ws" | "wss")
-        } else {
-            matches!(parsed.scheme(), "http" | "https")
-        };
-        if !scheme_ok || parsed.host_str().is_none() {
-            return Err(format!(
-                "{flag} {url}: must be a full {} base url",
-                if service.is_websocket() {
-                    "ws(s)"
-                } else {
-                    "http(s)"
+        let normalised = match service.value() {
+            ServiceValue::Authority => {
+                let (host, port) =
+                    split_authority(value).map_err(|e| format!("{flag} {value}: {e}"))?;
+                match port {
+                    Some(port) => format!("{host}:{port}"),
+                    None => host,
                 }
-            ));
-        }
-        if parsed.query().is_some() || parsed.fragment().is_some() {
-            return Err(format!(
-                "{flag} {url}: a base url takes no query or fragment"
-            ));
-        }
-        map.insert(service, parsed.as_str().trim_end_matches('/').to_owned());
+            }
+            kind => {
+                let parsed = url::Url::parse(value.trim())
+                    .map_err(|e| format!("{flag} {value}: not a url ({e})"))?;
+                let (scheme_ok, expected) = match kind {
+                    ServiceValue::Websocket => (matches!(parsed.scheme(), "ws" | "wss"), "ws(s)"),
+                    _ => (matches!(parsed.scheme(), "http" | "https"), "http(s)"),
+                };
+                if !scheme_ok || parsed.host_str().is_none() {
+                    return Err(format!(
+                        "{flag} {value}: must be a full {expected} base url"
+                    ));
+                }
+                if parsed.query().is_some() || parsed.fragment().is_some() {
+                    return Err(format!(
+                        "{flag} {value}: a base url takes no query or fragment"
+                    ));
+                }
+                parsed.as_str().trim_end_matches('/').to_owned()
+            }
+        };
+        map.insert(service, normalised);
     }
     // nothing given latches nothing: `latch` runs unconditionally, and no overrides means the
     // lock stays empty (every `service_override` None) rather than holding an empty map
@@ -105,17 +105,46 @@ pub fn service_override(service: Service) -> Option<&'static str> {
     SERVICES.get()?.get(&service).map(String::as_str)
 }
 
-/// The service's base url: its override, else its composition from the base domain.
+/// The service's base url (an authority service: its host) — its override, else its
+/// composition from the base domain.
 pub fn service(service: Service) -> String {
-    if let Some(url) = service_override(service) {
-        return url.to_owned();
+    if let Some(value) = service_override(service) {
+        return value.to_owned();
     }
     let (scheme, sub, path) = service.composition();
-    if sub.is_empty() {
-        format!("{scheme}://{}{path}", get())
+    let host = if sub.is_empty() {
+        get().to_owned()
     } else {
-        format!("{scheme}://{}{path}", host(sub))
+        self::host(sub)
+    };
+    if scheme.is_empty() {
+        host
+    } else {
+        format!("{scheme}://{host}{path}")
     }
+}
+
+/// `host` or `host:port` → (lowercased host, the port if given). Nothing else: no scheme,
+/// path, query, fragment or userinfo.
+fn split_authority(authority: &str) -> Result<(String, Option<u16>), String> {
+    let a = authority.trim();
+    if a.is_empty() || a.contains(['/', '?', '#', '@']) {
+        return Err("must be `host` or `host:port`".to_owned());
+    }
+    // behind a non-special scheme, so a default-looking port is kept as given
+    let parsed = url::Url::parse(&format!("dummy://{a}"))
+        .map_err(|e| format!("not a `host` or `host:port` ({e})"))?;
+    match parsed.host_str() {
+        Some(host) if !host.is_empty() => Ok((host.to_lowercase(), parsed.port())),
+        _ => Err("must be `host` or `host:port`".to_owned()),
+    }
+}
+
+/// An authority endpoint as (host, port): `authority` is `host` or `host:port` — an override, an
+/// env var, or the composed [`service`] host — and `default_port` fills in a missing port.
+pub fn with_default_port(authority: &str, default_port: u16) -> Result<(String, u16), String> {
+    let (host, port) = split_authority(authority)?;
+    Ok((host, port.unwrap_or(default_port)))
 }
 
 /// A url under a service: its base url with `path` (leading `/`) appended.
@@ -132,15 +161,6 @@ mod tests {
     #[test]
     fn default_composition_targets_decentraland() {
         assert_eq!(
-            https("auth-api", "/requests"),
-            "https://auth-api.decentraland.org/requests"
-        );
-        assert_eq!(
-            wss("rpc-social-service-ea", ""),
-            "wss://rpc-social-service-ea.decentraland.org"
-        );
-        assert_eq!(host("pulse-server"), "pulse-server.decentraland.org");
-        assert_eq!(
             url(Service::RealmProvider, "/main"),
             "https://realm-provider-ea.decentraland.org/main"
         );
@@ -152,6 +172,33 @@ mod tests {
             url(Service::SocialRpc, ""),
             "wss://rpc-social-service-ea.decentraland.org"
         );
+        assert_eq!(
+            service(Service::PulseServer),
+            "pulse-server.decentraland.org"
+        );
+    }
+
+    #[test]
+    fn authority_defaults_the_port_only() {
+        let ok = |a: &str| with_default_port(a, 7777).unwrap();
+        assert_eq!(
+            ok("pulse-server.decentraland.org"),
+            ("pulse-server.decentraland.org".to_owned(), 7777)
+        );
+        assert_eq!(ok(" Local:1234 "), ("local".to_owned(), 1234));
+        assert_eq!(ok("127.0.0.1:80"), ("127.0.0.1".to_owned(), 80));
+        assert_eq!(ok("[::1]"), ("[::1]".to_owned(), 7777));
+        for bad in [
+            "",
+            "https://h",
+            "h:1/x",
+            "h:99999",
+            "user@h",
+            "h?x",
+            ":7777",
+        ] {
+            assert!(with_default_port(bad, 7777).is_err(), "`{bad}`");
+        }
     }
 
     // NOTE: never latches (the OnceLock is process-wide); only the rejections are testable here.
@@ -163,6 +210,8 @@ mod tests {
             (Service::SocialRpc, "https://social.example"),
             (Service::Places, "https://places.example/?x=1"),
             (Service::Places, ""),
+            (Service::PulseServer, "https://pulse.example"),
+            (Service::PulseServer, "pulse.example:7777/x"),
         ] {
             assert!(
                 set_services([(service, bad)]).is_err(),

--- a/crates/comms/src/pulse/plugin.rs
+++ b/crates/comms/src/pulse/plugin.rs
@@ -57,14 +57,6 @@ use bevy::platform::collections::HashMap;
 #[derive(Resource)]
 pub struct PulseRealmOverride(pub String);
 
-/// Which Pulse server to connect to, `host:port`, stated at startup — `--pulse-server` on native
-/// and the headless server, `?pulseServer=` on web. Wins over the `PULSE_SERVER` env var and the
-/// built-in default. Zone and prod are separate Pulse servers with identical realm names, so a
-/// zone deployment must be told to use the zone server or its players land among prod's; the
-/// realm a client is on is deliberately not used to infer it.
-#[derive(Resource)]
-pub struct PulseEndpointOverride(pub String);
-
 /// Insert this resource to connect to a Pulse server. Absent → the plugin is fully inert.
 #[derive(Resource, Clone)]
 pub struct PulseConfig {
@@ -480,17 +472,13 @@ impl Plugin for PulsePlugin {
     }
 }
 
-/// Default Pulse endpoint (production). Native speaks ENet/UDP (7777); wasm has no ENet, so it speaks
-/// WebTransport on 7743. Override with the `PULSE_SERVER=host:port` env var — e.g.
-/// `pulse-server.decentraland.zone` for dev, or a local instance.
-#[cfg(not(target_arch = "wasm32"))]
-fn default_pulse_server() -> String {
-    format!("{}:7777", common::base_domain::host("pulse-server"))
-}
-#[cfg(target_arch = "wasm32")]
-fn default_pulse_server() -> String {
-    format!("{}:7743", common::base_domain::host("pulse-server"))
-}
+/// The Pulse port when the endpoint names none: native speaks ENet/UDP, wasm has no ENet so it
+/// speaks WebTransport.
+const DEFAULT_PULSE_PORT: u16 = if cfg!(target_arch = "wasm32") {
+    7743
+} else {
+    7777
+};
 
 /// SHA-256 to pin the server's TLS cert via WebTransport's `serverCertificateHashes`. Production is
 /// CA-signed → `None` (default trust); native (ENet) never needs one.
@@ -500,7 +488,7 @@ fn dev_cert_hash() -> Option<Vec<u8>> {
 }
 #[cfg(target_arch = "wasm32")]
 fn dev_cert_hash() -> Option<Vec<u8>> {
-    // To test against a local self-signed dev server, point default_pulse_server at it and return the
+    // To test against a local self-signed dev server, point --pulse-server at it and return the
     // SHA-256 of its cert (e.g. claude-work/pulse-dev-cert/cert.pem — regenerate + refresh if expired,
     // `openssl x509 -outform DER | openssl dgst -sha256`):
     // Some(vec![
@@ -513,35 +501,38 @@ fn dev_cert_hash() -> Option<Vec<u8>> {
 
 /// Insert the [`PulseConfig`] that activates the transport, on clients and servers alike — a server
 /// joins as a scene listener rather than a subject (see [`ListenerRole`]). Targets, in order of
-/// precedence, [`PulseEndpointOverride`] (a startup param), the `PULSE_SERVER` env var, then
-/// [`default_pulse_server`]. The grid is the Decentraland Genesis City `ParcelEncoder` from the
-/// server's appsettings ([`PulseParcelGrid::default`]).
-fn configure_pulse(mut commands: Commands, endpoint: Option<Res<PulseEndpointOverride>>) {
-    let (endpoint, source) = match endpoint {
-        Some(endpoint) => (endpoint.0.clone(), "startup param"),
+/// precedence, the `--pulse-server` / `?pulseServer=` override, the `PULSE_SERVER` env var, then
+/// `pulse-server.<base domain>` — each `host` or `host:port`, a missing port being the
+/// platform's. Zone and prod are separate Pulse servers with identical realm names, so a zone
+/// deployment must be told to use the zone server or its players land among prod's; the realm a
+/// client is on is deliberately not used to infer it. The grid is the Decentraland Genesis City
+/// `ParcelEncoder` from the server's appsettings ([`PulseParcelGrid::default`]).
+fn configure_pulse(mut commands: Commands) {
+    use common::base_domain::{service, service_override, with_default_port, Service};
+    let (authority, source) = match service_override(Service::PulseServer) {
+        Some(authority) => (authority.to_owned(), "--pulse-server"),
         None => match std::env::var("PULSE_SERVER") {
-            Ok(endpoint) => (endpoint, "PULSE_SERVER"),
-            Err(_) => (default_pulse_server(), "default"),
+            Ok(authority) => (authority, "PULSE_SERVER"),
+            Err(_) => (service(Service::PulseServer), "base domain"),
         },
     };
-    let Some((host, port)) = endpoint.rsplit_once(':') else {
-        warn!("pulse: server endpoint must be host:port, got {endpoint:?} ({source})");
-        return;
+    let (host, port) = match with_default_port(&authority, DEFAULT_PULSE_PORT) {
+        Ok(endpoint) => endpoint,
+        Err(e) => {
+            warn!("pulse: server endpoint {authority:?} ({source}): {e}");
+            return;
+        }
     };
-    let Ok(port) = port.parse::<u16>() else {
-        warn!("pulse: invalid port in server endpoint {endpoint:?} ({source})");
-        return;
-    };
+    info!("pulse: configured for {host}:{port} ({source})");
     commands.insert_resource(PulseConfig {
         transport: PulseTransportConfig {
-            host: host.to_owned(),
+            host,
             port,
             cert_hash: dev_cert_hash(),
         },
         parcel_grid: PulseParcelGrid::default(),
         server_id: String::new(),
     });
-    info!("pulse: configured for {endpoint} ({source})");
 }
 
 /// Build a fresh driver + its protocol-side link for `config`. `presence` is a weak handle to the
@@ -1642,37 +1633,43 @@ async fn build_auth_chain(wallet: &Wallet, server_id: &str) -> Result<Vec<u8>, S
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        configure_pulse, default_pulse_server, lsd_realm_key, PulseConfig, PulseEndpointOverride,
-    };
+    use super::{configure_pulse, lsd_realm_key, PulseConfig, DEFAULT_PULSE_PORT};
     use bevy::prelude::*;
 
-    /// The endpoint `configure_pulse` settles on for a given override / env pair.
-    fn configured_endpoint(startup: Option<&str>, env: Option<&str>) -> String {
+    /// The endpoint `configure_pulse` settles on for a given env var (and whatever override is
+    /// latched).
+    fn configured_endpoint(env: Option<&str>) -> String {
         match env {
             Some(env) => std::env::set_var("PULSE_SERVER", env),
             None => std::env::remove_var("PULSE_SERVER"),
         }
         let mut app = App::new();
-        if let Some(startup) = startup {
-            app.insert_resource(PulseEndpointOverride(startup.to_owned()));
-        }
         app.add_systems(Startup, configure_pulse);
         app.update();
         let config = app.world().resource::<PulseConfig>();
         format!("{}:{}", config.transport.host, config.transport.port)
     }
 
-    /// A startup param beats the env var beats the built-in default. One test rather than three
-    /// because the env var is process-wide: parallel tests would race on it.
+    /// The env var beats the base domain, the `--pulse-server` override beats both, and a bare
+    /// host takes the platform port. One test rather than several: the env var is process-wide
+    /// and the override latches once.
     #[test]
     fn endpoint_precedence() {
         assert_eq!(
-            configured_endpoint(Some("startup:1"), Some("env:2")),
-            "startup:1"
+            configured_endpoint(None),
+            format!("pulse-server.decentraland.org:{DEFAULT_PULSE_PORT}")
         );
-        assert_eq!(configured_endpoint(None, Some("env:2")), "env:2");
-        assert_eq!(configured_endpoint(None, None), default_pulse_server());
+        assert_eq!(configured_endpoint(Some("env:2")), "env:2");
+        assert_eq!(
+            configured_endpoint(Some("env")),
+            format!("env:{DEFAULT_PULSE_PORT}")
+        );
+        common::base_domain::set_services([(
+            common::base_domain::Service::PulseServer,
+            "startup:1",
+        )])
+        .unwrap();
+        assert_eq!(configured_endpoint(Some("env:2")), "startup:1");
         std::env::remove_var("PULSE_SERVER");
     }
 

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -48,10 +48,6 @@ pub struct LaunchOptions {
     #[arg(long, value_name = "url", display_order = 7)]
     pub content_server: Option<String>,
 
-    /// Pulse server as `host:port`; absent = the deployment's default
-    #[arg(long, value_name = "host:port", display_order = 8)]
-    pub pulse_server: Option<String>,
-
     /// Log the frame rate to the console
     #[arg(long, value_name = "true|false", display_order = 13)]
     pub log_fps: Option<bool>,
@@ -132,7 +128,6 @@ impl EngineRunOptions {
             &mut self.launch.realm,
             &mut self.launch.position,
             &mut self.launch.content_server,
-            &mut self.launch.pulse_server,
             &mut self.launch.base_domain,
             &mut self.client.system_scene,
             &mut self.client.portables,
@@ -218,7 +213,7 @@ mod tests {
             Some("http://localhost:3000")
         );
         assert_eq!(
-            options.launch.pulse_server.as_deref(),
+            options.launch.services.pulse_server.as_deref(),
             Some("localhost:7777")
         );
         assert!(options.launch.preview);

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -18,39 +18,49 @@ use serde::{Deserialize, Serialize};
 
 use crate::services::ServiceOverrides;
 
+/// The `--help` sections, shared so every binary spells them alike. Given per flag rather than
+/// per struct: clap_derive doesn't restore the parent's heading after a flatten, so a struct-level
+/// one would capture every flag a binary declares after the flattened struct. Unheaded flags are
+/// the destination: realm, position, preview, base domain. Groups print in the order their first
+/// flag is declared, flags within a group in declaration order — so field order IS the help order.
+pub mod help_heading {
+    pub const SYSTEM_SCENES: &str = "System scenes";
+    pub const SETTINGS: &str = "Settings overrides (this run only; use settings for persistence)";
+    pub const DEBUG: &str = "Debug";
+    pub const HOST: &str = "Set by the embedding host";
+    pub const SERVICES: &str = "Service endpoints";
+    pub const HEADLESS: &str = "Headless runner";
+}
+use help_heading::*;
+
 #[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
 #[serde(rename_all = "camelCase", default)]
 pub struct LaunchOptions {
     /// Realm to boot into; absent = the persisted home realm or default realm
-    #[arg(long, value_name = "url", display_order = 1)]
+    #[arg(long, value_name = "url")]
     pub realm: Option<String>,
 
     /// Spawn parcel as `x,y`; absent = the home parcel, or the realm's spawn point
-    #[arg(
-        long,
-        value_name = "x,y",
-        allow_hyphen_values = true,
-        display_order = 2
-    )]
+    #[arg(long, value_name = "x,y", allow_hyphen_values = true)]
     pub position: Option<String>,
 
     /// Scene preview mode: hot-reloading, no failed-asset backoff, plain-http fetches allowed,
     /// realm fixed.
-    #[arg(long, display_order = 3)]
+    #[arg(long)]
     pub preview: bool,
 
     /// The base domain for all services (comms, profiles, etc); absent = the hosting origin (on
     /// web), or decentraland.org
-    #[arg(long, value_name = "domain", display_order = 4)]
+    #[arg(long, value_name = "domain")]
     pub base_domain: Option<String>,
 
-    /// Override the content server only
-    #[arg(long, value_name = "url", display_order = 7)]
-    pub content_server: Option<String>,
-
     /// Log the frame rate to the console
-    #[arg(long, value_name = "true|false", display_order = 13)]
+    #[arg(long, value_name = "true|false", help_heading = SETTINGS)]
     pub log_fps: Option<bool>,
+
+    /// Override the content server only (normally a function of the realm)
+    #[arg(long, value_name = "url", help_heading = DEBUG)]
+    pub content_server: Option<String>,
 
     /// Per-service url overrides (`services.rs`): flags natively, keys of the `engine_run`
     /// object on web (the page resolves the same overrides for its own fetches first).
@@ -63,29 +73,29 @@ pub struct LaunchOptions {
 #[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ClientOptions {
-    /// Embedded in a scene editor (creator hub). Set by editor front-ends.
-    #[arg(long, display_order = 5)]
-    pub editor: bool,
-
-    /// Base url of the imposter store; absent = the default store. The realm-keyed path under
-    /// it is the same as the default store's
-    #[arg(long, value_name = "url", display_order = 9)]
-    pub imposter_source: Option<String>,
-
     /// Super-user ui scene source, or `none` for no ui scene. The engine trusts it completely.
     /// Absent = the default bridge scene for the react HUD; any explicit value opts out of the
     /// HUD
-    #[arg(long, value_name = "scene|none", display_order = 11)]
+    #[arg(long, value_name = "scene|none", help_heading = SYSTEM_SCENES)]
     pub system_scene: Option<String>,
 
     /// `;`-separated portable/startup scene sources; absent = `basiccontroller.dcl.eth`
     /// (DEFAULT_PORTABLES)
-    #[arg(long, value_name = "a;b", display_order = 12)]
+    #[arg(long, value_name = "a;b", help_heading = SYSTEM_SCENES)]
     pub portables: Option<String>,
 
     /// Cap per-frame gpu uploads
-    #[arg(long, value_name = "bytes", display_order = 17)]
+    #[arg(long, value_name = "bytes", help_heading = SETTINGS)]
     pub gpu_bytes_per_frame: Option<usize>,
+
+    /// Base url of the imposter store; absent = the default store. The realm-keyed path under
+    /// it is the same as the default store's
+    #[arg(long, value_name = "url", help_heading = SERVICES)]
+    pub imposter_source: Option<String>,
+
+    /// Embedded in a scene editor (creator hub). Set by editor front-ends.
+    #[arg(long, help_heading = HOST)]
+    pub editor: bool,
 }
 
 /// The web page's `engine_run` options: both structs as ONE flat object, which is also what the

--- a/crates/system_api_types/src/services.rs
+++ b/crates/system_api_types/src/services.rs
@@ -137,84 +137,80 @@ impl Service {
     }
 }
 
-/// One full base url per service, each replacing that service's base-domain composition. A
-/// value is taken verbatim with paths appended, so it carries its own scheme and port and no
-/// trailing slash (`http://localhost:3000`).
-// per-arg rather than the struct's `next_help_heading`: clap_derive doesn't restore the parent's
-// heading after a flatten, so a struct-level one would capture every flag a binary declares after
-// this struct
-const HELP_HEADING: &str =
-    "Service endpoints";
+use crate::launch_options::help_heading::SERVICES as HELP_HEADING;
 
+/// One full base url per service (pulse: `host[:port]`), each replacing that service's
+/// base-domain composition. A value is taken verbatim with paths appended, so it carries its own
+/// scheme and port and no trailing slash (`http://localhost:3000`).
 #[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ServiceOverrides {
     /// Realm provider (the realm list, and `/main` is the default realm); absent =
     /// `https://realm-provider-ea.<base>`
-    #[arg(long, value_name = "url", display_order = 61, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub realm_provider: Option<String>,
 
     /// Catalyst peer (`/content`, `/lambdas`); absent = `https://peer.<base>`
-    #[arg(long, value_name = "url", display_order = 62, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub catalyst: Option<String>,
 
     /// Worlds content server; absent = `https://worlds-content-server.<base>`
-    #[arg(long, value_name = "url", display_order = 63, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub worlds_server: Option<String>,
 
     /// Places api; absent = `https://places.<base>`
-    #[arg(long, value_name = "url", display_order = 64, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub places: Option<String>,
 
     /// Comms gatekeeper; absent = `https://comms-gatekeeper.<base>`
-    #[arg(long, value_name = "url", display_order = 65, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub comms_gatekeeper: Option<String>,
 
     /// Local-preview comms gatekeeper; absent = `https://comms-gatekeeper-local.<base>`
-    #[arg(long, value_name = "url", display_order = 66, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub preview_gatekeeper: Option<String>,
 
     /// Auth api the sign-in flow polls (native only); absent = `https://auth-api.<base>`
-    #[arg(long, value_name = "url", display_order = 67, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub auth_api: Option<String>,
 
     /// Sign-in page the browser opens (native only); absent = `https://<base>/auth`
-    #[arg(long, value_name = "url", display_order = 68, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub auth_page: Option<String>,
 
     /// Asset-bundle registry; absent = `https://asset-bundle-registry.<base>` (custom domains
     /// only: org and zone profiles use the registry of the profile's own environment)
-    #[arg(long, value_name = "url", display_order = 69, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub asset_bundle_registry: Option<String>,
 
     /// World storage; absent = `https://storage.<base>`. https only: an http instance is never
     /// signed for (the delegation claim must not go out in cleartext)
-    #[arg(long, value_name = "url", display_order = 70, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub storage: Option<String>,
 
     /// Ethereum json-rpc websocket; absent = `wss://rpc.<base>`
-    #[arg(long, value_name = "url", display_order = 71, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub ethereum_rpc: Option<String>,
 
     /// Social service websocket; absent = `wss://rpc-social-service-ea.<base>`
-    #[arg(long, value_name = "url", display_order = 72, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub social_rpc: Option<String>,
 
     /// OpenSea api; absent = `https://opensea.<base>`
-    #[arg(long, value_name = "url", display_order = 73, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub opensea: Option<String>,
 
     /// Reels (camera reel) api, used by the HUD; absent = `https://reels.<base>`
-    #[arg(long, value_name = "url", display_order = 74, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub reels: Option<String>,
 
     /// Map tile api, used by the HUD; absent = `https://api.<base>`
-    #[arg(long, value_name = "url", display_order = 75, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "url", help_heading = HELP_HEADING)]
     pub map_api: Option<String>,
 
     /// Pulse comms server, `host` or `host:port` (no port = the platform's: 7777 ENet on native,
     /// 7743 WebTransport on web); absent = `pulse-server.<base>`
-    #[arg(long, value_name = "host[:port]", display_order = 76, help_heading = HELP_HEADING)]
+    #[arg(long, value_name = "host[:port]", help_heading = HELP_HEADING)]
     pub pulse_server: Option<String>,
 }
 

--- a/crates/system_api_types/src/services.rs
+++ b/crates/system_api_types/src/services.rs
@@ -5,7 +5,8 @@
 //! following the domain. Resolution — override, else composition — is
 //! `common::base_domain::service`; on web the HUD resolves the same way from the same table
 //! (react-web lib/baseDomain.ts, from the generated `serviceTable.ts`) because it composes its
-//! own urls before the engine exists.
+//! own urls before the engine exists. One service is not a url: pulse is an authority,
+//! `host[:port]`, whose port the transport defaults per platform ([`ServiceValue`]).
 
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
@@ -42,10 +43,26 @@ pub enum Service {
     Reels,
     /// Map tile api — HUD only
     MapApi,
+    /// Pulse comms server — an authority, `host[:port]`; the port defaults per platform
+    PulseServer,
+}
+
+/// What a service's value looks like — its composition and any override alike.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug, ts_rs::TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub enum ServiceValue {
+    /// A full `http(s)://` base url
+    Http,
+    /// A full `ws(s)://` base url
+    Websocket,
+    /// `host` or `host:port` — no scheme or path; the consumer supplies the default port
+    Authority,
 }
 
 impl Service {
-    /// The deployment-convention default as `(scheme, sub, path)`; an empty sub is the apex.
+    /// The deployment-convention default as `(scheme, sub, path)`; an empty sub is the apex, an
+    /// empty scheme an authority service (the host alone).
     pub const fn composition(self) -> (&'static str, &'static str, &'static str) {
         match self {
             Service::RealmProvider => ("https", "realm-provider-ea", ""),
@@ -63,6 +80,7 @@ impl Service {
             Service::Opensea => ("https", "opensea", ""),
             Service::Reels => ("https", "reels", ""),
             Service::MapApi => ("https", "api", ""),
+            Service::PulseServer => ("", "pulse-server", ""),
         }
     }
 
@@ -85,6 +103,7 @@ impl Service {
             Service::Opensea => "opensea",
             Service::Reels => "reels",
             Service::MapApi => "map_api",
+            Service::PulseServer => "pulse_server",
         }
     }
 
@@ -109,10 +128,12 @@ impl Service {
         crate::web_params::camel_case(self.field())
     }
 
-    /// Whether the service is one of the secure-websocket ones (the override must be `ws(s)://`
-    /// rather than `http(s)://`).
-    pub fn is_websocket(self) -> bool {
-        self.composition().0 == "wss"
+    pub fn value(self) -> ServiceValue {
+        match self.composition().0 {
+            "" => ServiceValue::Authority,
+            "wss" => ServiceValue::Websocket,
+            _ => ServiceValue::Http,
+        }
     }
 }
 
@@ -123,7 +144,7 @@ impl Service {
 // heading after a flatten, so a struct-level one would capture every flag a binary declares after
 // this struct
 const HELP_HEADING: &str =
-    "Service endpoints (full base urls; absent = composed from the base domain)";
+    "Service endpoints";
 
 #[derive(clap::Args, Deserialize, Serialize, Default, Clone, PartialEq, Debug)]
 #[serde(rename_all = "camelCase", default)]
@@ -190,6 +211,11 @@ pub struct ServiceOverrides {
     /// Map tile api, used by the HUD; absent = `https://api.<base>`
     #[arg(long, value_name = "url", display_order = 75, help_heading = HELP_HEADING)]
     pub map_api: Option<String>,
+
+    /// Pulse comms server, `host` or `host:port` (no port = the platform's: 7777 ENet on native,
+    /// 7743 WebTransport on web); absent = `pulse-server.<base>`
+    #[arg(long, value_name = "host[:port]", display_order = 76, help_heading = HELP_HEADING)]
+    pub pulse_server: Option<String>,
 }
 
 impl ServiceOverrides {
@@ -210,6 +236,7 @@ impl ServiceOverrides {
             Service::Opensea => &self.opensea,
             Service::Reels => &self.reels,
             Service::MapApi => &self.map_api,
+            Service::PulseServer => &self.pulse_server,
         }
         .as_deref()
         .filter(|url| !url.is_empty())
@@ -230,6 +257,8 @@ impl ServiceOverrides {
 pub struct ServiceDef {
     /// The web param (and `ServiceOverrides` field in camelCase)
     pub name: String,
+    pub value: ServiceValue,
+    /// Empty for an authority service
     pub scheme: String,
     /// Empty = the apex domain
     pub sub: String,
@@ -243,6 +272,7 @@ pub fn service_table() -> Vec<ServiceDef> {
             let (scheme, sub, path) = service.composition();
             ServiceDef {
                 name: service.param(),
+                value: service.value(),
                 scheme: scheme.to_owned(),
                 sub: sub.to_owned(),
                 path: path.to_owned(),
@@ -293,6 +323,9 @@ mod tests {
         );
         assert_eq!(Service::WorldsServer.flag(), "--worlds-server");
         assert_eq!(Service::WorldsServer.param(), "worldsServer");
+        assert_eq!(Service::Catalyst.value(), ServiceValue::Http);
+        assert_eq!(Service::SocialRpc.value(), ServiceValue::Websocket);
+        assert_eq!(Service::PulseServer.value(), ServiceValue::Authority);
     }
 
     /// The sign-in services are native flags only: no row in the HUD's table.

--- a/crates/system_api_types/src/web_params.rs
+++ b/crates/system_api_types/src/web_params.rs
@@ -78,7 +78,6 @@ fn delivery(field: &str) -> Delivery {
         "system_scene"
         | "portables"
         | "preview"
-        | "pulse_server"
         | "imposter_source"
         | "content_server"
         | "log_fps"

--- a/crates/system_api_types/src/web_params.rs
+++ b/crates/system_api_types/src/web_params.rs
@@ -106,14 +106,25 @@ pub(crate) fn camel_case(snake: &str) -> String {
     out
 }
 
+/// The table, in the native `--help`'s order: the unheaded destination flags, the service
+/// endpoints, then the rest — each run in declaration order.
 pub fn web_params() -> Vec<WebParam> {
+    use crate::launch_options::help_heading::SERVICES;
     let launch = LaunchOptions::augment_args(clap::Command::new("launch"));
     let client = ClientOptions::augment_args(clap::Command::new("client"));
     let native_only =
         |field: &str| Service::all().any(|s| s.field() == field && !s.has_web_param());
-    launch
+    let section = |arg: &clap::Arg| match arg.get_help_heading() {
+        None => 0,
+        Some(SERVICES) => 1,
+        Some(_) => 2,
+    };
+    let mut args: Vec<_> = launch
         .get_arguments()
         .chain(client.get_arguments())
+        .collect();
+    args.sort_by_key(|arg| section(arg));
+    args.into_iter()
         .filter(|arg| !native_only(arg.get_id().as_str()))
         .map(|arg| {
             let field = arg.get_id().as_str();

--- a/deploy/web/engine/boot.js
+++ b/deploy/web/engine/boot.js
@@ -5,7 +5,7 @@
 // Contract with the host page (react-web/src/engine/engineRpc.ts):
 //   set BEFORE injecting:  window.PUBLIC_URL   — base for pkg/ fetches (versioned CDN in prod)
 //                          window.__bevyBootConfig — the engine_run options (keyed by the web
-//                            param table: systemScene, portables, preview, pulseServer, the
+//                            param table: systemScene, portables, preview, the
 //                            host-resolved baseDomain and service overrides …) minus
 //                            realm/position, forwarded verbatim by __bevyLaunch
 //   provided by this module:

--- a/deploy/web/engine/engine.js
+++ b/deploy/web/engine/engine.js
@@ -505,7 +505,7 @@ export function applyOptionsToUrlParams(urlParams, options) {
 /**
  * Starts the game engine. `options` is the engine_run options object — one named key per
  * launch parameter (LaunchOptions in crates/system_api_types/src/launch_options.rs: realm,
- * position, systemScene, portables, preview, editor, pulseServer, imposterSource). It comes from
+ * position, systemScene, portables, preview, editor, imposterSource, the service overrides). It comes from
  * boot.js's __bevyLaunch, fed by the React host. Absent keys take the engine's defaults; an
  * unknown key makes engine_run throw.
  */

--- a/react-web/src/lib/baseDomain.ts
+++ b/react-web/src/lib/baseDomain.ts
@@ -65,17 +65,25 @@ function service(name: string): ServiceDef {
 
 /**
  * The ?<service>= value the engine will accept (crates/common/src/base_domain.rs
- * `set_services`): a full http(s) — ws(s) for the websocket services — base url with no query or
- * fragment, trailing slash dropped. Anything else is null so the HUD and the engine fall back to
- * the same composed default rather than splitting. Recomposed from scheme, host and path rather
- * than serialised: a bare trailing `?` or `#` is empty to `search`/`hash` but a query/fragment to
- * the engine's parser, which would refuse it and fail the launch.
+ * `set_services`), in the service's shape: a full http(s) — ws(s) for the websocket services —
+ * base url with no query or fragment, trailing slash dropped; or, for an authority service
+ * (pulse), `host` or `host:port` and nothing else. Anything else is null so the HUD and the
+ * engine fall back to the same composed default rather than splitting. Recomposed from the
+ * parsed parts rather than serialised: a bare trailing `?` or `#` is empty to `search`/`hash`
+ * but a query/fragment to the engine's parser, which would refuse it and fail the launch.
  */
 export function normaliseServiceUrl(s: ServiceDef, raw: string | null): string | null {
   if (raw == null) return null
   try {
+    if (s.value === 'authority') {
+      const a = raw.trim()
+      if (a === '' || /[/?#@]/.test(a)) return null
+      // behind a non-special scheme, so a default-looking port is kept as given
+      const u = new URL(`dummy://${a}`)
+      return u.hostname === '' ? null : u.host.toLowerCase()
+    }
     const u = new URL(raw.trim())
-    const ok = s.scheme === 'wss' ? /^wss?:$/ : /^https?:$/
+    const ok = s.value === 'websocket' ? /^wss?:$/ : /^https?:$/
     if (!ok.test(u.protocol) || u.search !== '' || u.hash !== '') return null
     return `${u.protocol}//${u.host}${u.pathname}`.replace(/\/+$/, '')
   } catch {
@@ -94,13 +102,14 @@ export const SERVICE_OVERRIDES: Readonly<Record<string, string>> = {}
 }
 
 /**
- * A service's base url by its table name: the entry url's override, else composed from the base
- * domain, e.g. serviceUrl('places') → "https://places.decentraland.org".
+ * A service's base url (an authority service: its host) by its table name: the entry url's
+ * override, else composed from the base domain, e.g. serviceUrl('places') →
+ * "https://places.decentraland.org".
  */
 export function serviceUrl(name: string): string {
   const s = service(name)
   const host = s.sub === '' ? BASE_DOMAIN : `${s.sub}.${BASE_DOMAIN}`
-  return SERVICE_OVERRIDES[name] ?? `${s.scheme}://${host}${s.path}`
+  return SERVICE_OVERRIDES[name] ?? (s.value === 'authority' ? host : `${s.scheme}://${host}${s.path}`)
 }
 window.__serviceUrl = serviceUrl
 

--- a/react-web/src/lib/bootMode.ts
+++ b/react-web/src/lib/bootMode.ts
@@ -9,7 +9,7 @@
 //   ?systemScene=  debug: substitute the super-user ui scene (a url/dir, or "none" for the
 //                  engine's builtin ui). The scene owns login/UI in-engine (pre-react
 //                  behavior), so this implies a hidden HUD and no React login at all.
-// The engine-bound params (?portables=, ?pulseServer=, ?imposterSource=, …) are not boot-mode
+// The engine-bound params (?portables=, ?imposterSource=, ?pulseServer=, …) are not boot-mode
 // decisions: they come from the engine's web param table (lib/webParams.ts) and are handed over
 // as-is by EngineHost.
 export interface BootMode {

--- a/react-web/src/lib/launchGate.ts
+++ b/react-web/src/lib/launchGate.ts
@@ -3,7 +3,7 @@
 // it is decided here, because trust is a property of the host: the editor app trusts its editor
 // scene, this app trusts its bundled bridge scene and Decentraland's own deployments.
 
-import { SERVICES } from '../engine/generated'
+import { SERVICES, type ServiceDef } from '../engine/generated'
 import { BASE_DOMAIN, hostBaseDomain, isTrustedBaseDomain, normaliseServiceUrl } from './baseDomain'
 import { bootMode } from './bootMode'
 import { isTrustedSystemScene } from './systemScene'
@@ -60,15 +60,24 @@ function isTrustedContentServer(url: string): boolean {
     return false
   }
 }
-// Every per-service url override: worse than ?baseDomain= in that it can poison ONE service —
-// sign-in, profiles — while everything else looks normal. Same rule as the content server, and
-// native is exempt the same way as the base domain (the shell injects the user's own flags).
+/** A service value — url, or `host[:port]` for an authority service — under one of Decentraland's own deployments. */
+function isTrustedServiceUrl(s: ServiceDef, value: string): boolean {
+  try {
+    const u = new URL(s.value === 'authority' ? `dummy://${value}` : value)
+    return hostBaseDomain(u.hostname) != null
+  } catch {
+    return false
+  }
+}
+// Every per-service override: worse than ?baseDomain= in that it can poison ONE service —
+// sign-in, profiles, comms — while everything else looks normal. Same rule as the content server,
+// and native is exempt the same way as the base domain (the shell injects the user's own flags).
 // Read normalised, like the base domain: a value the HUD discards is never put to the user.
 for (const s of SERVICES) {
   GATES[s.name] = {
     warning: `Points the Explorer's "${s.name}" backend service at this server, with everything else looking normal. Whoever runs it would see the requests and choose the answers.`,
     read: (native) => (native ? null : normaliseServiceUrl(s, new URLSearchParams(location.search).get(s.name))),
-    isTrusted: isTrustedContentServer
+    isTrusted: (value) => isTrustedServiceUrl(s, value)
   }
 }
 for (const name of Object.keys(GATES)) webParam(name)

--- a/react-web/src/test/webParams.test.ts
+++ b/react-web/src/test/webParams.test.ts
@@ -10,12 +10,11 @@ import { normaliseServiceUrl } from '../lib/baseDomain'
 describe('launchOptionsFromUrl', () => {
   it('reads every launch param, flags by presence, strings verbatim, absent = undefined', () => {
     const q = new URLSearchParams(
-      '?pulseServer=localhost:7777&preview&portables=a;b&editor&logFps=true&gpuBytesPerFrame=500000&contentServer=https://peer.decentraland.org/content'
+      '?preview&portables=a;b&editor&logFps=true&gpuBytesPerFrame=500000&contentServer=https://peer.decentraland.org/content'
     )
     const opts = launchOptionsFromUrl(q)
     // editor is the creator-hub front-end's to set (delivery `host`), never a link's
     expect('editor' in opts).toBe(false)
-    expect(opts.pulseServer).toBe('localhost:7777')
     expect(opts.preview).toBe(true)
     expect(opts.portables).toBe('a;b')
     expect(opts.imposterSource).toBeUndefined()
@@ -37,6 +36,7 @@ describe('launchOptionsFromUrl', () => {
 describe('normaliseServiceUrl', () => {
   const catalyst = SERVICES.find((s) => s.name === 'catalyst')!
   const socialRpc = SERVICES.find((s) => s.name === 'socialRpc')!
+  const pulse = SERVICES.find((s) => s.name === 'pulseServer')!
 
   it('yields a base url the engine accepts: scheme + host + path, no trailing slash', () => {
     expect(normaliseServiceUrl(catalyst, ' https://peer.example/ ')).toBe('https://peer.example')
@@ -48,6 +48,16 @@ describe('normaliseServiceUrl', () => {
     expect(normaliseServiceUrl(catalyst, 'http://127.0.0.1:8799/?')).toBe('http://127.0.0.1:8799')
     expect(normaliseServiceUrl(catalyst, 'http://127.0.0.1:8799/#')).toBe('http://127.0.0.1:8799')
     expect(normaliseServiceUrl(catalyst, 'http://127.0.0.1:8799?#')).toBe('http://127.0.0.1:8799')
+  })
+
+  it('takes an authority service as host or host:port, nothing else', () => {
+    expect(normaliseServiceUrl(pulse, 'Pulse-Server.decentraland.zone:7777')).toBe('pulse-server.decentraland.zone:7777')
+    expect(normaliseServiceUrl(pulse, ' 127.0.0.1 ')).toBe('127.0.0.1')
+    expect(normaliseServiceUrl(pulse, '127.0.0.1:80')).toBe('127.0.0.1:80')
+    expect(normaliseServiceUrl(pulse, 'https://pulse.example')).toBeNull()
+    expect(normaliseServiceUrl(pulse, 'pulse.example:7777/x')).toBeNull()
+    expect(normaliseServiceUrl(pulse, 'pulse.example:99999')).toBeNull()
+    expect(normaliseServiceUrl(pulse, '')).toBeNull()
   })
 
   it('is null for anything else, so both sides fall back to the composed default', () => {
@@ -89,6 +99,23 @@ describe('untrustedLaunchParams', () => {
       expect(p.name).toBe('catalyst')
       expect(p.warning).toMatch(/"catalyst" backend service/)
       expect(untrustedLaunchParams({ native: true })).toEqual([])
+    } finally {
+      window.history.replaceState(null, '', '/')
+    }
+  })
+
+  it('gates an authority service by its host like the rest', () => {
+    window.history.replaceState(null, '', '/?pulseServer=pulse-server.decentraland.zone:7777')
+    try {
+      expect(untrustedLaunchParams({ native: false })).toEqual([])
+    } finally {
+      window.history.replaceState(null, '', '/?pulseServer=pulse.example')
+    }
+    try {
+      const [p, ...rest] = untrustedLaunchParams({ native: false })
+      expect(rest).toEqual([])
+      expect(p.name).toBe('pulseServer')
+      expect(p.value).toBe('pulse.example')
     } finally {
       window.history.replaceState(null, '', '/')
     }

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -57,7 +57,7 @@ use scene_runner::{
     renderer_context::RendererSceneContext,
     SceneRunnerPlugin,
 };
-use system_api_types::launch_options::LaunchOptions;
+use system_api_types::launch_options::{help_heading::HEADLESS, LaunchOptions};
 use system_bridge::SystemBridgePlugin;
 use tween::TweenPlugin;
 use user_input::avatar_movement::{
@@ -89,23 +89,22 @@ struct Args {
 
     /// Serve the scene: `isServer()` is true to scene code and realm-wide comms are never
     /// joined. Standalone (without --orchestrated) is a local-dev flow and requires --preview
-    #[arg(long, display_order = 50)]
+    #[arg(long, help_heading = HEADLESS)]
     server_mode: bool,
 
     /// Multi-scene worker driven over stdin by an orchestrator; implies --server-mode
-    #[arg(long, display_order = 51)]
+    #[arg(long, help_heading = HEADLESS)]
     orchestrated: bool,
 
     /// Exit cleanly after this many seconds
-    #[arg(long, value_name = "secs", display_order = 52)]
+    #[arg(long, value_name = "secs", help_heading = HEADLESS)]
     timeout: Option<f32>,
 
     /// Scene javascript threads; absent = 16 orchestrated, 4 otherwise
     #[arg(
         long,
         value_name = "n",
-        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..),
-        display_order = 53
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..), help_heading = HEADLESS
     )]
     scene_threads: Option<usize>,
 
@@ -114,26 +113,25 @@ struct Args {
         long,
         value_name = "hz",
         default_value_t = 30,
-        value_parser = clap::value_parser!(u32).range(1..),
-        display_order = 54
+        value_parser = clap::value_parser!(u32).range(1..), help_heading = HEADLESS
     )]
     tick_hz: u32,
 
     /// base64 world-storage delegation (hammurabi envelope), or the PROCESS_STORAGE_DELEGATION
     /// env var; single-scene runs only — orchestrated scenes receive theirs via the control
     /// channel
-    #[arg(long, value_name = "base64", display_order = 55)]
+    #[arg(long, value_name = "base64", help_heading = HEADLESS)]
     storage_delegation: Option<String>,
 
     /// Deterministic guest wallet (test harness): the address is derivable offline from the seed
-    #[arg(long, value_name = "seed", display_order = 56)]
+    #[arg(long, value_name = "seed", help_heading = HEADLESS)]
     wallet_seed: Option<u64>,
 
     /// Pulse realm to announce verbatim; `--server-mode` only, and optional there: absent, the
     /// engine derives the same key from a locally hosted scene's entity id once it loads, this
     /// just announces it sooner. Orchestrated servers host several realms at once and take one
     /// per scene on `add-scene` instead
-    #[arg(long, value_name = "key", display_order = 57)]
+    #[arg(long, value_name = "key", help_heading = HEADLESS)]
     pulse_realm: Option<String>,
 
     // resolved after parsing: realm defaults to a local preview server, position to 0,0

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -42,7 +42,6 @@ pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_ser
         base_domain: _,
         services: _,
         preview,
-        pulse_server,
         log_fps,
     } = launch;
 
@@ -51,12 +50,6 @@ pub fn apply(app: &mut App, launch: &LaunchOptions, config: &AppConfig, boot_ser
         is_preview: *preview,
         preview_parcel: None,
     });
-
-    if let Some(endpoint) = pulse_server {
-        app.insert_resource(comms::pulse::plugin::PulseEndpointOverride(
-            endpoint.clone(),
-        ));
-    }
 
     if log_fps.unwrap_or(config.graphics.log_fps) {
         // the HUD adds the frame timing too

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,10 @@ use scene_runner::{
 };
 use social::SocialPlugin;
 use system_api_types::{
-    launch_options::{ClientOptions, LaunchOptions},
+    launch_options::{
+        help_heading::{DEBUG, SETTINGS, SYSTEM_SCENES},
+        ClientOptions, LaunchOptions,
+    },
     web_params::DEFAULT_PORTABLES,
 };
 use system_bridge::{settings::NewCameraEvent, NativeUi, SystemBridgePlugin};
@@ -171,86 +174,82 @@ pub struct DecentralandArguments {
     #[command(flatten)]
     pub client: ClientOptions,
     /// Echo scene logs to the console
-    #[arg(long = "scene_log_to_console", display_order = 6)]
+    #[arg(long = "scene_log_to_console", help_heading = DEBUG)]
     pub scene_log_to_console: bool,
     /// Pause that scene's js runtime until a debugger (e.g. chrome://inspect) attaches. Needs
     /// `--features inspect`
-    #[arg(long, value_name = "scene_hash", display_order = 10)]
+    #[arg(long, value_name = "scene_hash", help_heading = DEBUG)]
     pub inspect: Option<String>,
-    /// Target fps (default 60; overridden by the refresh rate when vsync is on). Also `/fps`.
-    /// Current run only - use settings for persistence.
-    #[arg(long = "fps", value_name = "n", display_order = 14)]
+    /// Target fps (default 60; overridden by the refresh rate when vsync is on). Also `/fps`
+    #[arg(long = "fps", value_name = "n", help_heading = SETTINGS)]
     pub fps_target: Option<usize>,
     /// Run the portable/startup scenes in preview mode
-    #[arg(long = "ui-preview", display_order = 15)]
+    #[arg(long = "ui-preview", help_heading = SYSTEM_SCENES)]
     pub startup_scenes_preview: bool,
     /// Max simultaneous scene-javascript threads (default 4). Also `/scene_threads`
-    #[arg(long = "threads", value_name = "n", display_order = 16)]
+    #[arg(long = "threads", value_name = "n", help_heading = SETTINGS)]
     pub scene_threads: Option<usize>,
     /// Automated scene test mode: headless, no HUD (implied by --test_scenes)
-    #[arg(long = "testing", display_order = 18)]
+    #[arg(long = "testing", help_heading = DEBUG)]
     pub testing: bool,
     /// Run the scene test harness over those parcels and exit; a parcel may carry
     /// `/allowed/failures`
-    #[arg(long = "test_scenes", value_name = "x,y;x,y", display_order = 19)]
+    #[arg(long = "test_scenes", value_name = "x,y;x,y", help_heading = DEBUG)]
     pub test_scenes: Option<TestScenes>,
-    /// Vsync (default off). Current run only - use settings for persistence.
-    #[arg(long, value_name = "true|false", display_order = 20)]
+    /// Vsync (default off)
+    #[arg(long, value_name = "true|false", help_heading = SETTINGS)]
     pub vsync: Option<bool>,
-    /// Scene load distance in meters (default 100). Also `/scene_distance`. Current run only -
-    /// use settings for persistence.
-    #[arg(long = "distance", value_name = "m", display_order = 21)]
+    /// Scene load distance in meters (default 100). Also `/scene_distance`
+    #[arg(long = "distance", value_name = "m", help_heading = SETTINGS)]
     pub scene_load_distance: Option<f32>,
-    /// Extra distance before scenes are unloaded. Current run only - use settings for
-    /// persistence.
-    #[arg(long = "unload", value_name = "m", display_order = 22)]
+    /// Extra distance before scenes are unloaded
+    #[arg(long = "unload", value_name = "m", help_heading = SETTINGS)]
     pub scene_unload_extra_distance: Option<f32>,
-    /// Imposter distances. Current run only - use settings for persistence.
+    /// Imposter distances
     #[arg(
         long = "impost",
         value_name = "d1,d2,…",
-        value_delimiter = ',',
-        display_order = 23
+        value_delimiter = ',', help_heading = SETTINGS
     )]
     pub scene_imposter_distances: Option<Vec<f32>>,
     /// Imposter multisampling
-    #[arg(long = "impost_multi", value_name = "true|false", display_order = 24)]
+    #[arg(long = "impost_multi", value_name = "true|false", help_heading = SETTINGS)]
     pub scene_imposter_multisample: Option<bool>,
     /// Imposter local baking speed: f(ull), h(alf), q(uarter) or o(ff)
-    #[arg(long = "bake", value_name = "f|h|q|o", value_parser = parse_bake, display_order = 25)]
+    #[arg(long = "bake", value_name = "f|h|q|o", value_parser = parse_bake, help_heading = SETTINGS)]
     pub scene_imposter_bake: Option<SceneImposterBake>,
     /// Show the system info overlay
-    #[arg(long = "sysinfo", display_order = 26)]
+    #[arg(long = "sysinfo", help_heading = DEBUG)]
     pub sysinfo_visible: bool,
     /// Disable avatar rendering
-    #[arg(long = "no_avatar", display_order = 27)]
+    #[arg(long = "no_avatar", help_heading = DEBUG)]
     pub no_avatar: bool,
     /// Disable gltf loading
-    #[arg(long = "no_gltf", display_order = 28)]
+    #[arg(long = "no_gltf", help_heading = DEBUG)]
     pub no_gltf: bool,
     /// Disable distance fog
-    #[arg(long = "no_fog", display_order = 29)]
+    #[arg(long = "no_fog", help_heading = DEBUG)]
     pub no_fog: bool,
     /// Force the engine-drawn login back on
-    #[arg(long = "builtin-login", display_order = 30)]
+    #[arg(long = "builtin-login", help_heading = DEBUG)]
     pub login: bool,
     /// Force the engine-drawn emote wheel back on
-    #[arg(long = "builtin-emotes", display_order = 31)]
+    #[arg(long = "builtin-emotes", help_heading = DEBUG)]
     pub emote_wheel: bool,
     /// Force the engine-drawn chat back on
-    #[arg(long = "builtin-chat", display_order = 32)]
+    #[arg(long = "builtin-chat", help_heading = DEBUG)]
     pub chat: bool,
     /// Force the engine-drawn permission prompts back on
-    #[arg(long = "builtin-perms", display_order = 33)]
+    #[arg(long = "builtin-perms", help_heading = DEBUG)]
     pub permissions: bool,
     /// Force the engine-drawn nametags back on
-    #[arg(long = "builtin-nametags", display_order = 34)]
+    #[arg(long = "builtin-nametags", help_heading = DEBUG)]
     pub nametags: bool,
     /// Force the engine-drawn tooltips back on
-    #[arg(long = "builtin-tooltips", display_order = 35)]
+    #[arg(long = "builtin-tooltips", help_heading = DEBUG)]
     pub tooltips: bool,
     /// Force the engine-drawn loading scene ui back on
-    #[arg(long = "builtin-loading-scene-ui", display_order = 36)]
+    #[arg(long = "builtin-loading-scene-ui", help_heading = DEBUG)]
     pub loading_scene: bool,
     /// run the react HUD (native: the CEF overlay). False when an explicit --system-scene opted
     /// out in favour of the engine-side ui, and on wasm (the react page hosts the engine itself).


### PR DESCRIPTION
**Cleanup after #1221: the pulse server joins the service table, and `--help` gets sections.**

**Pulse as a service.** The pulse endpoint was the one backend outside the table, with its own launch option, a `PulseEndpointOverride` resource and a cfg-split default. It is now `Service::PulseServer`, an *authority* rather than a url: `--pulse-server` / `?pulseServer=` take `host` or `host:port` and nothing else, a given port is literal, and `base_domain::with_default_port` returns the resolved host and port — host from the override or the composed `pulse-server.<domain>`, port from the value or the platform's (7777 ENet native, 7743 WebTransport web). Precedence is unchanged: explicit arg, `PULSE_SERVER` env var, base domain, each in the same form, so the env var now also accepts a bare host. `ServiceValue` (http / websocket / authority) names each service's value shape for the latch and, through the generated table, the HUD, whose normaliser and launch gate handle the authority form. A link pointing comms at a foreign host is now gated where it was silent. The unused raw `https`/`wss`/`host` helpers are gone.

**Help sections.** Flags are grouped: Settings overrides (this run only), Debug, Service endpoints (imposter source joins them), System scenes, Set by the embedding host (editor), and Headless runner; realm, position, preview and base domain stay unheaded. Headings come from one shared module and are set per flag, because clap_derive does not restore the parent heading after a flatten. Clap prints groups in the order their first flag is declared and, absent display orders, flags in declaration order, so every `display_order` is removed and field order alone decides the layout.

**Web param table** follows the same order — unheaded, services, rest — so the entry-params dialog reads like `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
