### PR TITLE
Fix HUD startup coherence: premature playerReady and lost bridge messages

### DIFF
--- a/react-web/bridge-scene/src/bridge.ts
+++ b/react-web/bridge-scene/src/bridge.ts
@@ -85,9 +85,15 @@ export function startBridge(register: (ctx: Ctx) => void): void {
 
   register(ctx)
 
+  // Announce only once every domain is registered — the page starts sending as soon as it hears.
+  ctx.send({ kind: 'bridgeReady' })
+
   channel.onmessage = (e): void => {
     const env = e.data as Envelope | null
     if (env === null || env.to !== 'scene') return
+    // Every hello, not just the first: a page that reloads or starts late missed the
+    // announcement above and would otherwise queue forever.
+    if (env.msg.kind === 'hello') ctx.send({ kind: 'bridgeReady' })
     const list = handlers.get(env.msg.kind)
     if (list == null) return
     // Each handler is isolated: one domain throwing must not stop the others from seeing the

--- a/react-web/bridge-scene/src/domains/profile.ts
+++ b/react-web/bridge-scene/src/domains/profile.ts
@@ -145,14 +145,30 @@ async function fetchPhotos(address: string): Promise<string[] | undefined> {
 }
 
 export function registerProfile(ctx: Ctx): void {
-  ctx.on('getProfile', async () => {
+  // The page marks its world-entry profile fetch done as soon as it ASKS, so an answer of `null`
+  // costs it the profile for the whole session. `getPlayer()` is the scene's view of the player
+  // CRDT, which lags world entry by a good few hundred frames, so a request that arrives in that
+  // window is held rather than answered — the page only ever hears a profile it can use.
+  let wanted = false
+  let inFlight = false
+  const answerProfile = async (): Promise<void> => {
     const player = getPlayer()
-    if (player == null) {
-      ctx.send({ kind: 'profile', profile: null })
-      return
+    if (player == null || inFlight) return
+    wanted = false
+    inFlight = true
+    try {
+      const data = await fetchProfile(player.userId).catch(() => undefined)
+      ctx.send({ kind: 'profile', profile: toProfile(data?.avatars?.[0], player.userId, player.isGuest, player.name) })
+    } finally {
+      inFlight = false
     }
-    const data = await fetchProfile(player.userId).catch(() => undefined)
-    ctx.send({ kind: 'profile', profile: toProfile(data?.avatars?.[0], player.userId, player.isGuest, player.name) })
+  }
+  ctx.on('getProfile', () => {
+    wanted = true
+    void answerProfile()
+  })
+  ctx.push(() => {
+    if (wanted) void answerProfile()
   })
 
   // View Profile: fetch another user's full passport by address (profile + badges + photos).

--- a/react-web/bridge-scene/src/domains/session.ts
+++ b/react-web/bridge-scene/src/domains/session.ts
@@ -67,7 +67,8 @@ export function registerSession(ctx: Ctx): void {
     }
   })()
 
-  // Player-spawned signal (one-shot).
+  // Player-spawned signal: one-shot per page, not per scene. The page gates its world-entry
+  // fetches on it and never retries, so a page that arrives late is re-told on `hello`.
   let ready = false
   ctx.push(() => {
     if (ready) return
@@ -75,5 +76,8 @@ export function registerSession(ctx: Ctx): void {
       ready = true
       ctx.send({ kind: 'event', name: 'playerReady' })
     }
+  })
+  ctx.on('hello', () => {
+    if (ready) ctx.send({ kind: 'event', name: 'playerReady' })
   })
 }

--- a/react-web/src/App.tsx
+++ b/react-web/src/App.tsx
@@ -43,6 +43,7 @@ import { untrustedLaunchParams } from './lib/launchGate'
 import { ErrorBoundary } from './features/error/ErrorBoundary'
 import { CrashModal } from './features/error/CrashModal'
 import { openRealmError } from './features/error/RealmErrorModal'
+import { DIALOG_TITLE, isDialogSource } from './features/error/fatalError'
 import { openEntryParamsDialog } from './features/gate/EntryParamsDialog'
 import { unrecognisedEntryParams } from './lib/entryParams'
 
@@ -189,18 +190,22 @@ function Hud(): React.JSX.Element {
     return openEntryParamsDialog(UNRECOGNISED_PARAMS)
   }, [])
 
-  // A world that doesn't exist isn't a crash — it's an ordinary dialog on the popup layer, so it gets
-  // Escape/scrim-click for free and freezes nothing behind it (unlike CrashModal, see inputLock). Any
-  // close path clears the session's error, so a keyboard dismiss can't strand it.
-  const realmErrorMessage = session.fatalError?.source === 'realm' ? session.fatalError.message : null
+  // A world that doesn't exist, or a HUD bridge that never answered, isn't a crash — it's an ordinary
+  // dialog on the popup layer, so it gets Escape/scrim-click for free and freezes nothing behind it
+  // (unlike CrashModal, see inputLock). Any close path clears the session's error, so a keyboard
+  // dismiss can't strand it.
+  const dialogError =
+    session.fatalError != null && isDialogSource(session.fatalError.source)
+      ? { title: DIALOG_TITLE[session.fatalError.source], message: session.fatalError.message }
+      : null
   useEffect(() => {
-    if (realmErrorMessage == null) return
-    return openRealmError({ message: realmErrorMessage, onDismiss: session.dismissFatal })
+    if (dialogError == null) return
+    return openRealmError({ ...dialogError, onDismiss: session.dismissFatal })
     // eslint-disable-next-line react-hooks/exhaustive-deps -- re-open only when the message changes
-  }, [realmErrorMessage])
-  // Everything else IS a crash → the full-screen CrashModal (narrowed so it never sees 'realm').
+  }, [dialogError?.message])
+  // Everything else IS a crash → the full-screen CrashModal (narrowed so it never sees a dialog source).
   const crash =
