### PR TITLE
feat: report the emote lifecycle to scenes, and stopEmote

### DIFF
--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -12,16 +12,15 @@ use bevy::{
 use bevy_console::ConsoleCommand;
 use collectibles::{
     ext::AvatarEmotesExt, Collectible, CollectibleData, CollectibleError, CollectibleManager,
-    Emote, EmoteUrn,
+    Emote, EmoteExtraData, EmoteUrn,
 };
 use common::{
-    dynamics::PLAYER_COLLIDER_RADIUS,
     rpc::{RpcCall, RpcEventSender},
     sets::SceneSets,
     structs::{
-        AudioEmitter, AudioType, AvatarDynamicState, EmoteCommand, MoveKind, PlayerModifiers,
-        PrimaryUser, SceneDrivenAnim, SceneDrivenAnimationFeedback,
-        SceneDrivenAnimationFeedbackState,
+        AudioEmitter, AudioType, AvatarDynamicState, EmoteCommand, EmoteLifecycle,
+        EmoteLifecycleEvent, MoveKind, PlayerModifiers, PrimaryUser, SceneDrivenAnim,
+        SceneDrivenAnimationFeedback, SceneDrivenAnimationFeedbackState,
     },
     util::TryPushChildrenEx,
 };
@@ -29,15 +28,8 @@ use comms::{
     broadcast, global_crdt::ForeignPlayer, profile::CurrentUserProfile, BroadcastTarget, Transport,
 };
 use console::DoAddConsoleCommand;
-use dcl::interface::CrdtType;
-use dcl_component::{
-    proto_components::sdk::components::PbAvatarEmoteCommand, SceneComponentId, SceneEntityId,
-};
 use ipfs::IpfsAssetServer;
-use scene_runner::{
-    permissions::Permission, renderer_context::RendererSceneContext,
-    update_world::animation::Clips, ContainerEntity, ContainingScene,
-};
+use scene_runner::{permissions::Permission, update_world::animation::Clips};
 
 use crate::{process_avatar, AvatarDefinition};
 
@@ -64,9 +56,6 @@ static URN_GLIDE: std::sync::LazyLock<EmoteUrn> =
 pub struct AvatarAnimState {
     damped_velocity: Vec3,
     current_emote_min_velocity: f32,
-    /// A triggered emote is waiting to be reported to scenes. Set when the `EmoteCommand`
-    /// arrives, cleared once the emote resolves and the report goes out — see `animate`.
-    pending_emote_report: bool,
 }
 
 pub struct AvatarAnimationPlugin;
@@ -311,15 +300,12 @@ fn animate(
         &GlobalTransform,
         Option<(&mut ActiveEmote, &mut AvatarAnimState)>,
         Option<&ForeignPlayer>,
-        Option<&ContainerEntity>,
-        Option<&PrimaryUser>,
         Option<&mut LastEmoteCommand>,
         Option<Ref<SceneDrivenAnim>>,
     )>,
     time: Res<Time>,
     player: Query<(&PrimaryUser, Option<&PlayerModifiers>)>,
-    containing_scene: ContainingScene,
-    mut scenes: Query<&mut RendererSceneContext>,
+    mut lifecycle: EventWriter<EmoteLifecycleEvent>,
 ) {
     let (gravity, jump_height) = player
         .single()
@@ -336,8 +322,6 @@ fn animate(
         gt,
         active_emote,
         maybe_foreign,
-        maybe_container,
-        maybe_primary,
         last_emote,
         maybe_scene_anim,
     ) in avatars.iter_mut()
@@ -370,7 +354,7 @@ fn animate(
         let scene_anim = maybe_scene_anim.as_deref().and_then(|a| a.active.as_ref());
 
         // get requested emote
-        let (mut requested_emote, given_urn, request_loop) =
+        let (mut requested_emote, request_loop) =
             if let Some(EmoteCommand { urn, r#loop, .. }) = emote {
                 let parsed = EmoteUrn::new(urn.as_str()).ok();
                 // A scene emote's urn ends `-{loop}`. That trailing token is the only loop signal
@@ -381,80 +365,12 @@ fn animate(
                     .as_ref()
                     .and_then(EmoteUrn::scene_emote)
                     .is_some_and(|emote| emote.ends_with("-true"));
-                (parsed, Some(urn), *r#loop || scene_loop)
+                (parsed, *r#loop || scene_loop)
             } else {
-                (None, None, false)
+                (None, false)
             };
 
         let emote_changed = emote != last_emote.as_ref().map(|l| &l.0);
-
-        // Report a triggered emote to scenes once its loop state stops moving, rather than the
-        // frame the command lands. A wearable's loop flag lives in its `emoteDataADR74.loop`
-        // metadata, which `play_current_emote` only folds into `repeat` once the collectible
-        // loads, so reporting on arrival would publish `loop: false` for a looping emote.
-        // `broadcast_emote` gates the network announce on the same resolution.
-        if emote_changed {
-            anim_state.pending_emote_report = true;
-        }
-
-        // `active_emote` is still last frame's. Same urn with a stamped duration means the clip is
-        // playing and `repeat` is final; `finished` with no duration is a concrete resolution
-        // failure (urn missing, or no clip in the gltf) — report that too rather than going silent,
-        // carrying the loop state we do have. Still loading is neither, so we wait. Never on the
-        // arrival frame: `repeat` is rebuilt from the new `request_loop` below, so re-triggering the
-        // same urn would otherwise report the previous play's loop state.
-        //
-        // Sits ahead of the cancel checks deliberately — they clear `requested_emote` on
-        // `active_emote.finished`, which would drop a failed emote before it was ever reported.
-        let emote_settled = !emote_changed
-            && active_emote.source == ActiveEmoteSource::TriggeredEmote
-            && Some(&active_emote.urn) == requested_emote.as_ref()
-            && (active_emote.duration_ms.is_some() || active_emote.finished);
-
-        if anim_state.pending_emote_report && emote_settled {
-            anim_state.pending_emote_report = false;
-            let resolved_loop = active_emote.repeat;
-
-            let broadcast_urn = given_urn.unwrap();
-            debug!("broadcasting emote to scenes: {:?}", broadcast_urn);
-
-            let (scene, scene_id) = match (maybe_foreign, maybe_primary, maybe_container) {
-                (Some(f), ..) => (None, f.scene_id),
-                (None, Some(_), _) => (None, SceneEntityId::PLAYER),
-                (None, None, Some(container)) => {
-                    (Some(container.container), container.container_id)
-                }
-                _ => (Some(Entity::PLACEHOLDER), SceneEntityId::ROOT),
-            };
-
-            let report_scenes = match scene {
-                Some(scene) => vec![scene],
-                None => containing_scene
-                    .get_area(avatar_ent, PLAYER_COLLIDER_RADIUS)
-                    .into_iter()
-                    .collect(),
-            };
-
-            for scene_ent in report_scenes {
-                let Ok(mut scene) = scenes.get_mut(scene_ent) else {
-                    warn!("no scene to receive emote");
-                    continue;
-                };
-
-                let timestamp = scene.tick_number;
-                debug!("broadcast to scene {:?}", scene_ent);
-                scene.update_crdt(
-                    SceneComponentId::AVATAR_EMOTE_COMMAND,
-                    CrdtType::GO_ANY,
-                    scene_id,
-                    &PbAvatarEmoteCommand {
-                        emote_urn: broadcast_urn.to_string(),
-                        r#loop: resolved_loop,
-                        timestamp,
-                    },
-                );
-            }
-        }
 
         // check expired
         if !emote_changed && Some(&active_emote.urn) != requested_emote.as_ref() {
@@ -480,10 +396,22 @@ fn animate(
             let velocity_cancels = maybe_foreign.is_none()
                 && scene_anim.is_none()
                 && active_emote.source != ActiveEmoteSource::SceneMovementAnim;
+            // Scenes hear how a local or scene avatar's emote ended from playback here; a foreign
+            // avatar's end comes off the wire (`comms`), so the client and the headless server
+            // report it alike.
+            let mut ended = |event: EmoteLifecycle| {
+                if maybe_foreign.is_none() {
+                    lifecycle.write(EmoteLifecycleEvent {
+                        avatar: avatar_ent,
+                        event,
+                    });
+                }
+            };
             if scene_cancels {
                 debug!("clear on scene anim {:?}", active_emote.urn);
                 requested_emote = None;
                 anim_state.current_emote_min_velocity = 0.0;
+                ended(EmoteLifecycle::Interrupted);
             } else if velocity_cancels && damped_velocity_len * 0.9 > playing_min_vel {
                 // stop emotes on move
                 debug!(
@@ -492,6 +420,7 @@ fn animate(
                 );
                 requested_emote = None;
                 anim_state.current_emote_min_velocity = 0.0;
+                ended(EmoteLifecycle::Interrupted);
             } else {
                 anim_state.current_emote_min_velocity = damped_velocity_len.min(playing_min_vel);
             }
@@ -499,6 +428,7 @@ fn animate(
             if active_emote.finished {
                 debug!("finished emoting {:?}", active_emote.urn);
                 requested_emote = None;
+                ended(EmoteLifecycle::Finished);
             }
         } else {
             anim_state.current_emote_min_velocity = damped_velocity_len;
@@ -879,7 +809,7 @@ fn play_current_emote(
                                 ]),
                                 name: active_emote.urn.to_string(),
                                 description: active_emote.urn.to_string(),
-                                extra_data: (),
+                                extra_data: EmoteExtraData::default(),
                             },
                         },
                     );

--- a/crates/avatar/src/animate.rs
+++ b/crates/avatar/src/animate.rs
@@ -19,8 +19,8 @@ use common::{
     sets::SceneSets,
     structs::{
         AudioEmitter, AudioType, AvatarDynamicState, EmoteCommand, EmoteLifecycle,
-        EmoteLifecycleEvent, MoveKind, PlayerModifiers, PrimaryUser, SceneDrivenAnim,
-        SceneDrivenAnimationFeedback, SceneDrivenAnimationFeedbackState,
+        EmoteLifecycleEvent, EmoteLifecycleSource, MoveKind, PlayerModifiers, PrimaryUser,
+        SceneDrivenAnim, SceneDrivenAnimationFeedback, SceneDrivenAnimationFeedbackState,
     },
     util::TryPushChildrenEx,
 };
@@ -88,24 +88,35 @@ fn handle_trigger_emotes(
     let Ok((player, maybe_prev)) = player.single() else {
         return;
     };
+    let timestamp = maybe_prev
+        .map(|prev| prev.timestamp + 1)
+        .unwrap_or_default();
 
-    for (scene, urn, r#loop) in emote_cmds.read().filter_map(|ev| {
-        if let RpcCall::TriggerEmote { scene, urn, r#loop } = ev {
-            Some((scene, urn, *r#loop))
-        } else {
-            None
-        }
-    }) {
+    for ev in emote_cmds.read() {
+        // a stop is an empty command; `animate` reports the interruption
+        let (scene, command) = match ev {
+            RpcCall::TriggerEmote { scene, urn, r#loop } => (
+                scene,
+                EmoteCommand {
+                    urn: urn.clone(),
+                    r#loop: *r#loop,
+                    timestamp,
+                },
+            ),
+            RpcCall::StopEmote { scene } => (
+                scene,
+                EmoteCommand {
+                    urn: String::new(),
+                    r#loop: false,
+                    timestamp,
+                },
+            ),
+            _ => continue,
+        };
         perms.check(
             common::structs::PermissionType::PlayEmote,
             *scene,
-            EmoteCommand {
-                urn: urn.clone(),
-                r#loop,
-                timestamp: maybe_prev
-                    .map(|prev| prev.timestamp + 1)
-                    .unwrap_or_default(),
-            },
+            command,
             None,
             false,
         );
@@ -384,6 +395,14 @@ fn animate(
             requested_emote = None;
         }
 
+        let mut ended = |event: EmoteLifecycle| {
+            lifecycle.write(EmoteLifecycleEvent {
+                avatar: avatar_ent,
+                event,
+                source: EmoteLifecycleSource::Playback,
+            });
+        };
+
         // check / cancel requested emote
         if Some(&active_emote.urn) == requested_emote.as_ref() {
             let playing_min_vel = anim_state.current_emote_min_velocity;
@@ -396,17 +415,6 @@ fn animate(
             let velocity_cancels = maybe_foreign.is_none()
                 && scene_anim.is_none()
                 && active_emote.source != ActiveEmoteSource::SceneMovementAnim;
-            // Scenes hear how a local or scene avatar's emote ended from playback here; a foreign
-            // avatar's end comes off the wire (`comms`), so the client and the headless server
-            // report it alike.
-            let mut ended = |event: EmoteLifecycle| {
-                if maybe_foreign.is_none() {
-                    lifecycle.write(EmoteLifecycleEvent {
-                        avatar: avatar_ent,
-                        event,
-                    });
-                }
-            };
             if scene_cancels {
                 debug!("clear on scene anim {:?}", active_emote.urn);
                 requested_emote = None;
@@ -432,6 +440,16 @@ fn animate(
             }
         } else {
             anim_state.current_emote_min_velocity = damped_velocity_len;
+            // the command was cleared under a playing emote: an explicit stop (`stopEmote`, or a
+            // scene avatar's trigger cleared)
+            if emote_changed
+                && requested_emote.is_none()
+                && active_emote.source == ActiveEmoteSource::TriggeredEmote
+                && !active_emote.finished
+            {
+                debug!("clear on stop {:?}", active_emote.urn);
+                ended(EmoteLifecycle::Interrupted);
+            }
         }
 
         // Precompute the velocity-based selection up-front so we can use it both as the

--- a/crates/avatar/src/emote_report.rs
+++ b/crates/avatar/src/emote_report.rs
@@ -23,7 +23,9 @@ use bevy::{
 use collectibles::{CollectibleError, CollectibleManager, Emote, EmoteUrn};
 use common::{
     dynamics::PLAYER_COLLIDER_RADIUS,
-    structs::{EmoteCommand, EmoteLifecycle, EmoteLifecycleEvent, PrimaryUser},
+    structs::{
+        EmoteCommand, EmoteLifecycle, EmoteLifecycleEvent, EmoteLifecycleSource, PrimaryUser,
+    },
 };
 use comms::global_crdt::{process_transport_updates, CrdtContexts, ForeignPlayer};
 use dcl::interface::CrdtType;
@@ -78,6 +80,7 @@ fn queue_emote_reports(
     // Anything writing `EmoteCommand` on a local or scene avatar is a start. Foreign avatars are
     // driven by the wire alone (see `process_transport_updates`).
     triggered: Query<(Entity, &EmoteCommand), (Changed<EmoteCommand>, Without<ForeignPlayer>)>,
+    foreign: Query<(), With<ForeignPlayer>>,
     mut events: EventReader<EmoteLifecycleEvent>,
 ) {
     // this frame's entries per avatar, and the command that produced a start
@@ -102,7 +105,22 @@ fn queue_emote_reports(
         *last_command = Some(command.clone());
     }
 
-    for EmoteLifecycleEvent { avatar, event } in events.read() {
+    // the wire's word for a foreign avatar, playback's for the rest; the other is what this
+    // binary happens to observe, and the two would disagree on timing
+    for EmoteLifecycleEvent {
+        avatar,
+        event,
+        source,
+    } in events.read()
+    {
+        let authoritative = if foreign.contains(*avatar) {
+            EmoteLifecycleSource::Wire
+        } else {
+            EmoteLifecycleSource::Playback
+        };
+        if *source != authoritative {
+            continue;
+        }
         incoming
             .entry(*avatar)
             .or_default()

--- a/crates/avatar/src/emote_report.rs
+++ b/crates/avatar/src/emote_report.rs
@@ -185,6 +185,7 @@ fn flush_emote_reports(
                 containing_scene
                     .get_area(avatar, PLAYER_COLLIDER_RADIUS)
                     .into_iter()
+                    .filter(|scene| scenes.get(*scene).is_ok())
                     .collect(),
                 SceneEntityId::PLAYER,
             ),

--- a/crates/avatar/src/emote_report.rs
+++ b/crates/avatar/src/emote_report.rs
@@ -1,0 +1,481 @@
+//! Reports avatar emote playback to scenes as `AvatarEmoteCommand` entries: a start with the
+//! emote's resolved loop flag, then how it ended (`ES_FINISHED` / `ES_INTERRUPTED`), the way the
+//! reference client writes them.
+//!
+//! Render-free, so the client and the headless server run the same code over the same inputs.
+//! Foreign players' transitions come off the wire (raised by `comms`, in wire order); the local
+//! player's and scene avatars' from playback (`animate`). Every transition is reported, in order:
+//! a start whose loop flag is still loading holds the entries behind it for that avatar rather
+//! than being dropped, so what a scene hears never depends on which cache happened to be warm.
+//!
+//! Entries go to the scenes the avatar is in (a scene avatar's own scene), each scene's crdt
+//! alone, never the history. While an emote plays that set is kept in step: a scene the avatar
+//! moves out of (or that unloads) hears the emote end there, one it moves into (or that loads
+//! around it) hears it start, the way the reference client adds and removes the player's
+//! command in each scene.
+
+use std::collections::VecDeque;
+
+use bevy::{
+    platform::collections::{HashMap, HashSet},
+    prelude::*,
+};
+use collectibles::{CollectibleError, CollectibleManager, Emote, EmoteUrn};
+use common::{
+    dynamics::PLAYER_COLLIDER_RADIUS,
+    structs::{EmoteCommand, EmoteLifecycle, EmoteLifecycleEvent, PrimaryUser},
+};
+use comms::global_crdt::{process_transport_updates, CrdtContexts, ForeignPlayer};
+use dcl::interface::CrdtType;
+use dcl_component::{
+    proto_components::sdk::components::{EmoteState, PbAvatarEmoteCommand},
+    SceneComponentId, SceneEntityId,
+};
+use scene_runner::{renderer_context::RendererSceneContext, ContainerEntity, ContainingScene};
+
+/// Transitions one avatar may hold behind a start whose loop flag is still loading. Past this the
+/// start goes out with the flag it was triggered with rather than delaying the rest any longer.
+const MAX_PENDING: usize = 16;
+/// Longest a start waits on its loop flag. The collectible manager settles a bad urn as `Missing`
+/// or `Failed`, but an unreachable content server re-requests forever.
+const MAX_RESOLVE_SECS: f64 = 30.0;
+
+pub struct EmoteReportPlugin;
+
+impl Plugin for EmoteReportPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<EmoteLifecycleEvent>();
+        app.add_systems(
+            Update,
+            (queue_emote_reports, flush_emote_reports)
+                .chain()
+                .after(process_transport_updates),
+        );
+    }
+}
+
+/// Per-avatar report state. Despawns with the avatar.
+#[derive(Component, Default)]
+pub struct EmoteReportQueue {
+    pending: VecDeque<EmoteLifecycle>,
+    /// The start the scenes have been told about, `(urn, loop)`, echoed by its stop entry.
+    reported: Option<(String, bool)>,
+    /// The scenes told `reported`.
+    told: HashSet<Entity>,
+    /// `timestamp` of the last entry written. The sdk's grow-only set orders and trims by it, so
+    /// it only has to be monotonic per avatar.
+    sequence: u32,
+    /// Last `EmoteCommand` seen, so a rewrite of the same command isn't a new start.
+    last_command: Option<EmoteCommand>,
+    /// When the head start began waiting on its loop flag.
+    waiting_since: Option<f64>,
+}
+
+#[allow(clippy::type_complexity)]
+fn queue_emote_reports(
+    mut commands: Commands,
+    mut queues: Query<&mut EmoteReportQueue>,
+    // Anything writing `EmoteCommand` on a local or scene avatar is a start. Foreign avatars are
+    // driven by the wire alone (see `process_transport_updates`).
+    triggered: Query<(Entity, &EmoteCommand), (Changed<EmoteCommand>, Without<ForeignPlayer>)>,
+    mut events: EventReader<EmoteLifecycleEvent>,
+) {
+    // this frame's entries per avatar, and the command that produced a start
+    let mut incoming: HashMap<Entity, (VecDeque<EmoteLifecycle>, Option<EmoteCommand>)> =
+        HashMap::default();
+
+    for (avatar, command) in &triggered {
+        let last_command = queues
+            .get(avatar)
+            .ok()
+            .and_then(|queue| queue.last_command.as_ref());
+        if last_command == Some(command) {
+            continue;
+        }
+        let (pending, last_command) = incoming.entry(avatar).or_default();
+        if !command.urn.is_empty() {
+            pending.push_back(EmoteLifecycle::Started {
+                urn: command.urn.clone(),
+                r#loop: command.r#loop,
+            });
+        }
+        *last_command = Some(command.clone());
+    }
+
+    for EmoteLifecycleEvent { avatar, event } in events.read() {
+        incoming
+            .entry(*avatar)
+            .or_default()
+            .0
+            .push_back(event.clone());
+    }
+
+    for (avatar, (pending, last_command)) in incoming {
+        if let Ok(mut queue) = queues.get_mut(avatar) {
+            queue.pending.extend(pending);
+            if last_command.is_some() {
+                queue.last_command = last_command;
+            }
+        } else if let Ok(mut avatar) = commands.get_entity(avatar) {
+            avatar.insert(EmoteReportQueue {
+                pending,
+                last_command,
+                ..default()
+            });
+        }
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn flush_emote_reports(
+    mut queues: Query<(
+        Entity,
+        &mut EmoteReportQueue,
+        Option<&ForeignPlayer>,
+        Option<&PrimaryUser>,
+        Option<&ContainerEntity>,
+    )>,
+    mut emotes: CollectibleManager<Emote>,
+    mut scenes: Query<&mut RendererSceneContext>,
+    containing_scene: ContainingScene,
+    crdt_contexts: Res<CrdtContexts>,
+    time: Res<Time>,
+) {
+    let now = time.elapsed_secs_f64();
+
+    for (avatar, mut queue, foreign, primary, container) in queues.iter_mut() {
+        if queue.pending.is_empty() && queue.reported.is_none() {
+            continue;
+        }
+
+        // Which scenes hear this avatar, and as which entity. A player: the scenes around it that
+        // share its crdt context (all of them on a client; its room's on a multi-tenant server).
+        let (targets, id) = match (foreign, primary, container) {
+            (Some(foreign), ..) => {
+                let targets = containing_scene
+                    .get_area(avatar, PLAYER_COLLIDER_RADIUS)
+                    .into_iter()
+                    .filter(|scene| {
+                        scenes.get(*scene).is_ok_and(|scene| {
+                            crdt_contexts.try_for_scene_hash(&scene.hash) == Some(foreign.context)
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                (targets, foreign.scene_id)
+            }
+            (None, Some(_), _) => (
+                containing_scene
+                    .get_area(avatar, PLAYER_COLLIDER_RADIUS)
+                    .into_iter()
+                    .collect(),
+                SceneEntityId::PLAYER,
+            ),
+            (None, None, Some(container)) => (vec![container.root], container.container_id),
+            // e.g. the backpack preview avatar: no scene to tell
+            _ => (Vec::new(), SceneEntityId::ROOT),
+        };
+
+        queue.migrate(&targets, |scene, urn, loops, state, timestamp| {
+            if let Ok(mut scene) = scenes.get_mut(scene) {
+                write_entry(&mut scene, id, urn, loops, state, timestamp);
+            }
+        });
+        queue.advance(
+            now,
+            |urn, hint, force| resolve_loop(&mut emotes, urn, hint, force),
+            |urn, loops, state, timestamp| {
+                for scene in &targets {
+                    if let Ok(mut scene) = scenes.get_mut(*scene) {
+                        write_entry(&mut scene, id, urn, loops, state, timestamp);
+                    }
+                }
+            },
+        );
+        queue.heard(&targets);
+    }
+}
+
+fn write_entry(
+    scene: &mut RendererSceneContext,
+    id: SceneEntityId,
+    urn: &str,
+    loops: bool,
+    state: EmoteState,
+    timestamp: u32,
+) {
+    let entry = PbAvatarEmoteCommand {
+        emote_urn: urn.to_owned(),
+        r#loop: loops,
+        timestamp,
+        mask: None,
+        state: Some(state as i32),
+    };
+    debug!("emote report to {}: {entry:?}", scene.hash);
+    scene.update_crdt(
+        SceneComponentId::AVATAR_EMOTE_COMMAND,
+        CrdtType::GO_ANY,
+        id,
+        &entry,
+    );
+}
+
+impl EmoteReportQueue {
+    /// Keep the reported start in step with the scenes that now hear the avatar: one it has left
+    /// hears the emote end there, one it has entered hears it start. `emit` writes an entry to
+    /// one scene: `(scene, urn, loop, state, timestamp)`.
+    fn migrate(
+        &mut self,
+        targets: &[Entity],
+        mut emit: impl FnMut(Entity, &str, bool, EmoteState, u32),
+    ) {
+        let Some((urn, loops)) = self.reported.clone() else {
+            return;
+        };
+        let left = self
+            .told
+            .iter()
+            .copied()
+            .filter(|scene| !targets.contains(scene))
+            .collect::<Vec<_>>();
+        for scene in left {
+            self.told.remove(&scene);
+            self.sequence += 1;
+            emit(scene, &urn, loops, EmoteState::EsInterrupted, self.sequence);
+        }
+        let entered = targets
+            .iter()
+            .copied()
+            .filter(|scene| !self.told.contains(scene))
+            .collect::<Vec<_>>();
+        for scene in entered {
+            self.told.insert(scene);
+            self.sequence += 1;
+            emit(scene, &urn, loops, EmoteState::EsStarted, self.sequence);
+        }
+    }
+
+    /// After [`Self::advance`] wrote to `targets`: which scenes know the reported start.
+    fn heard(&mut self, targets: &[Entity]) {
+        self.told.clear();
+        if self.reported.is_some() {
+            self.told.extend(targets.iter().copied());
+        }
+    }
+
+    /// Drain the queue for as long as its head can be written. `resolve` gives a start's loop
+    /// flag (`None` while it's loading; the last argument asks it to answer regardless);
+    /// `emit` writes an entry: `(urn, loop, state, timestamp)`.
+    fn advance(
+        &mut self,
+        now: f64,
+        mut resolve: impl FnMut(&str, bool, bool) -> Option<bool>,
+        mut emit: impl FnMut(&str, bool, EmoteState, u32),
+    ) {
+        while let Some(head) = self.pending.front() {
+            let (urn, loops, state) = match head {
+                EmoteLifecycle::Started { urn, r#loop } => {
+                    let waiting_since = *self.waiting_since.get_or_insert(now);
+                    let force =
+                        self.pending.len() > MAX_PENDING || now - waiting_since > MAX_RESOLVE_SECS;
+                    let Some(loops) = resolve(urn, *r#loop, force) else {
+                        break;
+                    };
+                    (urn.clone(), loops, EmoteState::EsStarted)
+                }
+                EmoteLifecycle::Finished | EmoteLifecycle::Interrupted => {
+                    let Some((urn, loops)) = self.reported.take() else {
+                        // a stop for a start the scene never heard of
+                        self.pending.pop_front();
+                        continue;
+                    };
+                    let state = if matches!(head, EmoteLifecycle::Finished) {
+                        EmoteState::EsFinished
+                    } else {
+                        EmoteState::EsInterrupted
+                    };
+                    (urn, loops, state)
+                }
+            };
+            self.pending.pop_front();
+            self.waiting_since = None;
+
+            if state == EmoteState::EsStarted {
+                // the previous play ends where the new one starts; stop first, like the
+                // reference client
+                if let Some((urn, loops)) = self.reported.take() {
+                    self.sequence += 1;
+                    emit(&urn, loops, EmoteState::EsInterrupted, self.sequence);
+                }
+                self.reported = Some((urn.clone(), loops));
+            }
+            self.sequence += 1;
+            emit(&urn, loops, state, self.sequence);
+        }
+    }
+}
+
+/// The emote's loop flag: what it was triggered with, or what its metadata says. `None` while the
+/// metadata is loading, unless `force`d.
+fn resolve_loop(
+    emotes: &mut CollectibleManager<Emote>,
+    urn: &str,
+    hint: bool,
+    force: bool,
+) -> Option<bool> {
+    let Ok(parsed) = EmoteUrn::new(urn) else {
+        return Some(hint);
+    };
+    // a scene emote carries it in the urn's trailing `-{loop}` token
+    if let Some(scene_emote) = parsed.scene_emote() {
+        return Some(hint || scene_emote.ends_with("-true"));
+    }
+    match emotes.get_data(&parsed) {
+        Ok(data) => Some(hint || data.extra_data.loops),
+        Err(CollectibleError::Loading) if !force => None,
+        Err(e) => {
+            debug!("reporting {urn} with the triggered loop flag: {e:?}");
+            Some(hint)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SLOW: &str = "urn:decentraland:off-chain:base-emotes:slow";
+    const CACHED: &str = "urn:decentraland:off-chain:base-emotes:cached";
+
+    fn start(urn: &str) -> EmoteLifecycle {
+        EmoteLifecycle::Started {
+            urn: urn.to_owned(),
+            r#loop: false,
+        }
+    }
+
+    /// `SLOW` loops but resolves only once `slow_ready`; everything else is a one-shot, ready.
+    fn advance(
+        queue: &mut EmoteReportQueue,
+        now: f64,
+        slow_ready: bool,
+    ) -> Vec<(String, bool, EmoteState, u32)> {
+        let mut out = Vec::new();
+        queue.advance(
+            now,
+            |urn, hint, force| match (urn == SLOW, slow_ready, force) {
+                (true, false, false) => None,
+                (true, true, _) => Some(true),
+                _ => Some(hint),
+            },
+            |urn, loops, state, ts| out.push((urn.to_owned(), loops, state, ts)),
+        );
+        out
+    }
+
+    #[test]
+    fn slow_start_holds_later_entries_in_order() {
+        let mut queue = EmoteReportQueue::default();
+        queue
+            .pending
+            .extend([start(SLOW), EmoteLifecycle::Interrupted, start(CACHED)]);
+        // emote 2 is cached, but emote 1 hasn't resolved: nothing goes out yet
+        assert!(advance(&mut queue, 0.0, false).is_empty());
+        assert_eq!(
+            advance(&mut queue, 1.0, true),
+            vec![
+                (SLOW.to_owned(), true, EmoteState::EsStarted, 1),
+                (SLOW.to_owned(), true, EmoteState::EsInterrupted, 2),
+                (CACHED.to_owned(), false, EmoteState::EsStarted, 3),
+            ]
+        );
+        assert_eq!(queue.reported, Some((CACHED.to_owned(), false)));
+    }
+
+    #[test]
+    fn supersede_stops_the_reported_start_first_and_orphan_stops_are_dropped() {
+        let mut queue = EmoteReportQueue::default();
+        queue
+            .pending
+            .extend([EmoteLifecycle::Finished, start(CACHED), start("other")]);
+        assert_eq!(
+            advance(&mut queue, 0.0, true),
+            vec![
+                (CACHED.to_owned(), false, EmoteState::EsStarted, 1),
+                (CACHED.to_owned(), false, EmoteState::EsInterrupted, 2),
+                ("other".to_owned(), false, EmoteState::EsStarted, 3),
+            ]
+        );
+        queue.pending.push_back(EmoteLifecycle::Finished);
+        queue.pending.push_back(EmoteLifecycle::Finished);
+        assert_eq!(
+            advance(&mut queue, 0.0, true),
+            vec![("other".to_owned(), false, EmoteState::EsFinished, 4)]
+        );
+        assert!(queue.pending.is_empty());
+    }
+
+    #[test]
+    fn a_full_queue_or_a_long_wait_forces_the_head_start() {
+        let mut queue = EmoteReportQueue::default();
+        queue.pending.push_back(start(SLOW));
+        for _ in 0..MAX_PENDING {
+            queue.pending.push_back(start(CACHED));
+        }
+        // forced: reported with the triggered flag, not the metadata's
+        let out = advance(&mut queue, 0.0, false);
+        assert_eq!(out[0], (SLOW.to_owned(), false, EmoteState::EsStarted, 1));
+        assert_eq!(out.len(), 1 + 2 * MAX_PENDING);
+
+        let mut queue = EmoteReportQueue::default();
+        queue.pending.push_back(start(SLOW));
+        assert!(advance(&mut queue, 0.0, false).is_empty());
+        assert!(advance(&mut queue, MAX_RESOLVE_SECS, false).is_empty());
+        assert_eq!(
+            advance(&mut queue, MAX_RESOLVE_SECS + 1.0, false),
+            vec![(SLOW.to_owned(), false, EmoteState::EsStarted, 1)]
+        );
+    }
+
+    #[test]
+    fn moving_between_scenes_mid_emote_ends_it_there_and_starts_it_here() {
+        let (a, b) = (Entity::from_raw(1), Entity::from_raw(2));
+        let migrate = |queue: &mut EmoteReportQueue, targets: &[Entity]| {
+            let mut out = Vec::new();
+            queue.migrate(targets, |scene, urn, loops, state, ts| {
+                out.push((scene, urn.to_owned(), loops, state, ts))
+            });
+            out
+        };
+
+        let mut queue = EmoteReportQueue::default();
+        // nothing reported: nowhere to move it
+        assert!(migrate(&mut queue, &[a]).is_empty());
+        queue.heard(&[a]);
+        assert!(queue.told.is_empty());
+
+        queue.pending.push_back(start(CACHED));
+        advance(&mut queue, 0.0, true);
+        queue.heard(&[a]);
+        // still in the same scene
+        assert!(migrate(&mut queue, &[a]).is_empty());
+        // carried from a into b
+        assert_eq!(
+            migrate(&mut queue, &[b]),
+            vec![
+                (a, CACHED.to_owned(), false, EmoteState::EsInterrupted, 2),
+                (b, CACHED.to_owned(), false, EmoteState::EsStarted, 3),
+            ]
+        );
+        assert!(migrate(&mut queue, &[b]).is_empty());
+
+        // the stop goes to b alone, then there's nothing left to carry
+        queue.pending.push_back(EmoteLifecycle::Finished);
+        assert_eq!(
+            advance(&mut queue, 0.0, true),
+            vec![(CACHED.to_owned(), false, EmoteState::EsFinished, 4)]
+        );
+        queue.heard(&[b]);
+        assert!(queue.told.is_empty());
+        assert!(migrate(&mut queue, &[a]).is_empty());
+    }
+}

--- a/crates/avatar/src/emote_report.rs
+++ b/crates/avatar/src/emote_report.rs
@@ -23,6 +23,7 @@ use bevy::{
 use collectibles::{CollectibleError, CollectibleManager, Emote, EmoteUrn};
 use common::{
     dynamics::PLAYER_COLLIDER_RADIUS,
+    sets::SceneSets,
     structs::{
         EmoteCommand, EmoteLifecycle, EmoteLifecycleEvent, EmoteLifecycleSource, PrimaryUser,
     },
@@ -51,6 +52,7 @@ impl Plugin for EmoteReportPlugin {
             Update,
             (queue_emote_reports, flush_emote_reports)
                 .chain()
+                .in_set(SceneSets::RestrictedActions)
                 .after(process_transport_updates),
         );
     }

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -815,8 +815,9 @@ fn update_render_avatar(
                         .0
                         .expression_trigger_id
                         .as_ref()
-                        // a cleared trigger stops the emote: an empty command
-                        .or(Some(&String::new()))
+                        // a cleared trigger on a scene-sourced shape stops the emote: an empty
+                        // command. profile-derived shapes never carry a trigger.
+                        .or(selection.scene.is_some().then_some(&String::new()))
                         .and_then(|e| {
                             let urn = if e.is_empty() {
                                 String::new()

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -815,8 +815,12 @@ fn update_render_avatar(
                         .0
                         .expression_trigger_id
                         .as_ref()
+                        // a cleared trigger stops the emote: an empty command
+                        .or(Some(&String::new()))
                         .and_then(|e| {
-                            let urn = if e.starts_with("urn:") {
+                            let urn = if e.is_empty() {
+                                String::new()
+                            } else if e.starts_with("urn:") {
                                 e.clone()
                             } else {
                                 // File path emote (e.g. "models/emotes/foo.glb") — resolve

--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -37,6 +37,7 @@ pub mod attach;
 pub mod avatar_texture;
 pub mod colliders;
 mod dynamic_nametag;
+pub mod emote_report;
 pub mod foot_ik;
 pub mod foreign_dynamics;
 pub mod head_ik;
@@ -94,16 +95,30 @@ use crate::{
 
 use self::{
     animate::AvatarAnimationPlugin,
+    emote_report::EmoteReportPlugin,
     foreign_dynamics::PlayerMovementPlugin,
     mask_material::{MaskMaterial, MaskMaterialPlugin},
 };
+
+/// The render-free part of the avatar stack: what a headless server needs from foreign players
+/// (their bevy transforms, their profile in scene crdt, their emotes reported to scenes) without
+/// spawning an avatar. `AvatarPlugin` builds on it; the headless binary adds it alone.
+pub struct AvatarCorePlugin;
+
+impl Plugin for AvatarCorePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(PlayerMovementPlugin);
+        app.add_plugins(EmoteReportPlugin);
+        app.add_systems(Update, update_avatar_info);
+    }
+}
 
 pub struct AvatarPlugin;
 
 impl Plugin for AvatarPlugin {
     fn build(&self, app: &mut App) {
+        app.add_plugins(AvatarCorePlugin);
         app.add_plugins(MaskMaterialPlugin);
-        app.add_plugins(PlayerMovementPlugin);
         app.add_plugins(NpcMovementPlugin);
         app.add_plugins(AvatarAnimationPlugin);
         app.add_plugins(AttachPlugin);
@@ -126,7 +141,6 @@ impl Plugin for AvatarPlugin {
         app.add_systems(
             Update,
             (
-                update_avatar_info,
                 update_base_avatar_shape,
                 select_avatar,
                 update_render_avatar,

--- a/crates/collectibles/src/emotes.rs
+++ b/crates/collectibles/src/emotes.rs
@@ -24,14 +24,24 @@ pub fn base_bodyshapes() -> Vec<String> {
     ]
 }
 
+/// Emote pointer resolution and metadata (`CollectibleManager<Emote>`) alone: what a headless
+/// server needs to report an emote's loop flag. Loads no clip or sound.
+pub struct EmoteMetadataPlugin;
+
+impl Plugin for EmoteMetadataPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(CollectiblesTypePlugin::<Emote>::default());
+        app.register_asset_loader(EmoteMetaLoader);
+    }
+}
+
 pub struct EmotesPlugin;
 
 impl Plugin for EmotesPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<BaseEmotes>();
-        app.add_plugins(CollectiblesTypePlugin::<Emote>::default());
+        app.add_plugins(EmoteMetadataPlugin);
         app.register_asset_loader(EmoteLoader);
-        app.register_asset_loader(EmoteMetaLoader);
         app.add_systems(Update, (load_animations,));
     }
 }
@@ -232,7 +242,7 @@ fn load_animations(
                                         .collect(),
                                     name: friendly_name.to_owned(),
                                     description: Default::default(),
-                                    extra_data: (),
+                                    extra_data: EmoteExtraData { loops: repeat },
                                 },
                                 representations,
                             };
@@ -443,9 +453,16 @@ impl Emote {
     }
 }
 
+/// Emote metadata available without loading the clip (`collectible.emote_data`).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EmoteExtraData {
+    /// `emoteDataADR74.loop`: the emote loops until stopped.
+    pub loops: bool,
+}
+
 impl CollectibleType for Emote {
     type Meta = EmoteMeta;
-    type ExtraData = ();
+    type ExtraData = EmoteExtraData;
 
     fn base_collection() -> Option<&'static str> {
         Some("urn:decentraland:off-chain:base-emotes")
@@ -527,7 +544,9 @@ impl AssetLoader for EmoteLoader {
                 name: meta.name,
                 description: meta.description,
                 available_representations: representations.keys().cloned().collect(),
-                extra_data: (),
+                extra_data: EmoteExtraData {
+                    loops: meta.emote_extended_data.loops,
+                },
             },
             representations,
         })
@@ -582,7 +601,9 @@ impl AssetLoader for EmoteMetaLoader {
             name: meta.name,
             description: meta.description,
             available_representations,
-            extra_data: (),
+            extra_data: EmoteExtraData {
+                loops: meta.emote_extended_data.loops,
+            },
         })
     }
 }

--- a/crates/common/src/rpc/mod.rs
+++ b/crates/common/src/rpc/mod.rs
@@ -256,6 +256,9 @@ pub enum RpcCall {
         urn: String,
         r#loop: bool,
     },
+    StopEmote {
+        scene: Entity,
+    },
     UiFocus {
         scene: Entity,
         action: RpcUiFocusAction,

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -230,6 +230,26 @@ pub struct EmoteCommand {
     pub r#loop: bool,
 }
 
+/// A transition in an avatar's triggered-emote playback, reported to scenes as an
+/// `AvatarEmoteCommand` entry by `avatar::emote_report`. Raised by `comms` from the wire for
+/// foreign players (in wire order, so client and server report the same sequence), and by the
+/// avatar animator from playback for the local player and scene avatars.
+#[derive(Event, Clone, Debug)]
+pub struct EmoteLifecycleEvent {
+    pub avatar: Entity,
+    pub event: EmoteLifecycle,
+}
+
+#[derive(Clone, Debug)]
+pub enum EmoteLifecycle {
+    /// `r#loop` is the flag known at trigger time; the emote's own metadata may still make it loop.
+    Started { urn: String, r#loop: bool },
+    /// A one-shot ran to its end.
+    Finished,
+    /// Playback was cut short: movement, a scene animation, a stop from the wire.
+    Interrupted,
+}
+
 // Current scene-driven movement animation request for a player avatar. For the
 // primary player, written by the bridge system in `user_input` (after resolving
 // the scene-relative path against the active scene's content map). For foreign

--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -231,13 +231,20 @@ pub struct EmoteCommand {
 }
 
 /// A transition in an avatar's triggered-emote playback, reported to scenes as an
-/// `AvatarEmoteCommand` entry by `avatar::emote_report`. Raised by `comms` from the wire for
-/// foreign players (in wire order, so client and server report the same sequence), and by the
-/// avatar animator from playback for the local player and scene avatars.
+/// `AvatarEmoteCommand` entry by `avatar::emote_report`. Raised by `comms` from the wire (in wire
+/// order, so client and server report the same sequence) and by the avatar animator from
+/// playback; the reporter keeps the wire's word for foreign players and playback's for the rest.
 #[derive(Event, Clone, Debug)]
 pub struct EmoteLifecycleEvent {
     pub avatar: Entity,
     pub event: EmoteLifecycle,
+    pub source: EmoteLifecycleSource,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EmoteLifecycleSource {
+    Playback,
+    Wire,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -940,6 +940,11 @@ pub fn process_transport_updates(
                                     },
                                     source: EmoteLifecycleSource::Wire,
                                 });
+                            } else if !acceptable_emote_urn(&urn) {
+                                debug!(
+                                    "dropping emote with unacceptable urn from {:#x}",
+                                    update.address
+                                );
                             } else {
                                 commands.entity(entity).try_insert(EmoteCommand {
                                     timestamp: incremental_id as i64,
@@ -1342,5 +1347,34 @@ fn receive_new_voice_message_senders(
         if let SystemApi::GetVoiceStream(stream) = event {
             voice_message_streams.push(stream.clone());
         }
+    }
+}
+
+/// Room for any collectible or scene-emote urn, not for a peer to fill scene crdt with.
+const MAX_EMOTE_URN_BYTES: usize = 256;
+
+/// Whether a peer's emote urn may reach scenes: it lands verbatim in `AvatarEmoteCommand`, and
+/// nothing upstream bounds it (Pulse validates an emote's duration and position, not its id).
+pub fn acceptable_emote_urn(urn: &str) -> bool {
+    !urn.is_empty()
+        && urn.len() <= MAX_EMOTE_URN_BYTES
+        && !urn.chars().any(|c| c.is_whitespace() || c.is_control())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peer_emote_urns_are_bounded() {
+        assert!(acceptable_emote_urn(
+            "urn:decentraland:off-chain:base-emotes:wave"
+        ));
+        assert!(acceptable_emote_urn(&"x".repeat(MAX_EMOTE_URN_BYTES)));
+        assert!(!acceptable_emote_urn(""));
+        assert!(!acceptable_emote_urn(&"x".repeat(MAX_EMOTE_URN_BYTES + 1)));
+        assert!(!acceptable_emote_urn("urn:with space"));
+        assert!(!acceptable_emote_urn("urn:with\nnewline"));
+        assert!(!acceptable_emote_urn("urn:with\u{0}nul"));
     }
 }

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -10,7 +10,7 @@ use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender, RpcStreamSender},
     structs::{
-        AudioDecoderError, EmoteCommand, EmoteLifecycle, EmoteLifecycleEvent,
+        AudioDecoderError, EmoteCommand, EmoteLifecycle, EmoteLifecycleEvent, EmoteLifecycleSource,
         GlobalCrdtStateUpdate, HeadSync, MoveKind, PointAtSync, SceneDrivenAnimationRequest,
     },
     util::ModifyComponentExt,
@@ -938,6 +938,7 @@ pub fn process_transport_updates(
                                     } else {
                                         EmoteLifecycle::Interrupted
                                     },
+                                    source: EmoteLifecycleSource::Wire,
                                 });
                             } else {
                                 commands.entity(entity).try_insert(EmoteCommand {
@@ -948,6 +949,7 @@ pub fn process_transport_updates(
                                 emote_events.write(EmoteLifecycleEvent {
                                     avatar: entity,
                                     event: EmoteLifecycle::Started { urn, r#loop: false },
+                                    source: EmoteLifecycleSource::Wire,
                                 });
                             }
                         }

--- a/crates/comms/src/global_crdt.rs
+++ b/crates/comms/src/global_crdt.rs
@@ -10,8 +10,8 @@ use bimap::BiMap;
 use common::{
     rpc::{RpcCall, RpcEventSender, RpcStreamSender},
     structs::{
-        AudioDecoderError, EmoteCommand, GlobalCrdtStateUpdate, HeadSync, MoveKind, PointAtSync,
-        SceneDrivenAnimationRequest,
+        AudioDecoderError, EmoteCommand, EmoteLifecycle, EmoteLifecycleEvent,
+        GlobalCrdtStateUpdate, HeadSync, MoveKind, PointAtSync, SceneDrivenAnimationRequest,
     },
     util::ModifyComponentExt,
 };
@@ -102,6 +102,7 @@ impl Plugin for GlobalCrdtPlugin {
 
         app.init_resource::<VoiceMessageStreams>();
 
+        app.add_event::<EmoteLifecycleEvent>();
         app.add_systems(Update, process_transport_updates);
         app.add_systems(Update, despawn_players);
         app.add_observer(remove_transport_from_foreign_audio_source);
@@ -152,6 +153,9 @@ pub enum PlayerMessage {
         /// The server tick the emote started on; ordering only.
         incremental_id: u32,
         stopping: bool,
+        /// On a stop: the server's one-shot timer expired (a natural finish) rather than the
+        /// player cancelling.
+        completed: bool,
     },
     AudioStreamAvailable {
         transport: Entity,
@@ -181,11 +185,13 @@ impl std::fmt::Debug for PlayerMessage {
                 urn,
                 incremental_id,
                 stopping,
+                completed,
             } => f
                 .debug_struct("Emote")
                 .field("urn", urn)
                 .field("incremental_id", incremental_id)
                 .field("stopping", stopping)
+                .field("completed", completed)
                 .finish(),
             Self::AudioStreamAvailable { transport } => f
                 .debug_tuple("AudioStreamAvailable")
@@ -695,6 +701,7 @@ pub fn process_transport_updates(
     mut profile_events: EventWriter<ProfileEvent>,
     mut position_events: EventWriter<PlayerPositionEvent>,
     mut anim_events: EventWriter<PlayerSceneAnimEvent>,
+    mut emote_events: EventWriter<EmoteLifecycleEvent>,
     mut chat_events: EventWriter<ChatEvent>,
     mut string_senders: Local<HashMap<String, RpcEventSender>>,
     mut binary_senders: Local<HashMap<String, RpcStreamSender<(String, Vec<u8>)>>>,
@@ -913,18 +920,34 @@ pub fn process_transport_updates(
                             urn,
                             incremental_id,
                             stopping,
+                            completed,
                         } => {
                             debug!("emote: {urn} (stopping: {stopping})");
+                            // The wire is the only source of a foreign player's emote lifecycle
+                            // for scenes: raised here in wire order, on the client and the headless
+                            // server alike, so both report the same sequence.
                             if stopping {
                                 // Explicit stop (a looping emote cancelled, or a one-shot's server
                                 // completion). Foreign emotes no longer self-cancel on motion (see
                                 // `animate`), so the wire stop is what ends a looping one.
                                 commands.entity(entity).remove::<EmoteCommand>();
+                                emote_events.write(EmoteLifecycleEvent {
+                                    avatar: entity,
+                                    event: if completed {
+                                        EmoteLifecycle::Finished
+                                    } else {
+                                        EmoteLifecycle::Interrupted
+                                    },
+                                });
                             } else {
                                 commands.entity(entity).try_insert(EmoteCommand {
                                     timestamp: incremental_id as i64,
-                                    urn,
+                                    urn: urn.clone(),
                                     r#loop: false,
+                                });
+                                emote_events.write(EmoteLifecycleEvent {
+                                    avatar: entity,
+                                    event: EmoteLifecycle::Started { urn, r#loop: false },
                                 });
                             }
                         }

--- a/crates/comms/src/pulse/mod.rs
+++ b/crates/comms/src/pulse/mod.rs
@@ -169,8 +169,9 @@ pub enum PulseEvent {
         urn: String,
         tick: u32,
     },
-    /// Subject's emote stopped (one-shot completed or looping cancelled).
-    EmoteStop { address: Address },
+    /// Subject's emote stopped. `completed`: the server's one-shot timer expired (a natural
+    /// finish) rather than the player cancelling a looping emote.
+    EmoteStop { address: Address, completed: bool },
     /// A sequence gap was detected — transmit this reliably so the server replays full state.
     Resync(pulse::ResyncRequest),
 }
@@ -402,6 +403,7 @@ impl PulseDecoder {
                 if let Some(subject) = self.subjects.get(&e.subject_id) {
                     events.push(PulseEvent::EmoteStop {
                         address: subject.wallet,
+                        completed: e.reason == pulse::EmoteStopReason::Completed as i32,
                     });
                 }
                 events

--- a/crates/comms/src/pulse/plugin.rs
+++ b/crates/comms/src/pulse/plugin.rs
@@ -949,15 +949,17 @@ fn drain_inbound(
                         urn,
                         incremental_id: tick,
                         stopping: false,
+                        completed: false,
                     },
                 ),
-                PulseEvent::EmoteStop { address } => session.forward(
+                PulseEvent::EmoteStop { address, completed } => session.forward(
                     sinks,
                     address,
                     PlayerMessage::Emote {
                         urn: String::new(),
                         incremental_id: 0,
                         stopping: true,
+                        completed,
                     },
                 ),
                 // A peer entered our interest set. Report the arrival, then their initial profile

--- a/crates/dcl/src/js/modules/RestrictedActions.js
+++ b/crates/dcl/src/js/modules/RestrictedActions.js
@@ -27,9 +27,14 @@ module.exports.triggerEmote = async function (body) {
     return {} 
 }
 
-module.exports.triggerSceneEmote = async function (body) { 
+module.exports.triggerSceneEmote = async function (body) {
     Deno.core.ops.op_scene_emote(body.src, body.loop)
-    return {} 
+    return {}
+}
+
+module.exports.stopEmote = async function (body) {
+    Deno.core.ops.op_stop_emote()
+    return { success: true }
 }
 
 module.exports.changeRealm = async function (body) { 

--- a/crates/dcl/src/js/restricted_actions.rs
+++ b/crates/dcl/src/js/restricted_actions.rs
@@ -156,6 +156,14 @@ pub fn op_emote(op_state: &mut impl State, emote: String) -> Result<(), anyhow::
     send_emote(op_state, emote, false)
 }
 
+pub fn op_stop_emote(op_state: &mut impl State) -> Result<(), anyhow::Error> {
+    debug!("op_stop_emote");
+    let scene = op_state.borrow::<CrdtContext>().scene_id.0;
+    op_state
+        .borrow_mut::<RpcCalls>()
+        .push(RpcCall::StopEmote { scene })
+}
+
 pub async fn op_scene_emote(
     op_state: Rc<RefCell<impl State>>,
     emote: String,

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_emote_command.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/avatar_emote_command.proto
@@ -2,12 +2,31 @@ syntax = "proto3";
 package decentraland.sdk.components;
 
 import "decentraland/sdk/components/common/id.proto";
+import "decentraland/sdk/components/common/avatar_mask.proto";
 option (common.ecs_component_id) = 1088;
 
-// AvatarEmoteCommand is a grow only value set, used to signal the renderer about
-// avatar emotes playback.
+// EmoteState describes the lifecycle state of an emote playback.
+enum EmoteState {
+  // ES_STARTED indicates the emote started playing.
+  // This is the zero value and is used for backward compatibility — entries
+  // written by older explorers (field absent) read as "started".
+  ES_STARTED = 0;
+  // ES_FINISHED indicates a non-looping emote completed naturally.
+  ES_FINISHED = 1;
+  // ES_INTERRUPTED indicates playback was cancelled (movement, teleport,
+  // another emote superseding it, explicit stop, or scene change).
+  ES_INTERRUPTED = 2;
+}
+
+// AvatarEmoteCommand is a grow only value set, written by the explorer to report
+// avatar emote playback to the scene. It is appended to every player entity in the
+// scene (the local player and remote avatars alike).
 message PBAvatarEmoteCommand {
   string emote_urn = 1;
   bool loop = 2;
-  uint32 timestamp = 3;          // monotonic counter
+  uint32 timestamp = 3; // monotonic counter
+  optional decentraland.sdk.components.common.AvatarMask mask = 4;
+  // state describes the lifecycle event for this emote entry.
+  // When absent (older explorers), defaults to ES_STARTED.
+  optional EmoteState state = 5;
 }

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/common/avatar_mask.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/common/avatar_mask.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package decentraland.sdk.components.common;
+
+// Mask for which bones an animation applies to.
+enum AvatarMask {
+  AM_UPPER_BODY = 0;
+}

--- a/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/restricted_actions.rs
@@ -12,6 +12,7 @@ pub fn ops() -> Vec<OpDecl> {
         op_change_realm(),
         op_external_url(),
         op_emote(),
+        op_stop_emote(),
         op_scene_emote(),
         op_open_nft_dialog(),
         op_ui_focus(),
@@ -76,6 +77,11 @@ async fn op_external_url(
 #[op2(fast)]
 fn op_emote(op_state: &mut OpState, #[string] emote: String) -> Result<(), anyhow::Error> {
     dcl::js::restricted_actions::op_emote(op_state, emote)
+}
+
+#[op2(fast)]
+fn op_stop_emote(op_state: &mut OpState) -> Result<(), anyhow::Error> {
+    dcl::js::restricted_actions::op_stop_emote(op_state)
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/restricted_actions.rs
@@ -73,6 +73,12 @@ pub fn op_emote(op_state: &WorkerContext, emote: String) -> Result<(), WasmError
 }
 
 #[wasm_bindgen]
+pub fn op_stop_emote(op_state: &WorkerContext) -> Result<(), WasmError> {
+    dcl::js::restricted_actions::op_stop_emote(&mut *op_state.state.borrow_mut())
+        .map_err(WasmError::from)
+}
+
+#[wasm_bindgen]
 pub async fn op_scene_emote(
     op_state: &WorkerContext,
     emote: String,

--- a/src/bin/headless.rs
+++ b/src/bin/headless.rs
@@ -8,6 +8,7 @@
 
 use std::{str::FromStr, sync::OnceLock, time::Duration};
 
+use avatar::AvatarCorePlugin;
 use bevy::tasks::IoTaskPool;
 use bevy::{
     app::ScheduleRunnerPlugin,
@@ -24,6 +25,7 @@ use bevy::{
 };
 use bevy_dui::DuiPlugin;
 use clap::Parser;
+use collectibles::EmoteMetadataPlugin;
 use common::{
     inputs::InputMap,
     profile::SerializedProfile,
@@ -406,10 +408,14 @@ fn main() -> AppExit {
         })
         .add_plugins(WalletPlugin)
         .add_plugins(CommsPlugin)
-        // foreign avatar bevy transforms (render-free, unlike the rest of AvatarPlugin):
-        // without these, engine-side position logic — scene membership, avatar colliders,
-        // trigger areas — sees every remote player at the origin
-        .add_plugins(avatar::foreign_dynamics::PlayerMovementPlugin)
+        // emote metadata (the loop flag scenes are told) resolves through the collectible
+        // manager; no clip or sound is ever loaded here
+        .add_plugins(EmoteMetadataPlugin)
+        // the render-free part of the avatar stack: foreign avatar bevy transforms (without
+        // these, engine-side position logic — scene membership, avatar colliders, trigger
+        // areas — sees every remote player at the origin), profile info and emote reports
+        // in scene crdt
+        .add_plugins(AvatarCorePlugin)
         .add_plugins(DuiPlugin)
         .add_plugins(SystemBridgePlugin { bare: true });
 
@@ -530,16 +536,7 @@ fn main() -> AppExit {
         shutdown_signal::install();
         app.add_systems(Update, exit_on_shutdown_signal);
     }
-    app.add_systems(
-        Update,
-        (
-            drain_permissions,
-            // AvatarPlugin (render-bound) is omitted headless; without this, SDK
-            // getPlayer()/onEnterScene never see names or wearables
-            avatar::update_avatar_info,
-            reap_terminal_scene_rooms,
-        ),
-    );
+    app.add_systems(Update, (drain_permissions, reap_terminal_scene_rooms));
 
     if args.orchestrated {
         app.insert_resource(ControlChannel(std::sync::Mutex::new(spawn_stdin_reader())))


### PR DESCRIPTION
Scenes learn how an avatar's emote ended, not just that it started, and the headless server reports its foreign players' emotes at all. Adds the `stopEmote` rpc.

Replaces #1222. Closes #1173. Closes #1223.

**Depends on the Pulse side:** decentraland/Pulse#43 lifts the emote suppression for scene listeners. Without it the server never hears an emote, and this PR is a no-op on the server (the client half works regardless). Safe to merge in either order; the server path goes live when that lands and deploys.

Test scene: https://github.com/robtfm/emote-state-scene (auth-server scene; logs every `AvatarEmoteCommand` entry on both sides and syncs the server's view back to clients; README has the run recipe, including `DCL_BEVY_SERVER_PATH` to run a local headless build under the preview server).

## Reporting

`AvatarEmoteCommand` entries carry the protocol's `state` field (`ES_STARTED` / `ES_FINISHED` / `ES_INTERRUPTED`); the proto is re-vendored from protocol main, which also brings `mask` (not written, as the reference client doesn't either).

Every transition is reported, in order, per avatar. A start waits for its loop flag (emote metadata via the collectible manager) and holds the entries behind it rather than being dropped, so the client and the server emit the same sequence whatever their caches hold. Caps of 16 pending entries or 30 s force the head out with its triggered flag. The per-avatar sequence number is the entry timestamp, which only has to be monotonic for the sdk's grow-only set.

Foreign avatars are driven by the wire alone on both binaries: comms raises a lifecycle event for each Pulse emote start/stop, with the stop reason (completed vs cancelled) decoded. The local player's and scene avatars' transitions come from playback in `animate`. Events carry their source, and the reporter keeps the wire's word for foreign players and playback's for the rest. A start that supersedes a playing emote reports the interruption first, as unity does. The reporter runs in `SceneSets::RestrictedActions`, after the frame's emote commands and playback, so a frame's starts and ends are always seen together and in order.

## Routing

Entries are routed per scene through `RendererSceneContext` rather than the global crdt, so a scene that loads mid-emote is told the in-progress start and never the history. While an emote plays, the scenes hearing it are kept in step with the avatar's position: a scene it moves out of (or that unloads) hears it end, one it moves into (or that loads around it) hears it start. A scene counts only once it has its context, so one still loading when the avatar arrives is told when it does. Movement does not cancel an emote under a scene-driven idle animation, so this is reachable through ordinary content. On an orchestrated server every scene hosts as a portable, so targets are filtered by crdt context to keep rooms apart.

## stopEmote

The RestrictedActions `stopEmote` rpc ends the local player's triggered emote; a scene avatar's emote ends when its `AvatarShape` trigger is cleared. Only a scene-sourced shape reads a missing trigger as a stop; profile-derived shapes never carry one, so a wearable change or profile refresh leaves a playing emote alone. A stop is an empty `EmoteCommand`, the value every avatar starts with, so it takes the trigger's path: the rpc goes through the scene's `PlayEmote` permission like a trigger, and `animate` reports the interruption then falls through to the scene-driven or velocity animation as before. The Pulse stop for a looping emote goes out as before.

## Wire hygiene

A foreign player's emote urn lands verbatim in every nearby scene's `AvatarEmoteCommand` set, and Pulse validates an emote's duration and position but not its id. A start whose urn is empty, over 256 bytes, or contains whitespace or control characters is dropped at the wire boundary (carried over from #1222). The server-side counterpart is decentraland/Pulse#44.

## Fixes surfaced along the way

Scene avatars (`AvatarShape` triggers) reported into the wrong entity: `ContainerEntity::container` is the scene entity, not the root carrying the scene context, so the write never resolved. This was the source of the old "no scene to receive emote" warning. Fixed to `root`; scene avatars now report into their own scene for the first time.

## Plugin split

The render-free part of the avatar stack is `AvatarCorePlugin` (player movement, profile info, emote reporting) and the emote metadata loader is `EmoteMetadataPlugin`, so the headless binary runs the same reporting code without the animation and audio loaders (kira's asset type is not registered headless, which panics at first load).

## Deliberately not done

- The headless server does not report scene-avatar emotes. It would have to load the emote glb to learn when a one-shot finishes, a memory cost not worth paying when the triggering scene already knows what it triggered. Clients report them.
- `mask` is never written (unity doesn't either).
- `EmoteCommand.urn` keeps the empty string as "no emote", the pre-existing convention; an `Option` is a candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

