### PR TITLE
Auto transparency: stop treating a present alpha_test as a request for masking

### DIFF
--- a/crates/scene_runner/src/update_world/material.rs
+++ b/crates/scene_runner/src/update_world/material.rs
@@ -112,9 +112,11 @@ impl MaterialDefinition {
                     .map(Color4DclToBevy::convert_linear_rgba)
                     .unwrap_or(base.base_color);
 
-                let alpha_mode = if let Some(test) = unlit.alpha_test {
-                    AlphaMode::Mask(test)
-                } else if base_color.alpha() < 1.0 || tex_is_present(&unlit.alpha_texture) {
+                // Unlit materials have no transparency mode, so they always resolve like Auto:
+                // blend on diffuse alpha / alpha texture, otherwise opaque. `alpha_test` is
+                // ignored for the same reason as in the PBR Auto branch below.
+                let alpha_mode = if base_color.alpha() < 1.0 || tex_is_present(&unlit.alpha_texture)
+                {
                     AlphaMode::Blend
                 } else {
                     AlphaMode::Opaque
@@ -182,10 +184,13 @@ impl MaterialDefinition {
                         );
                         AlphaMode::Blend
                     }
+                    // Auto ignores `alpha_test`: the SDK documents a default of 0.5 for it and tools
+                    // (e.g. the Creator Hub inspector) write that default on every material, so its
+                    // presence is not a request for masking. Mirrors the Unity explorer's
+                    // `ResolveAutoMode`, which blends on albedo alpha / alpha texture and is otherwise
+                    // opaque; `alpha_test` only applies to the explicit alpha-test modes above.
                     Some(MaterialTransparencyMode::MtmAuto) | None => {
-                        if let Some(test) = pbr.alpha_test {
-                            AlphaMode::Mask(test)
-                        } else if base_color.alpha() < 1.0 || tex_is_present(&pbr.alpha_texture) {
+                        if base_color.alpha() < 1.0 || tex_is_present(&pbr.alpha_texture) {
                             AlphaMode::Blend
                         } else {
                             AlphaMode::Opaque


### PR DESCRIPTION
Setting a PBR material's albedo alpha from the Creator Hub gives a hard cutoff on bevy instead of a fade: the mesh is fully opaque above 0.5 and fully invisible below it. Unity fades smoothly for the same component.

## Why

`MaterialDefinition::from_base_and_material` resolves `MTM_AUTO` (and an unset `transparency_mode`) like this:

```rust
Some(MaterialTransparencyMode::MtmAuto) | None => {
    if let Some(test) = pbr.alpha_test {
        AlphaMode::Mask(test)
    } else if base_color.alpha() < 1.0 || tex_is_present(&pbr.alpha_texture) {
        AlphaMode::Blend
    } else {
        AlphaMode::Opaque
    }
}
```

The `alpha_test` arm wins whenever the field is *present*, regardless of its value. But `alpha_test` has a documented default of `0.5` in `material.proto`, and tooling writes that default on every material it touches — the Creator Hub inspector materializes `alphaTest: 0.5` alongside `transparencyMode: MTM_AUTO` on save. So in practice every editor-authored material ends up in `AlphaMode::Mask(0.5)`, and the albedo alpha the user is dragging becomes a step function.

The Unity explorer's `ResolveAutoMode` never looks at `alphaTest` in Auto: it blends when there is an alpha texture or the albedo alpha is below 1, otherwise it is opaque, and the cutoff value is only read in the explicit `AlphaTest` case. The unlit path there is the same, since unlit materials have no transparency mode and always resolve as Auto.

## Change

- PBR `MtmAuto | None`: drop the `alpha_test` arm. Blend on albedo alpha / alpha texture, otherwise opaque. `alpha_test` still drives `MtmAlphaTest`, where it is asked for.
- Unlit: same, for the same reason.

Behaviour that changes: a material in Auto mode with a transparent PNG texture and no albedo alpha, which used to be cut out at 0.5 on bevy because the editor had written `alpha_test`, now renders opaque — which is what Unity does and what the SDK docs describe ("it will be opaque by default, but you can activate its transparency by setting the `transparencyMode` to `MTM_ALPHA_BLEND`"). Scenes that want masking set `MTM_ALPHA_TEST` explicitly and are unaffected.

## Testing

- `cargo check -p scene_runner` and `rustfmt` on the touched file.
- Repro: Creator Hub, add a Material to a cube, drag the albedo alpha slider (which writes `albedoColor.a` with `transparencyMode: MTM_AUTO` and `alphaTest: 0.5`). Before: opaque/invisible flip at 0.5. After: smooth fade.

Found while testing decentraland/creator-hub#1470, which exposes the albedo alpha in the inspector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
