### PR TITLE
VirtualCamera.fov support; drop scale-as-zoom cinematic convention

### DIFF
--- a/crates/common/src/structs.rs
+++ b/crates/common/src/structs.rs
@@ -343,6 +343,10 @@ pub struct SceneDrivenAnimationFeedbackState {
     pub loop_count: u32,
 }
 
+/// vertical fov of the player camera, in radians (60 degrees). also the
+/// `PBVirtualCamera.fov` default, per the proto definition.
+pub const PLAYER_CAMERA_FOV: f32 = std::f32::consts::PI / 3.0;
+
 // main camera entity
 #[derive(Component)]
 pub struct PrimaryCamera {
@@ -365,10 +369,10 @@ pub struct CinematicSettings {
     pub yaw_range: Option<f32>,
     pub pitch_range: Option<f32>,
     pub roll_range: Option<f32>,
-    pub zoom_min: Option<f32>,
-    pub zoom_max: Option<f32>,
     pub look_at_entity: Option<Entity>,
     pub transition: Option<CameraTransition>,
+    /// vertical fov, in radians
+    pub fov: f32,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/camera_mode_area.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/camera_mode_area.proto
@@ -32,13 +32,11 @@ message CinematicSettings {
   uint32 camera_entity = 1;           // Entity that defines the cinematic camera transform.
                                       // Position -> camera's position
                                       // Rotation -> camera's direction
-                                      // scale.z -> zoom level
-                                      // scale.x and scale.y -> unused
+                                      // scale -> unused
   optional bool allow_manual_rotation = 2; // whether the user can move the camera's rotation. default false
   optional float yaw_range = 3;       // how far the camera can rotate around the y-axis / look left/right, in radians. default unrestricted
   optional float pitch_range = 4;     // how far the camera can rotate around the x-axis / look up-down, in radians. default unrestricted
                                       // note: cameras can never look up/down further than Vec3::Y
   optional float roll_range = 5;      // how far the camera can rotate around the z-axis / tilt, in radians. default unrestricted
-  optional float zoom_min = 6;        // minimum zoom level. must be greater than 0. defaults to the input zoom level
-  optional float zoom_max = 7;        // maximum zoom level. must be greater than 0. defaults to the input zoom level
+  reserved 6, 7;                      // zoom_min, zoom_max (removed)
 }

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/virtual_camera.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/virtual_camera.proto
@@ -10,7 +10,9 @@ option (common.ecs_component_id) = 1076;
 // an 'instant' transition (like using speed/time = 0)
 // * The lookAtEntity defines to which entity the Camera has to look at constantly (independent from 
 // the holding entity transform).
+// * The fov defines the Field of View of the virtual camera
 message PBVirtualCamera {
   optional common.CameraTransition default_transition = 1;
   optional uint32 look_at_entity = 2;
+  optional float fov = 3; // default: 60
 }

--- a/crates/scene_runner/src/update_world/camera_mode_area.rs
+++ b/crates/scene_runner/src/update_world/camera_mode_area.rs
@@ -12,7 +12,7 @@ use common::{
     sets::SceneSets,
     structs::{
         CameraOverride, CinematicSettings, PermissionState, PermissionType, PrimaryCamera,
-        PrimaryUser,
+        PrimaryUser, PLAYER_CAMERA_FOV,
     },
 };
 use dcl::interface::ComponentPosition;
@@ -252,10 +252,9 @@ pub fn update_camera_mode_area(
                         yaw_range: cinematic_settings.yaw_range,
                         pitch_range: cinematic_settings.pitch_range,
                         roll_range: cinematic_settings.roll_range,
-                        zoom_min: cinematic_settings.zoom_min,
-                        zoom_max: cinematic_settings.zoom_max,
                         look_at_entity: None,
                         transition: None,
+                        fov: PLAYER_CAMERA_FOV,
                     }));
                 }
                 None => {
@@ -269,8 +268,6 @@ pub fn update_camera_mode_area(
                         yaw_range: Some(0.0),
                         pitch_range: Some(0.0),
                         roll_range: Some(0.0),
-                        zoom_min: None,
-                        zoom_max: None,
                         look_at_entity: maybe_virtual
                             .as_ref()
                             .and_then(|v| v.0.look_at_entity)
@@ -280,6 +277,11 @@ pub fn update_camera_mode_area(
                         transition: maybe_virtual
                             .as_ref()
                             .and_then(|v| v.0.default_transition.clone()),
+                        fov: maybe_virtual
+                            .as_ref()
+                            .and_then(|v| v.0.fov)
+                            .map(f32::to_radians)
+                            .unwrap_or(PLAYER_CAMERA_FOV),
                     }));
                 }
             }

