### PR TITLE
fix: resolve bare base-emote names in AvatarShape.expressionTriggerId

### DIFF
--- a/crates/avatar/src/lib.rs
+++ b/crates/avatar/src/lib.rs
@@ -827,18 +827,32 @@ fn update_render_avatar(
                                 // File path emote (e.g. "models/emotes/foo.glb") — resolve
                                 // through the scene's content map to build a scene-emote URN,
                                 // mirroring the logic in op_scene_emote.
-                                let se = maybe_scene_ent?;
-                                let ctx = scenes.get(se.root).ok()?;
-                                let scene_hash = &ctx.hash;
-                                let ipfs_path = IpfsPath::new(IpfsType::new_content_file(
-                                    scene_hash.clone(),
-                                    e.to_lowercase(),
-                                ));
-                                let ipfs_context = ipfas.ipfs().context.blocking_read();
-                                let emote_hash = ipfs_path.hash(&ipfs_context)?;
-                                format!(
-                                    "urn:decentraland:off-chain:scene-emote:{scene_hash}-{emote_hash}-false"
-                                )
+                                let scene_emote = maybe_scene_ent
+                                    .and_then(|se| scenes.get(se.root).ok())
+                                    .and_then(|ctx| {
+                                        let scene_hash = &ctx.hash;
+                                        let ipfs_path = IpfsPath::new(IpfsType::new_content_file(
+                                            scene_hash.clone(),
+                                            e.to_lowercase(),
+                                        ));
+                                        let ipfs_context = ipfas.ipfs().context.blocking_read();
+                                        let emote_hash = ipfs_path.hash(&ipfs_context)?;
+                                        Some(format!(
+                                            "urn:decentraland:off-chain:scene-emote:{scene_hash}-{emote_hash}-false"
+                                        ))
+                                    });
+
+                                // otherwise a bare base-emote name ("robot"). content map
+                                // first because a file path is also a valid single-segment urn.
+                                match scene_emote
+                                    .or_else(|| EmoteUrn::new(e).ok().map(String::from))
+                                {
+                                    Some(urn) => urn,
+                                    None => {
+                                        warn!("ignoring avatar shape emote '{e}': not in the scene content map, and not a valid emote urn");
+                                        return None;
+                                    }
+                                }
                             };
                             Some(EmoteCommand {
                                 urn,

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # dev entry points. `just --list` for a summary.
-# node recipes assume node 20 on PATH (nvm users: the interactive shell's PATH is inherited).
+# node recipes assume node 22+ on PATH (nvm users: the interactive shell's PATH is inherited).
 
 # build the wasm engine into deploy/web/engine/pkg, then serve the react-web page (which hosts
 # the engine + live bridge-scene preview) and open a browser at the vite dev server.


### PR DESCRIPTION
Closes #1243.

A scene setting `AvatarShape.expressionTriggerId` to a bare base-emote name — `"robot"`, `"wave"` — got nothing on bevy: no emote, no `AvatarEmoteCommand` report, nothing logged. Unity plays the same string.

`update_render_avatar` treated any id without a `urn:` prefix as a scene file path and resolved it through the content map. A bare name isn't in the content map, so `ipfs_path.hash(…)?` returned `None` and aborted the whole `and_then` — producing no `EmoteCommand` at all, indistinguishable downstream from a scene that never set a trigger.

The content-map lookup now composes instead of short-circuiting, and falls back to `EmoteUrn::new`, which already expands single-segment values via the base collection (`Emote::base_collection()` is `urn:decentraland:off-chain:base-emotes`). The id now resolves the way it already does everywhere else in the engine.

### Why content-map first

The order isn't a toss-up — it's forced. `EmoteUrn::new("models/emotes/foo.glb")` **succeeds**: zero colons means it gets the base-collection prefix and parses as a valid 4-segment `base-emotes` urn. Trying the urn form first would therefore swallow every scene-file emote. Content-map-first leaves the existing file-path behaviour byte-identical and only adds a path where the old code returned `None`.

### Side effects, both wanted

- The urn is normalised at the source, so the `AvatarEmoteCommand` reported back to scenes carries `urn:decentraland:off-chain:base-emotes:robot` rather than the bare `robot` the scene wrote. `broadcast_urn` (`animate.rs`) is the raw `EmoteCommand.urn`, so this had to be fixed here rather than at the report site.
- A missing `SceneEntity` no longer kills the emote either; it just takes the urn path.

### On the warning

The `warn!` covers ids that fail urn *parsing*. A misspelled but well-formed name (`"wavee"`) still resolves to a valid urn here and surfaces later as a load failure, which since #1227 is reported to the scene as `finished` with no duration. That's the right layer for "no such emote" — it's the only one that knows.

### Unrelated to #1242

#1242 works on the `EmoteCommand`'s *lifetime* (permission gate, drop-on-transition); this only changes how its urn is derived. The construction it wraps is untouched.

### Also

Bumps the justfile's node comment from 20 to 22+. bridge-scene's `sdk-commands build` calls `fs.globSync`, which doesn't exist in node 20, so `just bundle-native` fails outright on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
