### PR TITLE
Launch failures report a real exit status

### DIFF
--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -143,9 +143,15 @@ struct Args {
     location: IVec2,
 }
 
+/// The launcher's "permanently unavailable here" status (EX_CONFIG). A refused argument is not
+/// worth retrying, and callers fall back to another server implementation on it — the npm
+/// launcher already answers its own argument checks with this
+/// (deploy/headless/launcher/bin/cli.js) and forwards whatever the engine returns.
+const EXIT_UNAVAILABLE: i32 = 78;
+
 fn usage_error(message: impl std::fmt::Display) -> ! {
     eprintln!("{message}");
-    std::process::exit(2);
+    std::process::exit(EXIT_UNAVAILABLE);
 }
 
 fn parse_args() -> Args {
@@ -153,7 +159,7 @@ fn parse_args() -> Args {
         Ok(args) => args,
         Err(e) => {
             let _ = e.print();
-            std::process::exit(if e.use_stderr() { 2 } else { 0 });
+            std::process::exit(if e.use_stderr() { EXIT_UNAVAILABLE } else { 0 });
         }
     };
     // latch first: everything below that composes a backend host reads it

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -300,7 +300,7 @@ fn spawn_stdin_reader() -> std::sync::mpsc::Receiver<ControlCommand> {
     rx
 }
 
-fn main() {
+fn main() -> AppExit {
     let session_time: chrono::DateTime<chrono::Utc> = chrono::DateTime::from_timestamp_millis(
         web_time::SystemTime::now()
             .duration_since(web_time::UNIX_EPOCH)
@@ -573,7 +573,9 @@ fn main() {
         .set(bevy::ecs::error::warn)
         .ok();
 
-    app.run();
+    // returned, not dropped: the supervisor's AppExit is the process status the launcher
+    // forwards (deploy/headless/launcher/bin/cli.js)
+    app.run()
 }
 
 /// Stands in for the render-only `ImageLoader`: without it the asset server errors

--- a/src/bin/impost.rs
+++ b/src/bin/impost.rs
@@ -51,7 +51,7 @@ use wallet::Wallet;
 
 static SESSION_LOG: OnceLock<String> = OnceLock::new();
 
-fn main() {
+fn main() -> AppExit {
     let session_time: chrono::DateTime<chrono::Utc> = chrono::DateTime::from_timestamp_millis(
         web_time::SystemTime::now()
             .duration_since(web_time::UNIX_EPOCH)
@@ -148,7 +148,7 @@ fn main() {
                 .collect::<Vec<_>>()
                 .join(" ")
         );
-        return;
+        return AppExit::from_code(2);
     }
 
     let mut app = App::new();
@@ -316,7 +316,7 @@ fn main() {
 
     app.add_systems(PreUpdate, check_done);
 
-    app.run();
+    app.run()
 }
 
 #[allow(clippy::type_complexity)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,22 +47,26 @@ fn main() {
     log_panics::init();
 
     // args first, so --help and a bad flag answer without spawning the scene runtime
-    match decentraland_app_config() {
+    let exit_code = match decentraland_app_config() {
         Ok(decentraland_app_config) => {
             // initialize v8 runtime from main thread
             init_runtime().unwrap();
             decentraland_app.build(decentraland_app_config).run();
+            0
         }
-        Err(UserError(false)) => panic!("Fatal error while building application configurations."),
-        Err(UserError(true)) => {
-            // Non need to generate a crash report if the failure
-            // is due to an user error
-        }
+        // No need to generate a crash report if the failure is due to an user error
+        Err(UserError(code)) => code,
     };
 
     // Graceful exits don't need to have the log sent to the analytics server
     // so we remove the touch file
     let _ = std::fs::remove_file(format!("{}.touch", SESSION_LOG.get().unwrap()));
+
+    // after the touch file is gone: an early exit would leave it behind and the next run would
+    // report the usage error as a crash
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
 }
 
 fn decentraland_app_config() -> Result<DecentralandAppConfig, UserError> {
@@ -108,18 +112,18 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
             } else {
                 let _ = e.print();
             }
-            return Err(UserError(true));
+            return Err(UserError(e.exit_code()));
         }
     };
 
     webgpu_build::launch::latch(&args.launch).map_err(|e| {
         error!("{e}");
-        UserError(true)
+        UserError(USAGE_ERROR)
     })?;
     if let Some(position) = &args.launch.position {
         IVec2Arg::from_str(position).map_err(|e| {
             error!("--position {position}: {e}");
-            UserError(true)
+            UserError(USAGE_ERROR)
         })?;
     }
 
@@ -205,14 +209,20 @@ fn decentraland_crash_file() -> Option<PathBuf> {
         })
 }
 
+/// A launch that stopped before the app ran, carrying the process exit status: 0 when the user
+/// asked for something and got it (`--help`), [`USAGE_ERROR`] when a flag or a value was refused.
 #[derive(Debug)]
-struct UserError(bool);
+struct UserError(i32);
+
+/// clap's exit status for a usage error, so a value this binary refuses reads to a script exactly
+/// like a flag clap refuses.
+const USAGE_ERROR: i32 = 2;
 
 impl Display for UserError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self(true) => write!(f, "Method failed due to user error."),
-            Self(false) => write!(f, "Method failed due to application error."),
+        match self.0 {
+            0 => write!(f, "Nothing to run."),
+            code => write!(f, "Method failed due to user error (exit code {code})."),
         }
     }
 }


