### PR TITLE
fix: resolve `..` segments when mapping a content path onto the content map

### DIFF
--- a/crates/ipfs/src/ipfs_path.rs
+++ b/crates/ipfs/src/ipfs_path.rs
@@ -295,7 +295,7 @@ where
                 file_path.push_str(stripped_file_name);
                 Ok(IpfsType::ContentFile {
                     content_hash,
-                    file_path,
+                    file_path: normalize_path(&file_path),
                 })
             }
             "$entity" => {
@@ -615,7 +615,91 @@ impl From<&IpfsPath> for PathBuf {
     }
 }
 
-// must be a better way to do this
+/// Content-map key form: forward slashes, `.`/`..` resolved. bevy_gltf joins a gltf's folder with
+/// its relative image uris, so `models/tree/../../textures/bark.png` must match the map's
+/// `textures/bark.png`. Empty segments are kept so a fallthrough url (`https://host/x`) survives.
 pub fn normalize_path(path: &str) -> String {
-    path.replace('\\', "/")
+    let forward = path.replace('\\', "/");
+    let mut segments: Vec<&str> = Vec::new();
+    for segment in forward.split('/') {
+        match segment {
+            "." => {}
+            ".." => {
+                if segments.last().is_some_and(|last| !last.is_empty()) {
+                    segments.pop();
+                }
+            }
+            other => segments.push(other),
+        }
+    }
+    segments.join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{normalize_path, IpfsPath, IpfsType};
+
+    #[test]
+    fn normalize_resolves_parent_and_current_segments() {
+        assert_eq!(
+            normalize_path("assets/models/tree/../../textures/bark.png"),
+            "assets/textures/bark.png"
+        );
+        assert_eq!(
+            normalize_path("assets/./models/./tree.glb"),
+            "assets/models/tree.glb"
+        );
+        assert_eq!(
+            normalize_path(r"assets\models\..\tex.png"),
+            "assets/tex.png"
+        );
+    }
+
+    #[test]
+    fn normalize_leaves_plain_paths_and_urls_alone() {
+        assert_eq!(
+            normalize_path("assets/textures/bark.png"),
+            "assets/textures/bark.png"
+        );
+        assert_eq!(
+            normalize_path("https://example.com/a/b.png"),
+            "https://example.com/a/b.png"
+        );
+        assert_eq!(
+            normalize_path("https://example.com/a/../b.png"),
+            "https://example.com/b.png"
+        );
+    }
+
+    #[test]
+    fn normalize_drops_a_climb_above_the_root() {
+        assert_eq!(
+            normalize_path("../../textures/bark.png"),
+            "textures/bark.png"
+        );
+        assert_eq!(normalize_path(".."), "");
+    }
+
+    #[test]
+    fn content_file_path_with_parent_segments_resolves_to_the_map_key() {
+        // bevy_gltf's path for uri `../../optimized-textures/Image_2.png` in
+        // `assets/asset-packs/admin_tools/admin_toolkit.glb`
+        let path = Path::new(
+            "$ipfs/$content_file/bafyhash/assets/asset-packs/admin_tools/../../optimized-textures/Image_2.png",
+        );
+        let ipfs_path = IpfsPath::new_from_path(path).unwrap().unwrap();
+        assert_eq!(
+            ipfs_path.ipfs_type,
+            IpfsType::ContentFile {
+                content_hash: "bafyhash".to_owned(),
+                file_path: "assets/optimized-textures/Image_2.png".to_owned(),
+            }
+        );
+        assert_eq!(
+            ipfs_path.content_path(),
+            Some("assets/optimized-textures/Image_2.png")
+        );
+    }
 }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -224,11 +224,11 @@ impl AssetLoader for SceneJsLoader {
 pub struct ContentMap(pub HashMap<String, String>);
 
 impl ContentMap {
-    // keys are stored lowercase with '/' separators (the dev server normalizes the
-    // same way); lookups mirror that so backslashed srcs still resolve
+    // keys are lowercase, '/'-separated, `.`/`..` resolved (the dev server normalizes the same
+    // way); lookups mirror that so backslashed and `../` srcs still resolve
     pub fn hash<'a>(&'a self, file: &str) -> Option<Cow<'a, str>> {
         self.0
-            .get(file.replace('\\', "/").to_lowercase().as_str())
+            .get(normalize_path(file).to_lowercase().as_str())
             .map(Into::into)
     }
 
@@ -245,7 +245,7 @@ impl ContentMap {
     }
 
     pub fn with(mut self, file: String, hash: String) -> Self {
-        self.0.insert(file.replace('\\', "/").to_lowercase(), hash);
+        self.0.insert(normalize_path(&file).to_lowercase(), hash);
         self
     }
 }
@@ -2009,7 +2009,19 @@ fn b64_split_at_key<'a>(decoded: &'a str, key: &str) -> Option<(&'a str, &'a str
 
 #[cfg(test)]
 mod tests {
-    use super::b64_split_at_key;
+    use super::{b64_split_at_key, ContentMap};
+
+    #[test]
+    fn content_map_resolves_a_reference_that_climbs_out_of_the_gltf_folder() {
+        let map = ContentMap::default().with(
+            "assets/optimized-textures/Image_2.png".to_owned(),
+            "bafyimage".to_owned(),
+        );
+        let looked_up =
+            map.hash("assets/asset-packs/admin_tools/../../optimized-textures/Image_2.png");
+        assert_eq!(looked_up.as_deref(), Some("bafyimage"));
+        assert_eq!(map.hash("assets/optimized-textures/missing.png"), None);
+    }
 
     #[test]
     fn splits_unix_path() {


### PR DESCRIPTION
**TL;DR** A glTF image uri like `../../textures/bark.png` never resolved: `normalize_path` only swapped backslashes, so the content-map lookup used `models/tree/../../textures/bark.png` and missed. Materials rendered with only their emissive map (Unity resolves the same uri fine). `normalize_path` now collapses `.`/`..`, and the `$content_file` parser plus `ContentMap` lookups go through it.

**Tests** — normalizer cases (`..`, `.`, backslashes, urls, climbing above root), `IpfsPath::new_from_path` on the exact path bevy_gltf produces, and a `ContentMap` lookup that climbs out of the gltf folder.

**Context** — found while building the Creator Hub model optimizer (decentraland/creator-hub#1566), which currently writes shared textures beside each model to work around this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)