### PR TITLE
Sign in via the auth site's deep-link handoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8638,11 +8638,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-compat",
+ "async-std",
  "async-tungstenite",
  "bevy",
  "directories",
  "futures-lite",
- "futures-timer",
  "futures-util",
  "js-sys",
  "reqwest 0.12.15",
@@ -8651,6 +8651,7 @@ dependencies = [
  "spin 0.9.9",
  "tokio",
  "tungstenite 0.21.0",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-fs",
@@ -12448,6 +12449,7 @@ dependencies = [
  "reqwest 0.12.15",
  "serde",
  "serde_json",
+ "uuid 1.26.0",
  "web-time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8656,6 +8656,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-fs",
  "web-sys",
+ "winreg",
  "ws_stream_wasm",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,6 @@ async-trait = "0.1.68"
 fastrand = "2"
 rand = "0.8.5"
 futures-util = "0.3.28"
-futures-timer = "3"
 async-native-tls = { version = "0.5", features = ["runtime-async-std"] }
 boimp = { git = "https://github.com/robtfm/boimp", branch = "feat/composite-bake-via-storage-texture" }
 crc = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ bevy_simple_text_input = { git = "https://github.com/robtfm/bevy_simple_text_inp
 ], branch = "0.16" }
 bevy_hanabi = { git = "https://github.com/robtfm/bevy_hanabi", branch = "0.16-dcl", default-features = false }
 directories = "6"
+winreg = "0.50"
 uuid = { version = "1.23", features = ["v4"] }
 build-time = "0.1.3"
 async-tungstenite = { version = "0.25", features = ["async-native-tls"] }

--- a/crates/assets/src/assets/ui/login.dui
+++ b/crates/assets/src/assets/ui/login.dui
@@ -49,22 +49,6 @@
                     "
                     text="Please follow the instructions in your browser to connect your wallet to your Decentraland account"
                 />
-                <div style="flex-direction: row;">
-                    <med-text style="
-                        color: black;
-                        text-align: center;
-                        margin: 2.8vmin;
-                        "
-                        text="Connection code: "
-                    />
-                    <large-text style="
-                        color: black;
-                        text-align: center;
-                        margin: 2.8vmin;
-                        "
-                        text="@code"
-                    />
-                </div>
             </div>
             <spinner />
         </div>

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -13,7 +13,7 @@ bevy = { workspace = true }
 anyhow = { workspace = true }
 tungstenite = { workspace = true }
 futures-util = { workspace = true }
-futures-timer = { workspace = true }
+async-std = { workspace = true }
 reqwest = { workspace = true }
 directories = { workspace = true }
 futures-lite = { workspace = true }
@@ -24,10 +24,9 @@ serde_json = { workspace = true }
 async-tungstenite = { workspace = true }
 async-compat = { workspace = true }
 tokio = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# wasm-bindgen feature swaps futures-timer's backend to setTimeout (gloo-timers)
-futures-timer = { workspace = true, features = ["wasm-bindgen"] }
 web-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -26,6 +26,9 @@ async-compat = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+winreg = { workspace = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -10,7 +10,6 @@ pub use wasm::*;
 
 use std::{future::Future, time::Duration};
 
-use futures_timer::Delay;
 use futures_util::{
     future::{select, Either},
     pin_mut, StreamExt,
@@ -23,11 +22,11 @@ struct Elapsed;
 ///
 /// Cross-target replacement for `tokio::time::timeout` (which isn't available here
 /// — tokio is built without the `time` feature, and it wouldn't work on wasm
-/// anyway). `futures-timer` backs this with a native timer thread or wasm
-/// `setTimeout`.
+/// anyway). `async-std` backs the timer natively and with `setTimeout` on wasm.
 async fn with_timeout<F: Future>(dur: Duration, fut: F) -> Result<F::Output, Elapsed> {
-    pin_mut!(fut);
-    match select(fut, Delay::new(dur)).await {
+    let timer = async_std::task::sleep(dur);
+    pin_mut!(fut, timer);
+    match select(fut, timer).await {
         Either::Left((out, _)) => Ok(out),
         Either::Right(_) => Err(Elapsed),
     }

--- a/crates/platform/src/native.rs
+++ b/crates/platform/src/native.rs
@@ -17,6 +17,8 @@ use futures_util::{
 use serde::Serialize;
 pub use tungstenite::client::IntoClientRequest;
 
+pub mod deeplink;
+
 pub struct WebSocket {
     inner: WebSocketStream<ConnectStream>,
 }

--- a/crates/platform/src/native/deeplink.rs
+++ b/crates/platform/src/native/deeplink.rs
@@ -42,9 +42,9 @@ struct BridgeFile {
 /// Who handles `decentraland://` links on this machine.
 enum Handler {
     None,
-    /// Our own registration, and the binary it points at (never on macos)
+    /// Our own registration, as written (never on macos)
     #[allow(dead_code)]
-    Ours(PathBuf),
+    Ours(String),
     /// Someone else's (normally the launcher): never touched
     Other,
 }
@@ -58,13 +58,14 @@ pub struct PlaceLink {
 }
 
 /// Make sure a `decentraland://` link opened from the browser can reach us: either something
-/// (normally the launcher) already handles the scheme, or we register this binary. A stale
-/// registration of ours (a dev build that moved or was cleaned) is redone. On macos
-/// registration needs an app bundle, so the launcher is required there.
+/// (normally the launcher) already handles the scheme, or we register this binary. A
+/// registration of ours that differs from what we would write now (a dev build that moved or
+/// was cleaned, a stale environment) is redone. On macos registration needs an app bundle, so
+/// the launcher is required there.
 pub fn ensure_scheme_handler() -> Result<(), anyhow::Error> {
     match os::handler() {
         Handler::Other => Ok(()),
-        Handler::Ours(path) if path == os::exe_path()? => Ok(()),
+        Handler::Ours(current) if current == os::registration()? => Ok(()),
         Handler::Ours(_) | Handler::None => os::register_handler(),
     }
 }

--- a/crates/platform/src/native/deeplink.rs
+++ b/crates/platform/src/native/deeplink.rs
@@ -101,7 +101,8 @@ pub fn signin_link_arg() -> Option<String> {
     })
 }
 
-/// Write `url` to the bridge file the way the launcher does.
+/// Write `url` to the bridge file the way the launcher does, in one step so a poller never
+/// reads a partial file.
 pub fn write_launcher_bridge(url: &str) -> Result<(), anyhow::Error> {
     let path = launcher_bridge_path().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
     if let Some(dir) = path.parent() {
@@ -110,7 +111,9 @@ pub fn write_launcher_bridge(url: &str) -> Result<(), anyhow::Error> {
     let json = serde_json::to_string(&BridgeFile {
         deeplink: url.to_owned(),
     })?;
-    std::fs::write(path, json)?;
+    let staging = path.with_extension("json.tmp");
+    std::fs::write(&staging, json)?;
+    std::fs::rename(staging, path)?;
     Ok(())
 }
 

--- a/crates/platform/src/native/deeplink.rs
+++ b/crates/platform/src/native/deeplink.rs
@@ -1,0 +1,228 @@
+//! `decentraland://` deep links, shared with the Decentraland launcher.
+//!
+//! The launcher owns the scheme wherever it is installed. When an explorer is already running
+//! (or the link carries `bridgeOnly`) it does not spawn one: it writes the link to a bridge
+//! file and waits for the consumer to delete it. We read that same file, so a sign-in link
+//! reaches us whether the OS handed it to the launcher or to ourselves (registered on
+//! windows/linux only when nothing else claims the scheme). Either way the explorer receives
+//! the raw link as its first argument; a place link (`realm`, `position`, `dclenv`) becomes
+//! launch options.
+
+use std::{path::PathBuf, time::Duration};
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+use linux as os;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+use macos as os;
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+mod unsupported;
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+use unsupported as os;
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+use windows as os;
+
+pub const SCHEME: &str = "decentraland";
+const LAUNCHER_DIR: &str = "DecentralandLauncherLight";
+const BRIDGE_FILE: &str = "deeplink-bridge.json";
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+#[derive(Serialize, Deserialize)]
+struct BridgeFile {
+    deeplink: String,
+}
+
+/// Who handles `decentraland://` links on this machine.
+enum Handler {
+    None,
+    /// Our own registration, and the binary it points at (never on macos)
+    #[allow(dead_code)]
+    Ours(PathBuf),
+    /// Someone else's (normally the launcher): never touched
+    Other,
+}
+
+/// A place link's launch options: `decentraland://open?realm=…&position=x,y&dclenv=org|zone`.
+#[derive(Default, Debug, PartialEq)]
+pub struct PlaceLink {
+    pub realm: Option<String>,
+    pub position: Option<String>,
+    pub base_domain: Option<String>,
+}
+
+/// Make sure a `decentraland://` link opened from the browser can reach us: either something
+/// (normally the launcher) already handles the scheme, or we register this binary. A stale
+/// registration of ours (a dev build that moved or was cleaned) is redone. On macos
+/// registration needs an app bundle, so the launcher is required there.
+pub fn ensure_scheme_handler() -> Result<(), anyhow::Error> {
+    match os::handler() {
+        Handler::Other => Ok(()),
+        Handler::Ours(path) if path == os::exe_path()? => Ok(()),
+        Handler::Ours(_) | Handler::None => os::register_handler(),
+    }
+}
+
+/// Wait for `decentraland://open?signin=<identityId>&authRequestId=<request_id>` to land in the
+/// bridge file and return the `signin` id. Links minted for another login (unity, or an
+/// earlier attempt) are left in place for their owner.
+pub async fn await_signin(request_id: &str, timeout: Duration) -> Result<String, anyhow::Error> {
+    let start_time = std::time::Instant::now();
+    loop {
+        if start_time.elapsed() >= timeout {
+            anyhow::bail!("timed out awaiting sign-in");
+        }
+        if let Some(link) = peek_launcher_bridge() {
+            if let Some(identity_id) = signin_for_request(&link, request_id) {
+                delete_launcher_bridge();
+                return Ok(identity_id);
+            }
+        }
+        async_std::task::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// A sign-in link on the command line, i.e. the OS launched us as the scheme handler for a login
+/// in progress.
+pub fn signin_link_arg() -> Option<String> {
+    std::env::args().skip(1).find(|arg| {
+        query(arg).is_some_and(|pairs| {
+            pairs
+                .iter()
+                .any(|(key, value)| key == "signin" && !value.is_empty())
+        })
+    })
+}
+
+/// Write `url` to the bridge file the way the launcher does.
+pub fn write_launcher_bridge(url: &str) -> Result<(), anyhow::Error> {
+    let path = launcher_bridge_path().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let json = serde_json::to_string(&BridgeFile {
+        deeplink: url.to_owned(),
+    })?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// The launch options a place link carries.
+pub fn parse_place_link(link: &str) -> Result<PlaceLink, anyhow::Error> {
+    let pairs = query(link).ok_or_else(|| anyhow::anyhow!("not a {SCHEME}:// link"))?;
+    let mut place = PlaceLink::default();
+    for (key, value) in pairs {
+        match key.as_str() {
+            "realm" => place.realm = Some(value),
+            "position" => place.position = Some(value),
+            "dclenv" => {
+                place.base_domain = Some(match value.as_str() {
+                    "org" => "decentraland.org".to_owned(),
+                    "zone" => "decentraland.zone".to_owned(),
+                    other => anyhow::bail!("unknown dclenv `{other}`"),
+                })
+            }
+            _ => (),
+        }
+    }
+    Ok(place)
+}
+
+/// `~/Library/Application Support/DecentralandLauncherLight/deeplink-bridge.json` on macos,
+/// `%LOCALAPPDATA%\DecentralandLauncherLight\deeplink-bridge.json` on windows; the same layout
+/// under `~/.local/share` on linux, where there is no launcher and only we write it.
+fn launcher_bridge_path() -> Option<PathBuf> {
+    directories::BaseDirs::new()
+        .map(|dirs| dirs.data_local_dir().join(LAUNCHER_DIR).join(BRIDGE_FILE))
+}
+
+fn peek_launcher_bridge() -> Option<String> {
+    let content = std::fs::read_to_string(launcher_bridge_path()?).ok()?;
+    serde_json::from_str::<BridgeFile>(&content)
+        .ok()
+        .map(|file| file.deeplink)
+}
+
+fn delete_launcher_bridge() {
+    if let Some(path) = launcher_bridge_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// The decoded query of a `decentraland://` link, or None for anything else. Like the launcher,
+/// a link without `?` (`decentraland://realm=…&position=…`) is all query.
+fn query(link: &str) -> Option<Vec<(String, String)>> {
+    let rest = link.strip_prefix(SCHEME)?.strip_prefix("://")?;
+    let query = rest.split_once('?').map_or(rest, |(_, query)| query);
+    Some(
+        url::form_urlencoded::parse(query.as_bytes())
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect(),
+    )
+}
+
+/// The `signin` id carried by `link`, if the link was minted for `request_id`.
+fn signin_for_request(link: &str, request_id: &str) -> Option<String> {
+    let mut signin = None;
+    let mut auth_request_id = None;
+    for (key, value) in query(link)? {
+        match key.as_str() {
+            "signin" => signin = Some(value),
+            "authRequestId" => auth_request_id = Some(value),
+            _ => (),
+        }
+    }
+    (auth_request_id.as_deref() == Some(request_id))
+        .then_some(signin)
+        .flatten()
+        .filter(|id| !id.is_empty())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn signin_matches_own_request_only() {
+        let link = "decentraland://open?signin=id-1&bridgeOnly=true&authRequestId=req-1";
+        assert_eq!(signin_for_request(link, "req-1").as_deref(), Some("id-1"));
+        assert_eq!(signin_for_request(link, "req-2"), None);
+        assert_eq!(
+            signin_for_request("decentraland://open?signin=&authRequestId=req-1", "req-1"),
+            None
+        );
+        assert_eq!(
+            signin_for_request("https://x/?signin=id-1&authRequestId=req-1", "req-1"),
+            None
+        );
+    }
+
+    #[test]
+    fn place_link_options() {
+        assert_eq!(
+            parse_place_link("decentraland://realm=http%3A%2F%2F127.0.0.1%3A8000&position=0%2C0")
+                .unwrap(),
+            PlaceLink {
+                realm: Some("http://127.0.0.1:8000".into()),
+                position: Some("0,0".into()),
+                base_domain: None
+            }
+        );
+        assert_eq!(
+            parse_place_link("decentraland:///?position=139,-40&dclenv=zone").unwrap(),
+            PlaceLink {
+                realm: None,
+                position: Some("139,-40".into()),
+                base_domain: Some("decentraland.zone".into())
+            }
+        );
+        assert!(parse_place_link("decentraland://open?dclenv=prod").is_err());
+        assert!(parse_place_link("https://decentraland.org/?position=1,2").is_err());
+    }
+}

--- a/crates/platform/src/native/deeplink/linux.rs
+++ b/crates/platform/src/native/deeplink/linux.rs
@@ -19,7 +19,13 @@ pub fn handler() -> Handler {
         return Handler::None;
     };
     if default != DESKTOP_FILE {
-        return Handler::Other;
+        // a registration whose desktop file is gone (an uninstalled app, a stale mimeapps.list)
+        // is nobody's
+        return if desktop_file_exists(&default) {
+            Handler::Other
+        } else {
+            Handler::None
+        };
     }
     applications_dir()
         .and_then(|dir| std::fs::read_to_string(dir.join(DESKTOP_FILE)).ok())
@@ -91,9 +97,60 @@ fn applications_dir() -> Option<PathBuf> {
     directories::BaseDirs::new().map(|dirs| dirs.data_local_dir().join("applications"))
 }
 
+/// Whether a desktop file with this id exists in any `applications` dir: the user's, those on
+/// `$XDG_DATA_DIRS` (or `/usr/local/share:/usr/share`), and the flatpak and snap exports, which
+/// are normally on it. An id is the path under `applications` with `/` written as `-`.
+fn desktop_file_exists(id: &str) -> bool {
+    let user = directories::BaseDirs::new().map(|dirs| dirs.data_local_dir().to_owned());
+    let system = match std::env::var_os("XDG_DATA_DIRS").filter(|dirs| !dirs.is_empty()) {
+        Some(dirs) => std::env::split_paths(&dirs).collect(),
+        None => vec![
+            PathBuf::from("/usr/local/share"),
+            PathBuf::from("/usr/share"),
+        ],
+    };
+    let sandboxed = [
+        user.as_ref().map(|user| user.join("flatpak/exports/share")),
+        Some(PathBuf::from("/var/lib/flatpak/exports/share")),
+        Some(PathBuf::from("/var/lib/snapd/desktop")),
+    ];
+    user.iter()
+        .chain(&system)
+        .chain(sandboxed.iter().flatten())
+        .any(|dir| contains_desktop_id(&dir.join("applications"), "", id, 4))
+}
+
+fn contains_desktop_id(dir: &Path, prefix: &str, id: &str, depth: usize) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if entry.path().is_dir() {
+            depth > 0
+                && contains_desktop_id(&entry.path(), &format!("{prefix}{name}-"), id, depth - 1)
+        } else {
+            format!("{prefix}{name}") == id
+        }
+    })
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn desktop_ids_cover_subdirectories() {
+        let dir = std::env::temp_dir().join(format!("dcl-desktop-ids-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("kde4")).unwrap();
+        std::fs::write(dir.join("top.desktop"), "").unwrap();
+        std::fs::write(dir.join("kde4/nested.desktop"), "").unwrap();
+        assert!(contains_desktop_id(&dir, "", "top.desktop", 4));
+        assert!(contains_desktop_id(&dir, "", "kde4-nested.desktop", 4));
+        assert!(!contains_desktop_id(&dir, "", "gone.desktop", 4));
+        assert!(!contains_desktop_id(&dir, "", "kde4-nested.desktop", 0));
+        std::fs::remove_dir_all(dir).unwrap();
+    }
 
     #[test]
     fn library_path_entries_become_absolute() {

--- a/crates/platform/src/native/deeplink/linux.rs
+++ b/crates/platform/src/native/deeplink/linux.rs
@@ -42,7 +42,7 @@ pub fn registration() -> Result<String, anyhow::Error> {
         None => {
             let env = match std::env::var_os("LD_LIBRARY_PATH") {
                 Some(value) => {
-                    let value = absolute_library_path(&value, &std::env::current_dir()?)?;
+                    let value = absolute_library_path(&value, std::env::current_dir)?;
                     format!("env \"LD_LIBRARY_PATH={}\" ", value.to_string_lossy())
                 }
                 None => String::new(),
@@ -56,8 +56,17 @@ pub fn registration() -> Result<String, anyhow::Error> {
     ))
 }
 
-/// `value` with each entry resolved against `cwd` (an empty entry means the cwd to ld.so).
-fn absolute_library_path(value: &OsStr, cwd: &Path) -> Result<OsString, anyhow::Error> {
+/// `value` with each entry resolved against the working directory (an empty entry means the cwd
+/// to ld.so). `cwd` is only called when an entry actually needs it, so an already-absolute path
+/// still registers from a directory that has since been deleted.
+fn absolute_library_path(
+    value: &OsStr,
+    cwd: impl FnOnce() -> std::io::Result<PathBuf>,
+) -> Result<OsString, anyhow::Error> {
+    if std::env::split_paths(value).all(|entry| entry.is_absolute()) {
+        return Ok(value.to_owned());
+    }
+    let cwd = cwd()?;
     Ok(std::env::join_paths(
         std::env::split_paths(value).map(|entry| cwd.join(entry)),
     )?)
@@ -154,10 +163,20 @@ mod test {
 
     #[test]
     fn library_path_entries_become_absolute() {
-        let cwd = Path::new("/home/u/dcl");
         assert_eq!(
-            absolute_library_path(OsStr::new(".:/opt/cef:lib:"), cwd).unwrap(),
+            absolute_library_path(OsStr::new(".:/opt/cef:lib:"), || Ok(PathBuf::from(
+                "/home/u/dcl"
+            )))
+            .unwrap(),
             OsString::from("/home/u/dcl/.:/opt/cef:/home/u/dcl/lib:/home/u/dcl/")
+        );
+        // nothing to resolve: the working directory is never looked up
+        assert_eq!(
+            absolute_library_path(OsStr::new("/opt/cef:/usr/lib"), || Err(
+                std::io::Error::other("no working directory")
+            ))
+            .unwrap(),
+            OsString::from("/opt/cef:/usr/lib")
         );
     }
 }

--- a/crates/platform/src/native/deeplink/linux.rs
+++ b/crates/platform/src/native/deeplink/linux.rs
@@ -18,46 +18,32 @@ pub fn handler() -> Handler {
     if default != DESKTOP_FILE {
         return Handler::Other;
     }
-    // ours: the binary is the quoted word before `%u` on the Exec line
-    let path = applications_dir()
+    applications_dir()
         .and_then(|dir| std::fs::read_to_string(dir.join(DESKTOP_FILE)).ok())
-        .and_then(|content| {
-            content.lines().find_map(|line| {
-                line.strip_prefix("Exec=")?
-                    .strip_suffix(" %u")?
-                    .strip_suffix('"')?
-                    .rsplit('"')
-                    .next()
-                    .map(PathBuf::from)
-            })
-        });
-    path.map_or(Handler::None, Handler::Ours)
+        .map_or(Handler::None, Handler::Ours)
 }
 
-/// Inside an AppImage `current_exe()` is the transient FUSE mount; the runtime exports the real
-/// path.
-pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
-    match std::env::var_os("APPIMAGE") {
-        Some(path) => Ok(PathBuf::from(path)),
-        None => Ok(std::env::current_exe()?),
-    }
-}
-
-pub fn register_handler() -> Result<(), anyhow::Error> {
-    let exe = exe_path()?;
-    // a dev build finds libcef through LD_LIBRARY_PATH, which the browser's environment lacks
+/// The desktop file for this binary. Inside an AppImage `current_exe()` is the transient FUSE
+/// mount, and the runtime exports the real path. A dev build finds libcef through
+/// LD_LIBRARY_PATH, which the browser's environment lacks, so it is baked in.
+pub fn registration() -> Result<String, anyhow::Error> {
+    let exe = match std::env::var_os("APPIMAGE") {
+        Some(path) => PathBuf::from(path),
+        None => std::env::current_exe()?,
+    };
     let env = std::env::var("LD_LIBRARY_PATH")
         .map(|value| format!("env \"LD_LIBRARY_PATH={value}\" "))
         .unwrap_or_default();
+    Ok(format!(
+        "[Desktop Entry]\nType=Application\nName=Decentraland Bevy Explorer (deep links)\nExec={env}\"{}\" %u\nNoDisplay=true\nMimeType=x-scheme-handler/{SCHEME};\n",
+        exe.display()
+    ))
+}
+
+pub fn register_handler() -> Result<(), anyhow::Error> {
     let applications = applications_dir().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
     std::fs::create_dir_all(&applications)?;
-    std::fs::write(
-        applications.join(DESKTOP_FILE),
-        format!(
-            "[Desktop Entry]\nType=Application\nName=Decentraland Bevy Explorer (deep links)\nExec={env}\"{}\" %u\nNoDisplay=true\nMimeType=x-scheme-handler/{SCHEME};\n",
-            exe.display()
-        ),
-    )?;
+    std::fs::write(applications.join(DESKTOP_FILE), registration()?)?;
     let output = std::process::Command::new("xdg-mime")
         .args([
             "default",
@@ -80,7 +66,7 @@ pub fn register_handler() -> Result<(), anyhow::Error> {
     let _ = std::process::Command::new("update-desktop-database")
         .arg(&applications)
         .output();
-    bevy::log::info!("registered {} as the {SCHEME}:// handler", exe.display());
+    bevy::log::info!("registered {} as the {SCHEME}:// handler", DESKTOP_FILE);
     Ok(())
 }
 

--- a/crates/platform/src/native/deeplink/linux.rs
+++ b/crates/platform/src/native/deeplink/linux.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
+};
 
 use super::{Handler, SCHEME};
 
@@ -24,20 +27,34 @@ pub fn handler() -> Handler {
 }
 
 /// The desktop file for this binary. Inside an AppImage `current_exe()` is the transient FUSE
-/// mount, and the runtime exports the real path. A dev build finds libcef through
-/// LD_LIBRARY_PATH, which the browser's environment lacks, so it is baked in.
+/// mount: the runtime exports the real path, and the bundled libraries are found by rpath. A dev
+/// build (or the tarball, run with `LD_LIBRARY_PATH=.`) finds libcef through LD_LIBRARY_PATH,
+/// which the browser's environment lacks, so it is baked in with absolute entries.
 pub fn registration() -> Result<String, anyhow::Error> {
-    let exe = match std::env::var_os("APPIMAGE") {
-        Some(path) => PathBuf::from(path),
-        None => std::env::current_exe()?,
+    let (exe, env) = match std::env::var_os("APPIMAGE") {
+        Some(path) => (PathBuf::from(path), String::new()),
+        None => {
+            let env = match std::env::var_os("LD_LIBRARY_PATH") {
+                Some(value) => {
+                    let value = absolute_library_path(&value, &std::env::current_dir()?)?;
+                    format!("env \"LD_LIBRARY_PATH={}\" ", value.to_string_lossy())
+                }
+                None => String::new(),
+            };
+            (std::env::current_exe()?, env)
+        }
     };
-    let env = std::env::var("LD_LIBRARY_PATH")
-        .map(|value| format!("env \"LD_LIBRARY_PATH={value}\" "))
-        .unwrap_or_default();
     Ok(format!(
         "[Desktop Entry]\nType=Application\nName=Decentraland Bevy Explorer (deep links)\nExec={env}\"{}\" %u\nNoDisplay=true\nMimeType=x-scheme-handler/{SCHEME};\n",
         exe.display()
     ))
+}
+
+/// `value` with each entry resolved against `cwd` (an empty entry means the cwd to ld.so).
+fn absolute_library_path(value: &OsStr, cwd: &Path) -> Result<OsString, anyhow::Error> {
+    Ok(std::env::join_paths(
+        std::env::split_paths(value).map(|entry| cwd.join(entry)),
+    )?)
 }
 
 pub fn register_handler() -> Result<(), anyhow::Error> {
@@ -72,4 +89,18 @@ pub fn register_handler() -> Result<(), anyhow::Error> {
 
 fn applications_dir() -> Option<PathBuf> {
     directories::BaseDirs::new().map(|dirs| dirs.data_local_dir().join("applications"))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn library_path_entries_become_absolute() {
+        let cwd = Path::new("/home/u/dcl");
+        assert_eq!(
+            absolute_library_path(OsStr::new(".:/opt/cef:lib:"), cwd).unwrap(),
+            OsString::from("/home/u/dcl/.:/opt/cef:/home/u/dcl/lib:/home/u/dcl/")
+        );
+    }
 }

--- a/crates/platform/src/native/deeplink/linux.rs
+++ b/crates/platform/src/native/deeplink/linux.rs
@@ -1,0 +1,89 @@
+use std::path::PathBuf;
+
+use super::{Handler, SCHEME};
+
+const DESKTOP_FILE: &str = "decentraland-bevy-deeplink.desktop";
+
+pub fn handler() -> Handler {
+    let Some(default) = std::process::Command::new("xdg-mime")
+        .args(["query", "default", &format!("x-scheme-handler/{SCHEME}")])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|default| !default.is_empty())
+    else {
+        return Handler::None;
+    };
+    if default != DESKTOP_FILE {
+        return Handler::Other;
+    }
+    // ours: the binary is the quoted word before `%u` on the Exec line
+    let path = applications_dir()
+        .and_then(|dir| std::fs::read_to_string(dir.join(DESKTOP_FILE)).ok())
+        .and_then(|content| {
+            content.lines().find_map(|line| {
+                line.strip_prefix("Exec=")?
+                    .strip_suffix(" %u")?
+                    .strip_suffix('"')?
+                    .rsplit('"')
+                    .next()
+                    .map(PathBuf::from)
+            })
+        });
+    path.map_or(Handler::None, Handler::Ours)
+}
+
+/// Inside an AppImage `current_exe()` is the transient FUSE mount; the runtime exports the real
+/// path.
+pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
+    match std::env::var_os("APPIMAGE") {
+        Some(path) => Ok(PathBuf::from(path)),
+        None => Ok(std::env::current_exe()?),
+    }
+}
+
+pub fn register_handler() -> Result<(), anyhow::Error> {
+    let exe = exe_path()?;
+    // a dev build finds libcef through LD_LIBRARY_PATH, which the browser's environment lacks
+    let env = std::env::var("LD_LIBRARY_PATH")
+        .map(|value| format!("env \"LD_LIBRARY_PATH={value}\" "))
+        .unwrap_or_default();
+    let applications = applications_dir().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
+    std::fs::create_dir_all(&applications)?;
+    std::fs::write(
+        applications.join(DESKTOP_FILE),
+        format!(
+            "[Desktop Entry]\nType=Application\nName=Decentraland Bevy Explorer (deep links)\nExec={env}\"{}\" %u\nNoDisplay=true\nMimeType=x-scheme-handler/{SCHEME};\n",
+            exe.display()
+        ),
+    )?;
+    let output = std::process::Command::new("xdg-mime")
+        .args([
+            "default",
+            DESKTOP_FILE,
+            &format!("x-scheme-handler/{SCHEME}"),
+        ])
+        .output()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "xdg-mime (xdg-utils) is needed to register the {SCHEME}:// handler: {e}"
+            )
+        })?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to register the {SCHEME}:// handler: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    // optional: refreshes the mime cache for desktops that read it
+    let _ = std::process::Command::new("update-desktop-database")
+        .arg(&applications)
+        .output();
+    bevy::log::info!("registered {} as the {SCHEME}:// handler", exe.display());
+    Ok(())
+}
+
+fn applications_dir() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|dirs| dirs.data_local_dir().join("applications"))
+}

--- a/crates/platform/src/native/deeplink/macos.rs
+++ b/crates/platform/src/native/deeplink/macos.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use super::{Handler, SCHEME};
+
+const LAUNCHER_BUNDLE_ID: &str = "com.decentraland.launcherlite";
+
+/// Only an app bundle can claim a scheme, so the check is "is the launcher installed"
+pub fn handler() -> Handler {
+    let in_applications = ["/Applications/Decentraland.app"]
+        .into_iter()
+        .map(PathBuf::from)
+        .chain(
+            directories::BaseDirs::new()
+                .map(|dirs| dirs.home_dir().join("Applications/Decentraland.app")),
+        )
+        .any(|path| path.exists());
+    if in_applications {
+        return Handler::Other;
+    }
+    let installed = std::process::Command::new("mdfind")
+        .arg(format!(
+            "kMDItemCFBundleIdentifier == '{LAUNCHER_BUNDLE_ID}'"
+        ))
+        .output()
+        .map(|output| output.status.success() && !output.stdout.trim_ascii().is_empty())
+        .unwrap_or(false);
+    if installed {
+        Handler::Other
+    } else {
+        Handler::None
+    }
+}
+
+pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
+    Ok(std::env::current_exe()?)
+}
+
+pub fn register_handler() -> Result<(), anyhow::Error> {
+    anyhow::bail!(
+        "nothing on this mac handles {SCHEME}:// links. Install the Decentraland launcher (https://decentraland.org/download) and try again"
+    )
+}

--- a/crates/platform/src/native/deeplink/macos.rs
+++ b/crates/platform/src/native/deeplink/macos.rs
@@ -31,8 +31,8 @@ pub fn handler() -> Handler {
     }
 }
 
-pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
-    Ok(std::env::current_exe()?)
+pub fn registration() -> Result<String, anyhow::Error> {
+    anyhow::bail!("no scheme registration on this platform")
 }
 
 pub fn register_handler() -> Result<(), anyhow::Error> {

--- a/crates/platform/src/native/deeplink/unsupported.rs
+++ b/crates/platform/src/native/deeplink/unsupported.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use super::Handler;
+
+pub fn handler() -> Handler {
+    Handler::None
+}
+
+pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
+    Ok(std::env::current_exe()?)
+}
+
+pub fn register_handler() -> Result<(), anyhow::Error> {
+    anyhow::bail!("deep-link sign-in is not supported on this platform")
+}

--- a/crates/platform/src/native/deeplink/unsupported.rs
+++ b/crates/platform/src/native/deeplink/unsupported.rs
@@ -1,13 +1,11 @@
-use std::path::PathBuf;
-
 use super::Handler;
 
 pub fn handler() -> Handler {
     Handler::None
 }
 
-pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
-    Ok(std::env::current_exe()?)
+pub fn registration() -> Result<String, anyhow::Error> {
+    anyhow::bail!("no scheme registration on this platform")
 }
 
 pub fn register_handler() -> Result<(), anyhow::Error> {

--- a/crates/platform/src/native/deeplink/windows.rs
+++ b/crates/platform/src/native/deeplink/windows.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::{Handler, SCHEME};
 
@@ -17,23 +17,33 @@ pub fn handler() -> Handler {
     else {
         return Handler::None;
     };
-    // `    (Default)    REG_SZ    "C:\...\some.exe" "%1"`: ours if the exe is named like us
-    let Some(path) = command.split('"').nth(1).map(PathBuf::from) else {
+    // `    (Default)    REG_SZ    "C:\...\some.exe" "%1"` (the value name is localised)
+    let Some(command) = command
+        .lines()
+        .find_map(|line| line.split_once("REG_SZ"))
+        .map(|(_, command)| command.trim())
+    else {
         return Handler::Other;
     };
-    let ours = exe_path()
+    let exe = command.split('"').nth(1).map(Path::new);
+    // a registration whose exe is gone (an uninstalled launcher) is nobody's
+    if exe.is_some_and(|exe| !exe.exists()) {
+        return Handler::None;
+    }
+    let ours = current_exe()
         .ok()
         .and_then(|exe| exe.file_name().map(|name| name.to_owned()))
-        .is_some_and(|name| path.file_name() == Some(name.as_os_str()));
+        .is_some_and(|name| exe.and_then(Path::file_name) == Some(name.as_os_str()));
     if ours {
-        Handler::Ours(path)
+        Handler::Ours(command.to_owned())
     } else {
         Handler::Other
     }
 }
 
-pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
-    Ok(std::env::current_exe()?)
+/// The `shell\open\command` for this binary.
+pub fn registration() -> Result<String, anyhow::Error> {
+    Ok(format!("\"{}\" \"%1\"", current_exe()?.display()))
 }
 
 pub fn register_handler() -> Result<(), anyhow::Error> {
@@ -52,13 +62,16 @@ pub fn register_handler() -> Result<(), anyhow::Error> {
         Ok(())
     }
 
-    let exe = exe_path()?;
+    let command = registration()?;
     let key = format!("HKCU\\Software\\Classes\\{SCHEME}");
     let command_key = format!("{key}\\shell\\open\\command");
-    let command = format!("\"{}\" \"%1\"", exe.display());
     reg_add(&[&key, "/ve", "/d", "URL:Decentraland"])?;
     reg_add(&[&key, "/v", "URL Protocol", "/d", ""])?;
     reg_add(&[&command_key, "/ve", "/d", &command])?;
-    bevy::log::info!("registered {} as the {SCHEME}:// handler", exe.display());
+    bevy::log::info!("registered {command} as the {SCHEME}:// handler");
     Ok(())
+}
+
+fn current_exe() -> Result<PathBuf, anyhow::Error> {
+    Ok(std::env::current_exe()?)
 }

--- a/crates/platform/src/native/deeplink/windows.rs
+++ b/crates/platform/src/native/deeplink/windows.rs
@@ -1,41 +1,41 @@
 use std::path::{Path, PathBuf};
 
+use winreg::{
+    enums::{HKEY_CLASSES_ROOT, HKEY_CURRENT_USER},
+    RegKey,
+};
+
 use super::{Handler, SCHEME};
 
 pub fn handler() -> Handler {
     // HKCR merges the machine and user registrations
-    let Some(command) = std::process::Command::new("reg")
-        .args([
-            "query",
-            &format!("HKCR\\{SCHEME}\\shell\\open\\command"),
-            "/ve",
-        ])
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+    let Ok(key) =
+        RegKey::predef(HKEY_CLASSES_ROOT).open_subkey(format!("{SCHEME}\\shell\\open\\command"))
     else {
         return Handler::None;
     };
-    // `    (Default)    REG_SZ    "C:\...\some.exe" "%1"` (the value name is localised)
-    let Some(command) = command
-        .lines()
-        .find_map(|line| line.split_once("REG_SZ"))
-        .map(|(_, command)| command.trim())
+    let Ok(command) = key.get_value::<String, _>("") else {
+        return Handler::Other;
+    };
+    // `"C:\...\some.exe" "%1"`; an unquoted command is someone else's and left alone
+    let Some(exe) = command
+        .trim()
+        .strip_prefix('"')
+        .and_then(|rest| rest.split('"').next())
+        .map(Path::new)
     else {
         return Handler::Other;
     };
-    let exe = command.split('"').nth(1).map(Path::new);
     // a registration whose exe is gone (an uninstalled launcher) is nobody's
-    if exe.is_some_and(|exe| !exe.exists()) {
+    if !exe.exists() {
         return Handler::None;
     }
     let ours = current_exe()
         .ok()
-        .and_then(|exe| exe.file_name().map(|name| name.to_owned()))
-        .is_some_and(|name| exe.and_then(Path::file_name) == Some(name.as_os_str()));
+        .and_then(|ours| ours.file_name().map(|name| name.to_owned()))
+        .is_some_and(|name| exe.file_name() == Some(name.as_os_str()));
     if ours {
-        Handler::Ours(command.to_owned())
+        Handler::Ours(command)
     } else {
         Handler::Other
     }
@@ -47,27 +47,16 @@ pub fn registration() -> Result<String, anyhow::Error> {
 }
 
 pub fn register_handler() -> Result<(), anyhow::Error> {
-    fn reg_add(args: &[&str]) -> Result<(), anyhow::Error> {
-        let output = std::process::Command::new("reg")
-            .arg("add")
-            .args(args)
-            .arg("/f")
-            .output()?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "failed to register the {SCHEME}:// handler: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-        Ok(())
-    }
-
     let command = registration()?;
-    let key = format!("HKCU\\Software\\Classes\\{SCHEME}");
-    let command_key = format!("{key}\\shell\\open\\command");
-    reg_add(&[&key, "/ve", "/d", "URL:Decentraland"])?;
-    reg_add(&[&key, "/v", "URL Protocol", "/d", ""])?;
-    reg_add(&[&command_key, "/ve", "/d", &command])?;
+    let write = || -> std::io::Result<()> {
+        let (key, _) = RegKey::predef(HKEY_CURRENT_USER)
+            .create_subkey(format!("Software\\Classes\\{SCHEME}"))?;
+        key.set_value("", &"URL:Decentraland")?;
+        key.set_value("URL Protocol", &"")?;
+        let (command_key, _) = key.create_subkey("shell\\open\\command")?;
+        command_key.set_value("", &command)
+    };
+    write().map_err(|e| anyhow::anyhow!("failed to register the {SCHEME}:// handler: {e}"))?;
     bevy::log::info!("registered {command} as the {SCHEME}:// handler");
     Ok(())
 }

--- a/crates/platform/src/native/deeplink/windows.rs
+++ b/crates/platform/src/native/deeplink/windows.rs
@@ -30,10 +30,15 @@ pub fn handler() -> Handler {
     if !exe.exists() {
         return Handler::None;
     }
+    // the filesystem is case-insensitive
     let ours = current_exe()
         .ok()
-        .and_then(|ours| ours.file_name().map(|name| name.to_owned()))
-        .is_some_and(|name| exe.file_name() == Some(name.as_os_str()));
+        .is_some_and(|ours| match (ours.file_name(), exe.file_name()) {
+            (Some(ours), Some(exe)) => ours
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&exe.to_string_lossy()),
+            _ => false,
+        });
     if ours {
         Handler::Ours(command)
     } else {

--- a/crates/platform/src/native/deeplink/windows.rs
+++ b/crates/platform/src/native/deeplink/windows.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use super::{Handler, SCHEME};
+
+pub fn handler() -> Handler {
+    // HKCR merges the machine and user registrations
+    let Some(command) = std::process::Command::new("reg")
+        .args([
+            "query",
+            &format!("HKCR\\{SCHEME}\\shell\\open\\command"),
+            "/ve",
+        ])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+    else {
+        return Handler::None;
+    };
+    // `    (Default)    REG_SZ    "C:\...\some.exe" "%1"`: ours if the exe is named like us
+    let Some(path) = command.split('"').nth(1).map(PathBuf::from) else {
+        return Handler::Other;
+    };
+    let ours = exe_path()
+        .ok()
+        .and_then(|exe| exe.file_name().map(|name| name.to_owned()))
+        .is_some_and(|name| path.file_name() == Some(name.as_os_str()));
+    if ours {
+        Handler::Ours(path)
+    } else {
+        Handler::Other
+    }
+}
+
+pub fn exe_path() -> Result<PathBuf, anyhow::Error> {
+    Ok(std::env::current_exe()?)
+}
+
+pub fn register_handler() -> Result<(), anyhow::Error> {
+    fn reg_add(args: &[&str]) -> Result<(), anyhow::Error> {
+        let output = std::process::Command::new("reg")
+            .arg("add")
+            .args(args)
+            .arg("/f")
+            .output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "failed to register the {SCHEME}:// handler: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Ok(())
+    }
+
+    let exe = exe_path()?;
+    let key = format!("HKCU\\Software\\Classes\\{SCHEME}");
+    let command_key = format!("{key}\\shell\\open\\command");
+    let command = format!("\"{}\" \"%1\"", exe.display());
+    reg_add(&[&key, "/ve", "/d", "URL:Decentraland"])?;
+    reg_add(&[&key, "/v", "URL Protocol", "/d", ""])?;
+    reg_add(&[&command_key, "/ve", "/d", &command])?;
+    bevy::log::info!("registered {} as the {SCHEME}:// handler", exe.display());
+    Ok(())
+}

--- a/crates/platform/src/native/deeplink/windows.rs
+++ b/crates/platform/src/native/deeplink/windows.rs
@@ -22,10 +22,11 @@ pub fn handler() -> Handler {
         .trim()
         .strip_prefix('"')
         .and_then(|rest| rest.split('"').next())
-        .map(Path::new)
+        .map(expand_env)
     else {
         return Handler::Other;
     };
+    let exe = Path::new(&exe);
     // a registration whose exe is gone (an uninstalled launcher) is nobody's
     if !exe.exists() {
         return Handler::None;
@@ -68,4 +69,50 @@ pub fn register_handler() -> Result<(), anyhow::Error> {
 
 fn current_exe() -> Result<PathBuf, anyhow::Error> {
     Ok(std::env::current_exe()?)
+}
+
+/// `%VAR%` references expanded the way the shell does before it launches the handler. A
+/// `REG_EXPAND_SZ` registration stores them as written and winreg hands them back that way, so
+/// without this a perfectly live `%LOCALAPPDATA%\...` exe looks like one that is gone.
+fn expand_env(value: &str) -> String {
+    let mut expanded = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some((before, after)) = rest.split_once('%') {
+        // an unterminated `%` is literal, and so is the whole tail after it
+        let Some((name, tail)) = after.split_once('%') else {
+            break;
+        };
+        expanded.push_str(before);
+        match std::env::var(name) {
+            Ok(value) => expanded.push_str(&value),
+            // `%%` and an unset variable are left as written, as the shell leaves them
+            Err(_) => {
+                expanded.push('%');
+                expanded.push_str(name);
+                expanded.push('%');
+            }
+        }
+        rest = tail;
+    }
+    expanded.push_str(rest);
+    expanded
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn env_references_expand() {
+        let system_root = std::env::var("SystemRoot").unwrap();
+        assert_eq!(
+            expand_env("%SystemRoot%\\a.exe"),
+            format!("{system_root}\\a.exe")
+        );
+        // left as written: an unset variable, an unterminated `%`, a literal `%%`
+        assert_eq!(expand_env("%DclNotSet%\\a.exe"), "%DclNotSet%\\a.exe");
+        assert_eq!(expand_env("C:\\a %b.exe"), "C:\\a %b.exe");
+        assert_eq!(expand_env("C:\\100%%\\a.exe"), "C:\\100%%\\a.exe");
+        assert_eq!(expand_env("C:\\plain\\a.exe"), "C:\\plain\\a.exe");
+    }
 }

--- a/crates/platform/src/wasm.rs
+++ b/crates/platform/src/wasm.rs
@@ -293,3 +293,19 @@ fn js_error_message(e: &wasm_bindgen::JsValue) -> String {
         })
         .unwrap_or_else(|| "save failed".to_string())
 }
+
+/// Deep-link sign-in is a native flow; the web page logs in through `LoginWithIdentity`.
+pub mod deeplink {
+    use std::time::Duration;
+
+    pub fn ensure_scheme_handler() -> Result<(), anyhow::Error> {
+        anyhow::bail!("deep-link sign-in is not available on web")
+    }
+
+    pub async fn await_signin(
+        _request_id: &str,
+        _timeout: Duration,
+    ) -> Result<String, anyhow::Error> {
+        anyhow::bail!("deep-link sign-in is not available on web")
+    }
+}

--- a/crates/system_api_types/src/launch_options.rs
+++ b/crates/system_api_types/src/launch_options.rs
@@ -96,6 +96,12 @@ pub struct ClientOptions {
     /// Embedded in a scene editor (creator hub). Set by editor front-ends.
     #[arg(long, help_heading = HOST)]
     pub editor: bool,
+
+    /// A `decentraland://` link as the scheme handler or the launcher passes it: `realm`,
+    /// `position` and `dclenv` fill the matching launch options (main.rs)
+    #[arg(hide = true, value_name = "decentraland://…")]
+    #[serde(skip)]
+    pub deep_link: Option<String>,
 }
 
 /// The web page's `engine_run` options: both structs as ONE flat object, which is also what the

--- a/crates/system_api_types/src/web_params.rs
+++ b/crates/system_api_types/src/web_params.rs
@@ -125,7 +125,7 @@ pub fn web_params() -> Vec<WebParam> {
         .collect();
     args.sort_by_key(|arg| section(arg));
     args.into_iter()
-        .filter(|arg| !native_only(arg.get_id().as_str()))
+        .filter(|arg| !arg.is_hide_set() && !native_only(arg.get_id().as_str()))
         .map(|arg| {
             let field = arg.get_id().as_str();
             WebParam {

--- a/crates/system_ui/src/login.rs
+++ b/crates/system_ui/src/login.rs
@@ -177,32 +177,8 @@ fn login(
     // handle task results
     if let Some(mut t) = req_code.take() {
         match t.try_recv() {
-            Ok(Ok(code)) => {
-                if let Some(mut commands) = dialog.and_then(|d| commands.get_entity(d).ok()) {
-                    commands.despawn();
-                    *dialog = None;
-                }
-
-                let components = commands
-                    .spawn(ZOrder::Login.default())
-                    .apply_template(
-                        &dui,
-                        "cancel-login",
-                        DuiProps::new()
-                            .with_prop(
-                                "buttons",
-                                vec![DuiButton::new_enabled(
-                                    "Cancel",
-                                    |mut e: EventWriter<LoginType>| {
-                                        e.write(LoginType::Cancel);
-                                    },
-                                )],
-                            )
-                            .with_prop("code", format!("{}", code.unwrap_or(-1))),
-                    )
-                    .unwrap();
-
-                *dialog = Some(components.root);
+            Ok(Ok(_)) => {
+                // no code to show: the waiting dialog spawned on click stays up
             }
             Ok(Err(e)) => {
                 toaster.add_toast("login profile", format!("Login failed: {e}"));
@@ -276,17 +252,15 @@ fn login(
                     .apply_template(
                         &dui,
                         "cancel-login",
-                        DuiProps::new()
-                            .with_prop(
-                                "buttons",
-                                vec![DuiButton::new_enabled(
-                                    "Cancel",
-                                    |mut e: EventWriter<LoginType>| {
-                                        e.write(LoginType::Cancel);
-                                    },
-                                )],
-                            )
-                            .with_prop("code", "...".to_string()),
+                        DuiProps::new().with_prop(
+                            "buttons",
+                            vec![DuiButton::new_enabled(
+                                "Cancel",
+                                |mut e: EventWriter<LoginType>| {
+                                    e.write(LoginType::Cancel);
+                                },
+                            )],
+                        ),
                     )
                     .unwrap();
 
@@ -394,56 +368,9 @@ fn get_previous_login(config: &AppConfig) -> Option<PreviousLogin> {
 /// user signed in (wallet/MetaMask, social, OTP, magic). The web page just reads it from
 /// localStorage and forwards it — there is nothing login-method-specific here.
 fn parse_auth_identity(payload: &str) -> Result<(Address, LocalWallet, Vec<ChainLink>), String> {
-    use base64::Engine as _;
-
-    #[derive(serde::Deserialize)]
-    struct Ephemeral {
-        #[serde(rename = "privateKey")]
-        private_key: String,
-    }
-    #[derive(serde::Deserialize)]
-    struct AuthIdentity {
-        #[serde(rename = "ephemeralIdentity")]
-        ephemeral_identity: Ephemeral,
-        #[serde(rename = "authChain")]
-        auth_chain: Vec<ChainLink>,
-    }
-
-    let json = base64::engine::general_purpose::STANDARD
-        .decode(payload.trim())
-        .map_err(|e| format!("bad identity base64: {e}"))?;
-    let identity: AuthIdentity =
-        serde_json::from_slice(&json).map_err(|e| format!("bad identity json: {e}"))?;
-
-    // Root wallet address = the SIGNER link's payload.
-    let signer = identity
-        .auth_chain
-        .iter()
-        .find(|l| l.ty == "SIGNER")
-        .ok_or_else(|| "identity missing SIGNER link".to_string())?;
-    let root_address =
-        Address::from_str(signer.payload.trim()).map_err(|e| format!("bad root address: {e}"))?;
-
-    // Ephemeral signer from the 0x-prefixed private key.
-    let key_hex = identity
-        .ephemeral_identity
-        .private_key
-        .trim()
-        .trim_start_matches("0x");
-    let local_wallet =
-        LocalWallet::from_str(key_hex).map_err(|e| format!("bad ephemeral key: {e}"))?;
-
-    // Delegate chain = everything except the SIGNER (the ECDSA_EPHEMERAL link the engine stores).
-    let auth: Vec<ChainLink> = identity
-        .auth_chain
-        .into_iter()
-        .filter(|l| l.ty != "SIGNER")
-        .collect();
-    if auth.is_empty() {
-        return Err("identity missing ephemeral delegate link".to_string());
-    }
-
-    Ok((root_address, local_wallet, auth))
+    wallet::browser_auth::parse_auth_identity(payload)
+        .and_then(wallet::browser_auth::auth_identity_parts)
+        .map_err(|e| e.to_string())
 }
 
 /// Fetch the profile, retrying on failure. Ok(None) means the user has no profile (or
@@ -564,7 +491,8 @@ fn process_login_bridge(
                         Ok(res) => res,
                     };
 
-                    code_sender.send(Ok(req.code));
+                    // the deep-link flow has no verification code
+                    code_sender.send(Ok(None));
 
                     let (root_address, local_wallet, auth, _) =
                         match finish_remote_ephemeral_request(req).await {

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -24,3 +24,4 @@ rand = { workspace = true }
 http = { workspace = true }
 platform = { workspace = true }
 web-time = { workspace = true }
+uuid = { workspace = true }

--- a/crates/wallet/src/browser_auth.rs
+++ b/crates/wallet/src/browser_auth.rs
@@ -1,12 +1,11 @@
 use anyhow::anyhow;
 use bevy::prelude::*;
 use common::{rpc::RPCSendableMessage, structs::ChainLink, util::AsH160};
-use ethers_core::types::{Signature, H160};
-use ethers_signers::{LocalWallet, Signer};
+use ethers_core::types::H160;
+use ethers_signers::LocalWallet;
 use http::StatusCode;
 use std::{str::FromStr, time::Duration};
 
-use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 
 use crate::SimpleAuthChain;
@@ -176,65 +175,133 @@ pub async fn remote_send_async(
         .map(|(_, payload)| payload)
 }
 
-fn get_ephemeral_message(ephemeral_address: &str, expiration: web_time::SystemTime) -> String {
-    let datetime: chrono::DateTime<chrono::Utc> = chrono::DateTime::from_timestamp_millis(
-        expiration
-            .duration_since(web_time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64,
-    )
-    .unwrap();
-    let formatted_time = datetime.format("%Y-%m-%dT%H:%M:%S%.3fZ");
-    format!(
-        "Decentraland Login\nEphemeral address: {ephemeral_address}\nExpiration: {formatted_time}",
-    )
-}
-
+/// The auth-server sign-in relay (`dcl_personal_sign` via `/requests`) was retired in 2026-07.
+/// Sign-in now runs entirely in the browser: the auth site builds the AuthIdentity itself,
+/// stores it with `POST /identities`, and hands the id back through a `decentraland://` deep
+/// link, which reaches us via the launcher's bridge file (see `platform::deeplink`). We then
+/// collect the identity with `GET /identities/{id}`; it is single-use, expires after an hour,
+/// and must be fetched from the same IP that created it.
 pub struct RemoteEphemeralRequest {
-    pub code: Option<i32>,
+    /// Client-minted UUID v4 (the site rejects anything else); it is embedded in the auth URL
+    /// and echoed back on the deep link as `authRequestId`, so we only consume our own link.
     request_id: String,
-    message: String,
-    ephemeral_wallet: LocalWallet,
 }
 
 pub async fn init_remote_ephemeral_request() -> Result<RemoteEphemeralRequest, anyhow::Error> {
-    let ephemeral_wallet = LocalWallet::new(&mut thread_rng());
-    let ephemeral_address = format!("{:#x}", ephemeral_wallet.address());
-    let expiration = web_time::SystemTime::now() + std::time::Duration::from_secs(30 * 24 * 3600);
-    let message = get_ephemeral_message(ephemeral_address.as_str(), expiration);
-
-    let request = CreateRequest {
-        method: "dcl_personal_sign".to_owned(),
-        params: vec![message.clone().into()],
-        auth_chain: None,
-    };
-    init_request(request)
-        .await
-        .map(|init| RemoteEphemeralRequest {
-            code: init.code,
-            request_id: init.request_id,
-            message,
-            ephemeral_wallet,
-        })
+    platform::deeplink::ensure_scheme_handler()?;
+    Ok(RemoteEphemeralRequest {
+        request_id: uuid::Uuid::new_v4().to_string(),
+    })
 }
 
 pub async fn finish_remote_ephemeral_request(
     request: RemoteEphemeralRequest,
 ) -> Result<(H160, LocalWallet, Vec<ChainLink>, u64), anyhow::Error> {
-    let RemoteEphemeralRequest {
-        request_id,
-        message,
-        ephemeral_wallet,
-        ..
-    } = request;
+    let RemoteEphemeralRequest { request_id } = request;
 
-    let (signer, result) = finish_request(request_id).await?;
-    let signature = Signature::from_str(result.as_str().ok_or(anyhow!("result is not a string"))?)?;
+    // `bridgeOnly`: an installed launcher must relay the link to us rather than start unity
+    let url = format!(
+        "{}/{request_id}?targetConfigId=alternative&flow=deeplink&bridgeOnly",
+        auth_front_url()
+    );
+    info!("opening {url} for sign-in");
+    opener::open_browser(url)?;
 
-    let delegate = ChainLink {
-        ty: "ECDSA_EPHEMERAL".to_owned(),
-        payload: message,
-        signature: format!("0x{signature}"),
-    };
-    Ok((signer, ephemeral_wallet, vec![delegate], 1))
+    let identity_id = platform::deeplink::await_signin(&request_id, AUTH_SERVER_TIMEOUT).await?;
+    info!("sign-in link received for request {request_id}, fetching identity");
+    let identity = fetch_identity(&identity_id).await?;
+    let (signer, ephemeral_wallet, delegates) = auth_identity_parts(identity)?;
+    Ok((signer, ephemeral_wallet, delegates, 1))
+}
+
+#[derive(Deserialize)]
+struct IdentityResponse {
+    identity: AuthIdentity,
+}
+
+/// The standard Decentraland AuthIdentity, as served by `GET /identities/{id}` and as the web
+/// page stores it in localStorage.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthIdentity {
+    ephemeral_identity: EphemeralIdentity,
+    auth_chain: Vec<ChainLink>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EphemeralIdentity {
+    private_key: String,
+}
+
+async fn fetch_identity(identity_id: &str) -> Result<AuthIdentity, anyhow::Error> {
+    let url = common::base_domain::url(
+        common::base_domain::Service::AuthApi,
+        &format!("/identities/{identity_id}"),
+    );
+    let response = reqwest::Client::builder()
+        .use_native_tls()
+        .build()
+        .unwrap()
+        .get(url)
+        .timeout(AUTH_SERVER_TIMEOUT)
+        .send()
+        .await?;
+
+    match response.status() {
+        status if status.is_success() => Ok(response.json::<IdentityResponse>().await?.identity),
+        StatusCode::NOT_FOUND => anyhow::bail!("sign-in was not found or was already used"),
+        StatusCode::GONE => anyhow::bail!("sign-in expired before it was collected"),
+        StatusCode::FORBIDDEN => anyhow::bail!(
+            "sign-in was created from a different IP address (a VPN or private relay may be interfering)"
+        ),
+        status => {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("error fetching sign-in identity {status}: {body}")
+        }
+    }
+}
+
+/// Split an AuthIdentity into the pieces the wallet needs: the root (signer) address, the
+/// ephemeral LocalWallet, and the delegate chain (everything except the SIGNER link).
+pub fn auth_identity_parts(
+    identity: AuthIdentity,
+) -> Result<(H160, LocalWallet, Vec<ChainLink>), anyhow::Error> {
+    let signer = identity
+        .auth_chain
+        .iter()
+        .find(|link| link.ty == "SIGNER")
+        .ok_or_else(|| anyhow!("identity missing SIGNER link"))?;
+    let root_address = signer
+        .payload
+        .as_h160()
+        .ok_or_else(|| anyhow!("bad root address: {:?}", signer.payload))?;
+
+    let key_hex = identity
+        .ephemeral_identity
+        .private_key
+        .trim()
+        .trim_start_matches("0x");
+    let ephemeral_wallet =
+        LocalWallet::from_str(key_hex).map_err(|e| anyhow!("bad ephemeral key: {e}"))?;
+
+    let delegates: Vec<ChainLink> = identity
+        .auth_chain
+        .into_iter()
+        .filter(|link| link.ty != "SIGNER")
+        .collect();
+    if delegates.is_empty() {
+        anyhow::bail!("identity missing ephemeral delegate link");
+    }
+
+    Ok((root_address, ephemeral_wallet, delegates))
+}
+
+/// Decode the base64(JSON) form the web page forwards from localStorage.
+pub fn parse_auth_identity(payload: &str) -> Result<AuthIdentity, anyhow::Error> {
+    use base64::Engine as _;
+    let json = base64::engine::general_purpose::STANDARD
+        .decode(payload.trim())
+        .map_err(|e| anyhow!("bad identity base64: {e}"))?;
+    serde_json::from_slice(&json).map_err(|e| anyhow!("bad identity json: {e}"))
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -71,6 +71,8 @@ pub fn apply_client(
         // the scene set is the binary's: the ui scene and the startup scenes
         system_scene: _,
         portables: _,
+        // mapped onto the launch options before they are latched (main.rs)
+        deep_link: _,
         editor,
         imposter_source,
         gpu_bytes_per_frame,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,17 @@ static GLOBAL: MiMalloc = MiMalloc;
 static SESSION_LOG: OnceLock<String> = OnceLock::new();
 
 fn main() {
+    // As the registered `decentraland://` handler (windows/linux) the OS spawns a fresh process
+    // per link: a sign-in link belongs to the running explorer, hand it over through the launcher
+    // bridge file and stop here. Any other link is a place to boot into (`deep_link` below).
+    if let Some(url) = platform::deeplink::signin_link_arg() {
+        if let Err(e) = platform::deeplink::write_launcher_bridge(&url) {
+            eprintln!("failed to relay deep link: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     decentraland_log_file();
     create_logs_folder();
     create_log_files();
@@ -115,6 +126,17 @@ fn decentraland_app_arguments() -> Result<DecentralandArguments, UserError> {
             return Err(UserError(e.exit_code()));
         }
     };
+
+    if let Some(link) = &args.client.deep_link {
+        let place = platform::deeplink::parse_place_link(link).map_err(|e| {
+            error!("{link}: {e}");
+            UserError(USAGE_ERROR)
+        })?;
+        // explicit flags win over the link
+        args.launch.realm = args.launch.realm.take().or(place.realm);
+        args.launch.position = args.launch.position.take().or(place.position);
+        args.launch.base_domain = args.launch.base_domain.take().or(place.base_domain);
+    }
 
     webgpu_build::launch::latch(&args.launch).map_err(|e| {
         error!("{e}");


### PR DESCRIPTION
Native login has failed since auth-server 53db603a (2026-07-28) retired `dcl_personal_sign`: every attempt ended in "400: the dcl_personal_sign method is not allowed", on org and zone alike. The auth site now builds the AuthIdentity itself, POSTs it to `/identities` and hands the id back through a `decentraland://` link carrying the client's `authRequestId`; the client fetches the single-use, same-IP identity. This is the flow unity and the creator hub use.

## Receiving the link without taking the scheme

The launcher (the foundation client's installer) owns `decentraland://` wherever it is installed, and only ever registers at install time, so claiming the scheme from it would stick. Instead:

- the auth URL carries `bridgeOnly`, which makes the launcher write the link to its `deeplink-bridge.json` and exit without starting unity; the login polls that file for its own `authRequestId` and leaves other logins' links in place
- on windows/linux, when nothing handles the scheme, the explorer registers itself the way the launcher would be (HKCU `Software\Classes`, or a hidden `.desktop` plus `xdg-mime`), taking the raw link as its first argument. A registration of our own that differs from what we would write today is redone; a foreign one is never replaced, unless its exe (windows) or desktop file (linux) is gone
- on macOS only an app bundle can claim a scheme and the URL never arrives on argv, so the login asks for the launcher to be installed (#1236)

The registered explorer handles every link, not just sign-ins: a sign-in link is relayed to the bridge file before anything else starts; a place link's `realm`, `position` and `dclenv` fill the launch options (a hidden positional in `ClientOptions`, off `--help` and the web param table). That is also the argument shape the launcher passes to an explorer. Linux dev builds (and the tarball, run with `LD_LIBRARY_PATH=.`) find libcef through `LD_LIBRARY_PATH`, which a browser-spawned process lacks, so the registration bakes it into the Exec line with each entry made absolute; an AppImage registers its own path rather than the transient mount and bakes nothing, its libraries resolve by rpath.

## Behaviour matrix

| | foundation client (launcher) installed | not installed |
|---|---|---|
| **macOS** | Browser hands the link to the launcher, which writes the bridge file and exits (`bridgeOnly`); the login consumes it. Verified live. Place links keep going to the launcher, so to unity. | Login fails with "install the Decentraland launcher". Place links have no handler. #1236 |
| **Windows** | Same as macOS: the launcher's HKCR registration is detected and left alone. A leftover registration whose exe is gone (launcher uninstalled without cleanup) counts as free. | First login registers `"<exe>" "%1"` under HKCU. Each link spawns a fresh explorer: a sign-in link is written to the bridge file for the running one; a place link boots a new instance into its realm/position/dclenv. |
| **Linux** | n/a: the launcher ships dmg and nsis only. A foreign registration, if any, is respected; one whose desktop file is gone (stale `mimeapps.list`) counts as free. | Always this column. First login writes a hidden `.desktop` and sets it via `xdg-mime` (needs xdg-utils), with the current `LD_LIBRARY_PATH` baked in as absolute entries; an AppImage registers `$APPIMAGE` with no environment. Otherwise as windows. |
| **Web** | unchanged: the page supplies the identity | unchanged |

Not covered: a place link while an explorer is already running starts a second instance on windows/linux (the launcher would have written the bridge file instead); a running explorer polling the bridge file for teleports is #1239. A manual paste fallback for when no handoff can reach the explorer is #1237.

## Also in here

- the login verification code is gone (LoginNew's code channel returns None) and the AuthIdentity parser moves from system_ui into wallet
- the platform crate's timers standardise on `async_std::task::sleep`; `futures-timer` is dropped
- the windows/linux registration modules are CI-verified only; the macOS side and the bridge-file login were exercised on a mac with the launcher installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)