-    session.fatalError != null && session.fatalError.source !== 'realm'
+    session.fatalError != null && !isDialogSource(session.fatalError.source)
       ? { message: session.fatalError.message, source: session.fatalError.source }
       : null
 

--- a/react-web/src/engine/EngineDriver.ts
+++ b/react-web/src/engine/EngineDriver.ts
@@ -8,12 +8,8 @@
 import { getStoredLogin, rootAddress, type AuthIdentity } from '../features/auth/sso'
 import type { LoginDriver } from './driver'
 import type { EngineRpc } from './engineRpc'
-import {
-  bridgeChannelName,
-  type Envelope,
-  type PageToScene,
-  type SceneToPage
-} from './protocol'
+import { BridgeChannel } from './bridgeChannel'
+import { bridgeChannelName, type PageToScene, type SceneToPage } from './protocol'
 
 // Pack a same-domain SSO AuthIdentity into a single base64 console-command argument. The
 // engine's `/login_identity` command decodes this (root address = authChain[0].payload,
@@ -23,21 +19,20 @@ function encodeIdentity(identity: AuthIdentity): string {
 }
 
 export class EngineDriver implements LoginDriver {
-  private readonly ch: BroadcastChannel
+  private readonly ch: BridgeChannel
   private readonly listeners = new Set<(msg: SceneToPage) => void>()
   private playerReadyFired = false
   private readyFallbackTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(private readonly rpc: EngineRpc) {
-    this.ch = new BroadcastChannel(bridgeChannelName())
-    this.ch.onmessage = (e: MessageEvent<Envelope>) => {
-      const env = e.data
-      if (env?.to !== 'page') return
-      if (env.msg.kind === 'event' && env.msg.name === 'playerReady') {
-        this.playerReadyFired = true
-      }
-      this.emit(env.msg)
-    }
+    this.ch = new BridgeChannel(
+      bridgeChannelName(),
+      (msg) => {
+        if (msg.kind === 'event' && msg.name === 'playerReady') this.playerReadyFired = true
+        this.emit(msg)
+      },
+      () => this.emit({ kind: 'bridgeUnavailable' })
+    )
   }
 
   async getPreviousLogin(): Promise<{ userId: string | null }> {
@@ -82,7 +77,11 @@ export class EngineDriver implements LoginDriver {
   }
 
   send(msg: PageToScene): void {
-    this.ch.postMessage({ to: 'scene', msg } satisfies Envelope)
+    this.ch.send(msg)
+  }
+
+  expectBridge(): void {
+    this.ch.expectReady()
   }
 
   on(fn: (msg: SceneToPage) => void): () => void {

--- a/react-web/src/engine/bridge.ts
+++ b/react-web/src/engine/bridge.ts
@@ -6,9 +6,9 @@
 // `on(msg => …)` subscription; only request/response (login) is correlated by id.
 
 import type { AuthIdentity } from '../features/auth/sso'
+import { BridgeChannel } from './bridgeChannel'
 import {
   bridgeChannelName,
-  type Envelope,
   type LoginPreviousResult,
   type PageToScene,
   type PreviousLogin,
@@ -19,17 +19,16 @@ import {
 type Pending = { resolve: (v: unknown) => void; reject: (e: Error) => void }
 
 export class BridgeClient {
-  private readonly ch: BroadcastChannel
+  private readonly ch: BridgeChannel
   private readonly pending = new Map<string, Pending>()
   private readonly listeners = new Set<(msg: SceneToPage) => void>()
 
   constructor(channel: string = bridgeChannelName()) {
-    this.ch = new BroadcastChannel(channel)
-    this.ch.onmessage = (e: MessageEvent<Envelope>) => {
-      const env = e.data
-      if (env?.to !== 'page') return // ignore our own / scene-addressed posts
-      this.handle(env.msg)
-    }
+    this.ch = new BridgeChannel(
+      channel,
+      (msg) => this.handle(msg),
+      () => this.handle({ kind: 'bridgeUnavailable' })
+    )
   }
 
   getPreviousLogin(): Promise<PreviousLogin> {
@@ -75,7 +74,11 @@ export class BridgeClient {
   }
 
   send(msg: PageToScene): void {
-    this.ch.postMessage({ to: 'scene', msg } satisfies Envelope)
+    this.ch.send(msg)
+  }
+
+  expectBridge(): void {
+    this.ch.expectReady()
   }
 
   on(fn: (msg: SceneToPage) => void): () => void {
@@ -93,7 +96,9 @@ export class BridgeClient {
     const id = crypto.randomUUID()
     return new Promise<T>((resolve, reject) => {
       this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject })
-      this.send({ kind: 'rpc:req', id, method })
+      // The engine's boot shim answers these before any bridge scene exists, so they skip the
+      // handshake queue rather than gating the login screen on a scene sign-in does not involve.
+      this.ch.sendNow({ kind: 'rpc:req', id, method })
     })
   }
 

--- a/react-web/src/engine/bridgeChannel.ts
+++ b/react-web/src/engine/bridgeChannel.ts
@@ -1,0 +1,110 @@
+// The page's half of the bridge handshake, shared by both drivers (BridgeClient on native/CEF,
+// EngineDriver on web) because the failure it prevents is a property of the transport, not of
+// either driver.
+//
+// A BroadcastChannel has no buffering and no connection: a message posted before the other end
+// subscribes is simply gone, and neither side is told. The page and the bridge scene start
+// independently — the engine boots the scene, the browser (or CEF) loads the page — so either can
+// win the race. Anything sent into that gap is lost silently, which is how the HUD ends up with
+// panels that never fill and no error to explain why (issue #1233).
+//
+// The handshake: the page says `hello` (repeatedly, since that too can be lost) until the scene
+// answers `bridgeReady`. Until then page→scene messages are held and then flushed in order, so
+// nothing is posted into the void. The scene answers every `hello`, so a page that reloads — or
+// arrives long after the scene — still gets an answer, and domains holding one-shot state can
+// re-send it to the newcomer.
+
+import type { Envelope, PageToScene, SceneToPage } from './protocol'
+
+const HELLO_INTERVAL_MS = 250
+
+/** Only armed by `expectReady()`: before sign-in there is legitimately no bridge on web, and a
+ *  clock started at construction just accuses an idle login screen. */
+const READY_TIMEOUT_MS = 30_000
+
+export class BridgeChannel {
+  private readonly ch: BroadcastChannel
+  private ready = false
+  /** Page→scene messages posted before the scene answered, flushed in order once it does. */
+  private readonly queue: PageToScene[] = []
+  private helloTimer: ReturnType<typeof setInterval> | null = null
+  private timeoutTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(
+    channelName: string,
+    private readonly onMessage: (msg: SceneToPage) => void,
+    private readonly onUnavailable?: () => void
+  ) {
+    this.ch = new BroadcastChannel(channelName)
+    this.ch.onmessage = (e: MessageEvent<Envelope>) => {
+      const env = e.data
+      if (env?.to !== 'page') return // ignore our own / scene-addressed posts
+      if (env.msg.kind === 'bridgeReady') this.markReady()
+      this.onMessage(env.msg)
+    }
+    this.hello()
+    this.helloTimer = setInterval(() => this.hello(), HELLO_INTERVAL_MS)
+  }
+
+  /** Start the clock: sign-in has begun, so a still-absent bridge is a fault worth showing rather
+   *  than a normal wait. Idempotent — the session calls it on every render past the login screen.
+   *  Keeps saying hello afterwards, so a scene that turns up late still recovers the queue. */
+  expectReady(): void {
+    if (this.ready || this.timeoutTimer != null) return
+    this.timeoutTimer = setTimeout(() => {
+      this.timeoutTimer = null
+      if (!this.ready) this.onUnavailable?.()
+    }, READY_TIMEOUT_MS)
+  }
+
+  send(msg: PageToScene): void {
+    if (!this.ready) {
+      this.queue.push(msg)
+      return
+    }
+    this.post(msg)
+  }
+
+  /** Post immediately, skipping the handshake. Only for messages something OTHER than the bridge
+   *  scene answers: on native the engine's boot shim serves the login RPCs, so queueing them would
+   *  make sign-in wait for a scene it does not need. */
+  sendNow(msg: PageToScene): void {
+    this.post(msg)
+  }
+
+  isReady(): boolean {
+    return this.ready
+  }
+
+  /** Named to match BroadcastChannel, since it stands in for one at both call sites. */
+  close(): void {
+    this.stopHello()
+    if (this.timeoutTimer != null) clearTimeout(this.timeoutTimer)
+    this.timeoutTimer = null
+    this.ch.close()
+  }
+
+  private markReady(): void {
+    // The scene answers every hello, so this fires more than once; only the first does anything.
+    if (this.ready) return
+    this.ready = true
+    this.stopHello()
+    if (this.timeoutTimer != null) clearTimeout(this.timeoutTimer)
+    this.timeoutTimer = null
+    for (const msg of this.queue.splice(0)) this.post(msg)
+  }
+
+  /** The handshake itself bypasses the queue — it is what opens the queue. */
+  private hello(): void {
+    this.post({ kind: 'hello' })
+  }
+
+  private post(msg: PageToScene): void {
+    this.ch.postMessage({ to: 'scene', msg } satisfies Envelope)
+  }
+
+  private stopHello(): void {
+    if (this.helloTimer != null) clearInterval(this.helloTimer)
+    this.helloTimer = null
+  }
+}

--- a/react-web/src/engine/bridgeChannel.ts
+++ b/react-web/src/engine/bridgeChannel.ts
@@ -18,8 +18,8 @@ import type { Envelope, PageToScene, SceneToPage } from './protocol'
 
 const HELLO_INTERVAL_MS = 250
 
-/** Only armed by `expectReady()`: before sign-in there is legitimately no bridge on web, and a
- *  clock started at construction just accuses an idle login screen. */
+/** Only armed by `expectReady()`: before the engine is launched there is legitimately no bridge on
+ *  web, and a clock started at construction just accuses an idle login screen or picker. */
 const READY_TIMEOUT_MS = 30_000
 
 export class BridgeChannel {
@@ -29,6 +29,8 @@ export class BridgeChannel {
   private readonly queue: PageToScene[] = []
   private helloTimer: ReturnType<typeof setInterval> | null = null
   private timeoutTimer: ReturnType<typeof setTimeout> | null = null
+  /** `expectReady()` is one-shot: a fault already reported must not come back on the next arm. */
+  private expected = false
 
   constructor(
     channelName: string,
@@ -46,11 +48,13 @@ export class BridgeChannel {
     this.helloTimer = setInterval(() => this.hello(), HELLO_INTERVAL_MS)
   }
 
-  /** Start the clock: sign-in has begun, so a still-absent bridge is a fault worth showing rather
-   *  than a normal wait. Idempotent — the session calls it on every render past the login screen.
-   *  Keeps saying hello afterwards, so a scene that turns up late still recovers the queue. */
+  /** Start the clock: the engine has been launched at a realm, so a still-absent bridge is a fault
+   *  worth showing rather than a normal wait. One-shot — the session calls it on every phase change
+   *  past launch, and a fault already reported must not be raised again by the next one. Keeps
+   *  saying hello afterwards, so a scene that turns up late still recovers the queue. */
   expectReady(): void {
-    if (this.ready || this.timeoutTimer != null) return
+    if (this.ready || this.expected) return
+    this.expected = true
     this.timeoutTimer = setTimeout(() => {
       this.timeoutTimer = null
       if (!this.ready) this.onUnavailable?.()

--- a/react-web/src/engine/driver.ts
+++ b/react-web/src/engine/driver.ts
@@ -44,6 +44,8 @@ export interface LoginDriver {
    *  screen keeps its CTAs in a "Starting…" state until this is true. Optional — the mock is always
    *  ready. */
   engineReady?(): boolean
+  /** Tell the transport the bridge scene is now expected, so its absence can be reported. */
+  expectBridge?(): void
   /** Real weighted boot progress (0–100) + active step id, surfaced from the engine loader for
    *  the login footer bar. Optional — the mock has no engine to download. */
   loadProgress?(): number

--- a/react-web/src/engine/mockBridge.ts
+++ b/react-web/src/engine/mockBridge.ts
@@ -352,8 +352,12 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
 
   // Simulate the engine spawning the player + loading the spawn scene after a
   // successful login: player-ready, then a scene-asset countdown, then "done".
+  // Mirrors the real session domain's latch, so a page that says hello after the player spawned
+  // (a reload) is re-told, as the bridge scene does.
+  let playerSpawned = false
   const spawnPlayer = (): void => {
     setTimeout(() => {
+      playerSpawned = true
       reply({ kind: 'event', name: 'playerReady' })
       reply({ kind: 'chatVisibility', open: true })
       // Two-step countdown then done — kept short so a throttled/backgrounded tab
@@ -481,6 +485,14 @@ export function startMockBridge(opts: Partial<MockOptions> = {}): () => void {
     const env = e.data
     if (env?.to !== 'scene') return
     const msg: PageToScene = env.msg
+
+    // Answered before the simulated latency: the page holds everything else until this lands.
+    if (msg.kind === 'hello') {
+      reply({ kind: 'bridgeReady' })
+      if (playerSpawned) reply({ kind: 'event', name: 'playerReady' })
+      return
+    }
+
     await wait(o.latency)
 
     if (msg.kind === 'sendChat') {

--- a/react-web/src/engine/protocol.ts
+++ b/react-web/src/engine/protocol.ts
@@ -109,7 +109,23 @@ export interface NavActionRequest {
   action: NavAction
 }
 
+/** Page→scene handshake ping, repeated until the scene answers `bridgeReady` (see BridgeChannel). */
+export interface HelloRequest {
+  kind: 'hello'
+}
+
+/** Scene→page: every domain is registered and the scene is listening. */
+export interface BridgeReadyMessage {
+  kind: 'bridgeReady'
+}
+
+/** Synthesised BY THE PAGE (never sent by the scene) when the bridge never answered. */
+export interface BridgeUnavailableMessage {
+  kind: 'bridgeUnavailable'
+}
+
 export type PageToScene =
+  | HelloRequest
   | RpcRequest
   | SendChatRequest
   | ReloadSceneRequest
@@ -997,6 +1013,8 @@ export interface AvatarClickMessage {
 }
 
 export type SceneToPage =
+  | BridgeReadyMessage
+  | BridgeUnavailableMessage
   | RpcResponse
   | HoverMessage
   | CursorLockMessage

--- a/react-web/src/features/error/RealmErrorModal.tsx
+++ b/react-web/src/features/error/RealmErrorModal.tsx
@@ -1,4 +1,5 @@
-// "World not found" — the realm the user asked for doesn't exist or isn't reachable.
+// "World not found" — the realm the user asked for doesn't exist or isn't reachable. Also carries
+// the other not-a-crash session error, "HUD not connected" (the bridge scene never answered).
 //
 // Not a crash: nothing is broken, the app just can't honour the request, so this is an ordinary
 // dialog on the popup layer (PopupHost owns the scrim, entrance, focus trap and Escape) rather than
@@ -19,7 +20,7 @@ import styles from './RealmErrorModal.module.css'
  *  error before the second mount and the dialog would self-destruct. (Contrast openPermissionDialog,
  *  where the cleanup close deliberately denies: its state is empty at mount, so the spurious run
  *  settles nothing.) */
-export function openRealmError(opts: { message: string; onDismiss: () => void }): () => void {
+export function openRealmError(opts: { title: string; message: string; onDismiss: () => void }): () => void {
   let settled = false
   const done = (): void => {
     if (settled) return
@@ -32,13 +33,13 @@ export function openRealmError(opts: { message: string; onDismiss: () => void })
         // Alert-style dialog: centered header with title-scale type, centered footer button.
         header={
           <div className={styles.head}>
-            <h2 className={styles.title}>World not found</h2>
-            {/* The realm message is human-readable and names the world — it IS the subtitle. */}
+            <h2 className={styles.title}>{opts.title}</h2>
+            {/* The message is human-readable (it names the world) — it IS the subtitle. */}
             <p className={styles.subtitle}>{opts.message}</p>
           </div>
         }
         role="alertdialog"
-        ariaLabel="World not found"
+        ariaLabel={opts.title}
         closeButton={false}
         actionsAlign="center"
         actions={

--- a/react-web/src/features/error/fatalError.ts
+++ b/react-web/src/features/error/fatalError.ts
@@ -3,17 +3,29 @@
 // - `launch` / `runtime` / `react` are CRASHES — something broke. They go to <CrashModal/>, a
 //   self-contained full-screen surface above everything that freezes HUD input (see inputLock), so
 //   the screen stays exactly as it was for a screenshot/bug report.
-// - `realm` is NOT a crash — the world the user asked for doesn't exist. It's an ordinary dialog on
-//   the popup layer (see openRealmError): Escape closes it, nothing else is frozen.
+// - `realm` and `bridge` are NOT crashes — the world the user asked for doesn't exist, or the HUD's
+//   bridge scene never answered while the world itself runs fine. They are ordinary dialogs on the
+//   popup layer (see openRealmError): Escape closes them, nothing else is frozen.
 
 export interface FatalError {
   message: string
   /**
    * 'launch' = boot panic (fatal), 'runtime' = engine crash (dismissable), 'react' = UI render
-   * crash (fatal), 'realm' = the requested ?realm/world doesn't exist (dismissable → picker).
+   * crash (fatal), 'realm' = the requested ?realm/world doesn't exist (dismissable → picker),
+   * 'bridge' = the HUD bridge scene never answered the handshake (dismissable, world keeps running).
    */
-  source: 'launch' | 'runtime' | 'react' | 'realm'
+  source: 'launch' | 'runtime' | 'react' | 'realm' | 'bridge'
 }
 
-/** The crash sources — everything <CrashModal/> handles. `realm` is deliberately not one of them. */
-export type CrashSource = Exclude<FatalError['source'], 'realm'>
+/** The crash sources — everything <CrashModal/> handles. `realm` and `bridge` are deliberately not
+ *  among them. */
+export type CrashSource = Exclude<FatalError['source'], DialogSource>
+/** The not-a-crash sources, each shown as a titled dialog on the popup layer. */
+export type DialogSource = 'realm' | 'bridge'
+export const DIALOG_TITLE: Record<DialogSource, string> = {
+  realm: 'World not found',
+  bridge: 'HUD not connected'
+}
+export function isDialogSource(source: FatalError['source']): source is DialogSource {
+  return source in DIALOG_TITLE
+}

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -638,6 +638,14 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
         case 'systemAction':
           systemActionRef.current(msg.action, msg.pressed)
           break
+        case 'bridgeUnavailable':
+          // Every panel behind the bridge would stay empty with nothing to explain why.
+          // Dismissable: the engine and the world itself are fine (issue #1233).
+          setFatalError((prev) => prev ?? {
+            message: 'The HUD could not reach the explorer bridge, so panels may stay empty. Restarting usually fixes it.',
+            source: 'runtime'
+          })
+          break
         case 'profile':
           setProfile(msg.profile)
           break
@@ -1471,6 +1479,12 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
       : loaderActive
         ? 'entering'
         : 'world'
+
+  // Past the login screen the bridge scene must exist — on web its realm has been picked, on
+  // native it booted with the engine — so from here on its absence is a fault, not a normal wait.
+  useEffect(() => {
+    if (phase !== 'login') driverRef.current?.expectBridge?.()
+  }, [phase])
 
   // HUD focus, declared to the engine (fire-and-forget; latest wins). `ui` reserves all
   // input above scenes — the avatar stops walking when a menu/popup opens — while the

--- a/react-web/src/features/session/useEngineSession.ts
+++ b/react-web/src/features/session/useEngineSession.ts
@@ -639,11 +639,11 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
           systemActionRef.current(msg.action, msg.pressed)
           break
         case 'bridgeUnavailable':
-          // Every panel behind the bridge would stay empty with nothing to explain why.
-          // Dismissable: the engine and the world itself are fine (issue #1233).
+          // Every panel behind the bridge would stay empty with nothing to explain why. Not a crash:
+          // the engine and the world itself are fine, so it opens as an ordinary dialog (issue #1233).
           setFatalError((prev) => prev ?? {
             message: 'The HUD could not reach the explorer bridge, so panels may stay empty. Restarting usually fixes it.',
-            source: 'runtime'
+            source: 'bridge'
           })
           break
         case 'profile':
@@ -1480,10 +1480,12 @@ export function useEngineSession(createDriver: () => LoginDriver): EngineSession
         ? 'entering'
         : 'world'
 
-  // Past the login screen the bridge scene must exist — on web its realm has been picked, on
-  // native it booted with the engine — so from here on its absence is a fault, not a normal wait.
+  // Once a launch has been requested the bridge scene must exist — on web the engine boots at the
+  // picked realm and the scene with it, on native it booted with the engine — so from here on its
+  // absence is a fault, not a normal wait. NOT 'picking': on web nothing is launched until the
+  // user picks, so an idle picker has no bridge to wait for.
   useEffect(() => {
-    if (phase !== 'login') driverRef.current?.expectBridge?.()
+    if (phase === 'entering' || phase === 'world') driverRef.current?.expectBridge?.()
   }, [phase])
 
   // HUD focus, declared to the engine (fire-and-forget; latest wins). `ui` reserves all

--- a/react-web/src/test/bridgeReadiness.test.ts
+++ b/react-web/src/test/bridgeReadiness.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { BridgeChannel } from '../engine/bridgeChannel'
+import type { Envelope, PageToScene, SceneToPage } from '../engine/protocol'
+import { renderSession, enterAsGuest } from './harness'
+
+// TRANSPORT: the page↔scene handshake. A BroadcastChannel drops anything posted before the other
+// end subscribes, so the page holds its messages until the scene answers `hello` (issue #1233).
+
+/** A stand-in for the bridge scene: records what the page posts, answers when told to. */
+class FakeScene {
+  readonly received: PageToScene[] = []
+  private readonly ch: BroadcastChannel
+  /** Answer every hello, like the real scene does. */
+  autoAnswer = false
+
+  constructor(name: string) {
+    this.ch = new BroadcastChannel(name)
+    this.ch.onmessage = (e: MessageEvent<Envelope>) => {
+      const env = e.data
+      if (env?.to !== 'scene') return
+      this.received.push(env.msg)
+      if (this.autoAnswer && env.msg.kind === 'hello') this.announce()
+    }
+  }
+
+  announce(): void {
+    this.send({ kind: 'bridgeReady' })
+  }
+
+  send(msg: SceneToPage): void {
+    this.ch.postMessage({ to: 'page', msg } satisfies Envelope)
+  }
+
+  kinds(): string[] {
+    return this.received.map((m) => m.kind)
+  }
+
+  close(): void {
+    this.ch.close()
+  }
+}
+
+/** BroadcastChannel delivery is a task, not microtask — let it land. */
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
+
+let open: Array<{ close: () => void }> = []
+const track = <T extends { close: () => void }>(x: T): T => {
+  open.push(x)
+  return x
+}
+afterEach(() => {
+  open.forEach((c) => c.close())
+  open = []
+  vi.useRealTimers()
+})
+
+let seq = 0
+const channelName = (): string => `test-bridge-${seq++}`
+
+describe('bridge readiness handshake', () => {
+  it('says hello on construction', async () => {
+    const name = channelName()
+    const scene = track(new FakeScene(name))
+    track(new BridgeChannel(name, () => {}))
+    await settle()
+    expect(scene.kinds()).toContain('hello')
+  })
+
+  it('holds page messages until the scene answers, then flushes them IN ORDER', async () => {
+    const name = channelName()
+    const scene = track(new FakeScene(name))
+    const ch = track(new BridgeChannel(name, () => {}))
+
+    ch.send({ kind: 'getProfile' })
+    ch.send({ kind: 'getNotifications' })
+    await settle()
+    // Nothing but the handshake has gone out.
+    expect(scene.kinds().filter((k) => k !== 'hello')).toEqual([])
+    expect(ch.isReady()).toBe(false)
+
+    scene.announce()
+    await settle()
+    expect(ch.isReady()).toBe(true)
+    expect(scene.kinds().filter((k) => k !== 'hello')).toEqual(['getProfile', 'getNotifications'])
+  })
+
+  it('sends straight through once ready', async () => {
+    const name = channelName()
+    const scene = track(new FakeScene(name))
+    scene.autoAnswer = true
+    const ch = track(new BridgeChannel(name, () => {}))
+    await settle()
+
+    ch.send({ kind: 'getProfile' })
+    await settle()
+    expect(scene.kinds()).toContain('getProfile')
+  })
+
+  it('keeps saying hello until answered, so a scene that starts LATE still hears it', async () => {
+    vi.useFakeTimers()
+    const name = channelName()
+    const ch = track(new BridgeChannel(name, () => {}))
+    ch.send({ kind: 'getProfile' })
+
+    // The scene subscribes only now, having missed every hello so far.
+    const scene = track(new FakeScene(name))
+    scene.autoAnswer = true
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(scene.kinds()).toContain('hello')
+    expect(scene.kinds()).toContain('getProfile')
+    expect(ch.isReady()).toBe(true)
+  })
+
+  it('says nothing while the bridge is not yet expected — an idle login screen has no realm', async () => {
+    vi.useFakeTimers()
+    const name = channelName()
+    const onUnavailable = vi.fn()
+    track(new BridgeChannel(name, () => {}, onUnavailable))
+
+    // Before sign-in there is legitimately no bridge scene on web.
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(onUnavailable).not.toHaveBeenCalled()
+  })
+
+  it('reports the bridge unavailable once expected, instead of queueing forever', async () => {
+    vi.useFakeTimers()
+    const name = channelName()
+    const onUnavailable = vi.fn()
+    const ch = track(new BridgeChannel(name, () => {}, onUnavailable))
+    ch.expectReady()
+
+    await vi.advanceTimersByTimeAsync(29_000)
+    expect(onUnavailable).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(onUnavailable).toHaveBeenCalledTimes(1)
+    expect(ch.isReady()).toBe(false)
+  })
+
+  it('does not report unavailable once the scene has answered', async () => {
+    vi.useFakeTimers()
+    const name = channelName()
+    const scene = track(new FakeScene(name))
+    scene.autoAnswer = true
+    const onUnavailable = vi.fn()
+    const ch = track(new BridgeChannel(name, () => {}, onUnavailable))
+    ch.expectReady()
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(onUnavailable).not.toHaveBeenCalled()
+  })
+
+  it('arming after the scene already answered never fires', async () => {
+    vi.useFakeTimers()
+    const name = channelName()
+    const scene = track(new FakeScene(name))
+    scene.autoAnswer = true
+    const onUnavailable = vi.fn()
+    const ch = track(new BridgeChannel(name, () => {}, onUnavailable))
+    await vi.advanceTimersByTimeAsync(300)
+
+    ch.expectReady()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(onUnavailable).not.toHaveBeenCalled()
+  })
+
+  it('sendNow bypasses the queue — the login RPCs the engine shim answers must not wait', async () => {
+    const name = channelName()
+    const scene = track(new FakeScene(name))
+    const ch = track(new BridgeChannel(name, () => {}))
+
+    ch.send({ kind: 'getProfile' }) // belongs to the scene: queued
+    ch.sendNow({ kind: 'rpc:req', id: 'a', method: 'loginPrevious' })
+    await settle()
+
+    // Sign-in reaches the engine while the scene is still booting; the scene's own request waits.
+    expect(scene.kinds()).toContain('rpc:req')
+    expect(scene.kinds()).not.toContain('getProfile')
+  })
+
+  it('delivers scene messages to the listener, and ignores its own posts', async () => {
+    const name = channelName()
+    const scene = track(new FakeScene(name))
+    const seen: SceneToPage[] = []
+    const ch = track(new BridgeChannel(name, (m) => seen.push(m)))
+    await settle()
+
+    ch.send({ kind: 'getProfile' }) // page→scene: must not come back to us
+    scene.send({ kind: 'event', name: 'playerReady' })
+    await settle()
+
+    expect(seen.map((m) => m.kind)).toContain('event')
+    expect(seen.some((m) => m.kind === 'getProfile' as unknown)).toBe(false)
+  })
+})
+
+describe('an unreachable bridge is surfaced, not silent', () => {
+  it('turns bridgeUnavailable into a dismissable crash the user can act on', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    expect(h.session().fatalError).toBeNull()
+
+    h.driver.emit({ kind: 'bridgeUnavailable' })
+    expect(h.session().fatalError?.source).toBe('runtime')
+    expect(h.session().fatalError?.message).toMatch(/bridge/i)
+  })
+
+  it('does not overwrite a crash already on screen', async () => {
+    const h = renderSession()
+    await enterAsGuest(h)
+    h.driver.emit({ kind: 'bridgeUnavailable' })
+    const first = h.session().fatalError
+    h.driver.emit({ kind: 'bridgeUnavailable' })
+    expect(h.session().fatalError).toBe(first)
+  })
+})

--- a/react-web/src/test/bridgeReadiness.test.ts
+++ b/react-web/src/test/bridgeReadiness.test.ts
@@ -141,6 +141,21 @@ describe('bridge readiness handshake', () => {
     expect(ch.isReady()).toBe(false)
   })
 
+  it('reports once: re-arming after the report does not raise it again', async () => {
+    vi.useFakeTimers()
+    const name = channelName()
+    const onUnavailable = vi.fn()
+    const ch = track(new BridgeChannel(name, () => {}, onUnavailable))
+    ch.expectReady()
+    await vi.advanceTimersByTimeAsync(31_000)
+    expect(onUnavailable).toHaveBeenCalledTimes(1)
+
+    // The session arms on every phase change past launch (entering → world).
+    ch.expectReady()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(onUnavailable).toHaveBeenCalledTimes(1)
+  })
+
   it('does not report unavailable once the scene has answered', async () => {
     vi.useFakeTimers()
     const name = channelName()
@@ -196,17 +211,17 @@ describe('bridge readiness handshake', () => {
 })
 
 describe('an unreachable bridge is surfaced, not silent', () => {
-  it('turns bridgeUnavailable into a dismissable crash the user can act on', async () => {
+  it('turns bridgeUnavailable into a dismissable dialog, not a crash', async () => {
     const h = renderSession()
     await enterAsGuest(h)
     expect(h.session().fatalError).toBeNull()
 
     h.driver.emit({ kind: 'bridgeUnavailable' })
-    expect(h.session().fatalError?.source).toBe('runtime')
+    expect(h.session().fatalError?.source).toBe('bridge')
     expect(h.session().fatalError?.message).toMatch(/bridge/i)
   })
 
-  it('does not overwrite a crash already on screen', async () => {
+  it('does not overwrite an error already on screen', async () => {
     const h = renderSession()
     await enterAsGuest(h)
     h.driver.emit({ kind: 'bridgeUnavailable' })

--- a/react-web/src/test/bridgeReadiness.test.ts
+++ b/react-web/src/test/bridgeReadiness.test.ts
@@ -40,8 +40,14 @@ class FakeScene {
   }
 }
 
-/** BroadcastChannel delivery is a task, not microtask — let it land. */
-const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
+/** BroadcastChannel delivery is asynchronous, and on a loaded CI runner it takes more than the one
+ *  macrotask a bare setTimeout(0) waits for — so poll for the outcome rather than assume a turn.
+ *  (A single `settle()` passed locally and failed in CI: bridgeReadiness at Build and Deploy Web.) */
+const until = (check: () => boolean): Promise<void> =>
+  vi.waitFor(() => {
+    if (!check()) throw new Error('not yet')
+  })
+
 
 let open: Array<{ close: () => void }> = []
 const track = <T extends { close: () => void }>(x: T): T => {
@@ -62,8 +68,7 @@ describe('bridge readiness handshake', () => {
     const name = channelName()
     const scene = track(new FakeScene(name))
     track(new BridgeChannel(name, () => {}))
-    await settle()
-    expect(scene.kinds()).toContain('hello')
+    await until(() => scene.kinds().includes('hello'))
   })
 
   it('holds page messages until the scene answers, then flushes them IN ORDER', async () => {
@@ -73,14 +78,14 @@ describe('bridge readiness handshake', () => {
 
     ch.send({ kind: 'getProfile' })
     ch.send({ kind: 'getNotifications' })
-    await settle()
+    await until(() => scene.kinds().includes('hello'))
     // Nothing but the handshake has gone out.
     expect(scene.kinds().filter((k) => k !== 'hello')).toEqual([])
     expect(ch.isReady()).toBe(false)
 
     scene.announce()
-    await settle()
-    expect(ch.isReady()).toBe(true)
+    await until(() => ch.isReady())
+    await until(() => scene.kinds().filter((k) => k !== 'hello').length === 2)
     expect(scene.kinds().filter((k) => k !== 'hello')).toEqual(['getProfile', 'getNotifications'])
   })
 
@@ -89,11 +94,10 @@ describe('bridge readiness handshake', () => {
     const scene = track(new FakeScene(name))
     scene.autoAnswer = true
     const ch = track(new BridgeChannel(name, () => {}))
-    await settle()
+    await until(() => ch.isReady())
 
     ch.send({ kind: 'getProfile' })
-    await settle()
-    expect(scene.kinds()).toContain('getProfile')
+    await until(() => scene.kinds().includes('getProfile'))
   })
 
   it('keeps saying hello until answered, so a scene that starts LATE still hears it', async () => {
@@ -171,10 +175,9 @@ describe('bridge readiness handshake', () => {
 
     ch.send({ kind: 'getProfile' }) // belongs to the scene: queued
     ch.sendNow({ kind: 'rpc:req', id: 'a', method: 'loginPrevious' })
-    await settle()
+    await until(() => scene.kinds().includes('rpc:req'))
 
     // Sign-in reaches the engine while the scene is still booting; the scene's own request waits.
-    expect(scene.kinds()).toContain('rpc:req')
     expect(scene.kinds()).not.toContain('getProfile')
   })
 
@@ -183,13 +186,11 @@ describe('bridge readiness handshake', () => {
     const scene = track(new FakeScene(name))
     const seen: SceneToPage[] = []
     const ch = track(new BridgeChannel(name, (m) => seen.push(m)))
-    await settle()
+    await until(() => scene.kinds().includes('hello'))
 
     ch.send({ kind: 'getProfile' }) // page→scene: must not come back to us
     scene.send({ kind: 'event', name: 'playerReady' })
-    await settle()
-
-    expect(seen.map((m) => m.kind)).toContain('event')
+    await until(() => seen.some((m) => m.kind === 'event'))
     expect(seen.some((m) => m.kind === 'getProfile' as unknown)).toBe(false)
   })
 })

--- a/react-web/src/test/error.test.tsx
+++ b/react-web/src/test/error.test.tsx
@@ -39,7 +39,7 @@ describe('openRealmError', () => {
     const onDismiss = vi.fn()
     render(<PopupHost />)
     act(() => {
-      openRealmError({ message: 'The world "nope.dcl.eth" doesn\'t exist.', onDismiss })
+      openRealmError({ title: 'World not found', message: 'The world "nope.dcl.eth" doesn\'t exist.', onDismiss })
     })
     expect(screen.getByText(/World not found/i)).toBeInTheDocument()
     expect(screen.getByText(/nope\.dcl\.eth/)).toBeInTheDocument()
@@ -53,7 +53,7 @@ describe('openRealmError', () => {
     const onDismiss = vi.fn()
     render(<PopupHost />)
     act(() => {
-      openRealmError({ message: 'The world "nope.dcl.eth" doesn\'t exist.', onDismiss })
+      openRealmError({ title: 'World not found', message: 'The world "nope.dcl.eth" doesn\'t exist.', onDismiss })
     })
     // Unlike a crash, a world-not-found freezes nothing behind it.
     expect(isInputLocked()).toBe(false)

--- a/src/react_hud_cef.rs
+++ b/src/react_hud_cef.rs
@@ -43,7 +43,7 @@ use cef_offscreen::prelude::{
     WebviewSize,
 };
 use common::rpc::{RpcResultReceiver, RpcResultSender, RpcStreamSender};
-use common::structs::PrimaryUser;
+use common::structs::{OutOfWorld, PrimaryUser};
 use input_manager::{InputPriorities, MouseInteractionComponent};
 use system_bridge::SystemApi;
 
@@ -677,9 +677,11 @@ fn pump_streams(state: Option<ResMut<ReactHudCef>>, mut commands: Commands) {
 }
 
 // Tell the page the player has spawned (drives entering -> world), once per page subscription.
+// The primary user entity exists from startup, so `Without<OutOfWorld>` is what makes this mean
+// "in world" rather than "signed in or not".
 fn player_ready(
     state: Option<ResMut<ReactHudCef>>,
-    players: Query<(), With<PrimaryUser>>,
+    players: Query<(), (With<PrimaryUser>, Without<OutOfWorld>)>,
     mut commands: Commands,
 ) {
     let Some(mut state) = state else { return };


### PR DESCRIPTION
Opening the menu on native showed no profile chip, for the whole session, even though the avatar wore the right wearables — the engine had the profile, the page did not. This is pre-existing on main, and turned out to be two independent problems with the same shape.

### The engine announced a player that had not entered the world

The CEF boot shim announced `playerReady` as soon as a `PrimaryUser` entity existed — true from startup, before the user has signed in. The page takes that as its world-entry signal and fetches the profile off it. The bridge scene answered with what it could see (`getPlayer()` was still null), and the page marked the fetch done for the session, so nothing ever asked again.

Gated on `Without<OutOfWorld>`, the engine's own marker for the pre-world state, which is the distinction the page is actually asking about.

### The transport dropped anything sent before the other end subscribed

A `BroadcastChannel` has no buffering and no connection: a message posted before the other end subscribes is gone, and neither side is told. The page and the bridge scene start independently — the engine boots the scene, the browser (or CEF) loads the page — so either can win that race, and whatever falls in the gap is lost silently. That is how the HUD ends up with panels that never fill and no error to explain why.

The page now repeats `hello` until the scene answers `bridgeReady`, holding page→scene messages and flushing them in order. `BridgeChannel` is shared by both drivers, since the failure belongs to the transport rather than to either one. The scene announces once its domains are registered and answers *every* hello, so a page that reloads or starts late is still answered, and the session domain re-sends its one-shot `playerReady` to the newcomer.

Either fix alone would have closed the reported bug; together they also close the class of it.

### The scene answers only what it can answer

`getProfile` used to reply `{ profile: null }` when `getPlayer()` — the scene's view of the player CRDT, which lags world entry by a few hundred frames — was still null. The page marks that fetch done as soon as it asks, so one null cost it the profile for the session. Even with the two fixes above, a request could still land in that window: on native when the bridge scene connects after the player is already in world, on web when a world takes longer to spawn the player than `EngineDriver`'s 6s synthetic `playerReady`. The request is now held and answered once the player exists, which also makes the domain's two gates agree — `playerReady` fires on `getPlayer() != null`, and now so does the profile that follows it.

### Two deliberate exceptions

- **Native login RPCs bypass the queue.** The engine's own boot shim answers them before any scene exists, so queueing them would gate the login screen on a scene that sign-in does not involve — measured at 20s of dead login screen with a slow bridge. Native-only by construction: only `BridgeClient` sends `rpc:req`; web's `EngineDriver` runs login over console commands.
- **The unavailable-bridge timeout is armed only once a launch has been requested.** On web nothing runs until the user picks a destination — the engine boots at the picked realm and the bridge scene with it — so a clock started at construction, or in the picker, just accuses an idle screen. It arms on `entering`/`world`, once. After 30s the page opens a dismissable "HUD not connected" dialog on the popup layer rather than the crash surface, since the engine and the world keep running; it keeps saying hello, so a scene that turns up later still flushes the queue.

Verified by hand on native and web, in the clean case and with the bridge scene artificially delayed by 20s.

Closes #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

