### PR TITLE
EngineInfo.scene_hidden: report scene visibility to scenes

### DIFF
--- a/crates/dcl/src/js/modules/SystemApi.js
+++ b/crates/dcl/src/js/modules/SystemApi.js
@@ -155,9 +155,11 @@ module.exports.setInputBindings = async function(bindings) {
 //   scroll: bool, // the cursor is over a scrollable HUD element: the Scroll actions are
 //                 // reserved, so every input bound to them stands down for world consumers
 //                 // while the action stream still resolves Scroll for the HUD to consume
+//   covered: bool, // a full-screen HUD surface (menu page, loading overlay) hides the world:
+//                  // scenes are told they are hidden (EngineInfo.scene_hidden)
 // }
 module.exports.setUiFocus = async function(focus) {
-    Deno.core.ops.op_set_ui_focus(focus?.ui ?? false, focus?.text ?? false, focus?.scroll ?? false)
+    Deno.core.ops.op_set_ui_focus(focus?.ui ?? false, focus?.text ?? false, focus?.scroll ?? false, focus?.covered ?? false)
 }
 
 

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -304,11 +304,17 @@ pub fn op_set_ui_focus(
     ui: bool,
     text: bool,
     scroll: bool,
+    covered: bool,
 ) -> Result<(), anyhow::Error> {
     state
         .borrow_mut()
         .borrow_mut::<SuperUserScene>()
-        .send(SystemApi::SetUiFocus { ui, text, scroll })?;
+        .send(SystemApi::SetUiFocus {
+            ui,
+            text,
+            scroll,
+            covered,
+        })?;
     Ok(())
 }
 

--- a/crates/dcl_component/src/proto/decentraland/sdk/components/engine_info.proto
+++ b/crates/dcl_component/src/proto/decentraland/sdk/components/engine_info.proto
@@ -12,5 +12,6 @@ message PBEngineInfo {
   uint32 frame_number = 1; // frame counter of the engine
   float total_runtime = 2; // total runtime of this scene in seconds
   uint32 tick_number  = 3; // tick counter of the scene as per ADR-148
+  bool scene_hidden   = 4; // visibility state of the scene regarding Explorer fullscreen UI
   double total_runtime_f64 = 5; // total_runtime at f64 precision: the float field cannot resolve frame deltas past ~36h of scene uptime
 }

--- a/crates/dcl_deno/src/js/op_wrappers/system_api.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/system_api.rs
@@ -218,8 +218,9 @@ pub fn op_set_ui_focus(
     ui: bool,
     text: bool,
     scroll: bool,
+    covered: bool,
 ) -> Result<(), AnyError> {
-    dcl::js::system_api::op_set_ui_focus(state, ui, text, scroll)
+    dcl::js::system_api::op_set_ui_focus(state, ui, text, scroll, covered)
 }
 
 #[op2(async)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
@@ -138,8 +138,10 @@ pub fn op_set_ui_focus(
     ui: bool,
     text: bool,
     scroll: bool,
+    covered: bool,
 ) -> Result<(), WasmError> {
-    dcl::js::system_api::op_set_ui_focus(state.rc(), ui, text, scroll).map_err(WasmError::from)
+    dcl::js::system_api::op_set_ui_focus(state.rc(), ui, text, scroll, covered)
+        .map_err(WasmError::from)
 }
 
 #[wasm_bindgen]

--- a/crates/input_manager/src/lib.rs
+++ b/crates/input_manager/src/lib.rs
@@ -828,7 +828,10 @@ fn handle_set_ui_focus(
     mut priorities: ResMut<InputPriorities>,
 ) {
     for (ui, text, scroll) in events.read().filter_map(|e| {
-        if let SystemApi::SetUiFocus { ui, text, scroll } = e {
+        if let SystemApi::SetUiFocus {
+            ui, text, scroll, ..
+        } = e
+        {
             Some((*ui, *text, *scroll))
         } else {
             None

--- a/crates/scene_runner/src/lib.rs
+++ b/crates/scene_runner/src/lib.rs
@@ -246,6 +246,25 @@ pub struct SceneLoopSchedule {
 #[derive(Default, Resource)]
 pub struct InteractableArea(pub Option<Vec4>);
 
+/// A full-screen HUD surface covers the world (`SystemApi::SetUiFocus.covered`).
+#[derive(Default, Resource)]
+pub struct HudFullscreen(pub bool);
+
+/// Frame-global inputs to `PBEngineInfo`. The world is hidden from the user while the engine's
+/// loading backdrop (player `OutOfWorld`) or a full-screen HUD surface covers it.
+#[derive(SystemParam)]
+struct EngineInfoSource<'w, 's> {
+    frame: Res<'w, FrameCount>,
+    hud_fullscreen: Res<'w, HudFullscreen>,
+    oow: Query<'w, 's, (), (With<PrimaryUser>, With<OutOfWorld>)>,
+}
+
+impl EngineInfoSource<'_, '_> {
+    fn scene_hidden(&self) -> bool {
+        self.hud_fullscreen.0 || !self.oow.is_empty()
+    }
+}
+
 impl InteractableArea {
     pub fn get_or_default(&self, width: f32, height: f32) -> Vec4 {
         self.0.unwrap_or_else(|| {
@@ -266,6 +285,7 @@ impl Plugin for SceneRunnerPlugin {
         app.init_resource::<Toasts>();
         app.init_resource::<TestingData>();
         app.init_resource::<InteractableArea>();
+        app.init_resource::<HudFullscreen>();
         // shared by pointer results, trigger areas and the avatar crate — owned here so
         // trigger areas keep working when the pointer-result systems are skipped
         app.init_resource::<update_scene::pointer_results::AvatarColliders>();
@@ -787,7 +807,7 @@ fn send_scene_updates(
     )>,
     mut updates: ResMut<SceneUpdates>,
     time: Res<Time>,
-    frame: Res<FrameCount>,
+    engine_info: EngineInfoSource,
     player: Query<&Transform, With<PrimaryUser>>,
     camera: Query<&Transform, With<PrimaryCamera>>,
     config: Res<AppConfig>,
@@ -1021,9 +1041,10 @@ fn send_scene_updates(
     // add engine info, only for the scene actually being sent
     buf.clear();
     DclWriter::new(buf).write(&PbEngineInfo {
-        frame_number: frame.0,
+        frame_number: engine_info.frame.0,
         total_runtime: context.total_runtime as f32,
         tick_number: context.tick_number,
+        scene_hidden: engine_info.scene_hidden(),
         total_runtime_f64: context.total_runtime,
     });
     context.crdt_store.force_update(
@@ -1332,10 +1353,13 @@ fn log_app_errors(mut toaster: Toaster, mut errors: EventReader<AppError>, frame
 fn set_ui_constraints(
     mut events: EventReader<SystemApi>,
     mut interactable_area: ResMut<InteractableArea>,
+    mut hud_fullscreen: ResMut<HudFullscreen>,
 ) {
     for ev in events.read() {
-        if let SystemApi::SetInteractableArea(area) = ev {
-            interactable_area.0 = Some(*area);
+        match ev {
+            SystemApi::SetInteractableArea(area) => interactable_area.0 = Some(*area),
+            SystemApi::SetUiFocus { covered, .. } => hud_fullscreen.0 = *covered,
+            _ => (),
         }
     }
 }

--- a/crates/system_bridge/src/lib.rs
+++ b/crates/system_bridge/src/lib.rs
@@ -82,10 +82,13 @@ pub enum SystemApi {
     /// HUD element — the Scroll ACTIONS are reserved, so every input bound to them (wheel,
     /// key, gamepad button) stands down for world consumers while the action stream still
     /// resolves Scroll itself; the HUD scrolls the hovered panel from those edges.
+    /// `covered`: a full-screen HUD surface (a menu page, the HUD's loading overlay) hides
+    /// the world — scenes are told they are hidden (`PBEngineInfo.scene_hidden`).
     SetUiFocus {
         ui: bool,
         text: bool,
         scroll: bool,
+        covered: bool,
     },
     LiveSceneInfo(RpcResultSender<Vec<LiveSceneInfo>>),
     GetHomeScene(RpcResultSender<HomeScene>),

--- a/react-web/bridge-scene/src/bevy-api.ts
+++ b/react-web/bridge-scene/src/bevy-api.ts
@@ -102,8 +102,10 @@ export type BevyApiInterface = {
    *  system-action stream keeps flowing); `text` = a HUD text field holds keyboard focus
    *  (keys are typing — no actions resolve at all); `scroll` = the cursor is over a
    *  scrollable HUD element (the Scroll ACTIONS are reserved, so every input bound to
-   *  them drives the panel rather than world consumers like camera zoom). */
-  setUiFocus: (focus: { ui: boolean; text: boolean; scroll: boolean }) => Promise<void>
+   *  them drives the panel rather than world consumers like camera zoom); `covered` = a
+   *  full-screen HUD surface (menu page, loading overlay) hides the world (scenes see
+   *  EngineInfo.scene_hidden). */
+  setUiFocus: (focus: { ui: boolean; text: boolean; scroll: boolean; covered: boolean }) => Promise<void>
   sendChat: (message: string, channel: string) => void
   getChatStream: () => Promise<AsyncIterable<ChatStreamMessage>>
   getSystemActionStream: () => Promise<AsyncIterable<SystemActionEvent>>

--- a/react-web/bridge-scene/src/domains/bindings.ts
+++ b/react-web/bridge-scene/src/domains/bindings.ts
@@ -32,7 +32,7 @@ export function registerBindings(ctx: Ctx): void {
   // HUD focus relay: fire-and-forget, latest state wins (the engine reserves/releases
   // idempotently, so replays are harmless).
   ctx.on('uiFocus', (msg) => {
-    void BevyApi.setUiFocus({ ui: msg.ui, text: msg.text, scroll: msg.scroll })
+    void BevyApi.setUiFocus({ ui: msg.ui, text: msg.text, scroll: msg.scroll, covered: msg.covered })
   })
 
   let activeCaptureId: string | null = null

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -905,12 +905,15 @@ export interface CaptureInputRequest {
  *  `scroll`: the cursor is over a scrollable HUD element — the engine reserves the Scroll
  *  ACTIONS, so every input bound to them (wheel, key, gamepad button) stands down for
  *  world consumers (camera zoom on a shared wheel) while the action stream still resolves
- *  Scroll for the HUD to drive the hovered panel. */
+ *  Scroll for the HUD to drive the hovered panel. `covered`: a full-screen HUD surface (a
+ *  menu page, the loading overlay) hides the world — the engine tells scenes they are hidden
+ *  (EngineInfo.scene_hidden). */
 export interface UiFocusMessage {
   kind: 'uiFocus'
   ui: boolean
   text: boolean
   scroll: boolean
+  covered: boolean
 }
 
 /** One interaction hint (a single key binding) for a world entity: the button to press + its label.

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -1562,10 +1562,13 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
     []
   )
   const uiFocus = anyPanelOpen || popupOpen || locked
+  // `covered` also spans the loading overlay: it outlives the engine's own out-of-world state
+  // (player spawn, render-settle, reveal debounce), so the engine can't see that tail itself.
+  const covered = menuPageOpen || phase === 'entering'
   useEffect(() => {
-    if (phase !== 'world') return
-    driverRef.current?.send({ kind: 'uiFocus', ui: uiFocus, text: textFocused, scroll: scrollHover })
-  }, [phase, uiFocus, textFocused, scrollHover])
+    if (phase !== 'world' && phase !== 'entering') return
+    driverRef.current?.send({ kind: 'uiFocus', ui: uiFocus, text: textFocused, scroll: scrollHover, covered })
+  }, [phase, uiFocus, textFocused, scrollHover, covered])
 
   // Pre-world the bridge stream doesn't exist, so popups opened during login/entering
   // (realm errors, world-visit prompts) need a DOM cancel fallback; in-world the engine's

--- a/react-web/src/test/systemActionShortcuts.test.tsx
+++ b/react-web/src/test/systemActionShortcuts.test.tsx
@@ -148,23 +148,30 @@ describe('system-action menu shortcuts', () => {
     expect(screen.queryByText('realm error')).toBeNull()
   })
 
-  it("declares uiFocus to the engine: panels/popups set ui, a focused text field sets text", async () => {
+  it('declares the loading overlay as covered until the world is revealed', async () => {
+    const h = renderSession({ userId: null })
+    await enterAsGuest(h, { keepSent: true })
+    const focus = h.driver.sent.filter((m) => m.kind === 'uiFocus').map((m) => m.covered)
+    expect(focus).toEqual([true, false])
+  })
+
+  it("declares uiFocus to the engine: panels/popups set ui, a full-screen page sets covered, a focused text field sets text", async () => {
     const h = await world()
     h.driver.clearSent()
     h.driver.emit(action('Places'))
     await waitFor(() =>
-      expect(h.driver.last('uiFocus')).toEqual({ kind: 'uiFocus', ui: true, text: false, scroll: false })
+      expect(h.driver.last('uiFocus')).toEqual({ kind: 'uiFocus', ui: true, text: false, scroll: false, covered: true })
     )
     h.driver.emit(action('Places'))
     await waitFor(() =>
-      expect(h.driver.last('uiFocus')).toEqual({ kind: 'uiFocus', ui: false, text: false, scroll: false })
+      expect(h.driver.last('uiFocus')).toEqual({ kind: 'uiFocus', ui: false, text: false, scroll: false, covered: false })
     )
 
     const input = document.createElement('input')
     document.body.appendChild(input)
     act(() => input.focus())
     await waitFor(() =>
-      expect(h.driver.last('uiFocus')).toEqual({ kind: 'uiFocus', ui: false, text: true, scroll: false })
+      expect(h.driver.last('uiFocus')).toEqual({ kind: 'uiFocus', ui: false, text: true, scroll: false, covered: false })
     )
   })
 


### PR DESCRIPTION
Writes the protocol's `PBEngineInfo.scene_hidden` (protocol #465) on every EngineInfo send. The scene is hidden while the engine's loading backdrop is up (the player is `OutOfWorld`, which recurs on every teleport) or while the react HUD covers the world.

**HUD → engine.** The HUD already declares its focus state with the `uiFocus` message; it gains a fourth flag, `covered`, rather than a new API. The HUD sets it for the full-screen menu pages (settings, backpack, communities, map, places, gallery) and for its own loading overlay, which outlives `OutOfWorld` through player spawn, render-settle and the reveal debounce. The relay now also fires in the `entering` phase so the engine hears that tail. Side panels (friends, profile, notifications, emote wheel, chat) leave the world visible and do not set it. `SystemApi.js` defaults the flag to false, so an older bridge bundle still works.

**Engine.** A `HudFullscreen` resource is set alongside the interactable area in `set_ui_constraints`. `send_scene_updates` reads it and the player's `OutOfWorld` state through a small SystemParam because the system already sat at bevy's 16-parameter limit.

**Parity.** Unity (decentraland/unity-explorer#9861) writes the field from its loading screen only and flips back to true when the loading screen returns; this matches that and adds the HUD term.

**Verified** with a test scene that beeps and shows a red cube while hidden: `true` at the scene's first update, `false` on reveal, then matched true/false pairs on every full-screen page open/close, no stray toggles.

**Known gap, out of scope.** The `uiFocus` relay is a fire-and-forget BroadcastChannel post with no buffering. A page that boots straight into `entering` (a URL destination) can post `covered: true` before the bridge scene is subscribed, and nothing re-sends it during the overlay tail, so on that first load `scene_hidden` can clear a beat before the overlay does. This is the general "HUD posts before the bridge is up" race, tracked in #1233 (bridge announces itself, HUD holds messages until then, timeout surfaces a bridge failure). No per-message workaround here.

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
