### PR TITLE
Bound the scene-supplied VirtualCamera fov

### DIFF
--- a/crates/scene_runner/src/update_world/camera_mode_area.rs
+++ b/crates/scene_runner/src/update_world/camera_mode_area.rs
@@ -25,6 +25,11 @@ use dcl_component::{
 
 use super::AddCrdtInterfaceExt;
 
+/// bounds for the scene-supplied `PBVirtualCamera.fov`, in degrees. 0 or negative gives a
+/// degenerate projection matrix, 180 or more inverts it, and a non-finite value poisons it.
+const MIN_FOV_DEGREES: f32 = 1.0;
+const MAX_FOV_DEGREES: f32 = 179.0;
+
 pub struct CameraModeAreaPlugin;
 
 #[derive(Component, Debug)]
@@ -280,7 +285,8 @@ pub fn update_camera_mode_area(
                         fov: maybe_virtual
                             .as_ref()
                             .and_then(|v| v.0.fov)
-                            .map(f32::to_radians)
+                            .filter(|fov| fov.is_finite())
+                            .map(|fov| fov.clamp(MIN_FOV_DEGREES, MAX_FOV_DEGREES).to_radians())
                             .unwrap_or(PLAYER_CAMERA_FOV),
                     }));
                 }


### PR DESCRIPTION
`PBVirtualCamera.fov` (#1231) reached `PerspectiveProjection.fov` with no validation:

```rust
fov: maybe_virtual.as_ref().and_then(|v| v.0.fov).map(f32::to_radians).unwrap_or(PLAYER_CAMERA_FOV),
```

A scene sending `0` or a negative value produces a degenerate clip matrix, `180` or more inverts it, and NaN/inf poisons it — in every case the camera stops rendering anything sensible, from a value that is entirely scene-controlled.

Clamp to 1–179 degrees, and drop non-finite values back to the 60° default. The `is_finite` filter is load-bearing separately from the clamp: `f32::clamp` returns NaN for a NaN input, so the clamp alone would not catch it.

### Why 1–179 and not something tighter

unity applies the value raw — `VirtualCameraUtils.ConfigureVirtualCameraFOV` assigns `pbVirtualCamera.Fov` straight to `freeLookCamera.m_Lens.FieldOfView` with no bounds of its own. 179 is Cinemachine's own `LensSettings.FieldOfView` ceiling, so it is the widest fov unity can end up displaying. Anything narrower would make a scene authored against unity render differently here; this guard only rules out the values that are actually broken rather than merely extreme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)