### PR TITLE
Keep wearable instance slots aligned when a gltf fails to load

### DIFF
--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -961,8 +961,10 @@ fn spawn_scenes(
                 match asset_server.get_load_state(h_gltf) {
                     Some(bevy::asset::LoadState::Loaded) => (),
                     otherwise => {
+                        // keep the slot so `wearable_instances` stays aligned with the
+                        // wearables that have models
                         warn!("wearable gltf didn't work out: {otherwise:?}");
-                        return None;
+                        return Some(None);
                     }
                 }
 


### PR DESCRIPTION
`spawn_scenes` dropped the slot entirely for a wearable whose gltf never reached `Loaded`, so `wearable_instances` came out shorter than the list of wearables that have models:

```rust
otherwise => {
    warn!("wearable gltf didn't work out: {otherwise:?}");
    return None;   // flat_map over Option -> element vanishes
}
```

The `outlineCompatible` zip added in #1232 pairs those two sequences by position:

```rust
let wearable_models = def.wearables.iter().filter_map(|w| w.model.as_ref());
for (instance, model) in loaded_avatar.wearable_instances.iter().zip(wearable_models) {
```

so a single failed wearable download shifts every subsequent wearable onto the previous one's outline flag, and `zip` truncates the last one out of the colouring loop entirely. Cosmetic, but silent, and a CDN hiccup is enough to trigger it.

Push a `None` placeholder instead of dropping the slot. `process_avatar` already has the `let Some(instance) = instance else { warn; continue }` arm to absorb it, and the other consumer (the `instance_is_really_ready` gate) already guards with `is_some_and`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)