--- a/crates/system_ui/src/emotes.rs
+++ b/crates/system_ui/src/emotes.rs
@@ -222,6 +222,7 @@ fn set_emotes_content(
                     scale: Vec3::ONE,
                 },
                 time: 0.5,
+                fov: None,
             });
         };
 

--- a/crates/system_ui/src/wearables.rs
+++ b/crates/system_ui/src/wearables.rs
@@ -387,6 +387,7 @@ fn set_wearables_content(
                                     settings.category.unwrap_or(&WearableCategory::BODY_SHAPE),
                                 ),
                                 time: 0.5,
+                                fov: None,
                             });
                         };
                     },

--- a/crates/tween/src/lib.rs
+++ b/crates/tween/src/lib.rs
@@ -571,34 +571,56 @@ fn clean_scene_tween_state(
 pub struct SystemTween {
     pub target: Transform,
     pub time: f32,
+    /// target perspective fov, tweened alongside the transform
+    pub fov: Option<f32>,
 }
 
 #[derive(Component)]
 pub struct SystemTweenData {
     start_pos: Transform,
+    start_fov: Option<f32>,
     start_time: f64,
 }
 
+fn perspective_fov(projection: Option<&Mut<Projection>>) -> Option<f32> {
+    match projection.map(|p| &**p) {
+        Some(Projection::Perspective(p)) => Some(p.fov),
+        _ => None,
+    }
+}
+
+fn set_perspective_fov(projection: &mut Option<Mut<Projection>>, fov: Option<f32>) {
+    if let (Some(Projection::Perspective(p)), Some(fov)) = (projection.as_deref_mut(), fov) {
+        if p.fov != fov {
+            p.fov = fov;
+        }
+    }
+}
+
+#[allow(clippy::type_complexity)]
 pub fn update_system_tween(
     mut commands: Commands,
     mut q: Query<(
         Entity,
         &mut Transform,
+        Option<&mut Projection>,
         Ref<SystemTween>,
         Option<&SystemTweenData>,
     )>,
     time: Res<Time>,
 ) {
-    for (ent, mut transform, tween, data) in q.iter_mut() {
+    for (ent, mut transform, mut projection, tween, data) in q.iter_mut() {
         match (tween.is_changed(), data) {
             (true, _) | (_, None) => {
                 if tween.time <= 0.0 {
                     debug!("system tween instant complete @ {:?}", tween.target);
                     *transform = tween.target;
+                    set_perspective_fov(&mut projection, tween.fov);
                 } else {
                     debug!("system tween starting {} @ {:?}", tween.time, tween.target);
                     commands.entity(ent).try_insert(SystemTweenData {
                         start_pos: *transform,
+                        start_fov: perspective_fov(projection.as_ref()),
                         start_time: time.elapsed_secs_f64(),
                     });
                 }
@@ -608,6 +630,7 @@ pub fn update_system_tween(
                 if elapsed >= tween.time {
                     debug!("system tween complete @ {:?}", tween.target);
                     *transform = tween.target;
+                    set_perspective_fov(&mut projection, tween.fov);
                     commands
                         .entity(ent)
                         .remove::<SystemTween>()
@@ -620,6 +643,12 @@ pub fn update_system_tween(
                         (1.0 - ratio) * data.start_pos.scale + ratio * tween.target.scale;
                     transform.rotation =
                         data.start_pos.rotation.slerp(tween.target.rotation, ratio);
+                    if let (Some(start), Some(target)) = (data.start_fov, tween.fov) {
+                        set_perspective_fov(
+                            &mut projection,
+                            Some((1.0 - ratio) * start + ratio * target),
+                        );
+                    }
                     debug!(
                         "system tween partial {}/{} @ {:?}",
                         elapsed, tween.time, transform

--- a/crates/user_input/src/camera.rs
+++ b/crates/user_input/src/camera.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::{FRAC_PI_4, PI};
+use std::f32::consts::PI;
 
 use bevy::{
     prelude::*,
@@ -10,7 +10,7 @@ use common::{
     inputs::{Action, SystemAction, CAMERA_SET, CAMERA_ZOOM, POINTER_SET},
     structs::{
         AppConfig, AvatarDynamicState, CameraOverride, CursorLocks, HeadSync, MoveKind,
-        PrimaryCamera, PrimaryUser,
+        PrimaryCamera, PrimaryUser, PLAYER_CAMERA_FOV,
     },
     util::ModifyComponentExt,
 };
@@ -26,8 +26,6 @@ pub struct CinematicInitialData {
     base_yaw: f32,
     base_pitch: f32,
     base_roll: f32,
-    base_distance: f32,
-    cinematic_transform: GlobalTransform,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -37,7 +35,6 @@ pub fn update_camera(
     locks: Res<CursorLocks>,
     mut cinematic_data: Local<Option<CinematicInitialData>>,
     input_manager: InputManager,
-    gt_helper: TransformHelper,
     config: Res<AppConfig>,
     mut smoothed_delta: Local<Vec2>,
 ) {
@@ -60,61 +57,30 @@ pub fn update_camera(
     let mut yaw_range = None;
     let mut pitch_range = None;
     let mut roll_range = None;
-    let mut zoom_range = None;
 
     // record/reset cinematic start state
     if let Some(CameraOverride::Cinematic(cine)) = options.scene_override.clone() {
-        let Ok(origin) = gt_helper.compute_global_transform(cine.origin) else {
-            warn!("failed to get gt");
-            return;
-        };
+        if cinematic_data.is_none() {
+            *cinematic_data = Some(CinematicInitialData {
+                base_yaw: options.yaw,
+                base_pitch: options.pitch,
+                base_roll: options.roll,
+            });
 
-        let (scale, _, _) = origin.to_scale_rotation_translation();
-        let cinematic_distance = scale.z;
-
-        match cinematic_data.as_mut() {
-            None => {
-                *cinematic_data = Some(CinematicInitialData {
-                    base_yaw: options.yaw,
-                    base_pitch: options.pitch,
-                    base_roll: options.roll,
-                    base_distance: options.distance,
-                    cinematic_transform: origin,
-                });
-
-                options.distance = cinematic_distance;
-                options.yaw = 0.0;
-                options.pitch = 0.0;
-                options.roll = 0.0;
-            }
-            Some(ref mut existing) => {
-                if existing.cinematic_transform != origin {
-                    // reset for updated transform
-                    let (scale, _, _) =
-                        existing.cinematic_transform.to_scale_rotation_translation();
-                    let prev_distance = scale.z;
-                    options.distance = cinematic_distance + options.distance - prev_distance;
-                    existing.cinematic_transform = origin;
-                }
-            }
+            options.yaw = 0.0;
+            options.pitch = 0.0;
+            options.roll = 0.0;
         }
 
         allow_cam_move = cine.allow_manual_rotation;
         yaw_range = cine.yaw_range.map(|r| -r..r);
         pitch_range = cine.pitch_range.map(|r| -r..r);
         roll_range = cine.roll_range.map(|r| -r..r);
-        zoom_range = Some(
-            cine.zoom_min.unwrap_or(scale.z).clamp(0.3, 100.0)
-                ..cine.zoom_max.unwrap_or(scale.z).clamp(0.3, 100.0),
-        );
     } else if let Some(initial) = cinematic_data.take() {
-        (options.yaw, options.pitch, options.roll, options.distance) = (
-            initial.base_yaw,
-            initial.base_pitch,
-            initial.base_roll,
-            initial.base_distance,
-        );
+        (options.yaw, options.pitch, options.roll) =
+            (initial.base_yaw, initial.base_pitch, initial.base_roll);
     }
+    let in_cinematic = cinematic_data.is_some();
 
     let mut mouse_delta = input_manager.get_analog(CAMERA_SET, InputPriority::Scene) * 10.0;
     if locks.0.contains("camera") {
@@ -148,6 +114,10 @@ pub fn update_camera(
         options.pitch = (options.pitch - mouse_delta.y * options.sensitivity / 1000.0)
             .clamp(-PI / 2.1, PI / 2.1);
         options.yaw -= mouse_delta.x * options.sensitivity / 1000.0;
+    }
+
+    // `distance` is the third-person follow distance; a cinematic camera has its own fov
+    if !in_cinematic {
         let zoom = input_manager
             .get_analog(CAMERA_ZOOM, InputPriority::Scene)
             .y;
@@ -166,9 +136,6 @@ pub fn update_camera(
     }
     if let Some(yaw_range) = yaw_range {
         options.yaw = options.yaw.clamp(yaw_range.start, yaw_range.end);
-    }
-    if let Some(zoom_range) = zoom_range {
-        options.distance = options.distance.clamp(zoom_range.start, zoom_range.end);
     }
 }
 
@@ -228,6 +195,7 @@ pub fn update_camera_position(
     }
 
     let mut target_transform = *camera_transform;
+    let mut target_fov = PLAYER_CAMERA_FOV;
     let mut target_transition = TransitionMode::Time(TRANSITION_TIME);
 
     if is_oow {
@@ -266,14 +234,7 @@ pub fn update_camera_position(
                 .unwrap_or(options.roll);
             rotation * Quat::from_euler(EulerRot::YXZ, yaw, pitch, roll)
         };
-        let target_fov = FRAC_PI_4 * 1.25 / options.distance;
-        let Projection::Perspective(PerspectiveProjection { ref mut fov, .. }) = &mut *projection
-        else {
-            panic!();
-        };
-        if *fov != target_fov {
-            *fov = target_fov;
-        }
+        target_fov = cine.fov;
         if let Some(transition) = cine
             .transition
             .as_ref()
@@ -284,14 +245,6 @@ pub fn update_camera_position(
 
         commands.entity(camera_ent).try_insert(ViewUserValue(0.0));
     } else {
-        let target_fov = (dynamic_state.velocity.length() / 4.0).clamp(1.25, 1.25) * FRAC_PI_4;
-        if let Projection::Perspective(PerspectiveProjection { ref mut fov, .. }) = &mut *projection
-        {
-            if *fov != target_fov {
-                *fov = target_fov;
-            }
-        };
-
         let mut distance = match options.scene_override {
             Some(CameraOverride::Distance(d)) => d,
             _ => options.distance,
@@ -322,6 +275,9 @@ pub fn update_camera_position(
             .try_insert(ViewUserValue(distance));
     }
 
+    // the camera never carries scale; scenes may set arbitrary scale on virtual camera entities
+    target_transform.scale = Vec3::ONE;
+
     let changed = (prev_override.is_some() != options.scene_override.is_some())
         || prev_override
             .as_ref()
@@ -347,20 +303,31 @@ pub fn update_camera_position(
         commands.entity(camera_ent).try_insert(SystemTween {
             target: target_transform,
             time,
+            fov: Some(target_fov),
         });
     } else if let Some(mut tween) = maybe_tween {
-        if target_transform != tween.bypass_change_detection().target {
+        let tween = tween.bypass_change_detection();
+        if target_transform != tween.target {
             debug!(
                 "tween changed to {:?} to {:?}",
                 camera_transform, target_transform
             );
-            tween.bypass_change_detection().target = target_transform;
+            tween.target = target_transform;
+        }
+        if tween.fov != Some(target_fov) {
+            tween.fov = Some(target_fov);
         }
     } else {
         commands
             .entity(camera_ent)
             .modify_component(move |t: &mut Transform| *t = target_transform);
         // *camera_transform = target_transform;
+        if let Projection::Perspective(PerspectiveProjection { ref mut fov, .. }) = &mut *projection
+        {
+            if *fov != target_fov {
+                *fov = target_fov;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1176.

## What

- Vendors `PBVirtualCamera.fov` (protocol main) and applies it when a virtual camera is active. Unset falls back to 60°, per the proto default. Degrees on the wire, radians internally.
- The fov is tweened alongside the transform via `SystemTween`, so a transition to a non-default fov eases in over the same time as the position/rotation rather than jumping. Changing fov on an already-active virtual camera stays instant, as in unity.
- The player camera fov moves from 56.25° (`FRAC_PI_4 * 1.25`) to 60°, a single `PLAYER_CAMERA_FOV` constant shared by the player camera, the virtual-camera default and the CameraModeArea cinematic path.

## Removed: scale.z as zoom

The bevy-only convention read the cinematic camera entity's `scale.z` as a zoom level and divided the fov by it. Real scenes set arbitrary scale on their camera entities (0, 5, …), which produced wild fovs. That path is gone: the origin's scale is never read, and the camera's own transform scale is pinned to `Vec3::ONE`.

With it gone, the cinematic `zoom_min` / `zoom_max` settings had no remaining producer — they only ever existed in bevy's vendored `camera_mode_area.proto`, and no SDK (main or bevy-features) exposes them. They're removed and the field numbers reserved. `PrimaryCamera::distance` is now always the third-person follow distance; zoom input is ignored while a cinematic camera is active, so scrolling during a cutscene no longer drifts the follow distance.

Side effects: fog and camera-mode reporting read `distance` and now see the real follow distance during cinematics rather than the zoom level (identical at the default distance of 1.0). The out-of-world camera now targets the default fov rather than inheriting whatever the projection last held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