### PR DESCRIPTION
**Every binary reported a refused argument as success, and headless threw away the status its own supervisor set.**

**A refused argument was exit 0.** `main()` matched the launch failure and fell through to a normal return, so a typo'd flag, a `--position` that doesn't parse and any `--base-domain` or `--<service>` value the latch refuses all left the process at 0 — a script or CI step could not tell a rejected flag from a clean run. `UserError` carries the status instead of a bool: clap's own `exit_code()` for a parse failure, so `--help` stays 0 while a bad flag is 2, and `USAGE_ERROR` for the two validations that run after parsing. The exit is taken *after* the session's `.touch` file is removed — leaving it behind would make the next run report the usage error as a crash. The `UserError(false)` arm went with the bool; nothing ever constructed it. `impost`'s hand-rolled arg parser had the same bug by a different route, a bare `return` on an unparsed argument.

**Headless dropped its own exit status.** Both `headless` and `impost` ended in `app.run();`, discarding the `AppExit` the run produced. The headless supervisor writes `AppExit::from_code(1)` for a broken scene — its doc comment says it "exits non-zero on a broken scene" — and `impost` does the same for a fatal bake error, but the process exited 0 either way. The npm launcher forwards the engine's status to its own caller (`deploy/headless/launcher/bin/cli.js`), so a broken scene reached the SDK preview, and the publish workflow's smoke step, as success. `fn main() -> AppExit` and `app.run()` unsuffixed: `AppExit` implements `Termination`, so the code reaches the process.

**A refused argument now exits 78 on headless.** `deploy/headless/launcher/README.md` documents 78 (EX_CONFIG) as "permanently unavailable here — unsupported platform, missing binary, or bad arguments — so a caller can fall back to another implementation instead of retrying", and `docs/headless-sdk-preview.md` describes the preview's close handler falling back to hammurabi on it. `cli.js` answers its own four argument checks with 78, but the engine answered its own with 2 and `cli.js` forwards the engine's status verbatim — so every argument the launcher does not itself validate reached the caller as a generic failure and no fallback happened. That gap widened with the service-endpoint flags, which the launcher knows nothing about.

Deliberately unchanged: a broken scene stays `AppExit(1)`, because the engine ran and is not "unavailable here"; the orchestrated case still reports a broken scene to the orchestrator rather than exiting; and the native binary keeps clap's 2, having no launcher and no consumer of a fallback status.

| | `--help` | refused argument | broken scene |
|---|---|---|---|
| `decentra-bevy` | 0 | 0 → **2** | n/a |
| `headless` | 0 | 2 → **78** | 0 → **1** |
| `impost` | n/a | 0 → **2** | 0 → **1** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
