### PR TITLE
HUD profiles through the engine's cache: getUserProfile op replaces the bridge's lambdas fetch

### DIFF
--- a/crates/dcl/src/js/modules/SystemApi.js
+++ b/crates/dcl/src/js/modules/SystemApi.js
@@ -121,8 +121,11 @@ module.exports.setAvatar = async function(avatar) {
     return await Deno.core.ops.op_set_avatar(avatar)
 }
 
-module.exports.getProfileExtras = async function() {
-    return await Deno.core.ops.op_get_profile_extras();
+// any user's full profile (own, nearby or remote), resolved through the engine's profile cache
+// and fetch cascade. Rejects if the address can't be resolved.
+// address: string => SerializedProfile
+module.exports.getUserProfile = async function(address) {
+    return await Deno.core.ops.op_get_user_profile(address);
 }
 
 // get the next key/button pressed by the user, identified as a string

--- a/crates/dcl/src/js/system_api.rs
+++ b/crates/dcl/src/js/system_api.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use bevy::{log::debug, math::Vec4};
 use common::{
     inputs::{Action, BindingsData, HudPanel, InputIdentifier, SystemActionEvent},
+    profile::SerializedProfile,
     rpc::{RpcCall, RpcResultReceiver, RpcResultSender, RpcStreamReceiver, RpcStreamSender},
     structs::{
         MicState, PermissionLevel, PermissionStrings, PermissionType, PermissionUsed,
@@ -482,29 +483,31 @@ pub async fn op_read_bridge_stream(
     Ok(res)
 }
 
-pub async fn op_get_profile_extras(
+/// Any user's full profile (own, nearby, or remote) as the engine holds it, resolved through the
+/// same cache and fetch cascade as nametags and `getPlayerData` — but unlike the latter, not
+/// squeezed into the SDK's `UserData`, so `extra_fields`, `name_color` and emotes survive.
+/// Rejects once the cascade has concluded with nothing.
+pub async fn op_get_user_profile(
     state: Rc<RefCell<impl State>>,
-) -> Result<std::collections::HashMap<String, serde_json::Value>, anyhow::Error> {
+    address: String,
+) -> Result<SerializedProfile, anyhow::Error> {
     let (sx, rx) = RpcResultSender::channel();
 
     let scene = state.borrow().borrow::<CrdtContext>().scene_id.0;
-    debug!("[{scene:?}] -> op_get_profile_extras");
+    debug!("[{scene:?}] -> op_get_user_profile {address}");
 
     state
         .borrow_mut()
         .borrow_mut::<RpcCalls>()
         .push(RpcCall::GetUserData {
-            user: None, // current user
+            user: Some(address),
             scene,
             response: sx,
         })?;
 
-    let profile = rx
-        .await
+    rx.await
         .map_err(|e| anyhow::anyhow!(e))?
-        .map_err(|_| anyhow::anyhow!("Not found"))?;
-
-    Ok(profile.extra_fields)
+        .map_err(|_| anyhow::anyhow!("Not found"))
 }
 
 pub fn op_quit(state: Rc<RefCell<impl State>>) {

--- a/crates/dcl_deno/src/js/op_wrappers/system_api.rs
+++ b/crates/dcl_deno/src/js/op_wrappers/system_api.rs
@@ -1,5 +1,6 @@
 use common::{
     inputs::{HudPanel, SystemActionEvent},
+    profile::SerializedProfile,
     structs::{MicState, PermissionType, PermissionUsed, PermissionValue},
 };
 use dcl::js::system_api::{JsBindingsData, PermissionTypeDetail};
@@ -48,7 +49,7 @@ pub fn ops(super_user: bool) -> Vec<OpDecl> {
             op_bridge_to_page(),
             op_get_bridge_stream(),
             op_read_bridge_stream(),
-            op_get_profile_extras(),
+            op_get_user_profile(),
             op_quit(),
             op_get_permission_request_stream(),
             op_read_permission_request_stream(),
@@ -315,10 +316,11 @@ pub async fn op_read_bridge_stream(
 
 #[op2(async)]
 #[serde]
-pub async fn op_get_profile_extras(
+pub async fn op_get_user_profile(
     state: Rc<RefCell<OpState>>,
-) -> Result<std::collections::HashMap<String, serde_json::Value>, deno_core::anyhow::Error> {
-    dcl::js::system_api::op_get_profile_extras(state).await
+    #[string] address: String,
+) -> Result<SerializedProfile, deno_core::anyhow::Error> {
+    dcl::js::system_api::op_get_user_profile(state, address).await
 }
 
 #[op2(fast)]

--- a/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
+++ b/crates/dcl_wasm/src/inner/op_wrappers/system_api.rs
@@ -209,10 +209,13 @@ pub fn op_send_chat(state: &WorkerContext, message: String, channel: String) {
 }
 
 #[wasm_bindgen]
-pub async fn op_get_profile_extras(state: &WorkerContext) -> Result<JsValue, WasmError> {
-    let extras = dcl::js::system_api::op_get_profile_extras(state.rc()).await;
+pub async fn op_get_user_profile(
+    state: &WorkerContext,
+    address: String,
+) -> Result<JsValue, WasmError> {
+    let profile = dcl::js::system_api::op_get_user_profile(state.rc(), address).await;
     // use a specific serializer to convert to object here, as wasm_bindgen's conversion otherwise produces a Map
-    extras
+    profile
         .map(|v| {
             v.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
                 .unwrap()

--- a/react-web/bridge-scene/src/bevy-api.ts
+++ b/react-web/bridge-scene/src/bevy-api.ts
@@ -3,6 +3,7 @@
 // the wire shapes React sees live in the shared protocol. Only the methods the domains use
 // are declared — extend as needed.
 import type { ActionWire, Setting } from '../../src/engine/protocol'
+import type { SerializedProfile } from './domains/profile'
 import type {
   AvatarModifierState,
   BlockedUserData,
@@ -128,6 +129,10 @@ export type BevyApiInterface = {
    *  never the bridge. */
   liveSceneInfo: () => Promise<LiveSceneInfo[]>
   setAvatar: (data: SetAvatarData) => Promise<unknown>
+  /** Any user's full deployed profile as the engine holds it (own, nearby and remote players,
+   *  guests included), resolved through its profile cache and fetch cascade. Rejects once the
+   *  engine has concluded the address can't be resolved. */
+  getUserProfile: (address: string) => Promise<SerializedProfile>
   kernelFetch: (req: KernelFetchRequest) => Promise<KernelFetchResponse>
   getRealmProvider: () => Promise<string>
   getPreviousLogin: () => Promise<{ userId: string | null }>

--- a/react-web/bridge-scene/src/domains/chat.ts
+++ b/react-web/bridge-scene/src/domains/chat.ts
@@ -1,10 +1,11 @@
 // Chat: incoming messages, sending, and the nearby-players roster.
 //   from: BevyApi.getChatStream() / sendChat(), @dcl/sdk PlayerIdentityData (nearby roster)
-//         + the catalyst profile cache (profile.ts) for faces.
+//         + the ENGINE's profile cache (~system/Players getPlayerData) for faces.
 import { engine, PlayerIdentityData, PointerLock } from '@dcl/sdk/ecs'
 import { getPlayer } from '@dcl/sdk/players'
+import { getPlayerData } from '~system/Players'
 import { BevyApi } from '../bevy-api'
-import { fetchProfile, profileCache, profileKey } from './profile'
+import { httpOrUndef, profileKey } from './profile'
 import { setChatBubble } from './nametags'
 import { onSystemAction } from './systemAction'
 import type { Ctx } from '../bridge'
@@ -64,6 +65,10 @@ export function registerChat(ctx: Ctx): void {
   })
 
   // Nearby players (PlayerIdentityData set) → chat header "Nearby · N". Poll ~3s, push on change.
+  // Faces come from the engine's profile cache, which already holds every nearby player's profile
+  // for their nametag: one RPC per address, answered once the engine has resolved it. An address
+  // it couldn't resolve is dropped, so the next tick asks again.
+  const faces = new Map<string, string | undefined>()
   let acc = 3
   let lastKey = ''
   ctx.push((dt) => {
@@ -73,14 +78,17 @@ export function registerChat(ctx: Ctx): void {
     const members: NearbyMember[] = []
     for (const [, data] of engine.getEntitiesWith(PlayerIdentityData)) {
       const address = data.address
-      if (!profileCache.has(profileKey(address))) {
-        void fetchProfile(address).catch(() => undefined)
+      const key = profileKey(address)
+      if (!faces.has(key)) {
+        faces.set(key, undefined)
+        getPlayerData({ userId: address })
+          .then((res) => faces.set(key, httpOrUndef(res.data?.avatar?.snapshots?.face256)))
+          .catch(() => faces.delete(key))
       }
-      const face = profileCache.get(profileKey(address))?.avatars?.[0]?.avatar?.snapshots?.face256
       members.push({
         address,
         name: getPlayer({ userId: address })?.name ?? '',
-        picture: typeof face === 'string' && face.startsWith('http') ? face : undefined
+        picture: faces.get(key)
       })
     }
     const key = members.map((m) => `${m.address}:${m.picture ?? ''}`).sort().join(',')

--- a/react-web/bridge-scene/src/domains/nametags.tsx
+++ b/react-web/bridge-scene/src/domains/nametags.tsx
@@ -133,7 +133,7 @@ function fnv1a64(str: string): bigint {
 // Name colour, matching the engine's UserProfile::name_color() resolution so the pill agrees with the
 // in-world point-at marker: a profile-set CUSTOM colour wins (claimed names only), else the address-
 // hashed palette. (We keep colouring unclaimed names by hash rather than greying them, per the
-// reference mobile nametags.) Custom colours come from the catalyst profile (resolveClaimed) and the
+// reference mobile nametags.) Custom colours come from the engine's profile (resolveClaimed) and the
 // hash is memoised — tagElement re-evaluates per texture render.
 const customColorCache = new Map<string, Color4>()
 const colorCache = new Map<string, Color4>()
@@ -148,25 +148,30 @@ function nameColor(userId: string): Color4 {
   return c
 }
 
-// hasClaimedName + custom name colour from the catalyst profile (async, cached); fall back to the
-// name-suffix heuristic until it resolves so the badge / discriminator don't flicker on first sight.
-const claimedCache = new Map<string, boolean>()
-const pendingClaimed = new Set<string>()
-function resolveClaimed(userId: string): void {
-  if (claimedCache.has(userId) || pendingClaimed.has(userId)) return
-  pendingClaimed.add(userId)
+// hasClaimedName + custom name colour from the engine's profile (async, cached per NAME: a rename is
+// exactly what claims or drops a unique name, and the engine's copy of the profile is already the
+// renamed one by the time the tag sees the new name); fall back to the name-suffix heuristic until
+// it resolves so the badge / discriminator don't flicker on first sight.
+const claimedCache = new Map<string, { name: string; claimed: boolean }>()
+const pendingClaimed = new Map<string, string>()
+function resolveClaimed(userId: string, name: string): void {
+  if (claimedCache.get(userId)?.name === name || pendingClaimed.get(userId) === name) return
+  pendingClaimed.set(userId, name)
   fetchProfile(userId)
-    .then((p) => {
-      const av = p?.avatars?.[0]
-      const name = getPlayer({ userId })?.name ?? ''
+    .then((av) => {
       const claimed = av?.hasClaimedName ?? !name.includes('#')
-      claimedCache.set(userId, claimed)
+      claimedCache.set(userId, { name, claimed })
       // The profile can set a custom name colour — engine logic applies it for claimed names only.
       const nc = av?.nameColor
       if (claimed && nc != null) customColorCache.set(userId, Color4.create(nc.r, nc.g, nc.b, 1))
+      else customColorCache.delete(userId)
     })
-    .catch(() => undefined)
-    .finally(() => pendingClaimed.delete(userId))
+    // Settle on the heuristic rather than leave the entry empty: Tag asks every frame, so an
+    // unresolvable profile would otherwise be re-requested every frame.
+    .catch(() => claimedCache.set(userId, { name, claimed: !name.includes('#') }))
+    .finally(() => {
+      if (pendingClaimed.get(userId) === name) pendingClaimed.delete(userId)
+    })
 }
 
 // The pill rendered into the tag's UiCanvas → texture. Re-evaluated each frame, so name/colour/
@@ -179,7 +184,8 @@ function tagElement(userId: string): () => ReactEcs.JSX.Element | null {
     const firstPerson = CameraMode.get(engine.CameraEntity).mode === CameraType.CT_FIRST_PERSON
     if (isSelf && firstPerson) return null
 
-    const isClaimed = claimedCache.get(userId) ?? !name.includes('#')
+    resolveClaimed(userId, name)
+    const isClaimed = claimedCache.get(userId)?.claimed ?? !name.includes('#')
     const baseName = name.split('#')[0]
     // ONE text element so the name and #wallet-id sit tight (no inter-element gap — the Figma shows
     // them flush). Name is bold in its hash colour (the element's base colour); the wallet id uses
@@ -342,7 +348,6 @@ export function initNametags(): void {
       const built = createPoolEntry(userId)
       entry = { anchor: built.anchor, plane: built.plane, userId }
       pool.set(key, entry)
-      resolveClaimed(userId)
     }
     AvatarAttach.createOrReplace(entry.anchor, { avatarId: entry.userId, anchorPointId: AvatarAnchorPointType.AAPT_NAME_TAG })
     const t = Transform.getMutableOrNull(entry.plane)

--- a/react-web/bridge-scene/src/domains/profile.ts
+++ b/react-web/bridge-scene/src/domains/profile.ts
@@ -1,7 +1,9 @@
 // Profile: the local player's profile card + any user's passport (View Profile).
 //   from: @dcl/sdk getPlayer() (address/name/isGuest)
-//       + catalyst lambda  GET /lambdas/profiles/:userId  (avatar face + body, name, links)
-//       + the ENGINE's profile cache via ~system/Players getPlayerData (display identity for a list)
+//       + the ENGINE's profile cache: BevyApi.getUserProfile (the full deployed profile — face +
+//         body snapshots, name, links, about-me) and ~system/Players getPlayerData (display
+//         identity for a list)
+//       + catalyst lambda  GET /lambdas/users/:id/names  (owned NFT names)
 //       + badges service   GET badges.decentraland.org/users/:id/badges
 //       + camera-reel       GET camera-reel-service.decentraland.org/api/users/:id/images
 import { getPlayer } from '@dcl/sdk/players'
@@ -17,7 +19,9 @@ import type { JsonValue } from '../../../src/engine/generated/serde_json/JsonVal
 import { BevyApi } from '../bevy-api'
 import type { Ctx } from '../bridge'
 
-type CatalystAvatar = {
+/** A deployed profile as the engine holds it (`common::profile::SerializedProfile`, serde JSON).
+ *  Only the keys the passport reads are typed here; anything else rides along untyped. */
+export type SerializedProfile = {
   name?: string
   hasClaimedName?: boolean
   /** Profile-set custom name colour (claimed names only), 0–1 floats. */
@@ -53,21 +57,17 @@ type CatalystAvatar = {
     emotes?: Array<{ slot: number; urn: string }>
   }
 }
-export type ProfileResponse = { avatars?: CatalystAvatar[] }
 
-/** Addresses are the cache key, always lowercased — the same wallet reaches us in either case. */
+/** Addresses are always lowercased — the same wallet reaches us in either case, and the engine
+ *  matches its cache on the lowercase form. */
 export const profileKey = (address: string): string => address.toLowerCase()
 
-const cache = new Map<string, ProfileResponse>()
-export { cache as profileCache }
-
-export async function fetchProfile(userId: string): Promise<ProfileResponse | undefined> {
-  const cached = cache.get(profileKey(userId))
-  if (cached != null) return cached
-  const base = await catalystBase()
-  const data = await getJson<ProfileResponse>(`${base}/lambdas/profiles/${userId}`).catch(() => undefined)
-  if (data != null) cache.set(profileKey(userId), data)
-  return data
+/** A user's deployed profile as the ENGINE holds it — the same cache and fetch cascade (registry,
+ *  catalyst, then peers) that nametags read, so a guest resolves too (their profile only exists
+ *  on the wire), and a save made through `setAvatar` is visible on the next read without a cache
+ *  of our own to keep in step. `undefined` when the engine can't resolve the address. */
+export async function fetchProfile(address: string): Promise<SerializedProfile | undefined> {
+  return await BevyApi.getUserProfile(profileKey(address)).catch(() => undefined)
 }
 
 /** What a list row needs to show a person: their name, face, and claimed-name seal. */
@@ -119,7 +119,7 @@ function identityOf(data: PlayerData | undefined, address: string): ProfileIdent
 
 const shortAddress = (a: string): string => (a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a)
 
-const httpOrUndef = (s?: string | null): string | undefined => (typeof s === 'string' && s.startsWith('http') ? s : undefined)
+export const httpOrUndef = (s?: string | null): string | undefined => (typeof s === 'string' && s.startsWith('http') ? s : undefined)
 
 /** The profile stores a non-claimed name bare; every explorer shows it with four hex digits of
  *  the address appended (the engine builds nametags the same way — `crates/avatar`), so the
@@ -127,7 +127,7 @@ const httpOrUndef = (s?: string | null): string | undefined => (typeof s === 'st
 const withAddressTag = (name: string, address: string, claimed: boolean): string =>
   claimed || name.includes('#') ? name : `${name}#${address.slice(-4)}`
 
-function toProfile(av: CatalystAvatar | undefined, address: string, isGuest: boolean, fallbackName: string): Profile {
+function toProfile(av: SerializedProfile | undefined, address: string, isGuest: boolean, fallbackName: string): Profile {
   const snaps = av?.avatar?.snapshots
   const claimed = av?.hasClaimedName ?? !fallbackName.includes('#')
   return {
@@ -158,7 +158,7 @@ const INFO_KEYS = {
   profession: 'profession',
   hobby: 'hobbies',
   realName: 'realName'
-} as const satisfies Partial<Record<keyof ProfileInfo, keyof CatalystAvatar>>
+} as const satisfies Partial<Record<keyof ProfileInfo, keyof SerializedProfile>>
 
 /** Epoch seconds (how the profile stores a birthdate) → the `YYYY-MM-DD` the passport edits.
  *  UTC on both sides: a birthday is a date, and shifting it by the viewer's timezone would let a
@@ -180,10 +180,10 @@ const fromIsoDate = (iso: string | undefined): number | undefined => {
 
 /** `undefined` when the profile carries no about-me fields at all, so the passport can tell an
  *  empty section from a missing one. */
-function toInfo(av: CatalystAvatar | undefined): ProfileInfo | undefined {
+function toInfo(av: SerializedProfile | undefined): ProfileInfo | undefined {
   if (av == null) return undefined
   const info: ProfileInfo = {}
-  for (const [wireKey, profileKey] of Object.entries(INFO_KEYS) as Array<[keyof ProfileInfo, keyof CatalystAvatar]>) {
+  for (const [wireKey, profileKey] of Object.entries(INFO_KEYS) as Array<[keyof ProfileInfo, keyof SerializedProfile]>) {
     const value = av[profileKey]
     if (typeof value === 'string' && value !== '') info[wireKey] = value
   }
@@ -275,24 +275,6 @@ function toProfileExtras(msg: SaveProfileRequest): Record<string, JsonValue> {
   return extras
 }
 
-/** Fold a save into the cached catalyst avatar, so every surface that re-reads the profile shows
- *  the new values immediately. The deploy is asynchronous and the catalyst reindexes later still,
- *  so without this a passport reopened right after saving would show the pre-edit profile. */
-function patchCachedAvatar(address: string, msg: SaveProfileRequest, hasClaimedName: boolean | undefined): void {
-  const cached = cache.get(profileKey(address)) ?? { avatars: [{}] }
-  const av = { ...((cached.avatars?.[0] ?? {}) as Record<string, unknown>) }
-  if (msg.name !== undefined) {
-    av.name = msg.name
-    if (hasClaimedName !== undefined) av.hasClaimedName = hasClaimedName
-  }
-  // A `null` from toProfileExtras means "remove this key", so those are dropped rather than
-  // written — the engine does the same to the profile itself.
-  const patch = toProfileExtras(msg)
-  const cleared = new Set(Object.keys(patch).filter((key) => patch[key] == null))
-  const patched = Object.fromEntries(Object.entries({ ...av, ...patch }).filter(([key]) => !cleared.has(key)))
-  cache.set(profileKey(address), { ...cached, avatars: [patched as CatalystAvatar, ...(cached.avatars ?? []).slice(1)] })
-}
-
 export function registerProfile(ctx: Ctx): void {
   ctx.on('getOwnedNames', async () => {
     const player = getPlayer()
@@ -307,14 +289,12 @@ export function registerProfile(ctx: Ctx): void {
     }
 
     const data: SetAvatarData = {}
-    let hasClaimedName: boolean | undefined
     if (msg.name !== undefined) {
       const owned = await fetchOwnedNames(player.userId).catch(() => [])
-      hasClaimedName = owned.some((n) => n.toLowerCase() === msg.name?.toLowerCase())
       // An empty bodyShapeUrn and null colors mean "leave the avatar alone" — the name is the only
       // thing this edit touches, and the Backpack owns the rest.
       data.base = { skinColor: null, eyesColor: null, hairColor: null, bodyShapeUrn: '', name: msg.name }
-      data.hasClaimedName = hasClaimedName
+      data.hasClaimedName = owned.some((n) => n.toLowerCase() === msg.name?.toLowerCase())
     }
     const extras = toProfileExtras(msg)
     if (Object.keys(extras).length > 0) data.profileExtras = extras
@@ -334,9 +314,10 @@ export function registerProfile(ctx: Ctx): void {
       return
     }
 
-    patchCachedAvatar(player.userId, msg, hasClaimedName)
     ctx.send({ kind: 'profileSaved', ok: true })
-    const av = cache.get(profileKey(player.userId))?.avatars?.[0]
+    // setAvatar amends the engine's own copy of the profile before it resolves, so re-reading it
+    // is the post-save state — no need to fold the edit in by hand.
+    const av = await fetchProfile(player.userId)
     ctx.send({ kind: 'profile', profile: toProfile(av, player.userId, player.isGuest, player.name) })
   })
 
@@ -352,8 +333,8 @@ export function registerProfile(ctx: Ctx): void {
     wanted = false
     inFlight = true
     try {
-      const data = await fetchProfile(player.userId).catch(() => undefined)
-      ctx.send({ kind: 'profile', profile: toProfile(data?.avatars?.[0], player.userId, player.isGuest, player.name) })
+      const av = await fetchProfile(player.userId)
+      ctx.send({ kind: 'profile', profile: toProfile(av, player.userId, player.isGuest, player.name) })
     } finally {
       inFlight = false
     }
@@ -368,20 +349,18 @@ export function registerProfile(ctx: Ctx): void {
 
   // View Profile: fetch another user's full passport by address (profile + badges + photos).
   ctx.on('getUserProfile', async (msg) => {
-    const [data, badges, photos] = await Promise.all([
-      fetchProfile(msg.address).catch(() => undefined),
+    const [av, badges, photos] = await Promise.all([
+      fetchProfile(msg.address),
       fetchBadges(msg.address).catch(() => undefined),
       fetchPhotos(msg.address).catch(() => undefined)
     ])
-    const av = data?.avatars?.[0]
     if (av == null && badges == null && photos == null) {
       ctx.send({ kind: 'userProfile', address: msg.address, profile: null })
       return
     }
-    // Your OWN passport: read the live avatar (getPlayer()) rather than the deployed catalyst
-    // profile, so it matches the Backpack exactly — a just-equipped item shows immediately instead
-    // of waiting for the profile to redeploy and the catalyst to reindex it. Other users have no
-    // live source (getPlayer(userId) only resolves nearby avatars), so they stay catalyst-only.
+    // Your OWN passport: read the live avatar (getPlayer()) so it matches the Backpack exactly.
+    // Other users have no live source (getPlayer(userId) only resolves nearby avatars), so they
+    // read the equipment their deployed profile lists.
     const me = getPlayer()
     const isSelf = me != null && me.userId.toLowerCase() === msg.address.toLowerCase()
     const wearableUrns = isSelf ? (me.wearables ?? []).map(String) : (av?.avatar?.wearables ?? [])

--- a/react-web/docs/backlog.md
+++ b/react-web/docs/backlog.md
@@ -479,7 +479,7 @@ priority. Each item is tagged at the start: `[DS]` design-system primitive / ext
     Needs a WASM rebuild, so it belongs in its own PR, not in the HUD stack.
 46. `[arch]` **Passport open blocks the whole panel on the equipped-items resolution** — *perceived
     latency, from PR #1058*. `getUserProfile` (`bridge-scene/src/domains/profile.ts`) awaits the
-    catalyst profile + badges + photos, then awaits `resolveEquippedSet` / `resolveEquippedEmotes`
+    engine profile + badges + photos, then awaits `resolveEquippedSet` / `resolveEquippedEmotes`
     (catalyst collections lambda, plus the marketplace items API for legacy collections-v1 items)
     before sending a single `userProfile` message. So name, avatar, About and badges — all already
     fetched — sit behind ~3 sequential round trips of work only the equipped grid needs. Unity does


### PR DESCRIPTION
Rebased onto main after #1249 merged.

## Why

The bridge scene fetched passports straight from `lambdas/profiles/{address}` and kept its own copy of the answer. Three things fell out of that:

- a **guest's own passport** flashed their name and then flipped to the raw address with a verified seal (a guest has no catalyst profile, so the fetch found nothing);
- a **save** had to be folded into that copy by hand (`patchCachedAvatar`) so a reopened passport didn't show pre-edit data;
- a **renamed player** kept a stale claimed-name tick on other clients' nametags for the whole session.

The engine already resolves any address through its profile cascade (registry batch, catalyst, then peers, guests via peers). The bridge only bypassed it because `getPlayerData` squeezes the answer into the SDK `UserData`, which drops the extra fields (description, links, about-me), the custom name colour and emotes.

## What

- **Engine op.** `getProfileExtras` (no callers anywhere) already went through `RpcCall::GetUserData` and threw away everything but the extras. It becomes `getUserProfile(address) -> SerializedProfile`, same path, with the deno and wasm wrappers following. No new bevy event or system.
- **Bridge.** Profile, nametags and chat faces read the engine copy. `profileCache`, `ProfileResponse` and `patchCachedAvatar` are gone; the post-save `profile` push just re-reads, since `setAvatar` amends the engine's copy before it resolves. Owned names, badges and camera-reel photos stay on their services (the engine doesn't hold them).
- **Nametags.** The claimed flag and custom colour are cached per *name*, so a rename re-resolves; a failed lookup settles on the suffix heuristic rather than re-asking every frame.
- The mock is unaffected: it stands in for the whole bridge scene at the page wire, which is unchanged.

Verified on this diff: `cargo fmt --check`, `cargo clippy -p dcl -p dcl_deno -- -D warnings`, bridge-scene build + type check, eslint. Native run by @robtfm: own/guest/other passports and nametags from both a logged-in and a guest client, including the rename case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
