### PR TITLE
Pulse: replay held peer state on a quick return to a realm

### DIFF
--- a/crates/comms/src/pulse/mod.rs
+++ b/crates/comms/src/pulse/mod.rs
@@ -193,7 +193,11 @@ struct Subject {
     /// none and don't need to: a realm change is always a teleport. A listener observing several
     /// realms needs this to tell two identically-numbered parcels apart.
     realm: Arc<str>,
+    /// Latest version the server has told us of, from `PlayerJoined` then each announcement.
+    profile_version: i32,
     last_seq: u32,
+    /// Raw server tick of the state in `baseline`, so a replay can stamp it honestly.
+    last_tick: u32,
     baseline: SubjectState,
 }
 
@@ -436,7 +440,9 @@ impl PulseDecoder {
             Subject {
                 wallet: address,
                 realm: realm.clone(),
+                profile_version: joined.profile_version,
                 last_seq: full.sequence,
+                last_tick: full.server_tick,
                 baseline,
             },
         );
@@ -492,6 +498,7 @@ impl PulseDecoder {
 
         subject.baseline = SubjectState::from_player_state(&state);
         subject.last_seq = sequence;
+        subject.last_tick = server_tick;
         // Only a teleport carries one, and only then can it differ.
         if let Some(realm) = realm.filter(|realm| &*subject.realm != realm.as_str()) {
             subject.realm = Arc::from(realm.as_str());
@@ -541,6 +548,7 @@ impl PulseDecoder {
 
         subject.baseline.apply_delta(&delta);
         subject.last_seq = delta.new_seq;
+        subject.last_tick = delta.server_tick;
         let address = subject.wallet;
         let realm = subject.realm.clone();
         let mut movement = self.to_movement_for(delta.subject_id);
@@ -562,14 +570,73 @@ impl PulseDecoder {
         }]
     }
 
-    fn on_profile(&self, subject_id: u32, version: i32) -> Vec<PulseEvent> {
-        match self.subjects.get(&subject_id) {
-            Some(subject) => vec![PulseEvent::ProfileVersion {
-                address: subject.wallet,
-                version,
-            }],
+    fn on_profile(&mut self, subject_id: u32, version: i32) -> Vec<PulseEvent> {
+        match self.subjects.get_mut(&subject_id) {
+            Some(subject) => {
+                subject.profile_version = version;
+                vec![PulseEvent::ProfileVersion {
+                    address: subject.wallet,
+                    version,
+                }]
+            }
             None => Vec::new(),
         }
+    }
+
+    /// Forget every subject. For a new connection: the server starts it with an empty view set and
+    /// re-announces everyone, and the ids it hands out are its own, so nothing from the previous
+    /// connection can be trusted — least of all the promise that a `PlayerLeft` would have arrived
+    /// for anyone who left while the link was down.
+    pub fn reset(&mut self) {
+        self.subjects.clear();
+    }
+
+    /// Re-emit the join + last known state of every subject the server placed in `realm`, as if
+    /// they had just been announced. The server keeps its per-observer view of a subject across the
+    /// observer's own realm change and only sends `PlayerJoined` on first sight, so a return to a
+    /// realm within its stale-view window brings no announcement at all; but it does send a
+    /// `PlayerLeft` for anyone dropped from that view, and every message reaches this decoder, so a
+    /// subject still held here is still held there. The baselines match too — deltas are diffed
+    /// from the last state the server sent us — so the first delta after the return corrects a
+    /// replayed position rather than fighting it. Flagged as a teleport: the state is a snapshot,
+    /// not travel. Subjects tagged with other realms stay as they are, untouched.
+    pub fn replay(&mut self, realm: &str) -> Vec<PulseEvent> {
+        let mut ids: Vec<u32> = self
+            .subjects
+            .iter()
+            .filter(|(_, subject)| &*subject.realm == realm)
+            .map(|(id, _)| *id)
+            .collect();
+        ids.sort_unstable();
+
+        let mut events = Vec::with_capacity(ids.len() * 2);
+        for id in ids {
+            let subject = &self.subjects[&id];
+            let address = subject.wallet;
+            let realm = subject.realm.clone();
+            let profile_version = subject.profile_version;
+            let last_tick = subject.last_tick;
+            let movement = self.to_movement(&subject.baseline);
+            events.push(PulseEvent::Joined {
+                subject_id: id,
+                address,
+                profile_version,
+                parcel: self.grid.parcel_coords(Vec3::new(
+                    movement.position_x,
+                    movement.position_y,
+                    movement.position_z,
+                )),
+                realm: realm.clone(),
+            });
+            events.push(PulseEvent::Movement {
+                address,
+                movement: Box::new(movement),
+                realm,
+                teleport: true,
+                timestamp: self.tick_secs(last_tick),
+            });
+        }
+        events
     }
 
     /// Convenience: convert an already-stored subject baseline.

--- a/crates/comms/src/pulse/native.rs
+++ b/crates/comms/src/pulse/native.rs
@@ -166,13 +166,11 @@ async fn drive(channels: &mut PulseDriverChannels, address: SocketAddr, stop: &A
                     return;
                 }
                 Ok(Some(enet::Event::Receive { packet, .. })) => {
-                    // Only surface peer state while a routing entity is alive (we're on a Pulse
-                    // realm). Off-realm we stay connected — the host is still serviced, keeping the
-                    // peer warm — but drop inbound so old-realm peers don't leak through; the Bevy
-                    // decoder's resulting gap is healed by resync/teleport on return.
-                    if channels.presence.strong_count() > 1 {
-                        let _ = channels.inbound.try_send(packet.data().to_vec());
-                    }
+                    // Every packet is surfaced, on or off a Pulse realm: the protocol layer's
+                    // decoder must see each `PlayerLeft` to keep its subject table an honest mirror
+                    // of the server's view of us, and it gates what reaches the engine itself
+                    // (nothing routes without a live routing entity).
+                    let _ = channels.inbound.try_send(packet.data().to_vec());
                 }
                 Ok(None) => break,
                 Err(err) => return fail(channels, format!("enet service error: {err}")),

--- a/crates/comms/src/pulse/plugin.rs
+++ b/crates/comms/src/pulse/plugin.rs
@@ -18,7 +18,7 @@
 //! the whole driver/link from `Down` (unless the last reason was terminal, in which case it parks in
 //! `Dead`). Initial connect is just the first such build.
 
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use bevy::prelude::*;
 use bevy::tasks::{IoTaskPool, Task};
@@ -138,11 +138,6 @@ pub(crate) struct PulseSession {
     /// connection, one outbound stream, so it lives with the session rather than with any one of
     /// the transports feeding it.
     last_state: Option<pulse::PlayerState>,
-    /// Liveness anchor for the realm's Pulse routing entity. The routing entity holds a strong clone
-    /// (`PulsePresence`) while it exists; the driver holds a `Weak` and surfaces inbound only while
-    /// `strong_count() > 1`. Lives here (not on the entity) so reconnects, which rebuild the driver,
-    /// can hand it a fresh `Weak` — the entity (and thus the signal) outlives any single driver.
-    liveness: Arc<()>,
     state: Connection,
 }
 
@@ -179,7 +174,8 @@ struct PlayerRole {
     sink: mpsc::Sender<NetworkUpdate>,
     /// The realm's routing `Transport` entity, which doubles as the `transport_id` every inbound
     /// Pulse update is attributed to. `None` off a Pulse realm (the entity is despawned with the
-    /// realm's transports), which is also when inbound is gated off by the liveness anchor.
+    /// realm's transports): nothing routes then, so peers the decoder still tracks stay out of
+    /// the engine until a routing entity exists again.
     ///
     /// Using the real transport entity — rather than a synthetic marker — is what makes presence
     /// work: `ForeignPlayer.transports` holds it, so despawning it on a realm change drops every
@@ -188,6 +184,10 @@ struct PlayerRole {
     /// The realm `routing_transport` was spawned for. `StartPulse` also fires for archipelago
     /// island hops within one realm, and those must NOT rebuild the transport — see `start_pulse`.
     routing_realm: Option<String>,
+    /// Set by `start_pulse` on a realm change, cleared by `flush_replay` once it has re-emitted the
+    /// decoder's held state for the realm — see [`PulseDecoder::replay`]. A flag rather than an
+    /// immediate replay because the routing entity it delivers on is spawned by a deferred command.
+    replay_pending: bool,
 }
 
 /// A scene listener's view of the world it hosts: which crdt context owns each parcel, the AoI those
@@ -219,11 +219,6 @@ struct ListenerRole {
     /// other. Never pruned: an entry for a despawned transport simply stops resolving, and the
     /// peer's next movement re-places it.
     peer_transport: HashMap<Address, Entity>,
-    /// A strong clone of [`PulseSession::liveness`]. A player anchors that on its routing transport;
-    /// a listener has none, and its per-context transports come and go with the scenes, so it holds
-    /// the anchor itself for as long as the session lives.
-    #[expect(dead_code)]
-    anchor: Arc<()>,
 }
 
 /// The crdt context channel a Pulse `Transport` feeds, held by the transport entity itself. Every
@@ -420,12 +415,6 @@ impl PulseSession {
     }
 }
 
-/// The realm's Pulse routing entity holds this while it exists (i.e. while we're on a Pulse realm).
-/// It's a strong clone of [`PulseSession::liveness`]; despawning the entity drops it, which the driver
-/// observes via its `Weak` to stop surfacing inbound peer state. See [`PulseSession::liveness`].
-#[derive(Component)]
-struct PulsePresence(#[expect(dead_code)] Arc<()>);
-
 /// The drain end of a Pulse `Transport` entity's channel — its companion, like
 /// `WebsocketRoomTransport.receiver`. `drain_pulse_outbox` decodes and bridges what lands here.
 #[derive(Component)]
@@ -535,13 +524,9 @@ fn configure_pulse(mut commands: Commands) {
     });
 }
 
-/// Build a fresh driver + its protocol-side link for `config`. `presence` is a weak handle to the
-/// session's liveness anchor, handed fresh to every (re)built driver so it survives reconnects.
-fn spawn_driver(
-    config: &PulseTransportConfig,
-    presence: Weak<()>,
-) -> (PulseLink, PulseDriverHandle) {
-    let (link, channels) = transport::pulse_channels(1024, presence);
+/// Build a fresh driver + its protocol-side link for `config`.
+fn spawn_driver(config: &PulseTransportConfig) -> (PulseLink, PulseDriverHandle) {
+    let (link, channels) = transport::pulse_channels(1024);
     let driver = transport::spawn_pulse_driver(config.clone(), channels);
     (link, driver)
 }
@@ -568,22 +553,15 @@ fn connect_pulse(
         return;
     };
 
-    let liveness = Arc::new(());
     let role = if common::structs::server_mode() {
-        // A listener never spawns a routing transport, so nothing else would hold the liveness
-        // anchor and the driver would drop every inbound frame — the handshake response included.
-        // Its connection is governed by its AoI, not by any one transport entity, so the anchor
-        // lives for as long as the role does.
-        PulseRole::Listener(ListenerRole {
-            anchor: liveness.clone(),
-            ..default()
-        })
+        PulseRole::Listener(ListenerRole::default())
     } else {
         PulseRole::Player(PlayerRole {
             context,
             sink: crdt.get_sender(),
             routing_transport: None,
             routing_realm: None,
+            replay_pending: false,
         })
     };
 
@@ -599,7 +577,6 @@ fn connect_pulse(
         server_id: config.server_id.clone(),
         wanted: false,
         last_state: None,
-        liveness,
         state: Connection::Down { respawn_at: 0.0 },
     });
 
@@ -614,6 +591,11 @@ fn connect_pulse(
 /// connected — announce the new realm with a teleport. The previous routing entity has been
 /// despawned by `process_realm_change` this same frame, so we spawn unconditionally (once per frame
 /// with an event) rather than presence-checking, which would race that deferred despawn.
+///
+/// That sweep also despawned every peer the old entity carried, while the server keeps its view of
+/// them for us across our own realm change and will not announce them again on a quick return. So a
+/// realm change also flags a replay of the decoder's held state for the realm entered
+/// ([`PulseDecoder::replay`]), which `flush_replay` delivers once the new entity is queryable.
 fn start_pulse(
     mut commands: Commands,
     mut events: EventReader<StartPulse>,
@@ -681,15 +663,13 @@ fn start_pulse(
             },
             PulseOutbox(receiver),
             PulseSink(player_role.sink.clone()),
-            // While this entity lives (i.e. we're on a Pulse realm) the driver sees a strong ref and
-            // surfaces inbound peer state; despawn (realm change away from Pulse) drops it.
-            PulsePresence(session.liveness.clone()),
         ))
         .id();
 
     let player_role = session.role.player_mut().expect("checked above");
     player_role.routing_transport = Some(routing_transport);
     player_role.routing_realm = Some(realm.address.clone());
+    player_role.replay_pending = true;
     session.wanted = true;
     // Already up (a later realm) → re-teleport now, unless out of world (position provisional behind
     // the loading screen); the spawn `PlayerTeleported` re-announces realm + position. Otherwise the
@@ -760,8 +740,103 @@ fn pump_pulse(
 
     drain_status(session, now);
     drive_connection(session, &wallet, profile_version, now);
+    flush_replay(session, &sinks, &realm);
     drain_inbound(session, &sinks, &realm, &player, in_world, now);
     flush_listener_aoi(session, now);
+}
+
+/// Deliver a `PulseDecoder::replay` of the realm just entered, the frame after `start_pulse` flagged
+/// it — its routing entity is a deferred spawn, and delivery resolves the `PulseSink` on it. Held
+/// while the realm can't be named yet (a local realm's key may still be fetching); a realm change in
+/// the meantime re-flags it for the new realm, and nothing is replayed for the one skipped.
+fn flush_replay(session: &mut PulseSession, sinks: &Query<&PulseSink>, realm: &CurrentRealm) {
+    let Some(player) = session.role.player_mut() else {
+        return;
+    };
+    if !player.replay_pending {
+        return;
+    }
+    match player.routing_transport {
+        Some(transport) if sinks.contains(transport) => {}
+        Some(_) => return,
+        None => {
+            player.replay_pending = false;
+            return;
+        }
+    }
+    let Some(realm_name) = realm_name(session, realm) else {
+        return;
+    };
+    session
+        .role
+        .player_mut()
+        .expect("checked above")
+        .replay_pending = false;
+
+    let events = session.decoder.replay(&realm_name);
+    if events.is_empty() {
+        return;
+    }
+    info!(
+        "pulse: replaying {} held peer(s) for realm {realm_name}",
+        events.len() / 2
+    );
+    for event in events {
+        match event {
+            PulseEvent::Joined {
+                address,
+                profile_version,
+                parcel,
+                realm,
+                ..
+            } => {
+                session.forward_at(sinks, address, &realm, parcel, PlayerMessage::Joined);
+                bridge_profile_version(session, sinks, address, profile_version);
+            }
+            PulseEvent::Movement {
+                address,
+                movement,
+                realm,
+                teleport,
+                timestamp,
+            } => forward_movement(
+                session, sinks, address, &realm, movement, teleport, timestamp,
+            ),
+            // `replay` emits only the two above
+            _ => {}
+        }
+    }
+}
+
+/// Bridge a decoded movement into the shared foreign-player pipeline as its own
+/// `PlayerMessage::Movement`, reusing `update_player` / `foreign_dynamics` verbatim. Realm + position
+/// is the placement: together they decide which of the server's scenes the peer is in, and so which
+/// context sees this and everything after it.
+fn forward_movement(
+    session: &mut PulseSession,
+    sinks: &Query<&PulseSink>,
+    address: Address,
+    realm: &str,
+    movement: Box<rfc4::Movement>,
+    teleport: bool,
+    timestamp: f64,
+) {
+    let parcel = session.grid.parcel_coords(Vec3::new(
+        movement.position_x,
+        movement.position_y,
+        movement.position_z,
+    ));
+    session.forward_at(
+        sinks,
+        address,
+        realm,
+        parcel,
+        PlayerMessage::Movement {
+            movement,
+            teleport,
+            timestamp,
+        },
+    )
 }
 
 /// Drain the driver's status channel into the connection state machine. `link`'s borrow ends at
@@ -811,8 +886,7 @@ fn drive_connection(session: &mut PulseSession, wallet: &Wallet, profile_version
             if !session.wanted || now < *respawn_at {
                 return;
             }
-            let (link, driver) =
-                spawn_driver(&session.transport_config, Arc::downgrade(&session.liveness));
+            let (link, driver) = spawn_driver(&session.transport_config);
             session.link = Some(link);
             session._driver = Some(driver);
             session.state = Connection::Connecting;
@@ -885,6 +959,16 @@ fn drain_inbound(
     in_world: bool,
     now: f64,
 ) {
+    // A player's realm is its whole area of interest, so a peer the server places anywhere else is
+    // not for the engine: a delta still in flight from the realm just left, or a peer teleporting
+    // out of this one. The decoder keeps tracking them regardless — that is what a later
+    // `replay` on returning to their realm is built from. A listener places by realm itself.
+    let own_realm = match session.role {
+        PulseRole::Player(_) => realm_name(session, realm),
+        PulseRole::Listener(_) => None,
+    };
+    let for_engine = |peer_realm: &str| own_realm.as_deref().is_none_or(|own| own == peer_realm);
+
     while let Some(Ok(bytes)) = session.link.as_mut().map(|link| link.inbound.try_recv()) {
         let events = match pulse::ServerMessage::decode(bytes.as_slice()) {
             Ok(message) => session.decoder.handle(message),
@@ -899,8 +983,6 @@ fn drain_inbound(
                 PulseEvent::Connected { success, error } => {
                     on_handshake_response(session, realm, player, in_world, now, success, error)
                 }
-                // Movement is bridged into the shared foreign-player pipeline as its own
-                // `PlayerMessage::Movement`, reusing `update_player` / `foreign_dynamics` verbatim.
                 PulseEvent::Movement {
                     address,
                     movement,
@@ -908,23 +990,11 @@ fn drain_inbound(
                     teleport,
                     timestamp,
                 } => {
-                    // Realm + position is the placement: together they decide which of the server's
-                    // scenes the peer is in, and so which context sees this and everything after it.
-                    let parcel = session.grid.parcel_coords(Vec3::new(
-                        movement.position_x,
-                        movement.position_y,
-                        movement.position_z,
-                    ));
-                    session.forward_at(
-                        sinks,
-                        address,
-                        &realm,
-                        parcel,
-                        PlayerMessage::Movement {
-                            movement,
-                            teleport,
-                            timestamp,
-                        },
+                    if !for_engine(&realm) {
+                        continue;
+                    }
+                    forward_movement(
+                        session, sinks, address, &realm, movement, teleport, timestamp,
                     )
                 }
                 // A sequence gap was detected — ask the server to replay full state, reliably.
@@ -972,6 +1042,9 @@ fn drain_inbound(
                     realm,
                     ..
                 } => {
+                    if !for_engine(&realm) {
+                        continue;
+                    }
                     session.forward_at(sinks, address, &realm, parcel, PlayerMessage::Joined);
                     bridge_profile_version(session, sinks, address, profile_version);
                 }
@@ -1020,6 +1093,9 @@ fn lost_connection(session: &mut PulseSession, retry: bool, now: f64) {
     }
     session.link = None;
     session._driver = None; // dropping joins the already-exited driver thread
+
+    // Whatever the next connection announces is the whole truth; nothing held from this one is.
+    session.decoder.reset();
     session.state = if retry {
         info!("pulse: transport dropped — reinitialising after cooldown");
         Connection::Down {
@@ -1319,6 +1395,16 @@ fn flush_listener_aoi(session: &mut PulseSession, now: f64) {
 /// by the server. `None` until the realm name is known, and on a locally served realm until a
 /// `b64-` addressed scene has loaded.
 fn announced_realm(session: &PulseSession, realm: &CurrentRealm) -> Option<String> {
+    let name = realm_name(session, realm);
+    if name.is_none() && !common::structs::multi_tenant() && !is_local_realm(realm) {
+        warn!("pulse: no realm name yet (no peers will be visible)");
+    }
+    name
+}
+
+/// The realm name as `announced_realm` resolves it, silently — for the per-frame inbound filter
+/// and the replay hold, which retry rather than complain.
+fn realm_name(session: &PulseSession, realm: &CurrentRealm) -> Option<String> {
     if let Some(announced) = session.realm_override.as_ref() {
         return Some(announced.clone());
     }
@@ -1345,10 +1431,6 @@ fn announced_realm(session: &PulseSession, realm: &CurrentRealm) -> Option<Strin
         .realm_name
         .clone()
         .filter(|name| !name.is_empty())
-        .or_else(|| {
-            warn!("pulse: no realm name yet (no peers will be visible)");
-            None
-        })
 }
 
 /// Pulse's `FieldValidator` `MaxRealmLength`.

--- a/crates/comms/src/pulse/test.rs
+++ b/crates/comms/src/pulse/test.rs
@@ -370,3 +370,134 @@ fn ticks_stay_monotonic_across_u32_rollover() {
     assert!((stamps[2] - stamps[1] - 0.041).abs() < 1e-6);
     assert!((stamps[3] - stamps[2] - 0.040).abs() < 1e-6);
 }
+
+fn joined_in_realm(
+    subject_id: u32,
+    wallet: &str,
+    realm: &str,
+    local: (f32, f32, f32),
+) -> pulse::server_message::Message {
+    pulse::server_message::Message::PlayerJoined(pulse::PlayerJoined {
+        user_id: wallet.to_string(),
+        profile_version: 3,
+        state: Some(pulse::PlayerStateFull {
+            subject_id,
+            sequence: 1,
+            server_tick: 1000,
+            state: Some(player_state(local, 0)),
+        }),
+        realm: realm.to_string(),
+    })
+}
+
+fn delta(
+    subject_id: u32,
+    baseline_seq: u32,
+    new_seq: u32,
+    tick: u32,
+    x: f32,
+) -> pulse::ServerMessage {
+    server_msg(pulse::server_message::Message::PlayerStateDelta(
+        pulse::PlayerStateDeltaTier0 {
+            subject_id,
+            baseline_seq,
+            new_seq,
+            server_tick: tick,
+            position_x: Some(pulse::PlayerStateDeltaTier0::position_x_quantized(x)),
+            ..Default::default()
+        },
+    ))
+}
+
+/// A realm change despawns every peer client-side while the server keeps its view of them for us,
+/// so a quick return brings no re-announcement. The decoder replays what it still holds for that
+/// realm — and only that realm — as a join plus a teleport-flagged snapshot of the latest state.
+#[test]
+fn replay_re_emits_held_subjects_of_that_realm_only() {
+    const OTHER_WALLET: &str = "0x0000000000000000000000000000000000000002";
+    let mut decoder = PulseDecoder::new(PulseParcelGrid::default());
+    decoder.handle(server_msg(joined_in_realm(
+        SUBJECT,
+        WALLET,
+        "home",
+        (1.0, 2.0, 3.0),
+    )));
+    decoder.handle(server_msg(joined_in_realm(
+        SUBJECT + 1,
+        OTHER_WALLET,
+        "elsewhere",
+        (1.0, 2.0, 3.0),
+    )));
+    // state moves on after the join: the replay must carry the latest, not the join snapshot
+    decoder.handle(delta(SUBJECT, 1, 2, 1500, 5.0));
+    decoder.handle(server_msg(
+        pulse::server_message::Message::PlayerProfileVersionAnnounced(
+            pulse::PlayerProfileVersionsAnnounced {
+                subject_id: SUBJECT,
+                version: 9,
+            },
+        ),
+    ));
+
+    let events = decoder.replay("home");
+    assert_eq!(
+        events.len(),
+        2,
+        "one join + one movement for the one home subject"
+    );
+    let PulseEvent::Joined {
+        subject_id,
+        address,
+        profile_version,
+        realm,
+        ..
+    } = &events[0]
+    else {
+        panic!("expected Joined first, got {:?}", events[0]);
+    };
+    assert_eq!(
+        (*subject_id, *address, *profile_version),
+        (SUBJECT, wallet(), 9)
+    );
+    assert_eq!(&**realm, "home");
+    let PulseEvent::Movement {
+        address,
+        movement,
+        teleport,
+        timestamp,
+        ..
+    } = &events[1]
+    else {
+        panic!("expected Movement second, got {:?}", events[1]);
+    };
+    assert_eq!(*address, wallet());
+    assert!(
+        *teleport,
+        "a replayed snapshot is a discontinuity, not travel"
+    );
+    approx(movement.position_x, 165.0); // 10*16 + 5 after the delta
+    assert!(
+        (*timestamp - 1.5).abs() < 1e-6,
+        "stamped with the delta's tick"
+    );
+
+    assert!(decoder.replay("nowhere").is_empty());
+    // replay is a read: the other realm's subject is still held for its own return
+    assert_eq!(decoder.replay("elsewhere").len(), 2);
+}
+
+#[test]
+fn reset_forgets_every_subject() {
+    let mut decoder = PulseDecoder::new(PulseParcelGrid::default());
+    decoder.handle(server_msg(joined_in_realm(
+        SUBJECT,
+        WALLET,
+        "home",
+        (1.0, 2.0, 3.0),
+    )));
+    decoder.reset();
+    assert!(decoder.replay("home").is_empty());
+    // and a delta for it is now a stranger's: full state is requested rather than applied
+    let events = decoder.handle(delta(SUBJECT, 1, 2, 1500, 5.0));
+    assert!(matches!(events.as_slice(), [PulseEvent::Resync(r)] if r.known_seq == 0));
+}

--- a/crates/comms/src/pulse/transport.rs
+++ b/crates/comms/src/pulse/transport.rs
@@ -8,7 +8,7 @@
 //! once, regardless of whether the driver is the native ENet thread or the wasm WebTransport task.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
@@ -164,17 +164,10 @@ pub struct PulseDriverChannels {
     pub outbound: mpsc::Receiver<PulseFrame>,
     pub inbound: mpsc::Sender<Vec<u8>>,
     pub status: mpsc::Sender<PulseStatus>,
-    /// Liveness handle for the realm's Pulse routing entity. A weak ref to the session's `Arc<()>`
-    /// anchor; the routing entity holds a strong clone while it exists, so `strong_count() > 1` means
-    /// "currently on a Pulse realm". The driver reads this to decide whether to surface inbound peer
-    /// state (it stays connected across realms either way). A `Weak` so the driver never keeps the
-    /// session alive, and a fresh one is handed to each rebuilt driver so reconnects don't lose it.
-    pub presence: Weak<()>,
 }
 
-/// Build a matched [`PulseLink`] / [`PulseDriverChannels`] pair. `presence` is the driver's liveness
-/// handle (see [`PulseDriverChannels::presence`]).
-pub fn pulse_channels(capacity: usize, presence: Weak<()>) -> (PulseLink, PulseDriverChannels) {
+/// Build a matched [`PulseLink`] / [`PulseDriverChannels`] pair.
+pub fn pulse_channels(capacity: usize) -> (PulseLink, PulseDriverChannels) {
     let (outbound_tx, outbound_rx) = mpsc::channel(capacity);
     let (inbound_tx, inbound_rx) = mpsc::channel(capacity);
     let (status_tx, status_rx) = mpsc::channel(16);
@@ -189,7 +182,6 @@ pub fn pulse_channels(capacity: usize, presence: Weak<()>) -> (PulseLink, PulseD
             outbound: outbound_rx,
             inbound: inbound_tx,
             status: status_tx,
-            presence,
         },
     )
 }

--- a/crates/comms/src/pulse/wasm.rs
+++ b/crates/comms/src/pulse/wasm.rs
@@ -16,7 +16,7 @@
 
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use bevy::log::warn;
 use futures_util::future::{select, Either};
@@ -57,7 +57,6 @@ async fn run(config: PulseTransportConfig, channels: PulseDriverChannels, stop: 
         outbound,
         inbound,
         status,
-        presence,
     } = channels;
 
     let _ = status.try_send(PulseStatus::Connecting);
@@ -114,19 +113,17 @@ async fn run(config: PulseTransportConfig, channels: PulseDriverChannels, stop: 
 
     let transport = Rc::new(transport);
 
-    // Reader tasks reassemble/forward inbound, gated by presence exactly like native. Each closes the
-    // session (→ the watcher reports Disconnected) when its stream ends or errors.
+    // Reader tasks reassemble/forward inbound. Each closes the session (→ the watcher reports
+    // Disconnected) when its stream ends or errors.
     spawn_local(read_stream(
         stream_reader,
         inbound.clone(),
-        presence.clone(),
         stop.clone(),
         transport.clone(),
     ));
     spawn_local(read_datagrams(
         datagram_reader,
         inbound,
-        presence,
         stop.clone(),
         transport.clone(),
     ));
@@ -220,12 +217,11 @@ async fn pump_outbound(
     }
 }
 
-/// Read the reliable bidi stream, reassemble length-framed messages, and forward each (while a
-/// routing entity is alive) into the shared inbound channel.
+/// Read the reliable bidi stream, reassemble length-framed messages, and forward each into the
+/// shared inbound channel.
 async fn read_stream(
     reader: ReadableStreamDefaultReader,
     inbound: mpsc::Sender<Vec<u8>>,
-    presence: Weak<()>,
     stop: Arc<AtomicBool>,
     transport: Rc<WebTransport>,
 ) {
@@ -241,7 +237,9 @@ async fn read_stream(
         assembler.append(&chunk);
         loop {
             match assembler.next_message() {
-                Ok(Some(message)) => surface(&inbound, &presence, message),
+                Ok(Some(message)) => {
+                    let _ = inbound.try_send(message);
+                }
                 Ok(None) => break,
                 Err(err) => {
                     // Unrecoverable framing — the stream's next boundary is lost; drop the session.
@@ -261,13 +259,14 @@ async fn read_stream(
 async fn read_datagrams(
     reader: ReadableStreamDefaultReader,
     inbound: mpsc::Sender<Vec<u8>>,
-    presence: Weak<()>,
     stop: Arc<AtomicBool>,
     transport: Rc<WebTransport>,
 ) {
     while !stop.load(Ordering::Relaxed) {
         match read_chunk(&reader).await {
-            Ok(Some(chunk)) => surface(&inbound, &presence, chunk),
+            Ok(Some(chunk)) => {
+                let _ = inbound.try_send(chunk);
+            }
             Ok(None) | Err(_) => break,
         }
     }
@@ -291,15 +290,6 @@ async fn watch_closed(
     };
     let _ = status.try_send(PulseStatus::Disconnected(reason));
     stop.store(true, Ordering::Relaxed);
-}
-
-/// Forward one inbound message only while a routing entity is alive (we're on a Pulse realm) — the
-/// same gate as native. Off-realm we keep draining the streams to keep them flowing but drop the
-/// payload; the decoder's resulting gap is healed by resync/teleport on return.
-fn surface(inbound: &mpsc::Sender<Vec<u8>>, presence: &Weak<()>, message: Vec<u8>) {
-    if presence.strong_count() > 1 {
-        let _ = inbound.try_send(message);
-    }
 }
 
 /// Read one chunk from a reader: `Ok(Some(bytes))` for data, `Ok(None)` when the stream is done,


### PR DESCRIPTION
A logged-in user who teleported out of a world and back within a few seconds could no longer see a peer who had stayed, until that peer moved. Logs showed the peer's entity was recreated on every return (LiveKit re-announces the room) but never received a position: the avatar sat at the world origin, over a kilometre from the scene.

## Why

Two sides disagree about what the observer's realm change means.

The client sweeps every `Transport` on a realm change, the Pulse routing entity included, which despawns every peer, and re-teleports over the same Pulse session. The Pulse server keeps its per-observer view of each subject across that teleport and only sends `PlayerJoined` on first sight; a view is dropped only when a periodic sweep finds it unseen for longer than its interval (5 s of 50 ms ticks, so a view survives 5–10 s out of the area of interest). A return inside that window re-stamps the old view: no `PlayerLeft`, no `PlayerJoined`, and since the server suppresses republishing unchanged input, an idle peer sends nothing at all. Any state change on the peer (moving, head yaw) produced a delta and revived them, which is why the symptom looked intermittent.

## What

The Pulse session already holds everything needed to recover: the decoder keeps a baseline per subject for delta application, and the server tells it, reliably, whenever a subject leaves its view. So a subject still held by the decoder is still held by the server, and the two baselines match (deltas are diffed from the last state the server sent us), so the first delta after a return corrects a replayed position rather than fighting it.

- **The driver no longer gates inbound on a routing entity being alive.** That gate dropped packets, `PlayerLeft` included, whenever no routing entity existed, which is exactly what would have made the decoder's table untrustworthy. Delivery to the engine was already gated at the routing layer (`route()` resolves nothing without a routing entity), so the driver-side check was redundant for its stated purpose. The liveness `Arc`, `PulsePresence` and the listener's anchor existed only for it and go with it. A listener held the anchor for its whole life, so nothing changes on the headless route.
- **The decoder mirrors the server's view set.** Each subject also records its profile version and last server tick. `reset()` clears the table on link loss: a new connection is a new peer index server-side with fresh views, and nothing held from the old one can be trusted.
- **A realm change replays held state for the realm entered.** `start_pulse` flags it; `flush_replay` delivers a `Joined` plus a teleport-flagged `Movement` per subject the following frame, once the freshly spawned routing entity is queryable, through the same forwarding path as live traffic. Subjects tagged with other realms stay untouched. This also covers a realm "change" to the same realm name, which the server can't tell apart from a no-op.
- **Delivery is filtered by realm** for a player: a `Joined` or `Movement` the server places in another realm never reaches the engine. That closes a pre-existing race where deltas still in flight on the way out of a realm recreated an old-realm peer in the new one, and it keeps a peer who teleports out from being moved to the other world's coordinates in this one.

One transient is new: a peer who left the world while you were away is replayed at their last position and disappears when the server's sweep sends `PlayerLeft`, within about ten seconds. That is the same staleness the client already shows for a peer walking out of the area-of-interest radius.

The server-side counterpart, dropping the observer's views on a `TeleportRequest` that changes realm, is the semantically right fix for every Pulse client and worth doing separately; this change stands without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
